### PR TITLE
Remove slug validation code.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,23 +55,9 @@ class ApplicationController < ActionController::Base
     render status: status_code, text: "#{status_code} error"
   end
 
-  def cacheable_404
-    set_expiry(10.minutes)
-    error 404
-  end
-
   def set_expiry(duration = 30.minutes)
     unless Rails.env.development?
       expires_in(duration, :public => true)
     end
-  end
-
-  def validate_slug_param(param_name = :slug)
-    param_to_use = params[param_name]
-    if param_to_use.parameterize != param_to_use
-      cacheable_404
-    end
-  rescue StandardError # Triggered by trying to parameterize malformed UTF-8
-    cacheable_404
   end
 end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,9 +1,6 @@
 class BrowseController < ApplicationController
   rescue_from GdsApi::HTTPNotFound, with: :error_404
 
-  before_filter(:only => [:top_level_browse_page, :second_level_browse_page]) { validate_slug_param(:top_level_slug) }
-  before_filter(:only => [:second_level_browse_page]) { validate_slug_param(:second_level_slug) }
-
   enable_request_formats top_level_browse_page: [:json]
   enable_request_formats second_level_browse_page: [:json]
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,4 @@
 class TopicsController < ApplicationController
-  before_filter { validate_slug_param(:topic_slug) }
-  before_filter(:except => [:topic]) { validate_slug_param(:subtopic_slug) }
   before_filter :set_slimmer_format
 
   rescue_from GdsApi::HTTPNotFound, :with => :error_404

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -28,14 +28,6 @@ describe BrowseController do
       assert_response 404
     end
 
-    it "return a cacheable 404 without calling content_api if the section slug is invalid" do
-      get :top_level_browse_page, top_level_slug: "this & that"
-
-      assert_equal "404", response.code
-      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
-      assert_not_requested(:get, %r{\A#{GdsApi::TestHelpers::ContentApi::CONTENT_API_ENDPOINT}})
-    end
-
     it "set slimmer format of browse" do
       TopLevelBrowsePage.stubs(:new).returns(stubbed_page_object)
 
@@ -60,14 +52,6 @@ describe BrowseController do
       get :second_level_browse_page, top_level_slug: "crime-and-justice", second_level_slug: "frume"
 
       assert_response 404
-    end
-
-    it "return a cacheable 404 without calling content_api if the section slug is invalid" do
-      get :second_level_browse_page, top_level_slug: "this & that", second_level_slug: "foo"
-
-      assert_equal "404", response.code
-      assert_equal "max-age=600, public",  response.headers["Cache-Control"]
-      assert_not_requested(:get, %r{\A#{GdsApi::TestHelpers::ContentApi::CONTENT_API_ENDPOINT}})
     end
 
     it "set slimmer format of browse" do

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -28,16 +28,6 @@ describe TopicsController do
 
       assert_equal 404, response.status
     end
-
-    describe "invalid slugs" do
-      it "returns a cacheable 404 without calling content-store if the sector slug is invalid" do
-        get :topic, topic_slug: "this & that"
-
-        assert_equal "404", response.code
-        assert_equal "max-age=600, public",  response.headers["Cache-Control"]
-        assert_not_requested(:get, %r{\A#{GdsApi::TestHelpers::ContentStore::CONTENT_STORE_ENDPOINT}})
-      end
-    end
   end
 
   describe "GET subtopic" do
@@ -90,16 +80,6 @@ describe TopicsController do
       get :subtopic, topic_slug: "oil-and-gas", subtopic_slug: "coal"
 
       assert_equal 404, response.status
-    end
-
-    describe "invalid slugs" do
-      it "returns a cacheable 404 without calling content-store if the subtopic slug is invalid" do
-        get :subtopic, topic_slug: "oil-and-gas", subtopic_slug: "this & that"
-
-        assert_equal "404", response.code
-        assert_equal "max-age=600, public", response.headers["Cache-Control"]
-        assert_not_requested(:get, %r{\A#{GdsApi::TestHelpers::ContentStore::CONTENT_STORE_ENDPOINT}})
-      end
     end
   end
 end


### PR DESCRIPTION
All routes to this application are now created as exact routes in the
router. This means that requests for pages with invalid or malformed
slugs will never make it to this application because the router will
return a 404 for them.