### PR TITLE
Fix analytics on browse pages.

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -349,12 +349,12 @@
         this.$breadcrumbs.find('li').slice(1).remove();
       }
     },
-    trackPageview: function(){
+    trackPageview: function(state){
       var sectionTitle = this.$section.find('h1').text();
       sectionTitle = sectionTitle ? sectionTitle.toLowerCase() : 'browse';
       if (GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.setSectionDimension) {
         GOVUK.analytics.setSectionDimension(sectionTitle);
-        GOVUK.analytics.trackPageview();
+        GOVUK.analytics.trackPageview(state.path);
       }
     }
   };


### PR DESCRIPTION
Since the switch to universal analytics, the GA events were being sent
with the wrong path (not taking the pushState stuff into account).

This fixes it by passing the path explicitly to analytics on these
events.

Trello: https://trello.com/c/7vxnLYkL/217