### PR TITLE
Remove unneeded includes and extends

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -1,9 +1,7 @@
 require 'active_model'
 
 class EmailSignup
-  include ActiveModel::Conversion
-  extend ActiveModel::Naming
-  include ActiveModel::Validations
+  include ActiveModel::Model
 
   validates_presence_of :subtopic
 
@@ -23,14 +21,6 @@ class EmailSignup
   def find_or_create_subscription
     Collections.services(:email_alert_api)
       .find_or_create_subscriber_list(subscription_params)
-  end
-
-  def valid?
-    super && subtopic.present?
-  end
-
-  def persisted?
-    false
   end
 
 private


### PR DESCRIPTION
From Rails 4 on, including `ActiveModel::Model` brings in the necessary modules previously included/extend in `EmailSignup`.

It also sets `persisted?` to a default of `false`, which enables us to remove that method from being declared. Since we are relying on `ActiveModel::Validations` and calling `validates_presence_of`, there is also no need to reopen the `valid?` method.
