### PR TITLE
Pay attention to the SCHEMA_GIT_COMMIT variable

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,15 +3,16 @@ set -x
 export DISPLAY=:99
 export GOVUK_APP_DOMAIN=test.gov.uk
 export GOVUK_ASSET_ROOT=http://static.test.gov.uk
-export REPO_NAME=${REPO_NAME:="alphagov/collections"}
-export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:="default"}
+export REPO_NAME=${REPO_NAME:-"alphagov/collections"}
+export CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+export GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
 env
 
 function github_status {
   REPO_NAME="$1"
   STATUS="$2"
   MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {
@@ -34,6 +35,10 @@ github_status "$REPO_NAME" pending "is running on Jenkins"
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
 git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+(
+  cd tmp/govuk-content-schemas
+  git checkout $SCHEMA_GIT_COMMIT
+)
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas RAILS_ENV=test bundle exec rake


### PR DESCRIPTION
If this is set, use this in calls to gh-status, and set the
govuk-content-schemas repo to be at this commit.

If it's not set, use the "GIT_COMMIT" setting for status messages, since
we'll be sending messages for our repo, and just use master for
govuk-content-schemas ("git checkout" with no parameter will do
nothing).