### PR TITLE
Adjust line spacing for curated lists

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -2,11 +2,11 @@ main.browse {
   .browse-panes {
     @extend %contain-floats;
     @include inner-block;
-    padding-bottom: 30px;
+    padding-bottom: $gutter;
     position: relative;
 
     @include media(tablet){
-      padding-top: 30px;
+      padding-top: $gutter;
     }
 
     &.section {
@@ -86,7 +86,7 @@ main.browse {
 
       @include media(tablet){
         margin-top: 0;
-        margin-bottom: 15px;
+        margin-bottom: $gutter-half;
       }
     }
 
@@ -97,7 +97,7 @@ main.browse {
 
       h1, h2 {
         @include media(tablet){
-          padding-left: 15px;
+          padding-left: $gutter-half;
         }
       }
       .sort-order {
@@ -117,7 +117,7 @@ main.browse {
           padding: 12px 25px 8px 0;
 
           @include media(tablet){
-            padding: 12px 30px 8px 15px;
+            padding: 12px $gutter 8px $gutter-half;
             @include core-16;
           }
 
@@ -130,7 +130,7 @@ main.browse {
             position: absolute;
             top: 50%;
             margin-top: -8px;
-            right: 10px;
+            right: $gutter-one-third;
             float: right;
             content:"\203A";
           }
@@ -186,7 +186,7 @@ main.browse {
             display: block;
             width: 75px;
             margin-left: -90px;
-            padding: 11px 0 15px 15px;
+            padding: 11px 0 $gutter-half $gutter-half;
           }
         }
       }
@@ -198,7 +198,7 @@ main.browse {
         }
 
         .pane-inner.curated-list {
-          padding-left: 30px;
+          padding-left: $gutter;
         }
       }
       h1 {
@@ -207,7 +207,7 @@ main.browse {
 
       .list-header {
         @include bold-19;
-        margin: 30px 0 0 0;
+        margin: $gutter 0 0 0;
       }
       .sort-order {
         display: none;
@@ -217,7 +217,7 @@ main.browse {
           float: left;
           width: 75px;
           margin-left: -100px;
-          padding: 11px 0 15px 15px;
+          padding: 11px 0 $gutter-half $gutter-half;
         }
       }
       ul {
@@ -232,7 +232,7 @@ main.browse {
             @include bold-19;
             display: block;
             text-decoration: none;
-            padding: 10px 30px 10px 0;
+            padding: $gutter-one-third $gutter $gutter-one-third 0;
           }
         }
       }

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -193,14 +193,17 @@ main.browse {
     }
     #subsection {
       @include media(tablet) {
-        .pane-inner.a-to-z {
-          padding-left: 100px;
-        }
+        .pane-inner {
+          &.a-to-z {
+            padding-left: 100px;
+          }
 
-        .pane-inner.curated-list {
-          padding-left: $gutter;
+          &.curated-list {
+            padding-left: $gutter;
+          }
         }
       }
+
       h1 {
         padding-left: 0;
       }

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -1,3 +1,5 @@
+$gutter-one-sixth: $gutter/6;
+
 main.browse {
   .browse-panes {
     @extend %contain-floats;
@@ -212,6 +214,13 @@ main.browse {
         @include bold-19;
         margin: $gutter 0 0 0;
       }
+
+      .curated-list {
+        .list-header {
+          margin: $gutter 0 $gutter-one-sixth 0;
+        }
+      }
+
       .sort-order {
         display: none;
         @include media(tablet){
@@ -223,6 +232,7 @@ main.browse {
           padding: 11px 0 $gutter-half $gutter-half;
         }
       }
+
       ul {
         padding: 0;
         list-style: none;
@@ -239,6 +249,17 @@ main.browse {
           }
         }
       }
+
+      .curated-list {
+        ul {
+          li {
+            a {
+              padding: $gutter-one-sixth $gutter $gutter-one-sixth 0;
+            }
+          }
+        }
+      }
+
       .detailed-guidance {
         margin-top: $gutter;
       }


### PR DESCRIPTION
The spacing between the subheadings and list items on curated browse topics wasn’t looking quite right.

This tightens the spacing between list items and balances the spacing with the list headers.

## Before

<img width="800" alt="browse-before" src="https://cloud.githubusercontent.com/assets/523014/8823625/5471e770-3066-11e5-9a9c-d9941bb974c6.png">

## After

<img width="800" alt="browse-after" src="https://cloud.githubusercontent.com/assets/523014/8823629/58bd7a1a-3066-11e5-8e58-d8308a826222.png">
