### PR TITLE
Configure asset pipeline correctly in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,9 @@ Collections::Application.configure do
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # config.assets.precompile += %w( search.js )
 
+  config.assets.prefix = "collections"
+  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This changes `config/environments/production.rb` to compile assets into the `collections` directory, and set the asset host to the `GOVUK_ASSET_HOST` environment variable.
