### PR TITLE
Handle base_path's in curated list data.

### DIFF
--- a/app/models/list_set/from_content_api.rb
+++ b/app/models/list_set/from_content_api.rb
@@ -36,8 +36,8 @@ class ListSet::FromContentAPI
 
   def build_curated_lists
     @group_data.map do |group|
-      contents = group["contents"].map do |api_url|
-        find_content_item(api_url)
+      contents = group["contents"].map do |api_url_or_base_path|
+        find_content_item(api_url_or_base_path)
       end.compact.map do |item|
         ListItem.new(
           item["title"],
@@ -63,10 +63,10 @@ class ListSet::FromContentAPI
     ]
   end
 
-  def find_content_item(api_url)
-    api_path = URI.parse(api_url).path
+  def find_content_item(api_url_or_base_path)
+    base_path = URI.parse(api_url_or_base_path).path.chomp(".json")
     content_tagged_to_topic.find do |content|
-      URI.parse(content["id"]).path == api_path
+      URI.parse(content["web_url"]).path == base_path
     end
   end
 

--- a/app/models/list_set/from_rummager.rb
+++ b/app/models/list_set/from_rummager.rb
@@ -33,9 +33,10 @@ class ListSet::FromRummager
 
   def curated_list
     @groups.map do |group|
-      contents = group["contents"].map do |api_url|
+      contents = group["contents"].map do |api_url_or_base_path|
+        base_path = URI.parse(api_url_or_base_path).path.chomp('.json')
         content_tagged_to_topic.find do |content|
-          content.base_path + ".json" == URI.parse(api_url).path
+          content.base_path == base_path
         end
       end.compact
 

--- a/test/models/list_set/from_content_api_test.rb
+++ b/test/models/list_set/from_content_api_test.rb
@@ -67,6 +67,31 @@ describe ListSet::FromContentAPI do
       refute list_titles.include?("Group with untagged items")
       refute list_titles.include?("Empty group")
     end
+
+    describe "handling base_paths in content-store curated lists data" do
+      setup do
+        @group_data[0]["contents"] = [
+           '/pay-paye-tax',
+           '/pay-psa',
+           '/pay-paye-penalty',
+        ]
+        @group_data[1]["contents"] = [
+           '/payroll-annual-reporting',
+           '/get-paye-forms-p45-p60',
+           '/employee-tax-codes',
+        ]
+      end
+
+      it "matches up the content items correctly" do
+        groups = @list_set.to_a
+
+        assert_equal 2, groups.size
+        assert_equal 3, groups[0].contents.size
+        assert_equal 3, groups[1].contents.size
+        assert_equal "Employee tax codes", groups[1].contents.to_a[2].title
+        assert_equal "/pay-psa", groups[0].contents.to_a[1].base_path
+      end
+    end
   end
 
   describe "for a non-curated topic" do

--- a/test/models/list_set/from_rummager_test.rb
+++ b/test/models/list_set/from_rummager_test.rb
@@ -76,6 +76,31 @@ describe ListSet::FromRummager do
       refute list_titles.include?("Group with untagged items")
       refute list_titles.include?("Empty group")
     end
+
+    describe "handling base_paths in content-store curated lists data" do
+      setup do
+        @group_data[0]["contents"] = [
+           '/pay-paye-tax',
+           '/pay-psa',
+           '/pay-paye-penalty',
+        ]
+        @group_data[1]["contents"] = [
+           '/payroll-annual-reporting',
+           '/get-paye-forms-p45-p60',
+           '/employee-tax-codes',
+        ]
+      end
+
+      it "matches up the content items correctly" do
+        groups = @list_set.to_a
+
+        assert_equal 2, groups.size
+        assert_equal 3, groups[0].contents.size
+        assert_equal 3, groups[1].contents.size
+        assert_equal "Employee tax codes", groups[1].contents.to_a[2].title
+        assert_equal "/pay-psa", groups[0].contents.to_a[1].base_path
+      end
+    end
   end
 
   describe "for a non-curated topic" do


### PR DESCRIPTION
Currently the curated list data contains an array of contentapi API urls
that are used to match up agains the data returned from contentapi. We
want to start pulling this data from Rummager, and it will be easier to
do so if this data is sent as an array of base_path's. This therefore
updates collections to handle this data sent in either format so that we
can make the switch on the publisher end.