### PR TITLE
Set a preceding slash in the assets prefix

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Collections::Application.configure do
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # config.assets.precompile += %w( search.js )
 
-  config.assets.prefix = "collections"
+  config.assets.prefix = "/collections"
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
None of our apps configure the 'config.assets.prefix' variable with a preceding slash, but the Rails configuration guide suggests we should do [1].

The previous change (#3) causes asset URLs to omit any slash between the hostname and path at all, so this seems like the most appropriate way to fix this problem.

[1] http://guides.rubyonrails.org/asset_pipeline.html#changing-the-assets-path
