### PR TITLE
Fix browse pages without guidance categories.

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,5 +1,5 @@
 class BrowseController < ApplicationController
-  rescue_from GdsApi::HTTPNotFound, with: :error_404
+  rescue_from ContentItem::NotFound, with: :error_404
 
   enable_request_formats top_level_browse_page: [:json]
   enable_request_formats second_level_browse_page: [:json]

--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -1,7 +1,7 @@
 class EmailSignupsController < ApplicationController
   protect_from_forgery except: [:create]
 
-  rescue_from GdsApi::HTTPNotFound, :with => :error_404
+  rescue_from ContentItem::NotFound, :with => :error_404
 
   def new
     slimmer_artefact = {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,7 +1,7 @@
 class TopicsController < ApplicationController
   before_filter :set_slimmer_format
 
-  rescue_from GdsApi::HTTPNotFound, :with => :error_404
+  rescue_from ContentItem::NotFound, :with => :error_404
 
   def topic
     @topic = Topic.find(request.path)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,9 @@
 class ContentItem
+  class NotFound < StandardError; end
+
   def self.find!(base_path)
     Collections.services(:content_store).content_item!(base_path)
+  rescue GdsApi::HTTPNotFound
+    raise NotFound
   end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -57,6 +57,8 @@ private
         item.content_with_tag.web_url,
       )
     end.sort_by(&:title)
+  rescue GdsApi::HTTPNotFound # Whitehall returns 404, not empty array with no categories.
+    return []
   end
 
   def linked_items(field)

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -156,6 +156,13 @@ describe MainstreamBrowsePage do
 
         assert_equal ['Alpha', 'Bravo', 'Charlie'], @page.related_topics.map(&:title)
       end
+
+      it "returns empty array when whitehall has no categories" do
+        # Yes, whitehall returns a 404, not empty array when there are no categories...
+        @mock_whitehall.stubs(:sub_sections).raises(GdsApi::HTTPNotFound.new("Not Found"))
+
+        assert_equal [], @page.related_topics
+      end
     end
   end
 


### PR DESCRIPTION
The Whitehall API returns 404, not empty array when there are no
detailed guidance categories for a given parent browse section.  This
was bubbling up to the controller, and being rescued causing the whole
page to 404.

This also updates the controller handling to rescue a specific error relating
to content items not being found, which should avoid masking errors like this in future.