### PR TITLE
Fix email signup with new /topic namespace

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -28,7 +28,7 @@ class EmailSignupsController < ApplicationController
 private
 
   def subtopic
-    @subtopic ||= Subtopic.find("/#{params[:topic_slug]}/#{params[:subtopic_slug]}")
+    @subtopic ||= Subtopic.find("/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}")
   end
   helper_method :subtopic
 

--- a/features/step_definitions/browsing_topics_steps.rb
+++ b/features/step_definitions/browsing_topics_steps.rb
@@ -3,7 +3,7 @@ Given /^there are documents in a subtopic$/ do
 end
 
 When /^I view the browse page for that subtopic$/ do
-  visit "/oil-and-gas/fields-and-wells"
+  visit "/topic/oil-and-gas/fields-and-wells"
 end
 
 Then /^I see a list of organisations associated with content in the subtopic$/ do

--- a/features/step_definitions/email_alert_signup_steps.rb
+++ b/features/step_definitions/email_alert_signup_steps.rb
@@ -3,7 +3,7 @@ Given(/^a topic$/) do
 end
 
 When(/^I access the email signup page via the topic$/) do
-  visit "/oil-and-gas/fields-and-wells/email-signup"
+  visit "/topic/oil-and-gas/fields-and-wells/email-signup"
 end
 
 When(/^I sign up to the email alerts$/) do
@@ -18,5 +18,9 @@ Then(/^my subscription should be registered$/) do
       "tags" => {
         "topics" => ["oil-and-gas/fields-and-wells"]
       }
-    ).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "/oil-and-gas/fields-and-wells")))
+    ).returns(OpenStruct.new("subscriber_list" =>
+      # This redirects to govdelivery in real life, but redirect to /topic/oil-and-gas/fields-and-wells
+      # here to make the tests work.
+      OpenStruct.new("subscription_url" => "/topic/oil-and-gas/fields-and-wells")
+    ))
 end

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -35,7 +35,7 @@ Given(/^there is latest content for a subtopic$/) do
 end
 
 When(/^I view the latest changes page for that subtopic$/) do
-  visit "/oil-and-gas/fields-and-wells/latest"
+  visit "/topic/oil-and-gas/fields-and-wells/latest"
 end
 
 Then(/^I see a date\-ordered list of content with change notes$/) do

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -24,8 +24,8 @@ module TopicHelper
     content_api_has_tag("specialist_sector","oil-and-gas/fields-and-wells","oil-and-gas")
     content_api_has_artefacts_with_a_tag("specialist_sector", "oil-and-gas/fields-and-wells", @content)
 
-    content_store_has_item("/oil-and-gas/fields-and-wells", {
-      base_path: "/oil-and-gas/fields-and-wells",
+    content_store_has_item("/topic/oil-and-gas/fields-and-wells", {
+      base_path: "/topic/oil-and-gas/fields-and-wells",
       title: "Fields and Wells",
       format: "topic",
       public_updated_at: 10.days.ago.iso8601,

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -4,8 +4,8 @@ describe EmailSignupsController do
   setup do
     @valid_subtopic_params = { topic_slug: 'oil-and-gas', subtopic_slug: 'wells' }
     content_store_has_item(
-      "/oil-and-gas/wells",
-      content_item_for_base_path("/oil-and-gas/wells").merge({
+      "/topic/oil-and-gas/wells",
+      content_item_for_base_path("/topic/oil-and-gas/wells").merge({
         "links" => {
           "parent" => [{
             "title" => "Oil and Gas",
@@ -16,7 +16,7 @@ describe EmailSignupsController do
     )
 
     @invalid_subtopic_params = { topic_slug: 'invalid', subtopic_slug: 'subtopic' }
-    content_store_does_not_have_item("/invalid/subtopic")
+    content_store_does_not_have_item("/topic/invalid/subtopic")
 
     @email_signup = EmailSignup.new(nil)
     @email_signup.stubs(:save)


### PR DESCRIPTION
We've moved to the /topic namespace, but didn't update the email signups controller. The tests didn't catch this because they still had the old URL specified.