### PR TITLE
Style the parent tag title on subsector pages

### DIFF
--- a/app/assets/stylesheets/views/_specialist-sectors.scss
+++ b/app/assets/stylesheets/views/_specialist-sectors.scss
@@ -18,6 +18,14 @@
           width: auto;
           padding: 0 0 15px;
         }
+
+        span {
+          @include core-27($line-height: 1);
+          display: block;
+          margin-bottom: 0.25em;
+          text-shadow: none;
+          color: $secondary-text-colour;
+        }
       }
 
       h2 {


### PR DESCRIPTION
As we no longer use the full wrapper template for collections, we’ve lost the styling on subsector pages for the title of the parent sector.

As we don’t use this style anywhere near as frequently as we used to on GOV.UK, it feels like this style should be an application concern, so here I’ve copied the rules from static into the specialist sectors stylesheet.

![screen shot 2014-07-14 at 10 30 11](https://cloud.githubusercontent.com/assets/71922/3569067/81b9a2de-0b39-11e4-97f7-02bdf2767055.png)
