### PR TITLE
Refactor MainstreamBrowsePage and Topic

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -1,5 +1,28 @@
 class ContentItem
   def self.find!(base_path)
-    Services.content_store.content_item!(base_path)
+    response = Services.content_store.content_item!(base_path)
+    new(response.to_hash)
+  end
+
+  def initialize(content_item_data)
+    @content_item_data = content_item_data
+  end
+
+  %i[base_path title description content_id].each do |field|
+    define_method field do
+      @content_item_data[field.to_s]
+    end
+  end
+
+  def details
+    @content_item_data["details"] || {}
+  end
+
+  def linked_items(field)
+    return [] unless @content_item_data["links"]
+
+    @content_item_data["links"][field].to_a.map { |item_hash|
+      self.class.new(item_hash)
+    }.sort_by(&:title)
   end
 end

--- a/app/models/linked_content_item.rb
+++ b/app/models/linked_content_item.rb
@@ -1,5 +1,0 @@
-LinkedContentItem = Struct.new(:title, :base_path, :description) do
-  def self.build(attributes)
-    new(attributes["title"], attributes["base_path"], attributes["description"])
-  end
-end

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -11,7 +11,7 @@ describe MainstreamBrowsePage do
       "links" => {
       },
     }
-    @page = MainstreamBrowsePage.new(@api_data)
+    @page = MainstreamBrowsePage.new(ContentItem.new(@api_data))
   end
 
   describe "basic properties" do

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -17,7 +17,7 @@ describe Topic do
         }],
       },
     }
-    @topic = Topic.new(@api_data)
+    @topic = Topic.new(ContentItem.new(@api_data))
   end
 
   describe "basic properties" do
@@ -38,10 +38,10 @@ describe Topic do
     end
 
     it "returns the topic's beta status" do
-      assert_equal false, @topic.beta?
+      refute @topic.beta?
 
       @api_data["details"]["beta"] = true
-      assert_equal true, @topic.beta?
+      assert @topic.beta?
     end
   end
 
@@ -135,7 +135,7 @@ describe Topic do
 
   describe "changed_documents" do
     setup do
-      @topic = Topic.new(@api_data, {:foo => "bar"})
+      @topic = Topic.new(ContentItem.new(@api_data), {:foo => "bar"})
     end
 
     it "passes the slug of the topic when constructing changed_documents" do


### PR DESCRIPTION
`MainstreamBrowsePage` and `Topic` have a lot in common. To avoid introducing abstractions we chose earlier not to use inheritance for these classes.

This PR instead delegates some of the data things to the `ContentItem` class, which is passed around as a real object instead of a hash. It cleans up some duplication while still being readable.