### PR TITLE
Disable sessions

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Collections::Application.config.session_store :cookie_store, key: '_collections_session'
+Collections::Application.config.session_store :disabled


### PR DESCRIPTION
This app doesn't use sessions, and therefore has no need to set a
session cookie.  Disabling the session_store prevents the cookie from
being set.