### PR TITLE
Hide curated lists with no remaining items.

### DIFF
--- a/app/models/topic/groups.rb
+++ b/app/models/topic/groups.rb
@@ -41,18 +41,16 @@ class Topic::Groups
   end
 
   def build_curated_groups
-    @group_data.map do |group|
-      List.new(
-        group["name"],
-        group["contents"].each_with_object([]) do |api_url, results|
-          if item = find_content_item(api_url)
-            results << ListItem.new(
-              item["title"],
-              URI.parse(item["web_url"]).path,
-            )
-          end
-        end,
-      )
+    @group_data.each_with_object([]) do |group, results|
+      contents = group["contents"].each_with_object([]) do |api_url, results|
+        if item = find_content_item(api_url)
+          results << ListItem.new(
+            item["title"],
+            URI.parse(item["web_url"]).path,
+          )
+        end
+      end
+      results << List.new(group["name"], contents) if contents.any?
     end
   end
 

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -34,14 +34,14 @@ module TopicHelper
           {
             name: "Oil rigs",
             contents: [
-              "http://example.com/api/what-is-oil.json",
-              "http://example.com/api/apply-for-an-oil-licence.json",
+              "http://example.com/what-is-oil.json",
+              "http://example.com/apply-for-an-oil-licence.json",
             ]
           },
           {
             name: "Piping",
             contents: [
-              "http://example.com/api/well-application-form.json",
+              "http://example.com/well-application-form.json",
             ]
           },
         ],

--- a/test/models/topic/groups_test.rb
+++ b/test/models/topic/groups_test.rb
@@ -50,6 +50,24 @@ describe Topic::Groups do
       assert_equal 3, groups[0].contents.size
       refute groups[0]["contents"].map(&:base_path).include?("/pay-bear-tax")
     end
+
+    it "omits groups with no active items in them" do
+      @group_data << {
+        "name" => "Group with untagged items",
+        "contents" => [
+          contentapi_url_for_slug('pay-bear-tax'),
+        ],
+      }
+      @group_data << {
+        "name" => "Empty group",
+        "contents" => [],
+      }
+
+      assert_equal 2, @groups.count
+      group_titles = @groups.map(&:title)
+      refute group_titles.include?("Group with untagged items")
+      refute group_titles.include?("Empty group")
+    end
   end
 
   describe "for a non-curated topic" do


### PR DESCRIPTION
If a curated list has no items in it (or all its items have been
untagged from the topic), it was being displayed as a title with nothing
next to it on the frontend, which looked odd. This updates the code to
omit these empty lists.

Trello: https://trello.com/c/Pp3YmEUx/229-collections-should-hide-curated-groups-containing-no-items