### PR TITLE
Improve narrow tablet screen styles

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -60,7 +60,10 @@ main.browse {
 
       @include media(tablet){
         border-left: 1px solid $border-colour;
-        min-height: 700px;
+        min-height: 950px;
+      }
+      @include media(desktop){
+        min-height:700px;
       }
     }
 
@@ -123,7 +126,7 @@ main.browse {
       background: $white;
       position: relative;
 
-      @include media(tablet){
+      @include media(desktop){
         &.with-sort {
           .pane-inner {
             padding-left: 96px;


### PR DESCRIPTION
- Removing the A-Z title for narrow tablet sized screens mean long words
  won't be longer than the column they have to be displayed in.
- Increasing the minimum height for narrow screens means the subsection
  border and background will always overlap the whole of the root list
