### PR TITLE
Handle missing public_timestamp in rummager response.

### DIFF
--- a/app/models/subtopic/changed_documents.rb
+++ b/app/models/subtopic/changed_documents.rb
@@ -34,10 +34,11 @@ class Subtopic::ChangedDocuments
 
   def documents
     @_documents ||= search_result["results"].map do |result|
+      timestamp = result["public_timestamp"].present? ? Time.parse(result["public_timestamp"]) : nil
       Document.new(
         result["title"],
         result["link"],
-        Time.parse(result["public_timestamp"]),
+        timestamp,
         result["latest_change_note"],
       )
     end


### PR DESCRIPTION
This was causing the latest page to break for some topics.