### PR TITLE
Add jenkins-schema for contract testing

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export REPO_NAME="alphagov/govuk-content-schemas"
+./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,7 +3,7 @@ set -x
 export DISPLAY=:99
 export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
-export REPO_NAME="alphagov/collections"
+export REPO_NAME=${REPO_NAME:="alphagov/collections"}
 env
 
 function github_status {


### PR DESCRIPTION
Adding jenkins-schema allows the CI to run the tests in this project whenever the contract (govuk-content-schemas) changes.

Since the tests run in less than 10 seconds, we choose not to restrict the run to only tests that use the content schemas, like other projects do.

More about setting up the CI:

https://github.com/alphagov/govuk-content-schemas/blob/master/docs/contract-testing-howto.md