### PR TITLE
Show section descriptions in section lists

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -104,7 +104,11 @@
       state.sectionData.results.sort(function(a, b){ return a.title.localeCompare(b.title); });
 
       this.setTitle(state.title);
-      this.$section.mustache('browse/_section', { title: state.title, options: state.sectionData.results});
+      this.$section.mustache('browse/_section', {
+        title: state.title,
+        options: state.sectionData.results,
+        showDescription: true
+      });
       this.highlightSection('root', state.path);
       this.$section.focus();
       this.removeLoading();
@@ -144,7 +148,8 @@
         title: state.title,
         options: state.sectionData.results,
         "detailed_guide_categories_any?": !!state.detailedGuideData.results,
-        detailed_guide_categories: state.detailedGuideData.results
+        detailed_guide_categories: state.detailedGuideData.results,
+        showDescription: false
       });
       this.highlightSection('section', state.path);
       this.highlightSection('root', '/browse/' + state.section);
@@ -179,7 +184,13 @@
       // update the data
     },
     getTitle: function(slug){
-      return this.$el.find('a[href$="/browse/'+slug+'"]:first').text();
+      var $link = this.$el.find('a[href$="/browse/'+slug+'"]:first'),
+          $heading = $link.find('h3');
+      if($heading.length > 0){
+        return $heading.text();
+      } else {
+        return $link.text();
+      }
     },
     setTitle: function(title){
       $('title').text(title);
@@ -299,11 +310,11 @@
       return donePromise;
     },
     navigate: function(e){
-      if(e.target.pathname.match(/^\/browse\/[^\/]+(\/[^\/]+)?$/)){
+      if(e.currentTarget.pathname.match(/^\/browse\/[^\/]+(\/[^\/]+)?$/)){
         e.preventDefault();
 
-        var $target = $(e.target);
-        var state = this.parsePathname(e.target.pathname);
+        var $target = $(e.currentTarget);
+        var state = this.parsePathname(e.currentTarget.pathname);
         state.title = $target.text();
 
         if(state.path === window.location.pathname){

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -37,7 +37,7 @@ main.browse {
         }
 
         color: $secondary-text-colour;
-        a {
+        a, p {
           color: $secondary-text-colour;
         }
       }
@@ -118,6 +118,15 @@ main.browse {
               content: "";
             }
           }
+
+          h3 {
+            font-weight: bold;
+          }
+
+          p {
+            color: $text-colour;
+            @include core-14;
+          }
         }
 
         li.active a {
@@ -126,6 +135,9 @@ main.browse {
 
           &:hover {
             background: $link-colour;
+          }
+          p {
+            color: $white;
           }
         }
       }

--- a/app/views/browse/_section.mustache
+++ b/app/views/browse/_section.mustache
@@ -3,7 +3,15 @@
   <p class="sort-order">A to Z</p>
   <ul>
     {{#options}}
-      <li><a href="{{web_url}}">{{title}}</a></li>
+      <li><a href="{{web_url}}">
+        {{#showDescription}}
+          <h3>{{title}}</h3>
+          <p>{{details.description}}</p>
+        {{/showDescription}}
+        {{^showDescription}}
+          {{title}}
+        {{/showDescription}}
+      </a></li>
     {{/options}}
   </ul>
 

--- a/app/views/browse/section.html.erb
+++ b/app/views/browse/section.html.erb
@@ -9,7 +9,10 @@
       <ul>
         <% section_tags.each do |section_tag| %>
           <li>
-            <%= link_to section_tag.title, section_tag.web_url %>
+            <%= link_to section_tag.web_url do %>
+              <h3><%= section_tag.title %></h3>
+              <p><%= section_tag.details.description %></p>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -35,7 +35,10 @@
       <ul>
         <% section_tags.each do |section_tag| %>
           <li<%= ' class="active"'.html_safe if sub_section_tag.slug == section_tag.slug %>>
-            <%= link_to section_tag.title, section_tag.web_url %>
+            <%= link_to section_tag.web_url do %>
+              <h3><%= section_tag.title %></h3>
+              <p><%= section_tag.details.description %></p>
+            <% end %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
- Update mustache to conditionally show descriptions
- Update section and subsection pages to show descriptions
- Update styles for descriptions
- Update navigate to use `currentTarget` rather than `target`.
  `currentTarget` will contain the element that jQuery is attaching the
  event to rather than the element within the link which was acutally
  clicked.
- Update `getTitle` to get the title out of a list item regardless of if
  it is in a heading in the list item or the list item is the title.
