### PR TITLE
Sort lists of browse pages and topics by title

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -40,7 +40,7 @@ class MainstreamBrowsePage
   end
 
   def related_topics
-    linked_items("related_topics").sort_by(&:title)
+    linked_items("related_topics")
   end
 
   def slug
@@ -54,7 +54,7 @@ private
         @content_item_data["links"].has_key?(field)
       @content_item_data["links"][field].map { |item_details|
         LinkedContentItem.build(item_details)
-      }
+      }.sort_by(&:title)
     else
       []
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -39,7 +39,7 @@ class Topic
         @content_item_data["links"].has_key?("children")
       @content_item_data["links"]["children"].map { |child|
         LinkedContentItem.build(child)
-      }
+      }.sort_by(&:title)
     else
       []
     end

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -66,15 +66,15 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
     within ".topics ul" do
       within "li:nth-child(1)" do
-        assert page.has_link?("Wells")
-      end
-
-      within "li:nth-child(2)" do
         assert page.has_link?("Fields")
       end
 
-      within "li:nth-child(3)" do
+      within "li:nth-child(2)" do
         assert page.has_link?("Offshore")
+      end
+
+      within "li:nth-child(3)" do
+        assert page.has_link?("Wells")
       end
     end
   end

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -72,9 +72,13 @@ describe MainstreamBrowsePage do
 
         items = @page.public_send(link_type)
 
-        assert_equal 'Foo', items[0].title
-        assert_equal '/browse/bar', items[1].base_path
-        assert_equal 'All about foo', items[0].description
+        assert_equal 'Bar', items[0].title
+        assert_equal 'All about bar', items[0].description
+        assert_equal '/browse/bar', items[0].base_path
+
+        assert_equal 'Foo', items[1].title
+        assert_equal 'All about foo', items[1].description
+        assert_equal '/browse/foo', items[1].base_path
       end
 
       it "returns empty array with no items" do

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -92,8 +92,8 @@ describe Topic do
         },
       ]
 
-      assert_equal 'Foo', @topic.children[0].title
-      assert_equal '/topic/business-tax/bar', @topic.children[1].base_path
+      assert_equal 'Bar', @topic.children[0].title
+      assert_equal 'Foo', @topic.children[1].title
     end
 
     it "returns empty array with no children" do


### PR DESCRIPTION
Previously, collections-publisher sent the `links` hash of tags alphabetically ordered. But soon the content-store will not guarantee the order anymore (https://trello.com/c/7KFaPRsz).

Therefore we need to sort the things in the `links` hash ourselves.

Apart from the unit tests, this was tested in development by shuffling the links in ContentItem  (`links.shuffle!`), and checking the frontend for changes.

Trello: https://trello.com/c/hBJ3RX1k
