### PR TITLE
Add Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'sass-rails', '4.0.2'
 gem 'uglifier', '2.5.0'
 
 gem 'unicorn', '4.8.2'
+gem 'airbrake', '3.1.15'
 
 group :test do
   gem 'capybara-webkit', '1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,9 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     addressable (2.3.6)
+    airbrake (3.1.15)
+      builder
+      multi_json
     arel (4.0.2)
     atomic (1.1.16)
     builder (3.1.4)
@@ -136,6 +139,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (= 3.1.15)
   capybara-webkit (= 1.1.1)
   cucumber-rails (= 1.4.0)
   minitest-spec-rails (= 4.7.6)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,7 @@
+# This file is overwritten on deploy
+#
+Airbrake.configure do |config|
+  # Adding "production" to the development environments causes Airbrake not
+  # to attempt to send notifications.
+  config.development_environments << "production"
+end


### PR DESCRIPTION
This adds the Airbrake gem for exception notifications. It includes a placeholder initializer which gets replaced at deploy time with our Errbit configuration.
