### PR TITLE
Disable CSRF checking for email signups.

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -1,4 +1,6 @@
 class EmailSignupsController < ApplicationController
+  protect_from_forgery except: [:create]
+
   def new
     return error_404 unless subtopic.present?
   end


### PR DESCRIPTION
Same reasoning as https://github.com/alphagov/finder-frontend/commit/7a0a25b0ebe53b61ed2127971da8bc6f3584fbd6
