### PR TITLE
Add beta label to topics

### DIFF
--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -1,5 +1,12 @@
 .topics-page {
 
+  // Topic beta labels have a lot of text. Limiting the width of the label
+  // prevents the lines to wrap under the label.
+  .topic-beta-label .govuk-beta-label span {
+    width: 75%;
+    vertical-align: top;
+  }
+
   header.page-header {
     .full-width {
       padding: 20px 30px;

--- a/app/models/subtopic.rb
+++ b/app/models/subtopic.rb
@@ -72,6 +72,10 @@ class Subtopic
     details.documents_total
   end
 
+  def beta?
+    details.beta
+  end
+
   def documents_start
     details.documents_start
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -14,6 +14,10 @@ class Topic
     child_tags_lookup
   end
 
+  def beta?
+    topic_content_from_content_store.details.beta
+  end
+
   def description
     details.description
   end
@@ -42,5 +46,9 @@ private
 
   def child_tags_lookup
     content_api_client.child_tags(TAG_TYPE, topic_slug, sort: "alphabetical")
+  end
+
+  def topic_content_from_content_store
+    @_from_cs ||= Collections.services(:content_store).content_item("/" + topic_slug)
   end
 end

--- a/app/views/shared/_topic_beta.html.erb
+++ b/app/views/shared/_topic_beta.html.erb
@@ -1,0 +1,7 @@
+<div class='topic-beta-label'>
+  <%= render 'govuk_component/beta_label',
+    message: %{
+      This page is in beta - it doesn’t include everything on '#{topic.title}'.
+      More content will be added in the next few months. You can also
+      #{link_to("search GOV.UK", "/search")} to find the information you need.} %>
+</div>

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -14,6 +14,7 @@
         </aside>
       <% end %>
     </div>
+
     <div class="latest-subscribe">
       <ul>
         <li class="email primary">
@@ -34,6 +35,10 @@
              locals: {
                message: "This part of #{link_to('GOV.UK', '/')} is new and being improved - #{link_to('find out what this means','/help/beta')}"
              } %>
+<% end %>
+
+<% if subtopic.beta? %>
+  <%= render 'shared/topic_beta', topic: subtopic %>
 <% end %>
 
 <div class="browse-container full-width">

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -11,6 +11,10 @@
   </div>
 </header>
 
+<% if @topic.beta? %>
+  <%= render 'shared/topic_beta', topic: @topic %>
+<% end %>
+
 <div class="browse-container full-width topics-page">
   <% if @topic.description.present? %>
     <div class="category-description">

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -1,6 +1,7 @@
 require_relative '../test_helper'
 
 describe TopicsController do
+  include ContentSchemaHelpers
 
   describe "GET topic with a valid topic slug" do
     before do
@@ -10,6 +11,7 @@ describe TopicsController do
 
       content_api_has_tag("specialist_sector", { slug: "oil-and-gas", title: "Oil and Gas", description: "Guidance for the oil and gas industry" })
       content_api_has_sorted_child_tags("specialist_sector", "oil-and-gas", "alphabetical", subtopics)
+      content_store_has_item('/oil-and-gas', content_schema_example(:topic, :topic))
     end
 
     it "requests a tag from the Content API and assign it" do

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -25,6 +25,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
   it "renders a topic tag page and list its subtopics" do
     set_up_valid_topic_page
+    content_store_has_item('/oil-and-gas', content_schema_example(:topic, :topic))
 
     visit "/oil-and-gas"
     assert page.has_title?("Oil and gas - GOV.UK")
@@ -52,6 +53,17 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  it "renders a beta topic" do
+    set_up_valid_topic_page
+
+    content_store_has_item('/oil-and-gas',
+      content_schema_example(:topic, :topic).merge(details: { beta: true }))
+
+    visit "/oil-and-gas"
+
+    assert page.has_content?("Beta")
+  end
+
   it "renders a subtopic and its artefacts" do
     stubbed_response = collections_api_has_content_for("/oil-and-gas/wells")
     stubbed_response_body = JSON.parse(stubbed_response.response.body)
@@ -71,6 +83,18 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     end
 
     assert page.has_content?(example_stubbed_artefact['contents'][0]['title'])
+  end
+
+  it "renders a beta subtopic" do
+    stub_topic_organisations('oil-and-gas/wells')
+
+    url = Plek.current.find('collections-api') + "/specialist-sectors/oil-and-gas/wells"
+    body = { parent: { title: "Oil and gas" }, details: { groups: [], beta: true } }
+    stub_request(:get, url).to_return(status: 200, body: body.to_json)
+
+    visit "/oil-and-gas/wells"
+
+    assert page.has_content?("Beta")
   end
 
   it 'does not display a link to itself on the latest feed' do

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -12,7 +12,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  it "renders a topic tag page and list its subtopics" do
+  def set_up_valid_topic_page
     subtopics = [
       { slug: "oil-and-gas/wells", title: "Wells", description: "Wells, wells, wells." },
       { slug: "oil-and-gas/fields", title: "Fields", description: "Fields, fields, fields." },
@@ -21,6 +21,10 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
     content_api_has_tag("specialist_sector", { slug: "oil-and-gas", title: "Oil and gas", description: "Guidance for the oil and gas industry" })
     content_api_has_sorted_child_tags("specialist_sector", "oil-and-gas", "alphabetical", subtopics)
+  end
+
+  it "renders a topic tag page and list its subtopics" do
+    set_up_valid_topic_page
 
     visit "/oil-and-gas"
     assert page.has_title?("Oil and gas - GOV.UK")


### PR DESCRIPTION
Users of Collections Publisher can mark a topic `beta`, which means the topic is not finished yet. Here we show the beta label for the topic.

- `Topics` get an extra call to the content store to find out if they're in beta.
- `Subtopics` get this information from Collections API.