### PR TITLE
Register redirects as "exact" routes

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -31,7 +31,7 @@ namespace :router do
     ]
 
     routes.each do |path, destination|
-      @router_api.add_redirect_route(path, 'prefix', destination)
+      @router_api.add_redirect_route(path, 'exact', destination)
     end
     @router_api.commit_routes
   end


### PR DESCRIPTION
The existing redirects are 'exact' routes, so they override the 'prefix' routes here. 

There isn't a good reason for these to be prefixes, so change them to 'exact'.
