### PR TITLE
Get second level browse page title from content store

### DIFF
--- a/app/models/browse_page_content_item.rb
+++ b/app/models/browse_page_content_item.rb
@@ -1,8 +1,6 @@
 class BrowsePageContentItem
   attr_reader :slug, :item_from_content_store
 
-  delegate :title, to: :tag_from_content_api
-
   def initialize(slug, item_from_content_store)
     @slug = slug
     @item_from_content_store = item_from_content_store
@@ -53,10 +51,6 @@ private
     @tagged_items_from_content_api ||= begin
       content_api.with_tag(slug).results.sort_by(&:title)
     end
-  end
-
-  def tag_from_content_api
-    @tag_from_content_api ||= content_api.tag(slug) || raise(GdsApi::HTTPNotFound, 404)
   end
 
   def content_api

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -17,13 +17,6 @@ class SecondLevelBrowsePage
     }
   end
 
-  def browse_page_content_item
-    @browse_page_content_item ||= BrowsePageContentItem.new(
-      "#{top_level_slug}/#{second_level_slug}",
-      content_store_item
-    )
-  end
-
   def related_topics
     RelatedTopicList.new(
       content_store_item,
@@ -48,6 +41,13 @@ private
   def content_store_item
     @content_store_item ||= Collections.services(:content_store).content_item!(
       "/browse/#{top_level_slug}/#{second_level_slug}"
+    )
+  end
+  
+  def browse_page_content_item
+    @browse_page_content_item ||= BrowsePageContentItem.new(
+      "#{top_level_slug}/#{second_level_slug}",
+      content_store_item
     )
   end
 end

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -1,7 +1,8 @@
 class SecondLevelBrowsePage
   attr_reader :top_level_slug, :second_level_slug
 
-  delegate :title, :curated_links?, :lists, to: :browse_page_content_item
+  delegate :curated_links?, :lists, to: :browse_page_content_item
+  delegate :title, to: :content_store_item
 
   def initialize(top_level_slug, second_level_slug)
     @top_level_slug = top_level_slug

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -38,3 +38,7 @@ end
 When(/^I click on a second level browse page$/) do
   click_link 'Judges'
 end
+
+Then(/^I should see the second level browse page$/) do
+  assert page.has_selector?('h1', text: 'Judges')
+end

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -15,6 +15,9 @@ module BrowseTestHelpers
     content_api_has_root_tags("section", [section])
     content_api_has_child_tags("section", section, [sub_section_slug])
     content_api_has_artefacts_with_a_tag("section", sub_section_slug, [artefact])
+
+    content_item = { title: 'Judges', links: {} }
+    content_store_has_item '/browse/crime-and-justice/judges', content_item
   end
 
   def stub_detailed_guidance
@@ -26,8 +29,6 @@ module BrowseTestHelpers
     Collections.services(:detailed_guidance_content_api, mock_api)
     results = stub("results", results: [detailed_guidance])
     mock_api.stubs(:sub_sections).returns(results)
-
-    content_store_has_item '/browse/crime-and-justice/judges', { links: {} }
   end
 
   def assert_can_see_linked_item(name)

--- a/features/viewing_browse.feature
+++ b/features/viewing_browse.feature
@@ -11,6 +11,7 @@ Feature: Viewing browse
     And I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
+    Then I should see the second level browse page
     Then I see the links tagged to the browse page
     And I should see the detailed guidance links
 
@@ -21,6 +22,7 @@ Feature: Viewing browse
     And I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
+    Then I should see the second level browse page
     Then I see the links tagged to the browse page
     And I should see the detailed guidance links
 

--- a/test/models/second_level_browse_page_test.rb
+++ b/test/models/second_level_browse_page_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+describe SecondLevelBrowsePage do
+  describe '#title' do
+    it 'delegates to the browse page' do
+      content_store_has_item('/browse/foo/bar', { title: 'Foo Bar' })
+
+      page = SecondLevelBrowsePage.new('foo', 'bar')
+
+      assert_equal page.title, 'Foo Bar'
+    end
+  end
+end


### PR DESCRIPTION
Currently the second level browse page gets its title from the content-api. This creates an unnecessary request because we already have the title from the content store object, and we don't need the
call to content-api for anything else.