### PR TITLE
Use standard link colour for browse links on hover

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -123,6 +123,7 @@ main.browse {
 
           &:hover {
             background: $panel-colour;
+            color: $link-colour;
           }
 
           &:after {


### PR DESCRIPTION
The normal hover colour is a shade of blue which doesn't have a high
enough contrast ratio. This uses the slightly darker standard link
colour which when on the panel background colour still has a high enough
contrast ratio.
