### PR TITLE
Display A to Z label only for alphabetically ordered pages

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -175,6 +175,9 @@ main.browse {
       @include media(desktop){
         &.with-sort {
           .pane-inner {
+            padding-left: $gutter;
+          }
+          .pane-inner.alphabetical {
             padding-left: 96px;
           }
           .sort-order {

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -45,8 +45,10 @@ private
 
   def second_level_browse_pages_partial(page)
     render_partial('_second_level_browse_pages',
-        title: page.title,
-        second_level_browse_pages: page.second_level_browse_pages)
+      title: page.title,
+      second_level_browse_pages: page.second_level_browse_pages,
+      curated_order: page.second_level_pages_curated?,
+    )
   end
 
   def set_slimmer_artefact_headers(dummy_artefact={})

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -31,6 +31,10 @@ class MainstreamBrowsePage
     linked_items("second_level_browse_pages")
   end
 
+  def second_level_pages_curated?
+    @content_item_data["details"] && @content_item_data["details"]["second_level_ordering"] == "curated"
+  end
+
   def lists
     @lists ||= ListSet.new("section", slug, groups)
   end

--- a/app/views/browse/_second_level_browse_pages.html.erb
+++ b/app/views/browse/_second_level_browse_pages.html.erb
@@ -1,6 +1,8 @@
 <div class="pane-inner">
   <h1 tabindex="-1"><%= title %></h1>
-  <p class="sort-order"><%= hairspace 'A to Z' %></p>
+  <% unless curated_order %>
+    <p class="sort-order"><%= hairspace 'A to Z' %></p>
+  <% end %>
   <ul>
     <% second_level_browse_pages.each do |browse_page| %>
       <li class='<%= browsing_in_second_level_page?(browse_page) ? 'active' : nil %>'>

--- a/app/views/browse/_second_level_browse_pages.html.erb
+++ b/app/views/browse/_second_level_browse_pages.html.erb
@@ -1,4 +1,4 @@
-<div class="pane-inner">
+<div class="<%= curated_order ? "pane-inner" : "pane-inner alphabetical" %>">
   <h1 tabindex="-1"><%= title %></h1>
   <% unless curated_order %>
     <p class="sort-order"><%= hairspace 'A to Z' %></p>

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -10,7 +10,8 @@
   <div id="section" class="pane">
     <%= render 'second_level_browse_pages',
       title: @page.active_top_level_browse_page.title,
-      second_level_browse_pages: @page.second_level_browse_pages %>
+      second_level_browse_pages: @page.second_level_browse_pages,
+      curated_order: @page.second_level_pages_curated? %>
   </div>
 
   <%= render 'top_level_browse_pages',

--- a/app/views/browse/top_level_browse_page.html.erb
+++ b/app/views/browse/top_level_browse_page.html.erb
@@ -6,7 +6,8 @@
   <div id="section" class="pane with-sort">
     <%= render 'second_level_browse_pages',
           title: @page.title,
-          second_level_browse_pages: @page.second_level_browse_pages %>
+          second_level_browse_pages: @page.second_level_browse_pages,
+          curated_order: @page.second_level_pages_curated? %>
   </div>
 
   <%= render 'top_level_browse_pages',

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,5 +1,4 @@
-Given(/^there is a browse page set up with links$/) do
-
+Given(/^there is an? (\w+) browse page set up with links$/) do |second_level_ordering|
   top_level_browse_pages = [{ title: 'Crime and justice', base_path: '/browse/crime-and-justice' }]
   second_level_browse_pages = [{ title: 'Judges', base_path: '/browse/crime-and-justice/judges' }]
 
@@ -13,7 +12,10 @@ Given(/^there is a browse page set up with links$/) do
     links: {
       top_level_browse_pages: top_level_browse_pages,
       second_level_browse_pages: second_level_browse_pages,
-    }
+    },
+    details: {
+      second_level_ordering: second_level_ordering,
+    },
   })
 
   content_store_has_item '/browse/crime-and-justice/judges', {
@@ -67,4 +69,12 @@ end
 
 Then(/^I should see the second level browse page$/) do
   assert page.has_selector?('h1', text: 'Judges')
+end
+
+Then(/^the A to Z label should be present$/) do
+  assert page.has_content?('A to Z')
+end
+
+Then(/^the A to Z label should be not present$/) do
+  assert page.has_no_content?('A to Z')
 end

--- a/features/viewing_browse.feature
+++ b/features/viewing_browse.feature
@@ -4,8 +4,8 @@ Feature: Viewing browse
   So that I can quickly the content I need
 
   @javascript
-  Scenario: Browse to a browse page page with Javascript
-    Given there is a browse page set up with links
+  Scenario: Browse to a browse page with Javascript
+    Given there is an alphabetical browse page set up with links
     And the page also has detailed guidance links
     When I visit the main browse page
     And I click on a top level browse page
@@ -15,8 +15,8 @@ Feature: Viewing browse
     Then I see the links tagged to the browse page
     And I should see the detailed guidance links
 
-  Scenario: Browse to a browse page page without Javascript
-    Given there is a browse page set up with links
+  Scenario: Browse to a browse page without Javascript
+    Given there is an alphabetical browse page set up with links
     And the page also has detailed guidance links
     When I visit the main browse page
     And I click on a top level browse page
@@ -27,9 +27,21 @@ Feature: Viewing browse
     And I should see the detailed guidance links
 
   Scenario: Browse to browse page that has no detailed guidance
-    Given there is a browse page set up with links
+    Given there is an alphabetical browse page set up with links
     And there is no detailed guidance category tagged to the page
     When I visit the main browse page
     And I click on a top level browse page
     When I click on a second level browse page
     Then I see the links tagged to the browse page
+
+  Scenario Outline: Browse to browse page and look for the A to Z label
+    Given there is a <child ordering> browse page set up with links
+    When I visit the main browse page
+    And I click on a top level browse page
+    Then the A to Z label should be <label presence>
+
+    Examples:
+      | child ordering | label presence |
+      |   alphabetical |        present |
+      |        curated |    not present |
+

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -86,6 +86,7 @@ describe BrowseController do
       active_top_level_browse_page: OpenStruct.new(title: 'aosudgad'),
       second_level_browse_pages: [],
       top_level_browse_pages: [],
+      second_level_pages_curated?: false,
     )
   end
 end

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -26,6 +26,29 @@ describe MainstreamBrowsePage do
     it "returns the browse page description" do
       assert_equal "Information about eligibility, claiming and when Child Benefit stops", @page.description
     end
+
+    describe "#second_level_pages_curated?" do
+
+      it "is true when second_level_ordering == curated" do
+        @api_data["details"]["second_level_ordering"] = "curated"
+        assert @page.second_level_pages_curated?
+      end
+
+      it "is false when second_level_ordering == alphabetical" do
+        @api_data["details"]["second_level_ordering"] = "alphabetical"
+        refute @page.second_level_pages_curated?
+      end
+
+      it "is false when second_level_ordering is unspecified" do
+        @api_data["details"] = {}
+        refute @page.second_level_pages_curated?
+      end
+
+      it "is false when details hash is missing" do
+        @api_data.delete("details")
+        refute @page.second_level_pages_curated?
+      end
+    end
   end
 
   [


### PR DESCRIPTION
Last PR needed for completing this ticket: https://trello.com/c/bcTrheDZ/244-don-t-show-a-to-z-on-mainstream-browse-columns-which-aren-t-in-alphabetical-order

Second level browse pages can now be ordered either alphabetically or customly. We should display the "A to Z" label only when pages are ordered alphabetically.

The work in this PR has been by taking advantage of `content-store` now holding the order type of second level browse page. 


Alphabetically ordered:
![screen shot 2015-07-14 at 10 42 44](https://cloud.githubusercontent.com/assets/5038475/8670554/00fc389e-2a16-11e5-873b-dc81977e0a52.png)

Non-alphabetically ordered:
![screen shot 2015-07-14 at 10 43 02](https://cloud.githubusercontent.com/assets/5038475/8670557/02714606-2a16-11e5-9012-86a45a466784.png)