### PR TITLE
Add latest changes page for topics.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '15.1.1'
+  gem 'gds-api-adapters', '16.0.0'
 end
 
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (15.1.1)
+    gds-api-adapters (16.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -188,7 +188,7 @@ DEPENDENCIES
   byebug
   capybara-webkit (= 1.1.1)
   cucumber-rails (= 1.4.0)
-  gds-api-adapters (= 15.1.1)
+  gds-api-adapters (= 16.0.0)
   govuk_frontend_toolkit (= 1.7.0)
   jasmine-rails
   launchy

--- a/app/models/subcategory.rb
+++ b/app/models/subcategory.rb
@@ -2,30 +2,34 @@ class Subcategory
   def self.find(slug)
     collections_api = Collections.services(:collections_api)
 
-    if collections_api_response = collections_api.curated_lists_for("/#{slug}")
+    if (collections_api_response = collections_api.topic("/#{slug}"))
       new(slug, collections_api_response)
     else
       nil
     end
   end
 
-  def initialize(slug, curated_content)
+  def initialize(slug, data)
     @slug = slug
-    @curated_content = curated_content
+    @data = data
   end
 
   attr_reader :slug
 
-  def content
+  def groups
     details.groups
   end
 
+  def changed_documents
+    details.documents
+  end
+
   def description
-    curated_content.description
+    data.description
   end
 
   def parent_sector
-    curated_content.parent
+    data.parent
   end
 
   def parent_sector_title
@@ -33,7 +37,7 @@ class Subcategory
   end
 
   def title
-    curated_content.title
+    data.title
   end
 
   def combined_title
@@ -42,9 +46,9 @@ class Subcategory
 
 private
 
-  attr_reader :curated_content
+  attr_reader :data
 
   def details
-    curated_content.details
+    data.details
   end
 end

--- a/app/views/subcategories/_subcategory.html.erb
+++ b/app/views/subcategories/_subcategory.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "#{subcategory.combined_title} - GOV.UK" %>
+<% content_for :page_class, "specialist-sector-browse" %>
+
+<header class="page-header group">
+  <div class="full-width">
+    <h1><span><%= subcategory.parent_sector_title %></span> <%= subcategory.title %></h1>
+
+    <% if organisations.any? %>
+      <aside class="metadata">
+        <dl>
+          <dt>From:</dt>
+          <dd><%= organisations.array_of_links.to_sentence.html_safe %></dd>
+        </dl>
+      </aside>
+    <% end %>
+  </div>
+</header>
+
+<div class="browse-container full-width">
+  <% if subcategory.description.present? %>
+    <div class="category-description">
+      <p><%= subcategory.description %></p>
+    </div>
+  <% end %>
+
+  <%= yield %>
+</div>

--- a/app/views/subcategories/latest_changes.html.erb
+++ b/app/views/subcategories/latest_changes.html.erb
@@ -1,0 +1,17 @@
+<%= render layout: "subcategory", locals: {subcategory: subcategory, organisations: organisations} do %>
+  <ul>
+    <% subcategory.changed_documents.each do |document| -%>
+      <li>
+        <h3><a href="<%= document.link %>"><%= document.title %></a></h3>
+        <p>
+          Updated <%= Time.parse(document.public_updated_at).strftime("%-d %B %Y") %>
+        </p>
+        <% if document.latest_change_note %>
+          <p>
+            <%= document.latest_change_note %>
+          </p>
+        <% end %>
+      </li>
+    <% end -%>
+  </ul>
+<% end %>

--- a/app/views/subcategories/show.html.erb
+++ b/app/views/subcategories/show.html.erb
@@ -1,28 +1,4 @@
-<% content_for :title, "#{@subcategory.combined_title} - GOV.UK" %>
-<% content_for :page_class, "specialist-sector-browse" %>
-
-<header class="page-header group">
-  <div class="full-width">
-    <h1><span><%= @subcategory.parent_sector_title %></span> <%= @subcategory.title %></h1>
-
-    <% if @organisations.any? %>
-      <aside class="metadata">
-        <dl>
-          <dt>From:</dt>
-          <dd><%= @organisations.array_of_links.to_sentence.html_safe %></dd>
-        </dl>
-      </aside>
-    <% end %>
-  </div>
-</header>
-
-<div class="browse-container full-width">
-  <% if @subcategory.description.present? %>
-    <div class="category-description">
-      <p><%= @subcategory.description %></p>
-    </div>
-  <% end %>
-
+<%= render layout: "subcategory", locals: {subcategory: subcategory, organisations: organisations} do %>
   <% @groups.each do |group| -%>
     <nav class="index-list" aria-labelledby="<%= group.artefact.name.parameterize %>">
       <h1 id="<%= group.artefact.name.parameterize %>"><%= group.artefact.name %></h1>
@@ -35,4 +11,4 @@
       </ul>
     </nav>
   <% end -%>
-</div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,9 @@ Collections::Application.routes.draw do
   get "/browse/:section/:sub_section.json" => redirect("/api/with_tag.json?tag=%{section}%%2F%{sub_section}")
   get "/browse/:section/:sub_section", as: "sub_section", to: "browse#sub_section"
 
-  get "/:sector", to: "specialist_sectors#show"
+  get "/:sector/:subcategory/latest", as: "latest_changes", to: "subcategories#latest_changes"
   get "/:sector/:subcategory", to: "subcategories#show"
+  get "/:sector", to: "specialist_sectors#show"
 
   resources :email_signups, path: "/:subtopic/email-signups", only: [:create], subtopic: %r{[^/]+/[^/]+}
   get "/:subtopic/email-signup", as: "email_signup", to: "email_signups#new", subtopic: %r{[^/]+/[^/]+}

--- a/features/latest_changes.feature
+++ b/features/latest_changes.feature
@@ -1,0 +1,9 @@
+Feature: Browsing latest changes
+  In order to see the most recently changed content for a topic (specialist sub-sector)
+  As a user with specialist needs
+  I can view a "latest changes" list of content ordered by date
+
+  Scenario: viewing curated content for a specialist sub-sector
+    Given there is latest content for a specialist sub-sector
+    When I view the latest changes page for that sub-sector
+    Then I see a date-ordered list of content with change notes

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -1,0 +1,12 @@
+Given(/^there is latest content for a specialist sub\-sector$/) do
+  stub_latest_changes_for("/oil-and-gas/fields-and-wells")
+  stub_specialist_sector_tag_lookups
+end
+
+When(/^I view the latest changes page for that sub\-sector$/) do
+  visit_latest_changes_for("/oil-and-gas/fields-and-wells")
+end
+
+Then(/^I see a date\-ordered list of content with change notes$/) do
+  assert_page_has_date_ordered_latest_changes
+end

--- a/features/support/curated_lists_helper.rb
+++ b/features/support/curated_lists_helper.rb
@@ -4,7 +4,7 @@ module CuratedListsHelper
   include GdsApi::TestHelpers::CollectionsApi
 
   def stub_curated_lists_for(base_path)
-    collections_api_has_curated_lists_for(base_path)
+    collections_api_has_content_for(base_path)
   end
 
   def assert_page_has_curated_lists

--- a/features/support/latest_changes_helper.rb
+++ b/features/support/latest_changes_helper.rb
@@ -1,0 +1,24 @@
+require 'gds_api/test_helpers/collections_api'
+
+module LatestChangesHelper
+  include GdsApi::TestHelpers::CollectionsApi
+
+  def stub_latest_changes_for(base_path)
+    collections_api_has_content_for(base_path)
+  end
+
+  def visit_latest_changes_for(base_path)
+    visit "#{base_path}/latest"
+  end
+
+  def assert_page_has_date_ordered_latest_changes
+    collections_api_example_documents.each_with_index do |document, index|
+      within("li:nth-of-type(#{index+1})") do
+        assert page.has_selector?("h3 a[href='#{document[:link]}']", text: document[:title])
+        assert page.has_content?(document[:latest_change_note]) if document[:latest_change_note]
+      end
+    end
+  end
+end
+
+World(LatestChangesHelper)

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 describe EmailSignupsController do
   setup do
     @subtopic_slug = "oil-and-gas/wells"
-    collections_api_has_curated_lists_for("/#{@subtopic_slug}")
-    collections_api_has_no_curated_lists_for("/invalid/subtopic")
+    collections_api_has_content_for("/#{@subtopic_slug}")
+    collections_api_has_no_content_for("/invalid/subtopic")
 
     @email_signup = EmailSignup.new(nil)
     @email_signup.stubs(:save)

--- a/test/controllers/subcategories_controller_test.rb
+++ b/test/controllers/subcategories_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe SubcategoriesController do
   describe "GET subcategory with a valid sector tag and subcategory" do
     setup do
-      collections_api_has_curated_lists_for("/oil-and-gas/wells")
+      collections_api_has_content_for("/oil-and-gas/wells")
 
       Collections::Application.config.search_client.stubs(:unified_search).with(
         count: "0",
@@ -60,7 +60,7 @@ describe SubcategoriesController do
     end
 
     it "returns a 404 status for GET subcategory with an invalid subcategory tag" do
-      collections_api_has_no_curated_lists_for("/oil-and-gas/coal")
+      collections_api_has_no_content_for("/oil-and-gas/coal")
       get :show, sector: "oil-and-gas", subcategory: "coal"
 
       assert_equal 404, response.status

--- a/test/integration/specialist_sector_browsing_test.rb
+++ b/test/integration/specialist_sector_browsing_test.rb
@@ -39,7 +39,7 @@ class SpecialistSectorBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a specialist sector sub-category and its artefacts" do
-    stubbed_response = collections_api_has_curated_lists_for("/oil-and-gas/wells")
+    stubbed_response = collections_api_has_content_for("/oil-and-gas/wells")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
     example_stubbed_artefact = stubbed_response_body['details']['groups'][0]
 

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -7,7 +7,7 @@ describe EmailSignup do
     @subtopic.stubs(slug: "oil-and-gas/wells")
     @subtopic.stubs(combined_title: "Oil and gas: Wells")
 
-    collections_api_has_curated_lists_for("/#{@subtopic.slug}")
+    collections_api_has_content_for("/#{@subtopic.slug}")
 
     @email_alert_api = mock
     Collections.services(:email_alert_api, @email_alert_api)

--- a/test/models/subcategory_test.rb
+++ b/test/models/subcategory_test.rb
@@ -3,16 +3,18 @@ require "test_helper"
 describe Subcategory, ".find" do
   it "finds the curated content for the given slug in the collections api" do
     slug = "oil-and-gas/wells"
-    collections_api_has_curated_lists_for("/#{slug}")
+    collections_api_has_content_for("/#{slug}")
 
     subcategory = Subcategory.find(slug)
 
     assert_instance_of Subcategory, subcategory
+    assert subcategory.groups
+    assert subcategory.changed_documents
   end
 
   it "returns nil if there is no content for the given slug in the collections api" do
     slug = "nothing-here"
-    collections_api_has_no_curated_lists_for("/#{slug}")
+    collections_api_has_no_content_for("/#{slug}")
 
     subcategory = Subcategory.find(slug)
 
@@ -20,22 +22,34 @@ describe Subcategory, ".find" do
   end
 end
 
-describe Subcategory, "#content" do
-  it "returns the content for the subcategory" do
+describe Subcategory, "#groups" do
+  it "returns the curated content for the subcategory" do
     slug = "oil-and-gas/wells"
-    stubbed_response = collections_api_has_curated_lists_for("/#{slug}")
+    stubbed_response = collections_api_has_content_for("/#{slug}")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
 
     subcategory = Subcategory.find(slug)
 
-    assert_equal stubbed_response_body['details']['groups'][0]['title'], subcategory.content.first.title
+    assert_equal stubbed_response_body['details']['groups'][0]['title'], subcategory.groups.first.title
+  end
+end
+
+describe Subcategory, "#changed_documents" do
+  it "returns the changed documents for the subcategory" do
+    slug = "oil-and-gas/wells"
+    stubbed_response = collections_api_has_content_for("/#{slug}")
+    stubbed_response_body = JSON.parse(stubbed_response.response.body)
+
+    subcategory = Subcategory.find(slug)
+
+    assert_equal stubbed_response_body['details']['documents'][0]['title'], subcategory.changed_documents.first.title
   end
 end
 
 describe Subcategory, "#description" do
   it "returns the description for the subcategory" do
     slug = "oil-and-gas/wells"
-    stubbed_response = collections_api_has_curated_lists_for("/#{slug}")
+    stubbed_response = collections_api_has_content_for("/#{slug}")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
 
     subcategory = Subcategory.find(slug)
@@ -47,7 +61,7 @@ end
 describe Subcategory, "#title" do
   it "returns the title for the subcategory" do
     slug = "oil-and-gas/wells"
-    stubbed_response = collections_api_has_curated_lists_for("/#{slug}")
+    stubbed_response = collections_api_has_content_for("/#{slug}")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
 
     subcategory = Subcategory.find(slug)
@@ -59,7 +73,7 @@ end
 describe Subcategory, "#parent_sector_title" do
   it "returns the parent sector for the subcategory" do
     slug = "oil-and-gas/wells"
-    stubbed_response = collections_api_has_curated_lists_for("/#{slug}")
+    stubbed_response = collections_api_has_content_for("/#{slug}")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
 
     subcategory = Subcategory.find(slug)
@@ -71,7 +85,7 @@ end
 describe Subcategory, "#combined_title" do
   it "combined the parent and child titles for added context" do
     slug = "oil-and-gas/wells"
-    stubbed_response = collections_api_has_curated_lists_for("/#{slug}")
+    stubbed_response = collections_api_has_content_for("/#{slug}")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
 
     subcategory = Subcategory.find(slug)
@@ -84,7 +98,7 @@ end
 describe Subcategory, "#slug" do
   it "returns the slug for the subcategory" do
     slug = "oil-and-gas/wells"
-    collections_api_has_curated_lists_for("/#{slug}")
+    collections_api_has_content_for("/#{slug}")
 
     subcategory = Subcategory.find(slug)
 


### PR DESCRIPTION
Brings latest changed documents into the `Subcategory` model and provides a page to display them.

May need some visual tweaks after release, but the URLs are not commonly known so that can happen as a subsequent step.
