### PR TITLE
Use `phase` instead of `details.beta`

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -14,6 +14,10 @@ class ContentItem
     end
   end
 
+  def beta?
+    @content_item_data["phase"] == "beta" 
+  end
+
   def details
     @content_item_data["details"] || {}
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,7 +1,7 @@
 class Topic
   attr_reader :content_item
   delegate :base_path, :title, :description, :content_id, :linked_items, :details,
-    to: :content_item
+    :beta?, to: :content_item
 
   def self.find(base_path, pagination_options = {})
     content_item = ContentItem.find!(base_path)
@@ -11,10 +11,6 @@ class Topic
   def initialize(content_item, pagination_options = {})
     @content_item = content_item
     @pagination_options = pagination_options
-  end
-
-  def beta?
-    details["beta"]
   end
 
   def parent

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -114,7 +114,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a beta subtopic" do
-    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {beta: true}))
+    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", { "phase" => "beta" }))
     stub_topic_organisations('oil-and-gas/offshore')
 
     visit "/topic/oil-and-gas/offshore"

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -80,11 +80,9 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a beta topic" do
-    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge({
-      :details => {
-        "beta" => true,
-      }
-    }))
+    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(
+      "phase" => "beta"
+    ))
 
     visit "/topic/oil-and-gas"
 

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -40,7 +40,7 @@ describe Topic do
     it "returns the topic's beta status" do
       refute @topic.beta?
 
-      @api_data["details"]["beta"] = true
+      @api_data["phase"] = "beta"
       assert @topic.beta?
     end
   end


### PR DESCRIPTION
Topics and mainstream browse pages are sent with the old `details.beta` and the newer `phase` attribute. This makes the code only use the `phase` attribute, so we can finally deprecate `details.beta`.

Depends on https://github.com/alphagov/collections-publisher/pull/198 being deployed first.