### PR TITLE
Register mainstream browse route

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -12,7 +12,7 @@ namespace :router do
     @router_api.add_backend('collections', Plek.current.find('collections', :force_http => true) + "/")
   end
 
-  task :register_browse => :router_environment do
+  task :register_browse => [:unregister_browse_redirects, :router_environment] do
     routes = [
       %w(/browse prefix),
       %w(/browse.json exact),
@@ -20,6 +20,22 @@ namespace :router do
 
     routes.each do |path, type|
       @router_api.add_route(path, type, 'collections')
+    end
+    @router_api.commit_routes
+  end
+
+  task :unregister_browse_redirects => :router_environment do
+    routes = [
+      %w(/browse/business exact),
+      %w(/browse/visas-immigration exact),
+    ]
+
+    routes.each do |path, type|
+      begin
+        @router_api.delete_route(path, type)
+      rescue GdsApi::HTTPNotFound
+        # the router api returns a 404 if the route doesn't already exist
+      end
     end
     @router_api.commit_routes
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/74123364

This adds a new Rake task to register the '/browse' and '/browse.json' routes to the collections app. 

At the present time, we do not want this to run automatically, so this remains a standalone Rake task that must be run manually in the preview environment.
