### PR TITLE
Reduce Rummager page size when 'fetching everything'

### DIFF
--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -1,5 +1,5 @@
 class RummagerSearch
-  PAGE_SIZE_TO_GET_EVERYTHING = 10_000
+  PAGE_SIZE_TO_GET_EVERYTHING = 1000
 
   include Enumerable
   delegate :each, to: :documents


### PR DESCRIPTION
Rummager itself has been updated to return, at most, 1000 documents in a
single call to the search API. This change ensures that fetching
everything for a given tag does not result in an error. Reducing the
requested page size to 1000 should remain more than sufficient for
rendering collection pages.