### PR TITLE
Correctly case title of "latest documents" page

### DIFF
--- a/app/views/topics/latest_changes.html.erb
+++ b/app/views/topics/latest_changes.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "#{@subtopic.title}: Latest documents - GOV.UK" %>
+<% content_for :title, "#{@subtopic.title}: latest documents - GOV.UK" %>
 <% content_for :page_title do %>
-  <span><%= @subtopic.title %></span> Latest documents
+  <span><%= @subtopic.title %></span> latest documents
 <% end %>
 
 <%= render layout: "subtopic", locals: {subtopic: @subtopic, organisations: organisations, link_to_latest_feed: false, beta_label: true} do %>

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -144,7 +144,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       # Then I should see the subtopic metadata
       within '.page-header' do
         within 'h1' do
-          assert page.has_content?("Offshore Latest documents")
+          assert page.has_content?("Offshore latest documents")
         end
 
         within '.metadata' do


### PR DESCRIPTION
The casing is a little off on the latest-documents page currently.

For example "VAT Latest documents" should be "VAT latest documents".

### Before
![screen shot 2015-08-26 at 16 23 06](https://cloud.githubusercontent.com/assets/233676/9497824/c6a8e73a-4c0e-11e5-8db0-6038efcbdcbf.png)

### After
![screen shot 2015-08-26 at 16 21 25](https://cloud.githubusercontent.com/assets/233676/9497823/c6a6705e-4c0e-11e5-93be-f53dce449a56.png)

