### PR TITLE
Remove descriptions from topics

### DIFF
--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -135,21 +135,6 @@
     @include ie-lte(8) {
       padding: 0 3.5% 30px;
     }
-
-    .category-description {
-      margin-bottom: 45px;
-      width: 65.5%;
-
-      @include media(mobile) {
-        margin-bottom: 15px;
-        width: auto;
-      }
-
-      p {
-        @include core-24;
-        margin: 0;
-      }
-    }
   }
 
   nav {

--- a/app/views/topics/_subtopic.html.erb
+++ b/app/views/topics/_subtopic.html.erb
@@ -42,11 +42,5 @@
 <% end %>
 
 <div class="browse-container full-width">
-  <% if subtopic.description.present? %>
-    <div class="category-description">
-      <p><%= subtopic.description %></p>
-    </div>
-  <% end %>
-
   <%= yield %>
 </div>

--- a/app/views/topics/topic.html.erb
+++ b/app/views/topics/topic.html.erb
@@ -17,12 +17,6 @@
 <% end %>
 
 <div class="browse-container full-width topics-page">
-  <% if @topic.description.present? %>
-    <div class="category-description">
-      <p><%= @topic.description %></p>
-    </div>
-  <% end %>
-
   <nav class="topics">
     <ul>
       <% @topic.children.each do |subtopic|%>

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -64,10 +64,6 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Oil and gas")
     end
 
-    within ".category-description" do
-      assert page.has_content?("Guidance for the oil and gas industry")
-    end
-
     within ".topics ul" do
       within "li:nth-child(1)" do
         assert page.has_link?("Wells")


### PR DESCRIPTION
Topics can currently display a description. They haven't until now, because the topics didn't have descriptions set before.

We're going to be setting the descriptions soon, and don't actually want it to show up on the pages, as discussed with @alextea.

## Before
![screen shot 2015-07-23 at 12 04 07](https://cloud.githubusercontent.com/assets/233676/8848970/cb41684e-3133-11e5-8721-93136809cd3f.png)

## After
![screen shot 2015-07-23 at 12 04 19](https://cloud.githubusercontent.com/assets/233676/8848973/cf56e7ce-3133-11e5-9dee-54ae3f5cca21.png)

