### PR TITLE
Fix beta label for topic pages

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -50,7 +50,7 @@ private
 
   def topic_content_from_content_store
     @topic_content_from_content_store ||= begin
-      Collections.services(:content_store).content_item("/" + topic_slug)
+      Collections.services(:content_store).content_item!("/topic/" + topic_slug)
     end
   end
 end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -11,7 +11,7 @@ describe TopicsController do
 
       content_api_has_tag("specialist_sector", { slug: "oil-and-gas", title: "Oil and Gas", description: "Guidance for the oil and gas industry" })
       content_api_has_sorted_child_tags("specialist_sector", "oil-and-gas", "alphabetical", subtopics)
-      content_store_has_item('/oil-and-gas', content_schema_example(:topic, :topic))
+      content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
     end
 
     it "sets the correct slimmer headers" do

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -16,7 +16,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
   it "renders a topic tag page and list its subtopics" do
     set_up_valid_topic_page
-    content_store_has_item('/oil-and-gas', content_schema_example(:topic, :topic))
+    content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
 
     visit "/oil-and-gas"
     assert page.has_title?("Oil and gas - GOV.UK")
@@ -47,7 +47,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   it "renders a beta topic" do
     set_up_valid_topic_page
 
-    content_store_has_item('/oil-and-gas',
+    content_store_has_item('/topic/oil-and-gas',
       content_schema_example(:topic, :topic).merge(details: { beta: true }))
 
     visit "/oil-and-gas"


### PR DESCRIPTION
Topic pages beta label is currently broken because we're asking the content store for `/oil-and-gas` and not `/topic/oil-and-gas`.

The tests didn't reflect the new URLs and therefore didn't catch this error.