### PR TITLE
Add support for deprecated route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,7 @@ Collections::Application.routes.draw do
   get "/:sector", to: "specialist_sectors#show"
   get "/:sector/:subcategory/email-signup", to: "email_signups#new", as: "email_signup"
   post "/:sector/:subcategory/email-signup", to: "email_signups#create"
+
+  # FIXME: This route is deprecated.
+  post "/:sector/:subcategory/email-signups", to: "email_signups#create"
 end


### PR DESCRIPTION
Adds support for the deprecated "/:sector/:subcategory/email-signups" (plural) route, which was recently removed.

Here to support the very special case where people loaded the form, then we deploy, and then they submit.