### PR TITLE
Fix schema integration test

### DIFF
--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -16,10 +16,14 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
 
   def stub_other_requests(content_item)
     _, _, section, sub_section = content_item['base_path'].split('/')
+
+    content_api_has_root_tags("section", ['foo', 'bar', section].compact)
+
+    return if content_item['base_path'] == '/browse'
+
     sub_section_slug = [section, sub_section].join('/')
     content_api_has_tag("section", section)
     content_api_has_tag("section", sub_section_slug)
-    content_api_has_root_tags("section", [section])
     content_api_has_child_tags("section", section, [sub_section_slug])
     content_api_has_artefacts_with_a_tag("section", sub_section_slug, [])
 

--- a/test/support/content_schema_helpers.rb
+++ b/test/support/content_schema_helpers.rb
@@ -1,7 +1,8 @@
 module ContentSchemaHelpers
   def content_schema_examples_for(format)
     examples = GovukContentSchemaTestHelpers::Examples.new.get_all_for_format(format)
-    examples.map { |json_example| JSON.parse(json_example) }
+    # Shuffle the examples to ensure tests don't become order dependent
+    examples.map { |json_example| JSON.parse(json_example) }.shuffle
   end
 
   def content_schema_example(format, example_name)


### PR DESCRIPTION
The integration test automatically tests all examples in the content schemas. We've added a new one for `/browse`. This doesn't need stubbing yet.