### PR TITLE
Use display:block for main

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -2,6 +2,7 @@
   border-bottom: 10px solid $govuk-blue;
 
   #content {
+    display: block;
     @include outer-block;
   }
 


### PR DESCRIPTION
In IE 11 the `main` element is rendered as an inline element by default.
As we are trying to set a max width on it that is ignored in IE11.
