### PR TITLE
Send informative message to schema github-status

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify collections against content schemas"
 ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,13 +4,14 @@ export DISPLAY=:99
 export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
 export REPO_NAME=${REPO_NAME:="alphagov/collections"}
+export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:="default"}
 env
 
 function github_status {
   REPO_NAME="$1"
   STATUS="$2"
   MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" >/dev/null
+  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {


### PR DESCRIPTION
Send a more informative message to the github-status API so we can differentiate between jenkins jobs.

Example: https://github.com/alphagov/govuk-content-schemas/pull/40 (our job here previously sent "default").

![screen shot 2015-04-28 at 15 13 57](https://cloud.githubusercontent.com/assets/233676/7371720/8afe4390-edba-11e4-977f-fd0a0cca42e8.png)

Thanks @heathd