### PR TITLE
Use content store for browse pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,15 +1,9 @@
 module ApplicationHelper
   def browsing_in_top_level_page?(top_level_page)
-    params[:top_level_slug].present? && params[:top_level_slug] == top_level_page.slug
+    request.path.starts_with?(top_level_page.base_path)
   end
 
   def browsing_in_second_level_page?(section)
-    params[:second_level_slug].present? && full_slug == section.slug
-  end
-
-private
-
-  def full_slug
-    [params[:top_level_slug], params[:second_level_slug]].join('/')
+    request.path.starts_with?(section.base_path)
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,0 +1,5 @@
+class ContentItem
+  def self.find!(base_path)
+    Collections.services(:content_store).content_item!(base_path)
+  end
+end

--- a/app/models/index_browse_page.rb
+++ b/app/models/index_browse_page.rb
@@ -14,8 +14,6 @@ class IndexBrowsePage
 private
 
   def content_store_item
-    @content_store_item ||= begin
-      Collections.services(:content_store).content_item!('/browse')
-    end
+    @content_store_item ||= ContentItem.find!('/browse')
   end
 end

--- a/app/models/index_browse_page.rb
+++ b/app/models/index_browse_page.rb
@@ -1,6 +1,6 @@
 class IndexBrowsePage
   def top_level_browse_pages
-    Collections.services(:content_api).root_sections.results.sort_by(&:title)
+    content_store_item.links.top_level_browse_pages
   end
 
   def slimmer_breadcrumb_options
@@ -9,5 +9,13 @@ class IndexBrowsePage
       section_name: "Browse",
       section_link: "/browse"
     }
+  end
+
+private
+
+  def content_store_item
+    @content_store_item ||= begin
+      Collections.services(:content_store).content_item!('/browse')
+    end
   end
 end

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -40,10 +40,9 @@ class SecondLevelBrowsePage
 private
 
   def content_store_item
-    @content_store_item ||= begin
-      content_path = "/browse/#{top_level_slug}/#{second_level_slug}"
-      Collections.services(:content_store).content_item!(content_path)
-    end
+    @content_store_item ||= ContentItem.find!(
+      "/browse/#{top_level_slug}/#{second_level_slug}"
+    )
   end
 
   def browse_page_content_item

--- a/app/models/second_level_browse_page.rb
+++ b/app/models/second_level_browse_page.rb
@@ -25,25 +25,27 @@ class SecondLevelBrowsePage
   end
 
   def active_top_level_browse_page
-    Collections.services(:content_api).tag(top_level_slug) || raise(GdsApi::HTTPNotFound, 404)
+    # Note that 'active_top_level_browse_page' will always have just one element.
+    content_store_item.links.active_top_level_browse_page.first
   end
 
   def second_level_browse_pages
-    Collections.services(:content_api).sub_sections(top_level_slug).results.sort_by(&:title)
+    content_store_item.links.second_level_browse_pages
   end
 
   def top_level_browse_pages
-    Collections.services(:content_api).root_sections.results.sort_by(&:title)
+    content_store_item.links.top_level_browse_pages
   end
 
 private
 
   def content_store_item
-    @content_store_item ||= Collections.services(:content_store).content_item!(
-      "/browse/#{top_level_slug}/#{second_level_slug}"
-    )
+    @content_store_item ||= begin
+      content_path = "/browse/#{top_level_slug}/#{second_level_slug}"
+      Collections.services(:content_store).content_item!(content_path)
+    end
   end
-  
+
   def browse_page_content_item
     @browse_page_content_item ||= BrowsePageContentItem.new(
       "#{top_level_slug}/#{second_level_slug}",

--- a/app/models/subtopic.rb
+++ b/app/models/subtopic.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 class Subtopic
 
   def self.find(base_path, pagination_options = {})
-    api_response = Collections.services(:content_store).content_item!(base_path)
+    api_response = ContentItem.find!(base_path)
     new(api_response.to_hash, pagination_options)
   end
 

--- a/app/models/top_level_browse_page.rb
+++ b/app/models/top_level_browse_page.rb
@@ -1,7 +1,7 @@
 class TopLevelBrowsePage
   attr_reader :slug
 
-  delegate :title, to: :item_in_content_api
+  delegate :title, to: :content_store_item
 
   def initialize(slug)
     @slug = slug
@@ -12,16 +12,18 @@ class TopLevelBrowsePage
   end
 
   def second_level_browse_pages
-    Collections.services(:content_api).sub_sections(slug).results.sort_by(&:title)
+    content_store_item.links.second_level_browse_pages
   end
 
   def top_level_browse_pages
-    Collections.services(:content_api).root_sections.results.sort_by(&:title)
+    content_store_item.links.top_level_browse_pages
   end
 
 private
 
-  def item_in_content_api
-    @source ||= Collections.services(:content_api).tag(slug) || raise(GdsApi::HTTPNotFound, 404)
+  def content_store_item
+    @content_store_item ||= begin
+      Collections.services(:content_store).content_item!("/browse/#{slug}")
+    end
   end
 end

--- a/app/models/top_level_browse_page.rb
+++ b/app/models/top_level_browse_page.rb
@@ -23,7 +23,7 @@ private
 
   def content_store_item
     @content_store_item ||= begin
-      Collections.services(:content_store).content_item!("/browse/#{slug}")
+      ContentItem.find!("/browse/#{slug}")
     end
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -50,7 +50,7 @@ private
 
   def topic_content_from_content_store
     @topic_content_from_content_store ||= begin
-      Collections.services(:content_store).content_item!("/topic/" + topic_slug)
+      ContentItem.find!("/topic/" + topic_slug)
     end
   end
 end

--- a/app/views/browse/_second_level_browse_pages.html.erb
+++ b/app/views/browse/_second_level_browse_pages.html.erb
@@ -4,9 +4,9 @@
   <ul>
     <% second_level_browse_pages.each do |browse_page| %>
       <li class='<%= browsing_in_second_level_page?(browse_page) ? 'active' : nil %>'>
-        <%= link_to browse_page.web_url do %>
+        <%= link_to browse_page.base_path do %>
           <h3><%= browse_page.title %></h3>
-          <p><%= browse_page.details.description %></p>
+          <p><%= browse_page.description %></p>
         <% end %>
       </li>
     <% end %>

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -3,7 +3,7 @@
   <ul>
     <% top_level_browse_pages.each do |page| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">
-        <%= link_to page.title, page.web_url %>
+        <%= link_to page.title, page.base_path %>
       </li>
     <% end %>
   </ul>

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -5,19 +5,6 @@ module BrowseTestHelpers
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::ContentStore
 
-  def stub_browse_sections(section: nil, sub_section: nil, artefact: nil,
-                           organisations: [])
-    sub_section_slug = [section, sub_section].join('/')
-    content_api_has_tag("section", section)
-    content_api_has_tag("section", sub_section_slug)
-    content_api_has_root_tags("section", [section])
-    content_api_has_child_tags("section", section, [sub_section_slug])
-    content_api_has_artefacts_with_a_tag("section", sub_section_slug, [artefact])
-
-    content_item = { title: 'Judges', links: {} }
-    content_store_has_item '/browse/crime-and-justice/judges', content_item
-  end
-
   def stub_detailed_guidance
     detailed_guidance = OpenStruct.new({
       title: 'Detailed guidance',

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,12 @@ if ENV["USE_SIMPLECOV"]
   SimpleCov.start 'rails'
 end
 
+# Duplicated in test_helper.rb
+ENV["GOVUK_WEBSITE_ROOT"] = "http://www.test.gov.uk"
+ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
+ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
+ENV["RAILS_ENV"] ||= "test"
+
 require 'cucumber/rails'
 require 'mocha/mini_test'
 require 'slimmer/test'

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -3,15 +3,15 @@ require "test_helper"
 describe BrowseController do
   describe "GET index" do
     it "set slimmer format of browse" do
-      content_api_has_root_sections(["crime-and-justice"])
+      IndexBrowsePage.stubs(:new).returns(stubbed_page_object)
 
       get :index
 
-      assert_equal "browse",  response.headers["X-Slimmer-Format"]
+      assert_equal "browse", response.headers["X-Slimmer-Format"]
     end
 
     it "set correct expiry headers" do
-      content_api_has_root_sections(["crime-and-justice"])
+      IndexBrowsePage.stubs(:new).returns(stubbed_page_object)
 
       get :index
 
@@ -20,13 +20,8 @@ describe BrowseController do
   end
 
   describe "GET top_level_browse_page" do
-    before do
-      content_api_has_root_sections(["crime-and-justice"])
-    end
-
     it "404 if the section does not exist" do
-      api_returns_404_for("/tags/banana.json")
-      api_returns_404_for("/tags.json?parent_id=banana&type=section")
+      TopLevelBrowsePage.stubs(:new).with("banana").raises(GdsApi::HTTPNotFound.new(404))
 
       get :top_level_browse_page, top_level_slug: "banana"
 
@@ -42,8 +37,7 @@ describe BrowseController do
     end
 
     it "set slimmer format of browse" do
-      content_api_has_section("crime-and-justice")
-      content_api_has_subsections("crime-and-justice", ["alpha"])
+      TopLevelBrowsePage.stubs(:new).returns(stubbed_page_object)
 
       get :top_level_browse_page, top_level_slug: "crime-and-justice"
 
@@ -51,8 +45,7 @@ describe BrowseController do
     end
 
     it "set correct expiry headers" do
-      content_api_has_section("crime-and-justice")
-      content_api_has_subsections("crime-and-justice", ["alpha"])
+      TopLevelBrowsePage.stubs(:new).returns(stubbed_page_object)
 
       get :top_level_browse_page, top_level_slug: "crime-and-justice"
 
@@ -62,8 +55,7 @@ describe BrowseController do
 
   describe "GET second_level_browse_page" do
     it "404 if the section does not exist" do
-      api_returns_404_for("/tags/crime-and-justice%2Ffrume.json")
-      api_returns_404_for("/tags/crime-and-justice.json")
+      SecondLevelBrowsePage.stubs(:new).with("crime-and-justice", "frume").raises(GdsApi::HTTPNotFound.new(404))
 
       get :second_level_browse_page, top_level_slug: "crime-and-justice", second_level_slug: "frume"
 
@@ -93,20 +85,20 @@ describe BrowseController do
 
       assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
     end
+  end
 
-    def stubbed_page_object
-      page = stubs('page')
-      page.stubs(
-        slimmer_breadcrumb_options: [],
-        title: 'Title',
-        curated_links?: false,
-        lists: [],
-        related_topics: [],
-        active_top_level_browse_page: OpenStruct.new(title: 'aosudgad'),
-        second_level_browse_pages: [],
-        top_level_browse_pages: []
-      )
-      page
-    end
+  def stubbed_page_object
+    page = stubs('page')
+    page.stubs(
+      slimmer_breadcrumb_options: [],
+      title: 'Title',
+      curated_links?: false,
+      lists: [],
+      related_topics: [],
+      active_top_level_browse_page: OpenStruct.new(title: 'aosudgad'),
+      second_level_browse_pages: [],
+      top_level_browse_pages: []
+    )
+    page
   end
 end

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -2,31 +2,23 @@ require 'integration_test_helper'
 
 class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
   test "that we can handle all examples" do
+    # Add all examples to the content store and content api to allow pages to
+    # request their parents and links.
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|
-      stub_other_requests(content_item)
       content_store_has_item(content_item['base_path'], content_item)
 
+      slugs = content_item['base_path'].gsub('/browse/', '')
+      stub_request(:get, "https://contentapi.test.gov.uk/with_tag.json?tag=#{slugs}").
+        to_return(body: JSON.dump(results: []))
+
+      stub_request(:get, "https://whitehall-admin.test.gov.uk/api/specialist/tags.json?parent_id=#{slugs}&type=section").
+        to_return(body: JSON.dump(results: []))
+    end
+
+    content_schema_examples_for(:mainstream_browse_page).each do |content_item|
       get content_item['base_path']
 
       assert_response 200
     end
-  end
-
-  private
-
-  def stub_other_requests(content_item)
-    _, _, section, sub_section = content_item['base_path'].split('/')
-
-    content_api_has_root_tags("section", ['foo', 'bar', section].compact)
-
-    return if content_item['base_path'] == '/browse'
-
-    sub_section_slug = [section, sub_section].join('/')
-    content_api_has_tag("section", section)
-    content_api_has_tag("section", sub_section_slug)
-    content_api_has_child_tags("section", section, [sub_section_slug])
-    content_api_has_artefacts_with_a_tag("section", sub_section_slug, [])
-
-    RelatedTopicList.any_instance.stubs(:legacy_fallback_to_whitehall).returns([])
   end
 end

--- a/test/models/browse_page_content_item_test.rb
+++ b/test/models/browse_page_content_item_test.rb
@@ -19,7 +19,7 @@ describe BrowsePageContentItem do
       }
       content_store_has_item '/browse/crime-and-justice/judges', content_item
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
-      content_store_item = Collections.services(:content_store).content_item!('/browse/crime-and-justice/judges')
+      content_store_item = ContentItem.find!('/browse/crime-and-justice/judges')
 
       lists = BrowsePageContentItem.new('crime-and-justice/judges', content_store_item).lists
 
@@ -50,7 +50,7 @@ describe BrowsePageContentItem do
     it "returns true when there are grouped links in the content store" do
       content_store_has_item '/browse/crime-and-justice/judges', { details: { groups: [ { name: "Movie Judges", contents: ['https://contentapi.test.gov.uk/judge-dredd.json'] }]} }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
-      content_store_item = Collections.services(:content_store).content_item!('/browse/crime-and-justice/judges')
+      content_store_item = ContentItem.find!('/browse/crime-and-justice/judges')
 
       sub_section = BrowsePageContentItem.new('crime-and-justice/judges', content_store_item)
 

--- a/test/models/browse_page_content_item_test.rb
+++ b/test/models/browse_page_content_item_test.rb
@@ -2,13 +2,7 @@ require "test_helper"
 
 describe BrowsePageContentItem do
   describe '#lists' do
-    before do
-      content_api_has_section "crime-and-justice"
-      content_api_has_subsections "crime-and-justice", ["judges"]
-    end
-
     it "returns an A-Z list when there is no curation" do
-      content_store_has_item '/browse/crime-and-justice/judges', { details: { } }
       content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
 
       lists = BrowsePageContentItem.new('crime-and-justice/judges', stub(:details)).lists
@@ -37,10 +31,9 @@ describe BrowsePageContentItem do
 
   describe '#curated_links?' do
     it "returns false when there is no curation" do
-      content_store_has_item '/browse/crime-and-justice/judges', { details: { } }
-      content_api_has_artefacts_with_a_tag "section", "crime-and-justice/judges", ["judge-dredd"]
+      content_item = stub(:details)
 
-      sub_section = BrowsePageContentItem.new('crime-and-justice/judges', stub(:details))
+      sub_section = BrowsePageContentItem.new('crime-and-justice/judges', content_item)
 
       refute sub_section.curated_links?
     end

--- a/test/models/index_browse_page_test.rb
+++ b/test/models/index_browse_page_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+describe IndexBrowsePage do
+  describe '#top_level_browse_pages' do
+    it 'returns the top level browse pages' do
+      content_store_has_item('/browse', { links: {
+        top_level_browse_pages: [{ title: 'Crime and justice', base_path: '/browse/crime-and-justice' }]
+        }
+      })
+
+      page = IndexBrowsePage.new
+      top_level_page = page.top_level_browse_pages.first
+
+      assert_equal 'Crime and justice', top_level_page.title
+      assert_equal '/browse/crime-and-justice', top_level_page.base_path
+    end
+  end
+end

--- a/test/models/top_level_browse_page_test.rb
+++ b/test/models/top_level_browse_page_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+describe TopLevelBrowsePage do
+  describe '#title' do
+    it 'delegates to the browse page' do
+      content_store_has_item('/browse/foo', { title: 'Foo Bar' })
+
+      page = TopLevelBrowsePage.new('foo')
+
+      assert_equal page.title, 'Foo Bar'
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ if ENV["USE_SIMPLECOV"]
   SimpleCov.start 'rails'
 end
 
+# Duplicated in features/support/env.rb
 ENV["GOVUK_WEBSITE_ROOT"] = "http://www.test.gov.uk"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
 ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"


### PR DESCRIPTION
This commit makes the first two browse pages request its data from the content-store instead of content-api.

This **cannot be merged** until we've [republished all browse pages](https://trello.com/c/v1B0aJxW/185). 

Trello: https://trello.com/c/4iq0DhfM/111

Previous PRs:
- https://github.com/alphagov/collections/pull/109
- https://github.com/alphagov/collections/pull/108

Depends on https://github.com/alphagov/collections-publisher/pull/96 being merged.