### PR TITLE
Use related topics from content-store for 'detailed guidance'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ end
 
 gem 'plek', '1.7.0'
 
+gem 'govuk-content-schema-test-helpers', '~> 1.1.0'
+
 group :test do
   gem 'capybara-webkit', '1.1.1'
   gem 'minitest-spec-rails', '4.7.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.3.6)
+    addressable (2.3.8)
     airbrake (3.1.15)
       builder
       multi_json
@@ -71,6 +71,8 @@ GEM
       rest-client (~> 1.6.3)
     gherkin (2.12.2)
       multi_json (~> 1.3)
+    govuk-content-schema-test-helpers (1.1.0)
+      json-schema (~> 2.5.1)
     govuk_frontend_toolkit (1.7.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -83,6 +85,8 @@ GEM
       rails (>= 3.1.0)
       sprockets-rails
     json (1.8.1)
+    json-schema (2.5.1)
+      addressable (~> 2.3.7)
     kgio (2.9.2)
     launchy (2.4.2)
       addressable (~> 2.3)
@@ -184,6 +188,7 @@ DEPENDENCIES
   capybara-webkit (= 1.1.1)
   cucumber-rails (= 1.4.0)
   gds-api-adapters (= 16.3.2)
+  govuk-content-schema-test-helpers (~> 1.1.0)
   govuk_frontend_toolkit (= 1.7.0)
   jasmine-rails
   launchy

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ retrieved from external sources.
 
 - [alphagov/govuk_content_api](https://github.com/alphagov/govuk_content_api) -
   provides topic and browse page content.
+- [alphagov/content-store](https://github.com/alphagov/content-store) -
+  provides content.
 - [alphagov/whitehall](https://github.com/alphagov/whitehall) -
   provides Detailed guidance content.
 - [alphagov/collections-api](https://github.com/alphagov/collections-api) -

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -21,6 +21,11 @@ class BrowseController < ApplicationController
   def sub_section
     return error_404 unless sub_section_tag
 
+    @related_topics = RelatedTopicList.new(
+      Collections.services(:content_store),
+      Collections.services(:detailed_guidance_content_api)
+    ).related_topics_for(request.fullpath)
+
     options = {title: "browse", section_name: section_tag.title, section_link: section_tag.web_url}
     set_slimmer_artefact_headers(options)
   end
@@ -59,13 +64,6 @@ private
     @root_sections ||= Collections.services(:content_api).root_sections.results.sort_by { |category| category.title }
   end
   helper_method :root_sections
-
-  def detailed_guide_categories
-    @detailed_categories ||= Collections.services(:detailed_guidance_content_api).sub_sections(sub_section_slug).results.sort_by { |category| category.title }
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
-    @detailed_categories ||= []
-  end
-  helper_method :detailed_guide_categories
 
   def validate_slug_param(param_name = :slug)
     if params[param_name].parameterize != params[param_name]

--- a/app/models/related_topic_list.rb
+++ b/app/models/related_topic_list.rb
@@ -1,0 +1,36 @@
+# FIXME: Once the content has been migrated to content store, remove whitehall code.
+class RelatedTopicList
+  def initialize(content_store, whitehall)
+    @content_store = content_store
+    @whitehall = whitehall
+  end
+
+  def related_topics_for(path)
+    fetch_results_for_path(path).sort_by(&:title)
+  end
+
+  private
+
+  def fetch_results_for_path(path)
+    results = @content_store.content_item(path).try(:links).try(:related_topics).to_a
+
+    if results.any?
+      results
+    else
+      legacy_fallback_to_whitehall(path)
+    end
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    []
+  end
+
+  def legacy_fallback_to_whitehall(path)
+    response = @whitehall.sub_sections(path.gsub('/browse/', ''))
+
+    response.results.map do |detailed_guide_category|
+      OpenStruct.new(
+        title: detailed_guide_category.title,
+        web_url: detailed_guide_category.content_with_tag.web_url
+      )
+    end
+  end
+end

--- a/app/views/browse/_section.mustache
+++ b/app/views/browse/_section.mustache
@@ -20,7 +20,7 @@
       <h2>Detailed guidance</h2>
       <ul>
         {{#detailed_guide_categories}}
-          <li><a href="{{content_with_tag.web_url}}">{{title}}</a></li>
+          <li><a href="{{web_url}}">{{title}}</a></li>
         {{/detailed_guide_categories}}
       </ul>
     </div>

--- a/app/views/browse/sub_section.html.erb
+++ b/app/views/browse/sub_section.html.erb
@@ -6,9 +6,8 @@
     <%= render_mustache('browse/section',
       title: sub_section_tag.title,
       options: sub_section_artefacts,
-      detailed_guide_categories_any?: detailed_guide_categories.any?,
-      detailed_guide_categories: detailed_guide_categories,
-      showDescription: false
+      detailed_guide_categories_any?: @related_topics.any?,
+      detailed_guide_categories: @related_topics
       ) %>
   </div>
 

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -32,3 +32,6 @@ Collections.services(:collections_api, GdsApi::CollectionsApi.new(Plek.new.find(
 
 require 'gds_api/email_alert_api'
 Collections.services(:email_alert_api, GdsApi::EmailAlertApi.new(Plek.new.find('email-alert-api')))
+
+require 'gds_api/content_store'
+Collections.services(:content_store, GdsApi::ContentStore.new(Plek.new.find('content-store')))

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -1,7 +1,9 @@
 require 'gds_api/test_helpers/content_api'
+require 'gds_api/test_helpers/content_store'
 
 module BrowseTestHelpers
   include GdsApi::TestHelpers::ContentApi
+  include GdsApi::TestHelpers::ContentStore
 
   def stub_browse_sections(section: nil, sub_section: nil, artefact: nil,
                            organisations: [])
@@ -22,10 +24,14 @@ module BrowseTestHelpers
     Collections.services(:detailed_guidance_content_api, mock_api)
     results = stub("results", results: [detailed_guidance])
     mock_api.stubs(:sub_sections).returns(results)
+
+    content_store_has_item '/browse/crime-and-justice/judges', { links: {} }
   end
 
   def stub_404_detailed_guidance_response
     stub_request(:get, "#{Plek.current.find('whitehall-admin')}/api/specialist/tags.json?parent_id=crime-and-justice/judges&type=section").to_raise(GdsApi::HTTPNotFound)
+
+    content_store_has_item '/browse/crime-and-justice/judges', { links: {} }
   end
 
   def browse_to_sub_section(section: nil, sub_section: nil)

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -73,10 +73,7 @@ describe BrowseController do
 
   describe "GET sub_section" do
     before do
-      mock_api = stub('guidance_api')
-      Collections.services(:detailed_guidance_content_api, mock_api)
-      @results = stub("results", results: [])
-      mock_api.stubs(:sub_sections).returns(@results)
+      RelatedTopicList.any_instance.stubs(:related_topics_for).returns([])
 
       content_api_has_tag("section", "crime-and-justice")
       content_api_has_tag("section", "crime-and-justice/judges")
@@ -92,18 +89,15 @@ describe BrowseController do
       assert_select "a", "Judge dredd"
     end
 
-    it "list detailed guidance categories in the sub section" do
-      detailed_guidance = OpenStruct.new({
-        title: 'Detailed guidance',
-        content_with_tag: OpenStruct.new(web_url: 'http://example.com/browse/detailed-guidance')
-      })
-
-      @results.stubs(:results).returns([detailed_guidance])
+    it "lists related topics in the subsection" do
+      RelatedTopicList.any_instance.stubs(:related_topics_for).returns(
+        [OpenStruct.new(title: 'A Related Topic', web_url: 'https://www.gov.uk/benefits/related')]
+      )
 
       get :sub_section, section: "crime-and-justice", sub_section: "judges"
 
       assert_select '.detailed-guidance' do
-        assert_select "li a[href='http://example.com/browse/detailed-guidance']", text: 'Detailed guidance'
+        assert_select "li a[href='https://www.gov.uk/benefits/related']", text: 'A Related Topic'
       end
     end
 

--- a/test/models/related_topic_list_test.rb
+++ b/test/models/related_topic_list_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+describe RelatedTopicList do
+  describe "#related_topics_for" do
+    it "returns related topics for a subsection" do
+      content_store = content_store_with_response(links: {related_topics: [{ title: 'From Content Store', web_url: 'http://example.org/whatever'}]})
+
+      topic_list = RelatedTopicList.new(content_store, nil)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever'),
+        [OpenStruct.new(title: 'From Content Store', web_url: 'http://example.org/whatever')]
+    end
+
+    it "returns guidance categories from whitehall when there are no related topics" do
+      content_store = content_store_with_response(links: {related_topics: []})
+      whitehall = whitehall_with_response([{title: 'From Whitehall', content_with_tag: { web_url: 'http://example.org/whatever'}}])
+
+      topic_list = RelatedTopicList.new(content_store, whitehall)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever'),
+        [OpenStruct.new(title: 'From Whitehall', web_url: 'http://example.org/whatever')]
+    end
+
+    it "handles missing links" do
+      content_store = content_store_with_response({})
+      whitehall = whitehall_with_response([{title: 'From Whitehall', content_with_tag: { web_url: 'http://example.org/whatever' }}])
+
+      topic_list = RelatedTopicList.new(content_store, whitehall)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever'),
+        [OpenStruct.new(title: 'From Whitehall', web_url: 'http://example.org/whatever')]
+    end
+
+    it "returns an empty array when content-store returns 404" do
+      content_store = stub()
+      content_store.expects(:content_item).with('/browse/whatever').raises(GdsApi::HTTPNotFound, 'A message')
+
+      topic_list = RelatedTopicList.new(content_store, nil)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever'), []
+    end
+
+    it "returns an empty array when content-store returns archived" do
+      content_store = stub()
+      content_store.expects(:content_item).with('/browse/whatever').raises(GdsApi::HTTPGone, 'A message')
+
+      topic_list = RelatedTopicList.new(content_store, nil)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever'), []
+    end
+
+    it "sorts the output by title" do
+      content_store = content_store_with_response(links: { related_topics: [
+          { title: 'B' },
+          { title: 'A' },
+          { title: 'C' }
+      ]})
+
+      topic_list = RelatedTopicList.new(content_store, nil)
+
+      assert_equal topic_list.related_topics_for('/browse/whatever').map(&:title), %w[A B C]
+    end
+
+    def content_store_with_response(results)
+      mock("content_store", content_item: build_ostruct_recursively(results))
+    end
+
+    def whitehall_with_response(results)
+      mock("whitehall", sub_sections: build_ostruct_recursively(results: results))
+    end
+  end
+end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -1,0 +1,12 @@
+class ActiveSupport::TestCase
+  def build_ostruct_recursively(value)
+    case value
+    when Hash
+      OpenStruct.new(Hash[value.map { |k, v| [k, build_ostruct_recursively(v)] }])
+    when Array
+      value.map { |v| build_ostruct_recursively(v) }
+    else
+      value
+    end
+  end
+end

--- a/test/support/mock_services.rb
+++ b/test/support/mock_services.rb
@@ -15,5 +15,4 @@ class ActiveSupport::TestCase
   after do
     Collections.services(:collections_api, @existing_services[:collections_api])
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,19 @@ Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 require 'gds_api/test_helpers/content_api'
 require 'gds_api/test_helpers/collections_api'
+require 'gds_api/test_helpers/content_store'
 require 'gds_api/test_helpers/rummager'
 
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::CollectionsApi
+  include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::Rummager
+
+  GovukContentSchemaTestHelpers.configure do |config|
+    config.schema_type = 'frontend'
+    config.project_root = Rails.root
+  end
 
   after do
     WebMock.reset!


### PR DESCRIPTION
Trello: https://trello.com/c/lTPNcdzI/18-collections-fe-uses-content-store-to-get-topic-links-for-mainstream-browse

Currently entries under "Detailed guidance" on the browse pages come from the whitehall API.

This change will first check content-store for related topics. When content-store doesn't have anything, it will fall back to using the content from whitehall.

The duplication will be removed when content-store serves all related content. Once that happens, we can clean up by removing the whitehall fallback in:

- `RelatedTopicList` model
- browse-columns.js

JS tests (which are outdated and don't run in CI) will be handled in a separate PR.

### Testing

Use the gds-content-schema dummy store. 

http://www.dev.gov.uk/browse/benefits/families

**Before** 

Detailed guidance lists "Support services for military and defence personnel and their families" (content from whitehall).

**After**

Detailed guidance lists "Universal credit" (content from content-store)