### PR TITLE
Only show root if there is nothing else to show

### DIFF
--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -86,6 +86,10 @@ describe('browse-columns.js', function() {
   it("should parse a pathname", function() {
     var paths = [
       {
+        path: '/browse',
+        output: { section: '', path: '/browse/tax', slug: '' }
+      },
+      {
         path: '/browse/tax',
         output: { section: 'tax', path: '/browse/tax', slug: 'tax' }
       },


### PR DESCRIPTION
popState can get called on page load without an original state event. In
this case we only want to show the root if there is no slug to show.

This was effecting Safari and iOS browsers.
