### PR TITLE
Don't pass on query params when querying content-store.

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -24,7 +24,7 @@ class BrowseController < ApplicationController
     @related_topics = RelatedTopicList.new(
       Collections.services(:content_store),
       Collections.services(:detailed_guidance_content_api)
-    ).related_topics_for(request.fullpath)
+    ).related_topics_for(request.path)
 
     options = {title: "browse", section_name: section_tag.title, section_link: section_tag.web_url}
     set_slimmer_artefact_headers(options)

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -65,12 +65,6 @@ private
   end
   helper_method :root_sections
 
-  def validate_slug_param(param_name = :slug)
-    if params[param_name].parameterize != params[param_name]
-      cacheable_404
-    end
-  end
-
   def set_slimmer_artefact_headers(dummy_artefact={})
     set_slimmer_headers(format: 'browse')
     set_slimmer_dummy_artefact(dummy_artefact) unless dummy_artefact.empty?

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -90,7 +90,7 @@ describe BrowseController do
     end
 
     it "lists related topics in the subsection" do
-      RelatedTopicList.any_instance.stubs(:related_topics_for).returns(
+      RelatedTopicList.any_instance.expects(:related_topics_for).with("/browse/crime-and-justice/judges").returns(
         [OpenStruct.new(title: 'A Related Topic', web_url: 'https://www.gov.uk/benefits/related')]
       )
 
@@ -99,6 +99,19 @@ describe BrowseController do
       assert_select '.detailed-guidance' do
         assert_select "li a[href='https://www.gov.uk/benefits/related']", text: 'A Related Topic'
       end
+    end
+
+    it "ignores query parameters when requesting related topics" do
+      RelatedTopicList.any_instance.expects(:related_topics_for).with("/browse/crime-and-justice/judges").returns(
+        [OpenStruct.new(title: 'A Related Topic', web_url: 'https://www.gov.uk/benefits/related')]
+      )
+
+      get :sub_section, section: "crime-and-justice", sub_section: "judges", :foo => "bar"
+
+      assert_select '.detailed-guidance' do
+        assert_select "li a[href='https://www.gov.uk/benefits/related']", text: 'A Related Topic'
+      end
+
     end
 
     it "404 if the section does not exist" do


### PR DESCRIPTION
Content-store will ignore them, but in some cases this was causing
URI errors due to garbage in the incoming URL.

This will fix errors like https://errbit.production.alphagov.co.uk/apps/53440a5c0da115938404564b/problems/5549694b6578634263ff0d00

This also removes a duplicated `validate_slug_param` method.