### PR TITLE
Use content schema examples in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk-content-schema-test-helpers', '~> 1.1.0'
-
 group :test do
   gem 'capybara-webkit', '1.1.1'
   gem 'minitest-spec-rails', '4.7.6'
@@ -34,6 +32,8 @@ group :test do
   gem 'webmock', '1.17.4', require: false
   gem 'cucumber-rails', "1.4.0", require: false
   gem 'launchy'
+
+  gem 'govuk-content-schema-test-helpers', '~> 1.1.0'
 end
 
 group :development, :test do

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -30,8 +30,12 @@ function error_handler {
 trap "error_handler ${LINENO}" ERR
 github_status "$REPO_NAME" pending "is running on Jenkins"
 
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RAILS_ENV=test bundle exec rake
+GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas RAILS_ENV=test bundle exec rake
 bundle exec rake assets:precompile
 
 export EXIT_STATUS=$?

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -21,11 +21,8 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     content_api_has_tag("section", sub_section_slug)
     content_api_has_root_tags("section", [section])
     content_api_has_child_tags("section", section, [sub_section_slug])
+    content_api_has_artefacts_with_a_tag("section", sub_section_slug, [])
 
-    stub_request(:get, "http://contentapi.dev.gov.uk/with_tag.json?tag=#{sub_section_slug}").
-      to_return(body: JSON.dump(results: []))
-
-    stub_request(:get, "http://whitehall-admin.dev.gov.uk/api/specialist/tags.json?parent_id=#{sub_section_slug}&type=section").
-      to_return(body: JSON.dump(results: []))
+    RelatedTopicList.any_instance.stubs(:legacy_fallback_to_whitehall).returns([])
   end
 end

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -1,0 +1,31 @@
+require 'integration_test_helper'
+
+class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
+  test "that we can handle all examples" do
+    content_schema_examples_for(:mainstream_browse_page).each do |content_item|
+      stub_other_requests(content_item)
+      content_store_has_item(content_item['base_path'], content_item)
+
+      get content_item['base_path']
+
+      assert_response 200
+    end
+  end
+
+  private
+
+  def stub_other_requests(content_item)
+    _, _, section, sub_section = content_item['base_path'].split('/')
+    sub_section_slug = [section, sub_section].join('/')
+    content_api_has_tag("section", section)
+    content_api_has_tag("section", sub_section_slug)
+    content_api_has_root_tags("section", [section])
+    content_api_has_child_tags("section", section, [sub_section_slug])
+
+    stub_request(:get, "http://contentapi.dev.gov.uk/with_tag.json?tag=#{sub_section_slug}").
+      to_return(body: JSON.dump(results: []))
+
+    stub_request(:get, "http://whitehall-admin.dev.gov.uk/api/specialist/tags.json?parent_id=#{sub_section_slug}&type=section").
+      to_return(body: JSON.dump(results: []))
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,8 +1,10 @@
 require_relative "test_helper"
+require_relative "support/content_schema_helpers"
 
 require 'capybara/rails'
 require 'slimmer/test'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
+  include ContentSchemaHelpers
 end

--- a/test/models/related_topic_list_test.rb
+++ b/test/models/related_topic_list_test.rb
@@ -1,18 +1,21 @@
 require 'test_helper'
 
 describe RelatedTopicList do
+  include ContentSchemaHelpers
+
   describe "#related_topics_for" do
     it "returns related topics for a subsection" do
-      content_store = content_store_with_response(links: {related_topics: [{ title: 'From Content Store', web_url: 'http://example.org/whatever'}]})
+      content_store = content_store_with_response(content_schema_example(:mainstream_browse_page, :level_2_page_with_related_topics))
 
       topic_list = RelatedTopicList.new(content_store, nil)
+      found_topic = topic_list.related_topics_for('/browse/whatever').first
 
-      assert_equal topic_list.related_topics_for('/browse/whatever'),
-        [OpenStruct.new(title: 'From Content Store', web_url: 'http://example.org/whatever')]
+      assert_equal found_topic.title, 'Universal credit'
+      assert_equal found_topic.web_url, 'https://www.gov.uk/benefits/universal-credit'
     end
 
     it "returns guidance categories from whitehall when there are no related topics" do
-      content_store = content_store_with_response(links: {related_topics: []})
+      content_store = content_store_with_response(content_schema_example(:mainstream_browse_page, :level_2_page))
       whitehall = whitehall_with_response([{title: 'From Whitehall', content_with_tag: { web_url: 'http://example.org/whatever'}}])
 
       topic_list = RelatedTopicList.new(content_store, whitehall)

--- a/test/support/content_schema_helpers.rb
+++ b/test/support/content_schema_helpers.rb
@@ -3,4 +3,9 @@ module ContentSchemaHelpers
     examples = GovukContentSchemaTestHelpers::Examples.new.get_all_for_format(format)
     examples.map { |json_example| JSON.parse(json_example) }
   end
+
+  def content_schema_example(format, example_name)
+    json_example = GovukContentSchemaTestHelpers::Examples.new.get(format, example_name)
+    JSON.parse(json_example)
+  end
 end

--- a/test/support/content_schema_helpers.rb
+++ b/test/support/content_schema_helpers.rb
@@ -1,0 +1,6 @@
+module ContentSchemaHelpers
+  def content_schema_examples_for(format)
+    examples = GovukContentSchemaTestHelpers::Examples.new.get_all_for_format(format)
+    examples.map { |json_example| JSON.parse(json_example) }
+  end
+end


### PR DESCRIPTION
We now use the [content schema examples](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/mainstream_browse_page), so that when the content schema of content-store changes, the tests will start failing.