### PR TITLE
Remove underlines from content item links

### DIFF
--- a/app/assets/stylesheets/views/_specialist-sectors.scss
+++ b/app/assets/stylesheets/views/_specialist-sectors.scss
@@ -136,6 +136,7 @@
 
       li a {
         @include bold-19;
+        text-decoration: none;
       }
     }
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/80192086

This removes underlines from links to content items on topic and sub-topic pages.

This will keep consistency between the Services and Information page in Whitehall, where links to content items already omit an underline.

We've only ever tested topic and sub-topic pages without underlines, and I can't seem to find any discussion or rationale for the underline appearing in the first place. I now think that this has probably happened by accident, possibly at the point when we moved specialist sectors out to the collections app.
