### PR TITLE
Use the section to generate the breadcrumb url

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -329,7 +329,7 @@
     updateBreadcrumbs: function(state){
       var $breadcrumbItems = this.$breadcrumbs.find('li');
       if(state.subsection){
-        var sectionSlug = state.subsection.split('/')[0];
+        var sectionSlug = state.section;
         var sectionTitle = this.$section.find('h1').text();
 
         if($breadcrumbItems.length === 1){

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -107,6 +107,29 @@ describe('browse-columns.js', function() {
     }
   });
 
+  it("should update breadcrumbs", function(){
+    var context;
 
+    // section to section
+    context = { $breadcrumbs: $('<ol><li>one</li></ol>') };
+    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, {});
+    expect(context.$breadcrumbs.find('li').length).toEqual(1);
 
+    // subsection to section
+    context = { $breadcrumbs: $('<ol><li>one</li><li>two</li></ol>') };
+    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, {});
+    expect(context.$breadcrumbs.find('li').length).toEqual(1);
+
+    // subsection to subsection
+    context = { $breadcrumbs: $('<ol><li>one</li><li>two</li></ol>'), $section: $('<div><h1>text</h1></div>') };
+    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, { subsection: "first/second", section: 'first' });
+    expect(context.$breadcrumbs.find('li').length).toEqual(2);
+    expect(context.$breadcrumbs.find('li a').attr('href')).toEqual('/browse/first');
+
+    // section to subsection
+    context = { $breadcrumbs: $('<ol><li>one</li></ol>'), $section: $('<div><h1>text</h1></div>') };
+    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, { subsection: "first/second", section: 'first' });
+    expect(context.$breadcrumbs.find('li').length).toEqual(2);
+    expect(context.$breadcrumbs.find('li a').attr('href')).toEqual('/browse/first');
+  });
 });


### PR DESCRIPTION
The subsection rightly contains the current section not a slug like this
was assuming. Make it use the section from the state to generate the
url.
