### PR TITLE
Refactor routing for email signups

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -27,7 +27,7 @@ class EmailSignupsController < ApplicationController
 private
 
   def subtopic
-    @subtopic ||= Subcategory.find(params[:subtopic])
+    @subtopic ||= Subcategory.find("#{params[:sector]}/#{params[:subcategory]}")
   end
   helper_method :subtopic
 

--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -10,7 +10,7 @@
 
 <section>
   <% if email_signup.valid? %>
-    <%= form_for email_signup, html: { class: "signup-form" } do |form| %>
+    <%= form_for email_signup, url: email_signup_path(params), html: { class: "signup-form" } do |form| %>
       <p>You'll get an email each time content is published or updated in this topic.</p>
 
       <%= button_tag 'Create subscription' %>

--- a/app/views/subcategories/_subcategory.html.erb
+++ b/app/views/subcategories/_subcategory.html.erb
@@ -17,7 +17,7 @@
     <div class="latest-subscribe">
       <ul>
         <li class="email primary">
-          <%= link_to email_signup_path(subtopic: subcategory.slug) do %>
+          <%= link_to email_signup_path(params) do %>
           Subscribe to email alerts
           <% end %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Collections::Application.routes.draw do
   get "/:sector/:subcategory/latest", as: "latest_changes", to: "subcategories#latest_changes"
   get "/:sector/:subcategory", as: "subcategory", to: "subcategories#show"
   get "/:sector", to: "specialist_sectors#show"
-
-  resources :email_signups, path: "/:subtopic/email-signups", only: [:create], subtopic: %r{[^/]+/[^/]+}
-  get "/:subtopic/email-signup", as: "email_signup", to: "email_signups#new", subtopic: %r{[^/]+/[^/]+}
+  get "/:sector/:subcategory/email-signup", to: "email_signups#new", as: "email_signup"
+  post "/:sector/:subcategory/email-signup", to: "email_signups#create"
 end

--- a/features/step_definitions/email_alert_signup_steps.rb
+++ b/features/step_definitions/email_alert_signup_steps.rb
@@ -9,7 +9,7 @@ When(/^I access the email signup page via the topic$/) do
   # visit_latest_page("oil-and-gas/fields-and-wells")
   # follow_email_signup_link
 
-  visit email_signup_path(subtopic: "oil-and-gas/fields-and-wells")
+  visit email_signup_path(sector: "oil-and-gas", subcategory: "fields-and-wells")
 end
 
 When(/^I sign up to the email alerts$/) do

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -2,8 +2,10 @@ require "test_helper"
 
 describe EmailSignupsController do
   setup do
-    @subtopic_slug = "oil-and-gas/wells"
-    collections_api_has_content_for("/#{@subtopic_slug}")
+    @valid_subtopic_params = { sector: 'oil-and-gas', subcategory: 'wells' }
+    collections_api_has_content_for("/oil-and-gas/wells")
+
+    @invalid_subtopic_params = { sector: 'invalid', subcategory: 'subtopic' }
     collections_api_has_no_content_for("/invalid/subtopic")
 
     @email_signup = EmailSignup.new(nil)
@@ -15,7 +17,7 @@ describe EmailSignupsController do
 
   describe 'GET :new with a valid subtopic' do
     it 'displays the subscription form' do
-      get :new, subtopic: @subtopic_slug
+      get :new, @valid_subtopic_params
 
       assert_response :success
       assert_select ".signup-form"
@@ -24,7 +26,7 @@ describe EmailSignupsController do
 
   describe 'GET :new with an invalid subtopic' do
     it 'shows an error message' do
-      get :new, subtopic: 'invalid/subtopic'
+      get :new, @invalid_subtopic_params
 
       assert_response :not_found
     end
@@ -39,11 +41,11 @@ describe EmailSignupsController do
     it 'registers the signup' do
       @email_signup.expects(:save).returns(true)
 
-      post :create, subtopic: @subtopic_slug
+      post :create, @valid_subtopic_params
     end
 
     it 'redirects to the govdelivery URL' do
-      post :create, subtopic: @subtopic_slug
+      post :create, @valid_subtopic_params
 
       assert_response :redirect
       assert_redirected_to 'http://govdelivery_signup_url'
@@ -54,11 +56,11 @@ describe EmailSignupsController do
     it "doesn't register the subscription" do
       @email_signup.expects(:save).never
 
-      post :create, subtopic: 'invalid/subtopic'
+      post :create, @invalid_subtopic_params
     end
 
     it "404s" do
-      post :create, subtopic: 'invalid/subtopic'
+      post :create, @invalid_subtopic_params
 
       assert_response :not_found
     end

--- a/test/integration/specialist_sector_browsing_test.rb
+++ b/test/integration/specialist_sector_browsing_test.rb
@@ -63,7 +63,7 @@ class SpecialistSectorBrowsingTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Oil and gas")
       assert page.has_content?(stubbed_response_body['title'])
 
-      assert page.has_link?('Subscribe to email alerts', href: email_signup_path('oil-and-gas/wells'))
+      assert page.has_link?('Subscribe to email alerts', href: email_signup_path('oil-and-gas', 'wells'))
     end
 
     assert page.has_content?(example_stubbed_artefact['contents'][0]['title'])
@@ -78,7 +78,7 @@ class SpecialistSectorBrowsingTest < ActionDispatch::IntegrationTest
     visit "/#{base_path}/latest"
 
     within "header.page-header" do
-      assert page.has_link?('Subscribe to email alerts', href: email_signup_path(base_path))
+      assert page.has_link?('Subscribe to email alerts', href: email_signup_path('oil-and-gas', 'wells'))
       assert page.has_no_link?('See latest changes')
     end
   end


### PR DESCRIPTION
Rails 4.2 changes the way parameter segments are escaped: https://github.com/rails/rails/commit/5460591f0226a9d248b7b4f89186bd5553e7768f

This conflicts with `email_signup_path` using the subcategory slug (like `oil-and-gas/wells`) in a single `subtopic` parameter.

For example, `email_signup_path("foo/bar")` will generate the URL `/foo%2Fbar/email-signup`, not `/foo/bar/email-signup`.

This commit refactors the email signup routes to use the same URL structure as other subtopic-related routes.
