### PR TITLE
Remove "Topics" title from topic page

### DIFF
--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -168,10 +168,6 @@
       margin: 0;
       padding: 0;
 
-      @include media(desktop){
-        margin-left: 20.5em;
-      }
-
       li {
         margin-bottom: 10px;
         list-style: none;
@@ -184,6 +180,12 @@
       li a {
         @include bold-19;
         text-decoration: none;
+      }
+    }
+
+    &.with-title ul {
+      @include media(desktop){
+        margin-left: 20.5em;
       }
     }
   }

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -5,7 +5,7 @@
 
 <%= render layout: "subtopic", locals: {subtopic: subtopic, organisations: organisations, link_to_latest_feed: true, beta_label: false} do %>
   <% @groups.each do |group| -%>
-    <nav class="index-list" aria-labelledby="<%= group.artefact.name.parameterize %>">
+    <nav class="index-list with-title" aria-labelledby="<%= group.artefact.name.parameterize %>">
       <h1 id="<%= group.artefact.name.parameterize %>"><%= group.artefact.name %></h1>
       <ul>
       <% group.artefact.contents.each do |group_item| -%>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,7 +15,6 @@
   <% end %>
 
   <nav class="topics">
-    <h1>Topics</h1>
     <ul>
       <% @topic.child_tags.each do |category|%>
         <li>


### PR DESCRIPTION
Topic-pages currently have a "Topics" title on the right side of the page.

This doesn't add any information and has been removed in this commit.

## Before
![before](https://cloud.githubusercontent.com/assets/233676/7726137/ecf6e554-fef7-11e4-92eb-3ff170198a86.png)

## After
![after](https://cloud.githubusercontent.com/assets/233676/7726140/ee2d9468-fef7-11e4-9902-7e3cd71458ef.png)

Trello: https://trello.com/c/o5NTo2u5/82-user-facing-on-a-subtopic-page-remove-topics-heading-shift-links-left