### PR TITLE
Fix report-a-problem styling

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -5,14 +5,4 @@
     display: block;
     @include outer-block;
   }
-
-  .report-a-problem-toggle {
-    @include core-16;
-    @include inner-block;
-    margin-bottom: $gutter;
-
-    a {
-      color: $secondary-text-colour;
-    }
-  }
 }

--- a/app/assets/stylesheets/views/_email-signups.scss
+++ b/app/assets/stylesheets/views/_email-signups.scss
@@ -39,8 +39,4 @@
     @include bold-24;
     margin: 20px 0;
   }
-
-  .report-a-problem-toggle {
-    padding: 0;
-  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
   <div id="wrapper">
     <main id="content" role="main" class="<%= yield :page_class %>">
       <%= yield %>
-      <div id="report-a-problem"></div>
     </main>
     <%= render_mustache_templates if Rails.env.development? %>
   </div>


### PR DESCRIPTION
When slimmer was bumped beyond v5.0.0, the div and styles for
the report-a-problem form weren't removed, meaning that the form
is misaligned.

This commit removes report-a-problem related code and leaves the
form to be completely presented by slimmer/static.

**Before**:

![image](https://cloud.githubusercontent.com/assets/23801/6694559/effd4902-ccd2-11e4-907c-38df2764441b.png)

**After**:

![image](https://cloud.githubusercontent.com/assets/23801/6694567/fa56c6d0-ccd2-11e4-85e4-8e873ac93d7e.png)
