### PR TITLE
Add content ID to payload sent to email-alert-api on email signup

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -31,6 +31,9 @@ private
       title: subtopic.combined_title,
       tags: {
         topics: [subtopic.slug]
+      },
+      links: {
+        topics: [subtopic.content_id]
       }
     }.deep_stringify_keys
   end

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -4,10 +4,14 @@ require 'ostruct'
 describe EmailSignup do
   setup do
     @subtopic = mock
-    @subtopic.stubs(slug: "oil-and-gas/wells")
+    @subtopic.stubs(slug: "oil-and-gas/wells", content_id: "uuid-888")
     @subtopic.stubs(combined_title: "Oil and gas: Wells")
 
-    Services.email_alert_api.stubs(:find_or_create_subscriber_list).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "http://govdelivery_signup_url")))
+    Services.email_alert_api.stubs(:find_or_create_subscriber_list).returns(
+      OpenStruct.new(
+        subscriber_list: OpenStruct.new(subscription_url: "http://govdelivery_signup_url")
+      )
+    )
   end
 
   it "is invalid with no subtopic" do
@@ -22,8 +26,13 @@ describe EmailSignup do
         "title" => "Oil and gas: Wells",
         "tags" => {
           "topics" => ["oil-and-gas/wells"]
-        }
-      ).returns(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => "http://govdelivery_signup_url")))
+        },
+        "links" => {
+          "topics" => ["uuid-888"]
+        },
+      ).returns(OpenStruct.new(
+        subscriber_list: OpenStruct.new(subscription_url: "http://govdelivery_signup_url"))
+      )
 
       assert email_signup.save
     end


### PR DESCRIPTION
The email-alert-api has been updated to support both slugs and content
IDs. This change moves us closer to handling email subscriptions and
notifications solely via the content ID.

Trello: https://trello.com/c/ZD65QUBN/326-email-alerts-based-on-links-hash