### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 18.11.0'
+  gem 'gds-api-adapters', '~> 20.1.1'
 end
 
 gem 'plek', '~> 1.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    gds-api-adapters (18.11.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -232,7 +232,7 @@ DEPENDENCIES
   byebug (~> 5.0.0)
   capybara (~> 2.4.1)
   cucumber-rails (~> 1.4.2)
-  gds-api-adapters (~> 18.11.0)
+  gds-api-adapters (~> 20.1.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (~> 4.0.1)
   jasmine-rails (~> 0.10.8)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information