### PR TITLE
Only render timestamp for latest documents if one is available.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '16.2.0'
+  gem 'gds-api-adapters', '16.3.2'
 end
 
 gem 'plek', '1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.0.2)
-    gds-api-adapters (16.2.0)
+    gds-api-adapters (16.3.2)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -183,7 +183,7 @@ DEPENDENCIES
   byebug
   capybara-webkit (= 1.1.1)
   cucumber-rails (= 1.4.0)
-  gds-api-adapters (= 16.2.0)
+  gds-api-adapters (= 16.3.2)
   govuk_frontend_toolkit (= 1.7.0)
   jasmine-rails
   launchy

--- a/app/views/subcategories/latest_changes.html.erb
+++ b/app/views/subcategories/latest_changes.html.erb
@@ -8,9 +8,13 @@
     <% subcategory.changed_documents.each do |document| -%>
       <li>
         <h3><a href="<%= document.link %>"><%= document.title %></a></h3>
-        <time class="updated-at" datetime="<%= document.public_updated_at %>">
-          <%= Time.parse(document.public_updated_at).strftime("%-d %B %Y") %>
-        </time>
+
+        <% if document.public_updated_at %>
+          <time class="updated-at" datetime="<%= document.public_updated_at %>">
+            <%= Time.parse(document.public_updated_at).strftime("%-d %B %Y") %>
+          </time>
+        <% end %>
+
         <% if document.latest_change_note %>
           <p>
             <%= document.latest_change_note %>

--- a/features/support/latest_changes_helper.rb
+++ b/features/support/latest_changes_helper.rb
@@ -16,6 +16,7 @@ module LatestChangesHelper
       within(".browse-container li:nth-of-type(#{index+1})") do
         assert page.has_selector?("h3 a[href='#{document[:link]}']", text: document[:title])
         assert page.has_content?(document[:latest_change_note]) if document[:latest_change_note]
+        assert page.has_selector?("time") if document[:public_updated_at]
       end
     end
   end


### PR DESCRIPTION
The bump to the API gem provides an example document without a timestamp to prove that the code continues to function.
