### PR TITLE
Change "A-Z" to "A to Z"

### DIFF
--- a/app/views/specialist_sectors/subcategory.html.erb
+++ b/app/views/specialist_sectors/subcategory.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <nav class="index-list">
-    <h1>A-Z</h1>
+    <h1>A to Z</h1>
     <ul>
       <% @results.each do |content| %>
         <li>


### PR DESCRIPTION
The GOV.UK style guide [uses "A to Z" to describe alphabetical lists](https://www.gov.uk/design-principles/style-guide/a-z). To keep consistency, this changes the copy on the subsector browse page to match.
