### PR TITLE
Subscribe to "topics" instead of "topic".

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -41,7 +41,7 @@ private
     {
       title: subtopic.combined_title,
       tags: {
-        topic: [subtopic.slug]
+        topics: [subtopic.slug]
       }
     }.deep_stringify_keys
   end

--- a/features/support/email_alert_signup_helper.rb
+++ b/features/support/email_alert_signup_helper.rb
@@ -11,7 +11,7 @@ module EmailAlertSignupHelper
       .with(
         "title" => "#{topic}: #{subtopic}",
         "tags" => {
-          "topic" => [slug]
+          "topics" => [slug]
         }
       )
       .returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "/#{slug}")))

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -26,7 +26,7 @@ describe EmailSignup do
       @email_alert_api.expects(:find_or_create_subscriber_list).with(
         "title" => "Oil and gas: Wells",
         "tags" => {
-          "topic" => ["oil-and-gas/wells"]
+          "topics" => ["oil-and-gas/wells"]
         }
       ).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "http://govdelivery_signup_url")))
 


### PR DESCRIPTION
This is in line with the tags sent from both publishers
to the content store, and the content store docs
themselves.
