### PR TITLE
Tighten up margins for email alerts on mobile

### DIFF
--- a/app/assets/stylesheets/views/_email-signups.scss
+++ b/app/assets/stylesheets/views/_email-signups.scss
@@ -1,7 +1,9 @@
 #wrapper #content.email-signup-new {
   @extend %site-width-container;
 
-  margin-top: 30px;
+  @include media(tablet){
+    margin-top: 30px;
+  }
 
   h1 {
     @include heading-48;
@@ -24,7 +26,11 @@
 
     p {
       @include core-19;
-      margin: 30px 0;
+      margin: 15px 0 10px;
+
+      @include media(tablet){
+        margin: 30px 0;
+      }
     }
   }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/81950824

This changes the stylesheet for email alerts to reduce the margins between elements on the email alert subscribe page, when viewed on mobile.

FAO @edds 

Before:
<img src="https://cloud.githubusercontent.com/assets/71922/5142067/dee6a252-7175-11e4-99a1-7977e05a8184.png" width="320px;">

After:
<img src="https://cloud.githubusercontent.com/assets/71922/5142069/e4757a68-7175-11e4-9269-83baa9385ec9.png" width="320px;">
