### PR TITLE
Fetch content item only once per browse page 

### DIFF
--- a/app/models/browse_page_content_item.rb
+++ b/app/models/browse_page_content_item.rb
@@ -1,10 +1,11 @@
 class BrowsePageContentItem
-  attr_reader :slug
+  attr_reader :slug, :item_from_content_store
 
   delegate :title, to: :tag_from_content_api
 
-  def initialize(slug)
+  def initialize(slug, item_from_content_store)
     @slug = slug
+    @item_from_content_store = item_from_content_store
   end
 
   def lists
@@ -51,14 +52,6 @@ private
   def tagged_items_from_content_api
     @tagged_items_from_content_api ||= begin
       content_api.with_tag(slug).results.sort_by(&:title)
-    end
-  end
-
-  # Returns an OpenStruct with the content blob.
-  def item_from_content_store
-    @item_from_content_store ||= begin
-      content_store = Collections.services(:content_store)
-      content_store.content_item('/browse/' + slug)
     end
   end
 

--- a/app/models/related_topic_list.rb
+++ b/app/models/related_topic_list.rb
@@ -1,7 +1,7 @@
 # FIXME: Once the content has been migrated to content store, remove whitehall code.
 class RelatedTopicList
-  def initialize(content_store, whitehall)
-    @content_store = content_store
+  def initialize(content_item, whitehall)
+    @content_item = content_item
     @whitehall = whitehall
   end
 
@@ -12,7 +12,7 @@ class RelatedTopicList
   private
 
   def fetch_results_for_path(path)
-    results = @content_store.content_item(path).try(:links).try(:related_topics).to_a
+    results = @content_item.try(:links).try(:related_topics).to_a
 
     if results.any?
       results
@@ -24,7 +24,7 @@ class RelatedTopicList
   end
 
   def legacy_fallback_to_whitehall(path)
-    response = @whitehall.sub_sections(path.gsub('/browse/', ''))
+    response = @whitehall.sub_sections(path)
 
     response.results.map do |detailed_guide_category|
       OpenStruct.new(

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -10,8 +10,8 @@ class SecondLevelBrowsePage
   def slimmer_breadcrumb_options
     {
       title: "browse",
-      section_name: parent_top_level_browse_page.title,
-      section_link: parent_top_level_browse_page.web_url
+      section_name: active_top_level_browse_page.title,
+      section_link: active_top_level_browse_page.web_url
     }
   end
 
@@ -26,7 +26,7 @@ class SecondLevelBrowsePage
     ).related_topics_for("/browse/#{top_level_slug}/#{second_level_slug}")
   end
 
-  def parent_top_level_browse_page
+  def active_top_level_browse_page
     Collections.services(:content_api).tag(top_level_slug) || raise(GdsApi::HTTPNotFound, 404)
   end
 

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -1,10 +1,11 @@
 class SecondLevelBrowsePage
   attr_reader :top_level_slug, :second_level_slug
 
-  delegate :title, :curated_links?, :lists, to: :browse_page_content_iten
+  delegate :title, :curated_links?, :lists, to: :browse_page_content_item
 
   def initialize(top_level_slug, second_level_slug)
-    @top_level_slug, @second_level_slug = top_level_slug, second_level_slug
+    @top_level_slug = top_level_slug
+    @second_level_slug = second_level_slug
   end
 
   def slimmer_breadcrumb_options
@@ -15,15 +16,18 @@ class SecondLevelBrowsePage
     }
   end
 
-  def browse_page_content_iten
-    @model ||= BrowsePageContentItem.new("#{top_level_slug}/#{second_level_slug}")
+  def browse_page_content_item
+    @browse_page_content_item ||= BrowsePageContentItem.new(
+      "#{top_level_slug}/#{second_level_slug}",
+      content_store_item
+    )
   end
 
   def related_topics
     RelatedTopicList.new(
-      Collections.services(:content_store),
+      content_store_item,
       Collections.services(:detailed_guidance_content_api)
-    ).related_topics_for("/browse/#{top_level_slug}/#{second_level_slug}")
+    ).related_topics_for("#{top_level_slug}/#{second_level_slug}")
   end
 
   def active_top_level_browse_page
@@ -36,5 +40,13 @@ class SecondLevelBrowsePage
 
   def top_level_browse_pages
     Collections.services(:content_api).root_sections.results.sort_by(&:title)
+  end
+
+private
+
+  def content_store_item
+    @content_store_item ||= Collections.services(:content_store).content_item!(
+      "/browse/#{top_level_slug}/#{second_level_slug}"
+    )
   end
 end

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -8,7 +8,7 @@
 
   <div id="section" class="pane">
     <%= render 'second_level_browse_pages',
-      title: @page.parent_top_level_browse_page.title,
+      title: @page.active_top_level_browse_page.title,
       second_level_browse_pages: @page.second_level_browse_pages %>
   </div>
 

--- a/test/models/browse_page_content_item_test.rb
+++ b/test/models/browse_page_content_item_test.rb
@@ -11,7 +11,7 @@ describe BrowsePageContentItem do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { } }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
 
-      lists = BrowsePageContentItem.new('crime-and-justice/judges').lists
+      lists = BrowsePageContentItem.new('crime-and-justice/judges', stub(:details)).lists
 
       assert_equal 1, lists.size
       assert_equal 'A&#8202;to&#8202;Z', lists.first.name
@@ -25,8 +25,9 @@ describe BrowsePageContentItem do
       }
       content_store_has_item '/browse/crime-and-justice/judges', content_item
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
+      content_store_item = Collections.services(:content_store).content_item!('/browse/crime-and-justice/judges')
 
-      lists = BrowsePageContentItem.new('crime-and-justice/judges').lists
+      lists = BrowsePageContentItem.new('crime-and-justice/judges', content_store_item).lists
 
       assert_equal 1, lists.size
       assert_equal 'Movie Judges', lists.first.name
@@ -39,7 +40,7 @@ describe BrowsePageContentItem do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { } }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
 
-      sub_section = BrowsePageContentItem.new('crime-and-justice/judges')
+      sub_section = BrowsePageContentItem.new('crime-and-justice/judges', stub(:details))
 
       refute sub_section.curated_links?
     end
@@ -48,7 +49,7 @@ describe BrowsePageContentItem do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { groups: [] } }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
 
-      sub_section = BrowsePageContentItem.new('crime-and-justice/judges')
+      sub_section = BrowsePageContentItem.new('crime-and-justice/judges', stub(:details))
 
       refute sub_section.curated_links?
     end
@@ -56,8 +57,9 @@ describe BrowsePageContentItem do
     it "returns true when there are grouped links in the content store" do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { groups: [ { name: "Movie Judges", contents: ['https://contentapi.test.gov.uk/judge-dredd.json'] }]} }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
+      content_store_item = Collections.services(:content_store).content_item!('/browse/crime-and-justice/judges')
 
-      sub_section = BrowsePageContentItem.new('crime-and-justice/judges')
+      sub_section = BrowsePageContentItem.new('crime-and-justice/judges', content_store_item)
 
       assert sub_section.curated_links?
     end

--- a/test/models/related_topic_list_test.rb
+++ b/test/models/related_topic_list_test.rb
@@ -5,9 +5,9 @@ describe RelatedTopicList do
 
   describe "#related_topics_for" do
     it "returns related topics for a subsection" do
-      content_store = content_store_with_response(content_schema_example(:mainstream_browse_page, :level_2_page_with_related_topics))
+      content_item = content_item_with(content_schema_example(:mainstream_browse_page, :level_2_page_with_related_topics))
 
-      topic_list = RelatedTopicList.new(content_store, nil)
+      topic_list = RelatedTopicList.new(content_item, nil)
       found_topic = topic_list.related_topics_for('/browse/whatever').first
 
       assert_equal found_topic.title, 'Universal credit'
@@ -15,57 +15,39 @@ describe RelatedTopicList do
     end
 
     it "returns guidance categories from whitehall when there are no related topics" do
-      content_store = content_store_with_response(content_schema_example(:mainstream_browse_page, :level_2_page))
+      content_item = content_item_with(content_schema_example(:mainstream_browse_page, :level_2_page))
       whitehall = whitehall_with_response([{title: 'From Whitehall', content_with_tag: { web_url: 'http://example.org/whatever'}}])
 
-      topic_list = RelatedTopicList.new(content_store, whitehall)
+      topic_list = RelatedTopicList.new(content_item, whitehall)
 
       assert_equal topic_list.related_topics_for('/browse/whatever'),
         [OpenStruct.new(title: 'From Whitehall', web_url: 'http://example.org/whatever')]
     end
 
     it "handles missing links" do
-      content_store = content_store_with_response({})
+      content_item = content_item_with({})
       whitehall = whitehall_with_response([{title: 'From Whitehall', content_with_tag: { web_url: 'http://example.org/whatever' }}])
 
-      topic_list = RelatedTopicList.new(content_store, whitehall)
+      topic_list = RelatedTopicList.new(content_item, whitehall)
 
       assert_equal topic_list.related_topics_for('/browse/whatever'),
         [OpenStruct.new(title: 'From Whitehall', web_url: 'http://example.org/whatever')]
     end
 
-    it "returns an empty array when content-store returns 404" do
-      content_store = stub()
-      content_store.expects(:content_item).with('/browse/whatever').raises(GdsApi::HTTPNotFound, 'A message')
-
-      topic_list = RelatedTopicList.new(content_store, nil)
-
-      assert_equal topic_list.related_topics_for('/browse/whatever'), []
-    end
-
-    it "returns an empty array when content-store returns archived" do
-      content_store = stub()
-      content_store.expects(:content_item).with('/browse/whatever').raises(GdsApi::HTTPGone, 'A message')
-
-      topic_list = RelatedTopicList.new(content_store, nil)
-
-      assert_equal topic_list.related_topics_for('/browse/whatever'), []
-    end
-
     it "sorts the output by title" do
-      content_store = content_store_with_response(links: { related_topics: [
+      content_item = content_item_with(links: { related_topics: [
           { title: 'B' },
           { title: 'A' },
           { title: 'C' }
       ]})
 
-      topic_list = RelatedTopicList.new(content_store, nil)
+      topic_list = RelatedTopicList.new(content_item, nil)
 
       assert_equal topic_list.related_topics_for('/browse/whatever').map(&:title), %w[A B C]
     end
 
-    def content_store_with_response(results)
-      mock("content_store", content_item: build_ostruct_recursively(results))
+    def content_item_with(results)
+      build_ostruct_recursively(results)
     end
 
     def whitehall_with_response(results)


### PR DESCRIPTION
Currently both `BrowsePageContentItem` and `RelatedTopicList` fetch the same content-store item. This commit makes the `SecondLevelBrowsePage` fetch the content item and pass it on to objects that need it. This saves an external call and cleans up the code.

It makes some tests redundant as well.

Best reviewed per-commit.

This is the final PR to make the changes of https://trello.com/c/4iq0DhfM/111 easy.

Previous PR: https://github.com/alphagov/collections/pull/108