### PR TITLE
Provide a shortcut email signup URL.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Collections::Application.routes.draw do
   get "/:sector", to: "specialist_sectors#show"
   get "/:sector/:subcategory", to: "subcategories#show"
 
-  resources :email_signups, path: "/:subtopic/email-signups", only: [:new, :create], subtopic: %r{[^/]+/[^/]+}
+  resources :email_signups, path: "/:subtopic/email-signups", only: [:create], subtopic: %r{[^/]+/[^/]+}
+  get "/:subtopic/email-signup", as: "email_signup", to: "email_signups#new", subtopic: %r{[^/]+/[^/]+}
 end

--- a/features/step_definitions/email_alert_signup_steps.rb
+++ b/features/step_definitions/email_alert_signup_steps.rb
@@ -9,7 +9,7 @@ When(/^I access the email signup page via the topic$/) do
   # visit_latest_page("oil-and-gas/fields-and-wells")
   # follow_email_signup_link
 
-  visit new_email_signup_path(subtopic: "oil-and-gas/fields-and-wells")
+  visit email_signup_path(subtopic: "oil-and-gas/fields-and-wells")
 end
 
 Then(/^I should see a description of what I'm signing up to$/) do


### PR DESCRIPTION
`/oil-and-gas/fields-and-wells/email-signups/new` is a bit ugly.
