### PR TITLE
Register browse routes on deploy

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -12,7 +12,7 @@ namespace :router do
     @router_api.add_backend('collections', Plek.current.find('collections', :force_http => true) + "/")
   end
 
-  task :register_browse => [:unregister_browse_redirects, :router_environment] do
+  task :register_browse => [:unregister_browse_redirects, :register_browse_redirects, :router_environment] do
     routes = [
       %w(/browse prefix),
       %w(/browse.json exact),
@@ -20,6 +20,18 @@ namespace :router do
 
     routes.each do |path, type|
       @router_api.add_route(path, type, 'collections')
+    end
+    @router_api.commit_routes
+  end
+
+  task :register_browse_redirects => :router_environment do
+    routes = [
+      %w(/visas-immigration /browse/visas-immigration),
+      %w(/business /browse/business),
+    ]
+
+    routes.each do |path, destination|
+      @router_api.add_redirect_route(path, 'prefix', destination)
     end
     @router_api.commit_routes
   end


### PR DESCRIPTION
Run the router:register_browse task as part of the router:register task
which gets called automatically on deploy.

Also register redirects for `/business` and `/visas-immigration` on deploy. These will eventually be added to router-data and removed from here, but to make the deployment simpler, we're going to enforce these as part of Collection's route registration for now.
