### PR TITLE
Add `/topic` page

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,6 +3,10 @@ class TopicsController < ApplicationController
 
   rescue_from ContentItem::NotFound, :with => :error_404
 
+  def index
+    @topic = Topic.find(request.path)
+  end
+
   def topic
     @topic = Topic.find(request.path)
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -63,10 +63,4 @@ class Topic
   def slug
     base_path.sub(%r{\A/topic/}, '')
   end
-
-private
-
-  def self.filtered_api_options(options)
-    options.slice(:start, :count).reject {|_,v| v.blank? }
-  end
 end

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -13,16 +13,14 @@
 </header>
 
 <% if @topic.beta? %>
-  <%= render 'topic_beta', topic: @topic %>
+  <%= render 'govuk_component/beta_label',
+    message: %{
+      This page is in beta. It doesn’t cover the full range of content available on GOV.UK -
+      more will be added over the next few months. You can also
+      #{link_to("search GOV.UK", "/search")} to find the information you need.} %>
 <% end %>
 
 <div class="browse-container full-width topics-page">
-  <% if @topic.description.present? %>
-    <div class="category-description">
-      <p><%= @topic.description %></p>
-    </div>
-  <% end %>
-
   <nav class="topics">
     <ul>
       <% @topic.children.each do |subtopic|%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Collections::Application.routes.draw do
   get "/browse/:top_level_slug", to: "browse#top_level_browse_page"
   get "/browse/:top_level_slug/:second_level_slug", to: "browse#second_level_browse_page"
 
+  get "/topic", to: "topics#index", as: :topics
   get "/topic/:topic_slug/:subtopic_slug/latest", to: "topics#latest_changes", as: :latest_changes
   get "/topic/:topic_slug/:subtopic_slug", to: "topics#subtopic", as: :subtopic
   get "/topic/:topic_slug", to: "topics#topic", as: :topic

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -15,6 +15,28 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     base.merge(params)
   end
 
+  it "is possible to visit the topic index page" do
+    content_store_has_item("/topic", {
+      base_path: "/topic",
+      title: "Topics",
+      format: "topic",
+      public_updated_at: 10.days.ago.iso8601,
+      details: {},
+      links: {
+        children: [
+          {
+            title: "Oil and Gas",
+            base_path: "/topic/oil-and-gas",
+          },
+        ],
+      }
+    })
+
+    visit "/topic"
+
+    assert page.has_content?("Oil and Gas")
+  end
+
   it "renders a topic tag page and list its subtopics" do
     content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge({
       :links => {


### PR DESCRIPTION
Since we have introduced the `/topic` namespace for topics, an index page has been sorely missing. This page shows all topics in a list, comparable to the topic view.

## Before

![screen shot 2015-07-17 at 14 26 43](https://cloud.githubusercontent.com/assets/233676/8748074/e051616a-2c8f-11e5-98b9-144bc32b0acb.png)

## After

![screen shot 2015-07-17 at 16 32 28](https://cloud.githubusercontent.com/assets/233676/8750799/6ec1e990-2ca1-11e5-98e9-b81a6e674ea1.png)

Trello: https://trello.com/c/L84pTDgJ/233-create-page-at-topic

:no_entry_sign: Don't merge. https://github.com/alphagov/collections-publisher/pull/124 has to be merged, deployed and republished first.