### PR TITLE
Prevent auto-downloads of phantomjs.

### DIFF
--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -28,3 +28,6 @@ spec_files:
 # (spec runner and asset cache)
 # defaults to tmp/jasmine
 tmp_dir: "tmp/jasmine"
+
+# Prevent auto-downloads of phantomjs.
+use_phantom_gem: false


### PR DESCRIPTION
Phantomjs is managed by puppet in our environment.  We don't want
another conflicting method of managing phantomjs.

See https://github.com/searls/jasmine-rails/pull/154.