### PR TITLE
Exclude travel advice from /browse and /topics

### DIFF
--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -7,6 +7,7 @@ class ListSet
     news_article
     speech
     world_location_news_article
+    travel-advice
   ).to_set
 
   def initialize(tag_type, tag_slug, group_data = nil)


### PR DESCRIPTION
Foreign travel advice is showing up in the /browse pages and they are making it harder to see what other content is present.

https://trello.com/c/COmww1sJ/392-do-not-show-travel-advice-on-browse-pages