### PR TITLE
Remove outline focus from columns

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -72,6 +72,7 @@ main.browse {
 
 
     #root, #section {
+      outline: none;
       min-height: 20px;
 
       h1, h2 {
@@ -140,6 +141,8 @@ main.browse {
       }
     }
     #subsection {
+      outline: none;
+
       .pane-inner {
         padding-left: 65px;
 


### PR DESCRIPTION
When calling focus on the elements it puts a blue glow around the list.
This removes that glow as it is confusing.
