### PR TITLE
Fix tabindex on index page

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for :title, "All categories - GOV.UK" %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes root" aria-live="polite" tabindex="-1">
-  <div id="root" class="pane">
+<div class="browse-panes root" aria-live="polite">
+  <div id="root" class="pane" tabindex="-1">
     <ul>
       <% root_sections.each do |result| %>
         <li><%= link_to result.title, result.web_url %></li>


### PR DESCRIPTION
The tabindex needs to be added to the element which contains the
individual list not the element which contains all the lists.
