### PR TITLE
Explicitly enable public action request formats

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,40 @@ class ApplicationController < ActionController::Base
   before_filter :set_expiry
   before_filter :set_slimmer_template
 
+  before_filter :restrict_request_formats
+
+  # Allows additional request formats to be enabled.
+  #
+  # By default, PublicFacingController actions will only respond to HTML requests. To enable
+  # additional formats on any given action, use this helper method. For example:
+  #
+  #   enable_request_formats index: [:atom, :json]
+  #
+  # That would allow both atom and JSON requests for the :index action to be processed.
+  #
+  def self.enable_request_formats(options)
+    options.each do |action, formats|
+      self.acceptable_formats[action.to_sym] ||= Set.new
+      self.acceptable_formats[action.to_sym] += Array(formats)
+    end
+  end
+
+  def self.acceptable_formats
+    @acceptable_formats ||= {}
+  end
+
   private
+
+  def restrict_request_formats
+    unless can_handle_format?(request.format)
+      render status: :not_acceptable, text: "Request format #{request.format} not handled."
+    end
+  end
+
+  def can_handle_format?(format)
+    return true if format == Mime::HTML
+    format && self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
+  end
 
   def set_slimmer_template
     set_slimmer_headers(template: 'header_footer_only')

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+
+class ConcreteTestController < ApplicationController
+  enable_request_formats json: :json, js_or_atom: [:js, :atom]
+
+  def test
+    render text: 'ok'
+  end
+
+  def json
+    respond_to do |format|
+      format.html { render text: 'html' }
+      format.json { render text: '{}' }
+    end
+  end
+
+  def js_or_atom
+    respond_to do |format|
+      format.html  { render text: 'html' }
+      format.js    { render text: 'javascript' }
+      format.atom  { render text: 'atom' }
+    end
+  end
+end
+
+describe ConcreteTestController do
+  def with_test_routing
+    with_routing do |map|
+      map.draw do
+        get '/test', to: 'concrete_test#test'
+        get '/test', to: 'concrete_test#json'
+        get '/test', to: 'concrete_test#js_or_atom'
+      end
+      yield
+    end
+  end
+
+  it "allows HTML requests by default" do
+    mime_types = ["text/html", "application/xhtml+xml"]
+
+    with_test_routing do
+      mime_types.each do |type|
+        @request.env['HTTP_ACCEPT'] = type
+        get :test
+
+        assert_equal 200, response.status, "mime type #{type} should be acceptable"
+        assert_equal Mime::HTML, response.content_type
+      end
+    end
+  end
+
+  it "rejects non-HTML requests by default" do
+    with_test_routing do
+      [:json, :xml, :atom].each do |format|
+        get :test, format: format
+
+        assert_response :not_acceptable
+      end
+    end
+  end
+
+  it "allows additional formats which are explicitly enabled" do
+    with_test_routing do
+      get :json
+      assert_response :success
+      assert_equal Mime::HTML, response.content_type
+      assert_equal 'html', response.body
+
+      get :json, format: :json
+      assert_response :success
+      assert_equal Mime::JSON, response.content_type
+      assert_equal '{}', response.body
+
+      get :json, format: :atom
+      assert_response :not_acceptable
+    end
+  end
+
+  it "allows multiple formats which are explicitly enabled" do
+    with_test_routing do
+      get :js_or_atom
+      assert_response :success
+      assert_equal Mime::HTML, response.content_type
+      assert_equal 'html', response.body
+
+      get :js_or_atom, format: :js
+      assert_response :success
+      assert_equal Mime::JS, response.content_type
+      assert_equal 'javascript', response.body
+
+      get :js_or_atom, format: :atom
+      assert_response :success
+      assert_equal Mime::ATOM, response.content_type
+      assert_equal 'atom', response.body
+
+      get :js_or_atom, format: :json
+      assert_response :not_acceptable
+    end
+  end
+
+  it "returns an appropriate response for unrecognised/invalid request formats" do
+    with_test_routing do
+      get :test, format: 'atom\\'
+      assert_response :not_acceptable
+    end
+  end
+end


### PR DESCRIPTION
Instead of throwing 500 errors for requests for formats that are not
supported, return a 406. Actions that need to respond to formats other
than html must now explicitly enable them using the
enable_request_format helper.

https://www.pivotaltracker.com/story/show/80724644
