### PR TITLE
Remove the email alerts/latest feed feature flag

### DIFF
--- a/app/views/subcategories/_subcategory.html.erb
+++ b/app/views/subcategories/_subcategory.html.erb
@@ -15,18 +15,16 @@
       <% end %>
     </div>
     <div class="latest-subscribe">
-      <% if Collections.email_signup_link_enabled? %>
-        <ul>
-          <li class="email primary">
-            <%= link_to email_signup_path(subtopic: subcategory.slug) do %>
-            Subscribe to email alerts
-            <% end %>
-          </li>
-          <% if local_assigns[:link_to_latest_feed] %>
-            <li><%= link_to 'See latest changes to this content', latest_changes_path(sector: params[:sector], subcategory: params[:subcategory]) %></li>
+      <ul>
+        <li class="email primary">
+          <%= link_to email_signup_path(subtopic: subcategory.slug) do %>
+          Subscribe to email alerts
           <% end %>
-        </ul>
-      <% end %>
+        </li>
+        <% if local_assigns[:link_to_latest_feed] %>
+          <li><%= link_to 'See latest changes to this content', latest_changes_path(sector: params[:sector], subcategory: params[:subcategory]) %></li>
+        <% end %>
+      </ul>
     </div>
   </div>
 </header>

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,7 +1,0 @@
-# This initializer will be replaced on deploy.
-#
-module Collections
-  def self.email_signup_link_enabled?
-    Rails.env.development? || Rails.env.test?
-  end
-end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82945330

This removes the feature flag from the sub-topic pages, which previously controlled whether or not we linked to the latest changes feed and email signup form.

We're now ready for these to go live, so we can remove the feature flag to enable the links in all environments.
