### PR TITLE
Bump gds-api-adapters to pass on Original URL header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 24.4.0'
+  gem 'gds-api-adapters', '~> 28.2.1'
 end
 
 gem 'plek', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,15 +76,15 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160216)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (28.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gherkin (2.12.2)
@@ -122,7 +122,7 @@ GEM
       mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     minitest-spec-rails (5.3.0)
@@ -151,7 +151,7 @@ GEM
       byebug (~> 8.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -227,7 +227,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -250,7 +250,7 @@ DEPENDENCIES
   binding_of_caller
   capybara (~> 2.5.0)
   cucumber-rails (~> 1.4.2)
-  gds-api-adapters (~> 24.4.0)
+  gds-api-adapters (~> 28.2.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_frontend_toolkit (~> 4.3.0)
   jasmine-rails (~> 0.12.1)


### PR DESCRIPTION
This version of api-adapters contains a change to pass on the
`HTTP_GOVUK_ORIGINAL_URL` header to API calls. This allows us to get
better visibility on the data flow between applications.

Trello: https://trello.com/c/JVZPH4S9/410