### PR TITLE
Handle specific content-store error from api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 20.1.2'
+  gem 'gds-api-adapters', '~> 22.0.0'
 end
 
 gem 'plek', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
-    gds-api-adapters (20.1.2)
+    gds-api-adapters (22.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -242,7 +242,7 @@ DEPENDENCIES
   byebug (~> 5.0.0)
   capybara (~> 2.4.1)
   cucumber-rails (~> 1.4.2)
-  gds-api-adapters (~> 20.1.2)
+  gds-api-adapters (~> 22.0.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (~> 4.0.1)
   jasmine-rails (~> 0.10.8)

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,5 +1,5 @@
 class BrowseController < ApplicationController
-  rescue_from ContentItem::NotFound, with: :error_404
+  rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
 
   enable_request_formats top_level_browse_page: [:json]
   enable_request_formats second_level_browse_page: [:json]

--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -1,7 +1,7 @@
 class EmailSignupsController < ApplicationController
   protect_from_forgery except: [:create]
 
-  rescue_from ContentItem::NotFound, :with => :error_404
+  rescue_from GdsApi::ContentStore::ItemNotFound, :with => :error_404
 
   def new
     slimmer_artefact = {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,7 +1,7 @@
 class TopicsController < ApplicationController
   before_filter :set_slimmer_format
 
-  rescue_from ContentItem::NotFound, :with => :error_404
+  rescue_from GdsApi::ContentStore::ItemNotFound, :with => :error_404
 
   def index
     @topic = Topic.find(request.path)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,9 +1,5 @@
 class ContentItem
-  class NotFound < StandardError; end
-
   def self.find!(base_path)
     Collections.services(:content_store).content_item!(base_path)
-  rescue GdsApi::HTTPNotFound
-    raise NotFound
   end
 end


### PR DESCRIPTION
gds-api-adapters now raises a specific exception that we can handle, so
there's no need to have our own specific handling in this app.

Note: This will fail until alphagov/gds-api-adapters#334 is released, and the version bumped here.