### PR TITLE
Add IE specific stylesheets

### DIFF
--- a/app/assets/stylesheets/application-ie6.scss
+++ b/app/assets/stylesheets/application-ie6.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 6 COMPILER
+
+$is-ie: true;
+$ie-version: 6;
+
+@import "application";

--- a/app/assets/stylesheets/application-ie7.scss
+++ b/app/assets/stylesheets/application-ie7.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 7 COMPILER
+
+$is-ie: true;
+$ie-version: 7;
+
+@import "application";

--- a/app/assets/stylesheets/application-ie8.scss
+++ b/app/assets/stylesheets/application-ie8.scss
@@ -1,0 +1,6 @@
+// BASE STYLESHEET FOR IE 8 COMPILER
+
+$is-ie: true;
+$ie-version: 8;
+
+@import "application";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,10 @@
 <head>
   <title><%= yield :title %></title>
   <%= stylesheet_link_tag    "application", media: "all" %>
-  <%= javascript_include_tag "application" %>
+  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
+  <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->
+  <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><script>var ieVersion = 7;</script><![endif]-->
+  <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><script>var ieVersion = 8;</script><![endif]-->
   <%= csrf_meta_tags %>
 </head>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,11 @@ Collections::Application.configure do
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
+  config.assets.precompile += %w(
+    application-ie8.css
+    application-ie7.css
+    application-ie6.css
+  )
 
   config.assets.prefix = "/collections"
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']


### PR DESCRIPTION
This lets them get desktop styles rather than mobile stylesheets. Also
add in IE specific varables for JavaScript incase they are needed in the
future.

Add the new stylesheets to the precompile so they are on production.
