### PR TITLE
Fix subsection-to-section animation for curated pages

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -137,7 +137,11 @@
       this.$subsection.hide();
       this.$section.css('margin-right', '63%');
       if(this.isDesktop()){
-        this.$section.find('.pane-inner').animate({
+        this.$section.find('.pane-inner.curated').animate({
+          paddingLeft: '30px'
+        }, this.animateSpeed);
+
+        this.$section.find('.pane-inner.alphabetical').animate({
           paddingLeft: '96px'
         }, this.animateSpeed);
 

--- a/app/views/browse/_second_level_browse_pages.html.erb
+++ b/app/views/browse/_second_level_browse_pages.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= curated_order ? "pane-inner" : "pane-inner alphabetical" %>">
+<div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
   <h1 tabindex="-1"><%= title %></h1>
   <% unless curated_order %>
     <p class="sort-order"><%= hairspace 'A to Z' %></p>


### PR DESCRIPTION
Curated pages have no A to Z heading, but the animation still expects it to have a margin.

When showing a curated list, we animate to the gutter width (30px). The solution chosen here is not very elegant. Some refactoring of the
animation code later might be a good idea, so we can remove duplication between css and JS.

Trello: https://trello.com/c/bcTrheDZ/244-don-t-show-a-to-z-on-mainstream-browse-columns-which-aren-t-in-alphabetical-order

## Before

![before](https://cloud.githubusercontent.com/assets/233676/8676914/2b5d8ef2-2a44-11e5-9ff5-d5f26997f44d.gif)

## After

![after](https://cloud.githubusercontent.com/assets/233676/8676920/3015e854-2a44-11e5-95cf-33f926db2061.gif)
