### PR TITLE
Upgrade Slimmer, explicitly set layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '~> 8.2.1'
+  gem 'slimmer', '9.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -253,7 +253,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
-  slimmer (~> 8.2.1)
+  slimmer (= 9.0.0)
   uglifier (~> 2.7.1)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,13 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Headers
+  include Slimmer::Template
   include Slimmer::SharedTemplates
+
+  slimmer_template 'header_footer_only'
 
   protect_from_forgery with: :exception
 
   before_filter :set_expiry
-  before_filter :set_slimmer_template
   before_filter :restrict_request_formats
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
@@ -41,10 +43,6 @@ class ApplicationController < ActionController::Base
   def can_handle_format?(format)
     return true if format == Mime::HTML || format == Mime::ALL
     format && self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
-  end
-
-  def set_slimmer_template
-    set_slimmer_headers(template: 'header_footer_only')
   end
 
   def error_404; error 404; end


### PR DESCRIPTION
This is a no-op change to app behaviour. The same Slimmer layout is used as be
before, but set in a simple, standardised way with `slimmer_template`, which is
easier to grep for than the other methods.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use `core_layout`:
 - breadcrumbs
 - using the modern grid helpers
 - using page title component

[1] https://github.com/alphagov/slimmer/pull/136