### PR TITLE
Update GdsAPIAdapters to 15.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '15.0.0'
+  gem 'gds-api-adapters', '15.1.1'
 end
 
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (15.0.0)
+    gds-api-adapters (15.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -188,7 +188,7 @@ DEPENDENCIES
   byebug
   capybara-webkit (= 1.1.1)
   cucumber-rails (= 1.4.0)
-  gds-api-adapters (= 15.0.0)
+  gds-api-adapters (= 15.1.1)
   govuk_frontend_toolkit (= 1.7.0)
   jasmine-rails
   launchy


### PR DESCRIPTION
This is required in order for email signup requests to hit the correct
EmailAlertAPI endpoint.
