### PR TITLE
Modify how formats are excluded from 'A to Z' lists

### DIFF
--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -2,12 +2,19 @@ class ListSet
   include Enumerable
   delegate :each, to: :lists
 
-  FORMATS_TO_EXCLUDE = %w(
+  BROWSE_FORMATS_TO_EXCLUDE = %w(
     fatality_notice
     news_article
     speech
     world_location_news_article
     travel-advice
+  ).to_set
+
+  TOPIC_FORMATS_TO_EXCLUDE = %w(
+    fatality_notice
+    news_article
+    speech
+    world_location_news_article
   ).to_set
 
   def initialize(tag_type, tag_slug, group_data = nil)
@@ -34,7 +41,7 @@ class ListSet
     [ListSet::List.new(
       "A to Z",
       content_tagged_to_tag.reject do |content|
-        ListSet::FORMATS_TO_EXCLUDE.include? content.format
+        excluded_formats.include? content.format
       end.sort_by(&:title)
     )]
   end
@@ -65,6 +72,14 @@ class ListSet
       :filter_mainstream_browse_pages
     else
       :filter_specialist_sectors
+    end
+  end
+
+  def excluded_formats
+    if @tag_type == 'section'
+      BROWSE_FORMATS_TO_EXCLUDE
+    else
+      TOPIC_FORMATS_TO_EXCLUDE
     end
   end
 end

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -175,4 +175,34 @@ describe ListSet do
       assert_nil documents.first.public_updated_at
     end
   end
+
+  describe "filtering uncurated lists" do
+    before do
+      @list_set = ListSet.new("section", "browse/abroad/living-abroad")
+    end
+
+    it "shouldn't display a document if its format is excluded" do
+      rummager_has_documents_for_browse_page(
+        'browse/abroad/living-abroad',
+        ['baz'],
+        ListSet::BROWSE_FORMATS_TO_EXCLUDE.to_a.last,
+        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+      )
+
+      assert_equal 0, @list_set.first.contents.length
+    end
+
+    it "should display a document if its format isn't excluded" do
+      rummager_has_documents_for_browse_page(
+        'browse/abroad/living-abroad',
+        ['baz'],
+        'some-format-not-excluded',
+        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+      )
+
+      results = @list_set.first.contents
+      assert_equal 1, results.length
+      assert_equal 'Baz', results.first.title
+    end
+  end
 end


### PR DESCRIPTION
/browse and /topic pages may exclude different formats, so they require to be dealt with separately.

Ticket: https://trello.com/c/COmww1sJ/392-do-not-show-travel-advice-on-browse-pages