### PR TITLE
Support both namespaced and non-namespaced topic paths.

### DIFF
--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -6,7 +6,7 @@ class SubtopicsController < ApplicationController
   rescue_from GdsApi::HTTPNotFound, :with => :error_404
 
   def show
-    @subtopic = Subtopic.find("/#{slug}")
+    @subtopic = Subtopic.find(request.path)
 
     if @subtopic.parent
       set_slimmer_dummy_artefact(
@@ -17,7 +17,8 @@ class SubtopicsController < ApplicationController
   end
 
   def latest_changes
-    @subtopic = Subtopic.find("/#{slug}", pagination_params)
+    subtopic_base_path = request.path.sub(%r{/latest\z}, '')
+    @subtopic = Subtopic.find(subtopic_base_path, pagination_params)
     @pagination_presenter = ChangedDocumentsPaginationPresenter.new(@subtopic.changed_documents, view_context)
 
     slimmer_artefact = {

--- a/app/helpers/temporary_route_helper.rb
+++ b/app/helpers/temporary_route_helper.rb
@@ -1,0 +1,48 @@
+module TemporaryRouteHelper
+
+  # FIXME: These helper methods are a temporary measure to allow us to support
+  # topics under both the root namespace, and the /topic namespace.  Once
+  # everything has been migrated to the /topic namespace, these will no longer
+  # be necessary.
+  #
+  # They mimic the regular Rails routing helpers, and merely deletage to the
+  # appripriate real routing helper depending on the incoming request path.
+
+  def topic_path(*args)
+    if request_using_namespaced_path?
+      namespaced_topic_path(*args)
+    else
+      non_namespaced_topic_path(*args)
+    end
+  end
+
+  def subtopic_path(*args)
+    if request_using_namespaced_path?
+      namespaced_subtopic_path(*args)
+    else
+      non_namespaced_subtopic_path(*args)
+    end
+  end
+
+  def latest_changes_path(*args)
+    if request_using_namespaced_path?
+      namespaced_latest_changes_path(*args)
+    else
+      non_namespaced_latest_changes_path(*args)
+    end
+  end
+
+  def email_signup_path(*args)
+    if request_using_namespaced_path?
+      namespaced_email_signup_path(*args)
+    else
+      non_namespaced_email_signup_path(*args)
+    end
+  end
+
+  private
+
+  def request_using_namespaced_path?
+    request.path.start_with?("/topic/")
+  end
+end

--- a/app/models/subtopic.rb
+++ b/app/models/subtopic.rb
@@ -53,7 +53,7 @@ class Subtopic
   end
 
   def slug
-    base_path[1..-1]
+    base_path.split('/')[-2..-1].join('/')
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,20 +9,25 @@ Collections::Application.routes.draw do
   # Make the topics temporarily available under both /topic and their old route.
   # When all Topics have been updated to use the namespace in the content-store,
   # we can remove the duplication.
-  get "/topic/:topic_slug/:subtopic_slug/latest", to: "subtopics#latest_changes"
-  get "/topic/:topic_slug/:subtopic_slug", to: "subtopics#show"
-  get "/topic/:topic_slug", to: "topics#show"
-  get "/topic/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#new"
+  #
+  # While we need to support both routes, there are some helpers in
+  # app/helpers/temporary_route_helper.rb that mimic the route_helpers.  These
+  # deletgate to either namespaced_foo ot non_namespaced_foo depending on the
+  # request path.
+  get "/topic/:topic_slug/:subtopic_slug/latest", to: "subtopics#latest_changes", as: :namespaced_latest_changes
+  get "/topic/:topic_slug/:subtopic_slug", to: "subtopics#show", as: :namespaced_subtopic
+  get "/topic/:topic_slug", to: "topics#show", as: :namespaced_topic
+  get "/topic/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#new", as: :namespaced_email_signup
   post "/topic/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#create"
 
   # Note that this app only receives requests for routes registered with the
   # content-store (by collections-publisher) - whenever the routes below
   # change, also change the routes claimed by collections-publisher.
 
-  get "/:topic_slug/:subtopic_slug/latest", as: "latest_changes", to: "subtopics#latest_changes"
-  get "/:topic_slug/:subtopic_slug", as: :subtopic, to: "subtopics#show"
-  get "/:topic_slug", to: "topics#show", as: :topic
+  get "/:topic_slug/:subtopic_slug/latest", as: "non_namespaced_latest_changes", to: "subtopics#latest_changes"
+  get "/:topic_slug/:subtopic_slug", as: :non_namespaced_subtopic, to: "subtopics#show"
+  get "/:topic_slug", to: "topics#show", as: :non_namespaced_topic
 
-  get "/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#new", as: "email_signup"
+  get "/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#new", as: "non_namespaced_email_signup"
   post "/:topic_slug/:subtopic_slug/email-signup", to: "email_signups#create"
 end

--- a/features/step_definitions/email_alert_signup_steps.rb
+++ b/features/step_definitions/email_alert_signup_steps.rb
@@ -3,7 +3,7 @@ Given(/^a topic$/) do
 end
 
 When(/^I access the email signup page via the topic$/) do
-  visit email_signup_path(topic_slug: "oil-and-gas", subtopic_slug: "fields-and-wells")
+  visit "/oil-and-gas/fields-and-wells/email-signup"
 end
 
 When(/^I sign up to the email alerts$/) do

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -4,7 +4,7 @@ describe SubtopicsController do
   describe "GET subtopic with a valid topic and subtopic slug" do
     setup do
       content_store_has_item(
-        "/oil-and-gas/wells",
+        "/topic/oil-and-gas/wells",
         content_item_for_base_path("/oil-and-gas/wells").merge({
           "links" => {
             "parent" => [{
@@ -44,7 +44,7 @@ describe SubtopicsController do
     end
 
     it "returns a 404 status for GET subtopic with an invalid subtopic tag" do
-      content_store_does_not_have_item("/oil-and-gas/coal")
+      content_store_does_not_have_item("/topic/oil-and-gas/coal")
 
       get :show, topic_slug: "oil-and-gas", subtopic_slug: "coal"
 

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -5,7 +5,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   def oil_and_gas_subtopic_item(subtopic_slug, params = {})
     base = {
-      base_path: "/oil-and-gas/#{subtopic_slug}",
+      base_path: "/topic/oil-and-gas/#{subtopic_slug}",
       title: subtopic_slug.humanize,
       description: "Offshore drilling and exploration",
       format: "topic",
@@ -16,7 +16,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       links: {
         "parent" => [
           "title" => "Oil and Gas",
-          "base_path" => "/oil-and-gas",
+          "base_path" => "/topic/oil-and-gas",
         ]
       },
     }
@@ -40,7 +40,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   it "renders a curated subtopic" do
     # Given a curated subtopic exists
-    content_store_has_item("/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {
+    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {
       groups: [
         {
           name: "Oil rigs",
@@ -61,7 +61,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     stub_topic_organisations('oil-and-gas/offshore')
 
     # When I visit the subtopic page
-    visit "/oil-and-gas/offshore"
+    visit "/topic/oil-and-gas/offshore"
 
     # Then I should see the subtopic metadata
     within '.page-header' do
@@ -87,11 +87,11 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   it "renders a non-curated subtopic" do
     # Given a non-curated subtopic exists
-    content_store_has_item("/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
+    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
     stub_topic_organisations('oil-and-gas/offshore')
 
     # When I visit the subtopic page
-    visit "/oil-and-gas/offshore"
+    visit "/topic/oil-and-gas/offshore"
 
     # Then I should see the subtopic metadata
     within '.page-header' do
@@ -115,17 +115,17 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a beta subtopic" do
-    content_store_has_item("/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {beta: true}))
+    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {beta: true}))
     stub_topic_organisations('oil-and-gas/offshore')
 
-    visit "/oil-and-gas/offshore"
+    visit "/topic/oil-and-gas/offshore"
 
     assert page.has_content?("This page is in beta"), "has beta-label"
   end
 
   describe "latest page for a subtopic" do
     setup do
-      content_store_has_item("/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
+      content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
       stub_topic_organisations('oil-and-gas/offshore')
     end
 
@@ -139,7 +139,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       ])
 
       # When I view the latest page for a subtopic
-      visit "/oil-and-gas/offshore"
+      visit "/topic/oil-and-gas/offshore"
       click_on "See latest changes to this content"
 
       # Then I should see the subtopic metadata
@@ -171,7 +171,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       rummager_has_latest_documents_for_subtopic("oil-and-gas/offshore", (1..55).map {|n| "document-#{n}" })
 
       # When I view the latest page for a subtopic
-      visit "/oil-and-gas/offshore"
+      visit "/topic/oil-and-gas/offshore"
       click_on "See latest changes to this content"
 
       # Then I should see the first 50 documents

--- a/test/models/subtopic_test.rb
+++ b/test/models/subtopic_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe Subtopic do
   setup do
     @api_data = {
-      "base_path" => "/business-tax/paye",
+      "base_path" => "/topic/business-tax/paye",
       "title" => "PAYE",
       "description" => "Pay As You Earn",
       "details" => {
@@ -11,7 +11,7 @@ describe Subtopic do
       "links" => {
         "parent" => [{
           "title"=>"Business tax",
-          "base_path"=>"/business-tax",
+          "base_path"=>"/topic/business-tax",
           "description"=>"All about tax for businesses",
         }],
       },
@@ -21,7 +21,7 @@ describe Subtopic do
 
   describe "basic properties" do
     it "returns the subtopic base_path" do
-      assert_equal "/business-tax/paye", @subtopic.base_path
+      assert_equal "/topic/business-tax/paye", @subtopic.base_path
     end
 
     it "returns the subtopic title" do
@@ -46,7 +46,7 @@ describe Subtopic do
     end
 
     it "returns the parent base_path" do
-      assert_equal "/business-tax", @subtopic.parent.base_path
+      assert_equal "/topic/business-tax", @subtopic.parent.base_path
     end
 
     it "returns the combined_title" do
@@ -71,6 +71,18 @@ describe Subtopic do
         @api_data.delete("links")
         assert_nil @subtopic.parent
       end
+    end
+  end
+
+  describe "slug" do
+    it "returns the slug for a topic at the root of the namespace" do
+      @api_data["base_path"] = "/business-tax/paye"
+      assert_equal "business-tax/paye", @subtopic.slug
+    end
+
+    it "returns the slug for a topic under the /topic namespace" do
+      @api_data["base_path"] = "/topic/business-tax/paye"
+      assert_equal "business-tax/paye", @subtopic.slug
     end
   end
 


### PR DESCRIPTION
While topics are being migrated from the root namespace to the /topic
namespace, this needs to support both.  Once the migration is complete,
support for the root namespace can be removed.

This creates some temporary helper methods that wrap the corresponging
route helpers, selecting the appropriate one based on the request path.

This also updates the integration tests to use the namespaced paths.
The cucumber tests remain using the non-namespaced paths to give some
coverage of both variants.