### PR TITLE
Use consistent page titles for latest changes

### DIFF
--- a/app/views/topics/latest_changes.html.erb
+++ b/app/views/topics/latest_changes.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{@subtopic.title}: latest documents - GOV.UK" %>
 <% content_for :page_title do %>
-  <span><%= @subtopic.title %></span> latest documents
+  <span><%= @subtopic.title %></span>: latest documents
 <% end %>
 
 <%= render layout: "subtopic", locals: {subtopic: @subtopic, organisations: organisations, link_to_latest_feed: false, beta_label: true} do %>

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -144,7 +144,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       # Then I should see the subtopic metadata
       within '.page-header' do
         within 'h1' do
-          assert page.has_content?("Offshore latest documents")
+          assert page.has_content?("Offshore: latest documents")
         end
 
         within '.metadata' do


### PR DESCRIPTION
The browser title has a colon between the subtopic title and "latest documents". We'll be consistent in the page title.

## Before

![screen shot 2015-08-28 at 15 54 30](https://cloud.githubusercontent.com/assets/233676/9549287/148639b4-4d9d-11e5-83e6-08b2c871cb23.png)

## After

![screen shot 2015-08-28 at 15 54 18](https://cloud.githubusercontent.com/assets/233676/9549286/14828d1e-4d9d-11e5-9010-307d90dadc0b.png)
