### PR TITLE
Bump slimmer for new rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'logstasher', '0.5.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '8.2.0'
+  gem 'slimmer', '8.2.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
       sass (~> 3.2.0)
       sprockets (~> 2.8, <= 2.11.0)
       sprockets-rails (~> 2.0.0)
-    slimmer (8.2.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -227,7 +227,7 @@ DEPENDENCIES
   plek (= 1.7.0)
   rails (= 4.2.1)
   sass-rails (= 4.0.2)
-  slimmer (= 8.2.0)
+  slimmer (= 8.2.1)
   uglifier (= 2.5.0)
   unicorn (= 4.8.2)
   webmock (= 1.17.4)


### PR DESCRIPTION
This now uses the GOVUK_APP_NAME env variable rather than the
application class name so it can be cross referenced to other things in
the stack.

This contains https://github.com/alphagov/slimmer/pull/128