### PR TITLE
Add namespaced routes for topics

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,15 @@ Collections::Application.routes.draw do
   get "/browse/:top_level_slug", to: "browse#top_level_browse_page"
   get "/browse/:top_level_slug/:second_level_slug", to: "browse#second_level_browse_page"
 
+  # Make the topics temporarily available under both /topic and their old route.
+  # When all Topics have been updated to use the namespace in the content-store,
+  # we can remove the duplication.
+  get "/topic/:topic_slug/:subtopic_slug/latest", to: "subtopics#latest_changes"
+  get "/topic/:topic_slug/:subtopic_slug", to: "subtopics#show"
+  get "/topic/:topic_slug", to: "topics#show"
+  get "/topic/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#new"
+  post "/topic/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#create"
+
   # Note that this app only receives requests for routes registered with the
   # content-store (by collections-publisher) - whenever the routes below
   # change, also change the routes claimed by collections-publisher.

--- a/test/routing/topic_namespacing_test.rb
+++ b/test/routing/topic_namespacing_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class TopicRoutingTest < ActionDispatch::IntegrationTest
+  it "routes to the topic show page" do
+    assert_recognizes({
+      controller: 'topics',
+      action: 'show',
+      topic_slug: 'foo-topic',
+    }, '/foo-topic')
+
+    assert_recognizes({
+      controller: 'topics',
+      action: 'show',
+      topic_slug: 'foo-topic',
+    }, '/topic/foo-topic')
+  end
+
+  it "routes to the subtopic show page" do
+    assert_recognizes({
+      controller: 'subtopics',
+      action: 'show',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/foo-topic/bar-topic')
+
+    assert_recognizes({
+      controller: 'subtopics',
+      action: 'show',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/topic/foo-topic/bar-topic')
+  end
+
+  it "routes to the subtopic latest page" do
+    assert_recognizes({
+      controller: 'subtopics',
+      action: 'latest_changes',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/foo-topic/bar-topic/latest')
+
+    assert_recognizes({
+      controller: 'subtopics',
+      action: 'latest_changes',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/topic/foo-topic/bar-topic/latest')
+  end
+
+  it "routes to the subtopic email signup page" do
+    assert_recognizes({
+      controller: 'email_signups',
+      action: 'new',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/foo-topic/bar-topic/email-signup')
+
+    assert_recognizes({
+      controller: 'email_signups',
+      action: 'new',
+      topic_slug: 'foo-topic',
+      subtopic_slug: 'bar-topic',
+    }, '/topic/foo-topic/bar-topic/email-signup')
+  end
+end


### PR DESCRIPTION
Topics will be moving to the `/topic` namespace. To keep the content available when this app has been deployed, but collections-publisher has not, we'll serve topics from both the namespaced and non-namespaced URLs.

Trello: https://trello.com/c/EoWPp4qZ/187-move-topics-to-topic

After collections-publisher has deployed and the content has been migrated, we can remove the non-namespaced routes.

Related: https://github.com/alphagov/collections-publisher/pull/94