### PR TITLE
Sort related topics alphabetically

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -40,7 +40,7 @@ class MainstreamBrowsePage
   end
 
   def related_topics
-    linked_items("related_topics")
+    linked_items("related_topics").sort_by(&:title)
   end
 
   def slug

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -126,9 +126,22 @@ describe MainstreamBrowsePage do
         },
       ]
 
-      assert_equal 'Foo', @page.related_topics[0].title
-      assert_equal '/browse/bar', @page.related_topics[1].base_path
-      assert_equal 'All about foo', @page.related_topics[0].description
+      assert_equal 'Foo', @page.related_topics[1].title
+      assert_equal '/browse/bar', @page.related_topics[0].base_path
+      assert_equal 'All about foo', @page.related_topics[1].description
+    end
+
+    it "returns related topics alphabetised" do
+      @api_data["links"]["related_topics"] = [
+        {
+          "title"=>"Foo",
+        },
+        {
+          "title"=>"Bar",
+        },
+      ]
+
+      assert_equal ['Bar', 'Foo'], @page.related_topics.map(&:title)
     end
 
     it "returns empty array with no items" do


### PR DESCRIPTION
The ordering of items in the `links` hash is undefined (https://github.com/alphagov/content-store/blob/master/doc/content_item_fields.md#links). It's best if they are sorted alphabetically in the UI.

## Before

![screen shot 2015-11-13 at 11 11 47](https://cloud.githubusercontent.com/assets/233676/11144804/721bd2a0-89f7-11e5-8cc1-4b198984c862.png)

## After

![screen shot 2015-11-13 at 11 11 02](https://cloud.githubusercontent.com/assets/233676/11144803/72069610-89f7-11e5-83d2-d3458c934b11.png)

