### PR TITLE
Handle an empty list of subsection curated groups.

### DIFF
--- a/app/models/sub_section.rb
+++ b/app/models/sub_section.rb
@@ -16,7 +16,7 @@ class SubSection
   end
 
   def curated_links?
-    subsection_from_content_store.details && subsection_from_content_store.details.groups
+    groups.any?
   end
 
   def exists?
@@ -25,8 +25,12 @@ class SubSection
 
 private
 
+  def groups
+    (subsection_from_content_store.details && subsection_from_content_store.details.groups) || []
+  end
+
   def curated_lists
-    subsection_from_content_store.details.groups.map do |group|
+    groups.map do |group|
       links = group.contents.map do |url|
         tagged_items_from_content_api.find { |artefact| artefact.id == url }
       end

--- a/test/models/sub_section_test.rb
+++ b/test/models/sub_section_test.rb
@@ -44,6 +44,15 @@ describe SubSection do
       refute sub_section.curated_links?
     end
 
+    it "returns false when there is an empty list of gurated groups" do
+      content_store_has_item '/browse/crime-and-justice/judges', { details: { groups: [] } }
+      content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
+
+      sub_section = SubSection.new('crime-and-justice/judges')
+
+      refute sub_section.curated_links?
+    end
+
     it "returns true when there are grouped links in the content store" do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { groups: [ { name: "Movie Judges", contents: ['https://contentapi.test.gov.uk/judge-dredd.json'] }]} }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]


### PR DESCRIPTION
Previously, if an empty list of curated groups had been sent to the
content-store, collections would treat this as a curated page, and not
display the A-Z list.  This fixes that.