### PR TITLE
Move focus to headings and remove aria-live

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -69,6 +69,7 @@ main.browse {
       @include bold-27;
       margin-bottom: $gutter-one-third;
       margin-top: $gutter-one-third;
+      outline: none;
 
       @include media(tablet){
         margin-top: 0;
@@ -79,7 +80,6 @@ main.browse {
 
 
     #root, #section {
-      outline: none;
       min-height: 20px;
 
       h1, h2 {
@@ -175,8 +175,6 @@ main.browse {
       }
     }
     #subsection {
-      outline: none;
-
       .pane-inner {
         @include media(tablet){
           padding-left: 100px;

--- a/app/views/browse/_section.mustache
+++ b/app/views/browse/_section.mustache
@@ -1,5 +1,5 @@
 <div class="pane-inner">
-  <h1>{{ title }}</h1>
+  <h1 tabindex="-1">{{ title }}</h1>
   <p class="sort-order">A to Z</p>
   <ul>
     {{#options}}

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,8 +1,9 @@
 <% content_for :title, "All categories - GOV.UK" %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes root" aria-live="polite">
-  <div id="root" class="pane" tabindex="-1">
+<div class="browse-panes root">
+  <div id="root" class="pane">
+    <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
     <ul>
       <% root_sections.each do |result| %>
         <li><%= link_to result.title, result.web_url %></li>

--- a/app/views/browse/section.html.erb
+++ b/app/views/browse/section.html.erb
@@ -1,10 +1,10 @@
 <% content_for :title, "#{section_tag.title} - GOV.UK" %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes section" data-state="section" aria-live="polite">
-  <div id="section" class="pane with-sort" tabindex="-1">
+<div class="browse-panes section" data-state="section">
+  <div id="section" class="pane with-sort">
     <div class="pane-inner">
-      <h1><%= section_tag.title %></h1>
+      <h1 tabindex="-1"><%= section_tag.title %></h1>
       <p class="sort-order">A to Z</p>
       <ul>
         <% section_tags.each do |section_tag| %>
@@ -19,8 +19,8 @@
     </div>
   </div>
 
-  <div id="root" class="pane" tabindex="-1">
-    <h2 class="visuallyhidden">All categories</h2>
+  <div id="root" class="pane">
+    <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
     <ul>
       <% root_sections.each do |root_section| %>
         <li<%= ' class="active"'.html_safe if section_tag.slug == root_section.slug %>>

--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -1,10 +1,10 @@
 <% content_for :title, "#{sub_section_tag.title} - GOV.UK" %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes subsection" data-state="subsection" aria-live="polite">
-  <div id="subsection" class="pane with-sort" tabindex="-1">
+<div class="browse-panes subsection" data-state="subsection">
+  <div id="subsection" class="pane with-sort">
     <div class="pane-inner">
-      <h1><%= sub_section_tag.title %></h1>
+      <h1 tabindex="-1"><%= sub_section_tag.title %></h1>
       <p class="sort-order">A to Z</p>
       <ul>
         <% sub_section_artefacts.each do |sub_section_artefact| %>
@@ -29,9 +29,9 @@
     </div>
   </div>
 
-  <div id="section" class="pane" tabindex="-1">
+  <div id="section" class="pane">
     <div class="pane-inner">
-      <h1><%= section_tag.title %></h1>
+      <h1 tabindex="-1"><%= section_tag.title %></h1>
       <ul>
         <% section_tags.each do |section_tag| %>
           <li<%= ' class="active"'.html_safe if sub_section_tag.slug == section_tag.slug %>>
@@ -45,8 +45,8 @@
     </div>
   </div>
 
-  <div id="root" class="pane" tabindex="-1">
-    <h2 class="visuallyhidden">All categories</h2>
+  <div id="root" class="pane">
+    <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
     <ul>
       <% root_sections.each do |root_section| %>
         <li<%= ' class="active"'.html_safe if section_tag.slug == root_section.slug %>>


### PR DESCRIPTION
Having the focus (and relevent tabindex) sent to the column wrappers
caused browsers to jump down to try and get as much of the column in
view as possible. This was visually distracting. Moving the focus (and
tabindex) to the heading at the top of the column. This removed the
visuall jump.

Used deferreds to send the focus to the heading after the animation has
completed.

In trying to fix this I also challenged my assumptions about how the
screen readers were reading it and listened. Having the entire block
wrapped in an aria-live forced the screen reader to read out all of the
new content. This is very unhelpful. As we are already now having the
correct heading focused and thus read out reading out anything extra is
superfluous. So I removed the aria-live.
