### PR TITLE
Remove calls to detailed guide API from collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ retrieved from external sources.
   provides topic and browse page content.
 - [alphagov/content-store](https://github.com/alphagov/content-store) -
   provides subtopics and their curated lists.
-- [alphagov/whitehall](https://github.com/alphagov/whitehall) -
-  provides Detailed guidance content.
 - [alphagov/rummager](https://github.com/alphagov/rummager) -
   provides Latest changes content.
 - [alphagov/email-alert-api](https://github.com/alphagov/email-alert-api) -

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -40,7 +40,7 @@ class MainstreamBrowsePage
   end
 
   def related_topics
-    @related_topics ||= build_related_topics
+    linked_items("related_topics")
   end
 
   def slug
@@ -48,22 +48,6 @@ class MainstreamBrowsePage
   end
 
 private
-
-  # FIXME: this can be replaced with a simple call to linked_items once we no
-  # longer need to support whitehall detailed guide categories
-  def build_related_topics
-    topics = linked_items("related_topics")
-    return topics if topics.any?
-
-    Collections.services(:detailed_guidance_content_api).sub_sections(slug).results.map do |item|
-      LinkedContentItem.new(
-        item.title,
-        item.content_with_tag.web_url,
-      )
-    end.sort_by(&:title)
-  rescue GdsApi::HTTPNotFound # Whitehall returns 404, not empty array with no categories.
-    return []
-  end
 
   def linked_items(field)
     if @content_item_data.has_key?("links") &&

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -27,10 +27,6 @@ Collections.services(:content_api, GdsApi::ContentApi.new(
   { web_urls_relative_to: Plek.current.website_root }
 ))
 
-Collections.services(:detailed_guidance_content_api, GdsApi::ContentApi.new(
-  "#{Plek.current.find('whitehall-admin')}/api/specialist"
-))
-
 require 'gds_api/email_alert_api'
 Collections.services(:email_alert_api, GdsApi::EmailAlertApi.new(Plek.new.find('email-alert-api')))
 

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -24,7 +24,8 @@ Given(/^there is an? (\w+) browse page set up with links$/) do |second_level_ord
     links: {
       top_level_browse_pages: top_level_browse_pages,
       second_level_browse_pages: second_level_browse_pages,
-      active_top_level_browse_page: [{ title: 'Crime and justice', base_path: '/browse/crime-and-justice' }]
+      active_top_level_browse_page: [{ title: 'Crime and justice', base_path: '/browse/crime-and-justice' }],
+      related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
     }
   }
 
@@ -35,20 +36,8 @@ Given(/^there is an? (\w+) browse page set up with links$/) do |second_level_ord
     to_return(:status => 200, :body => JSON.dump(results: [{title: 'Judge dredd', web_url: 'http://gov.uk/judge'}]))
 end
 
-Given(/^the page also has detailed guidance links$/) do
-  stub_detailed_guidance
-end
-
-Given(/^there is no detailed guidance category tagged to the page$/) do
-  stub_request(:get, "#{Plek.current.find('whitehall-admin')}/api/specialist/tags.json?parent_id=crime-and-justice/judges&type=section").to_raise(GdsApi::HTTPNotFound)
-end
-
 Then(/^I see the links tagged to the browse page/) do
   assert_can_see_linked_item('Judge dredd')
-end
-
-Then(/^I should see the detailed guidance links$/) do
-  assert_can_see_linked_item('Detailed guidance')
 end
 
 When(/^I visit the main browse page$/) do
@@ -77,4 +66,12 @@ end
 
 Then(/^the A to Z label should be not present$/) do
   assert page.has_no_content?('A to Z')
+end
+
+When(/^I visit that browse page$/) do
+  visit '/browse/crime-and-justice/judges'
+end
+
+Then(/^I should see the topics linked under Detailed guidance$/) do
+  assert page.has_content?('A linked topic')
 end

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -5,17 +5,6 @@ module BrowseTestHelpers
   include GdsApi::TestHelpers::ContentApi
   include GdsApi::TestHelpers::ContentStore
 
-  def stub_detailed_guidance
-    detailed_guidance = OpenStruct.new({
-      title: 'Detailed guidance',
-      content_with_tag: OpenStruct.new(web_url: 'http://example.com/browse/detailed-guidance')
-    })
-    mock_api = stub('guidance_api')
-    Collections.services(:detailed_guidance_content_api, mock_api)
-    results = stub("results", results: [detailed_guidance])
-    mock_api.stubs(:sub_sections).returns(results)
-  end
-
   def assert_can_see_linked_item(name)
     assert page.has_selector?('a', text: name)
   end

--- a/features/viewing_browse.feature
+++ b/features/viewing_browse.feature
@@ -6,32 +6,20 @@ Feature: Viewing browse
   @javascript
   Scenario: Browse to a browse page with Javascript
     Given there is an alphabetical browse page set up with links
-    And the page also has detailed guidance links
     When I visit the main browse page
     And I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
     Then I should see the second level browse page
     Then I see the links tagged to the browse page
-    And I should see the detailed guidance links
 
   Scenario: Browse to a browse page without Javascript
     Given there is an alphabetical browse page set up with links
-    And the page also has detailed guidance links
     When I visit the main browse page
     And I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
     Then I should see the second level browse page
-    Then I see the links tagged to the browse page
-    And I should see the detailed guidance links
-
-  Scenario: Browse to browse page that has no detailed guidance
-    Given there is an alphabetical browse page set up with links
-    And there is no detailed guidance category tagged to the page
-    When I visit the main browse page
-    And I click on a top level browse page
-    When I click on a second level browse page
     Then I see the links tagged to the browse page
 
   Scenario Outline: Browse to browse page and look for the A to Z label
@@ -45,3 +33,7 @@ Feature: Viewing browse
       |   alphabetical |        present |
       |        curated |    not present |
 
+  Scenario: Browse to browse page that has "Detailed guidance"
+    Given there is an alphabetical browse page set up with links
+    When I visit that browse page
+    Then I should see the topics linked under Detailed guidance

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -10,9 +10,6 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
       slugs = content_item['base_path'].gsub('/browse/', '')
       stub_request(:get, "https://contentapi.test.gov.uk/with_tag.json?section=#{slugs}").
         to_return(body: JSON.dump(results: []))
-
-      stub_request(:get, "https://whitehall-admin.test.gov.uk/api/specialist/tags.json?parent_id=#{slugs}&type=section").
-        to_return(body: JSON.dump(results: []))
     end
 
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -131,61 +131,13 @@ describe MainstreamBrowsePage do
       assert_equal 'All about foo', @page.related_topics[0].description
     end
 
-    # FIXME: replace the describe below with these 2 tests when we no longer
-    # need to support detailed guide categories from whitehall
-    #it "returns empty array with no items" do
-      #assert_equal [], @page.related_topics
-    #end
+    it "returns empty array with no items" do
+      assert_equal [], @page.related_topics
+    end
 
-    #it "returns empty array when the links field is missing" do
-      #@api_data.delete("links")
-      #assert_equal [], @page.related_topics
-    #end
-
-    describe "when there are no related_topics" do
-      before do
-        @original_whitehall = Collections.services(:detailed_guidance_content_api)
-        @mock_whitehall = stub("whitehall")
-        Collections.services(:detailed_guidance_content_api, @mock_whitehall)
-      end
-      after do
-        Collections.services(:detailed_guidance_content_api, @original_whitehall)
-      end
-
-      it "returns guidance categories from whitehall" do
-        @mock_whitehall.stubs(:sub_sections).returns(stubbed_whitehall_response(
-          [{
-            "title" => "From Whitehall",
-            "content_with_tag" => {
-              "web_url" => "/foo/bar/baz",
-            },
-          }]
-        ))
-
-        topics = @page.related_topics
-        assert_equal 1, topics.size
-        assert_equal "From Whitehall", topics.first.title
-        assert_equal "/foo/bar/baz", topics.first.base_path
-      end
-
-      it "sorts the whitehall categories by title" do
-        @mock_whitehall.stubs(:sub_sections).returns(stubbed_whitehall_response(
-          [
-            {"title" => "Bravo", "content_with_tag" => {"web_url" => "/foo"}},
-            {"title" => "Alpha", "content_with_tag" => {"web_url" => "/foo"}},
-            {"title" => "Charlie", "content_with_tag" => {"web_url" => "/foo"}},
-          ]
-        ))
-
-        assert_equal ['Alpha', 'Bravo', 'Charlie'], @page.related_topics.map(&:title)
-      end
-
-      it "returns empty array when whitehall has no categories" do
-        # Yes, whitehall returns a 404, not empty array when there are no categories...
-        @mock_whitehall.stubs(:sub_sections).raises(GdsApi::HTTPNotFound.new("Not Found"))
-
-        assert_equal [], @page.related_topics
-      end
+    it "returns empty array when the links field is missing" do
+      @api_data.delete("links")
+      assert_equal [], @page.related_topics
     end
   end
 
@@ -221,9 +173,5 @@ describe MainstreamBrowsePage do
 
       assert_equal :a_lists_instance, @page.lists
     end
-  end
-
-  def stubbed_whitehall_response(results)
-    build_ostruct_recursively(results: results)
   end
 end


### PR DESCRIPTION
Now that no mainstream browse pages are linking to detailed guide categories, we do not need to call the whitehall API to find out about these links.

:fire:

Trello: https://trello.com/c/9wIGlKYV/251-remove-calls-to-detailed-guide-api-from-collections