### PR TITLE
Update exclude filters to rummager-formats

### DIFF
--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -4,11 +4,8 @@ class ListSet
 
   FORMATS_TO_EXCLUDE = %w(
     fatality_notice
-    government_response
-    news_story
-    press_release
+    news_article
     speech
-    statement
     world_location_news_article
   ).to_set
 


### PR DESCRIPTION
The `FORMATS_TO_EXCLUDE` currently has the format names used by panopticon in them. Rummager uses the actual format names used in whitehall, so we should use those to accurately filter the lists of links:

- `government_response`, `news_story`, `press_release` all have the format `news_article` (via `NewsArticleTypes`) in Whitehall
- `statement` is probably a kind of `speech`.

To verify that all these exist and that we have exclude the correct formats, we've made a list of all formats in rummager's database:

https://gist.github.com/tijmenb/4b5ffc79d37bd74d0afd