### PR TITLE
Fix section caching

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -296,7 +296,8 @@
         $.ajax({
           url: url + state.slug
         }).done(function(data){
-          this.sectionCache('secton', state.slug, data);
+          this.sectionCache('section', state.slug, data);
+
           out.resolve(data);
         }.bind(this));
       }


### PR DESCRIPTION
This typo caused the section cache to always miss, resulting in extra requests.

Will revisit the tests for this after Jasmine is hooked up to CI.