### PR TITLE
No-op on page load pop, fix detailed guide pop

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -51,6 +51,10 @@
         state = this.parsePathname(window.location.pathname);
       }
 
+      if(this.lastState.slug === state.slug){
+        return; // nothing has changed
+      }
+
       if(state.slug == ''){
         loadPromise = this.showRoot();
       } else if(state.subsection){
@@ -261,7 +265,7 @@
       var donePromise = this.getSectionData(state);
       if(state.subsection){
         var sectionPromise = donePromise;
-        var detailedGuidePromise = this.getDetailedGuideData(state.slug);
+        var detailedGuidePromise = this.getDetailedGuideData(state);
         donePromise = $.when(sectionPromise, detailedGuidePromise);
       }
 


### PR DESCRIPTION
Loading detailed guides in is failing due to changes in method arguments
not being updated.

Also don't try and update the page if the page we are currently showing
is the page we are going to show.
