### PR TITLE
Track pageviews and custom vars in Universal

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -391,14 +391,11 @@
       }
     },
     trackPageview: function(){
-      if(_gaq){
-        var sectionTitle = this.$section.find('h1').text();
-        if(sectionTitle){
-          _gaq.push(["_setCustomVar",1,"Section",sectionTitle.toLowerCase(),3]);
-        } else {
-          _gaq.push(["_setCustomVar",1,"Section","browse",3]);
-        }
-        _gaq.push(["_trackPageview"]);
+      var sectionTitle = this.$section.find('h1').text();
+      sectionTitle = sectionTitle ? sectionTitle.toLowerCase() : 'browse';
+      if (GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.setSectionDimension) {
+        GOVUK.analytics.setSectionDimension(sectionTitle);
+        GOVUK.analytics.trackPageview();
       }
     }
   };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/87740262

Wraps the GA event in the [newly introduced](alphagov/static#549) analytics API. This will aid in the migration from GA Classic to Universal Analytics, while remaining functionally equivalent during the migration.

/cc @benilovj