### PR TITLE
Bump slimmer to 8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'logstasher', '0.5.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '5.1.0'
+  gem 'slimmer', '8.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,10 +141,10 @@ GEM
     shared_mustache (0.1.2)
       execjs (>= 1.2.4)
       mustache (~> 0.99.4)
-    slimmer (5.1.0)
+    slimmer (8.1.0)
       activesupport
       json
-      nokogiri (~> 1.5.0)
+      nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
       rack (>= 1.3.5)
@@ -194,7 +194,7 @@ DEPENDENCIES
   rails (= 4.0.12)
   sass-rails (= 4.0.2)
   shared_mustache (= 0.1.2)
-  slimmer (= 5.1.0)
+  slimmer (= 8.1.0)
   uglifier (= 2.5.0)
   unicorn (= 4.8.2)
   webmock (= 1.17.4)


### PR DESCRIPTION
* Update Slimmer to 8.1.0 to stop using Javascript variables and start using `<meta>` tags, for our analytics to set custom dimensions in Google Analytics.

Relevant slimmer PRs:
https://github.com/alphagov/slimmer/pull/119

Changelog:
https://github.com/alphagov/slimmer/blob/master/CHANGELOG.md