### PR TITLE
Correct email-alert-api data access

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -15,7 +15,7 @@ class EmailSignup
 
   def save
     if valid?
-      @subscription_url = find_or_create_subscription.fetch("subscription_url")
+      @subscription_url = find_or_create_subscription.subscriber_list.subscription_url
       true
     end
   end

--- a/features/support/email_alert_signup_helper.rb
+++ b/features/support/email_alert_signup_helper.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module EmailAlertSignupHelper
   def check_for_description_about(topic:, subtopic:)
     assert page.has_content?("e-mail alerts for the #{topic}: #{subtopic} topic")
@@ -12,7 +14,7 @@ module EmailAlertSignupHelper
           "topic" => [slug]
         }
       )
-      .returns("subscription_url" => "/#{slug}")
+      .returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "/#{slug}")))
   end
 
   def subscribe_to_email_alerts

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 describe EmailSignup do
   setup do
@@ -11,7 +12,7 @@ describe EmailSignup do
     @email_alert_api = mock
     Collections.services(:email_alert_api, @email_alert_api)
 
-    @email_alert_api.stubs(:find_or_create_subscriber_list).returns("subscription_url" => "http://govdelivery_signup_url")
+    @email_alert_api.stubs(:find_or_create_subscriber_list).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "http://govdelivery_signup_url")))
   end
 
   it "is invalid with no subtopic" do
@@ -27,7 +28,7 @@ describe EmailSignup do
         "tags" => {
           "topic" => ["oil-and-gas/wells"]
         }
-      ).returns("subscription_url" => "http://govdelivery_signup_url")
+      ).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "http://govdelivery_signup_url")))
 
       assert email_signup.save
     end


### PR DESCRIPTION
The type of data that [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) returns is an [`OpenStruct`-like object](https://github.com/alphagov/gds-api-adapters/blob/534e9671ca2aa9e159a5b29176d1268067fbe0c2/lib/gds_api/response.rb#L77-L79) rather than a hash.

Additionally, the expected response is actually nested inside a `subscriber_list` top-level JSON structure.

This commit updates the model to look for methods instead of keys, and changes the tests to use `OpenStructs` everywhere.

I'm aware this is pretty quick and dirty - ideally we'd use the test helpers provided by `gds-api-adapters` instead of this, but I need a quick release as this is blocking a bunch of other things.
