### PR TITLE
Remove /browse route registration

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -6,24 +6,6 @@ namespace :router do
     @router_api = GdsApi::Router.new(Plek.current.find('router-api'))
   end
 
-  task :register => [:register_backend, :register_browse]
-
-  task :register_backend => :router_environment do
-    @router_api.add_backend('collections', Plek.current.find('collections', :force_http => true) + "/")
-  end
-
-  task :register_browse => [:unregister_browse_redirects, :register_browse_redirects, :router_environment] do
-    routes = [
-      %w(/browse prefix),
-      %w(/browse.json exact),
-    ]
-
-    routes.each do |path, type|
-      @router_api.add_route(path, type, 'collections')
-    end
-    @router_api.commit_routes
-  end
-
   task :register_browse_redirects => :router_environment do
     routes = [
       %w(/visas-immigration /browse/visas-immigration),


### PR DESCRIPTION
This is now covered by collections-publisher.

:no_entry_sign: Note: https://github.gds/gds/alphagov-deployment/pull/962 needs to be merged before this.