### PR TITLE
Sort 2nd level browse pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '9.0.1'
+  gem 'slimmer', '9.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.0.1)
+    slimmer (9.1.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -270,7 +270,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 9.0.1)
+  slimmer (= 9.1.0)
   uglifier (~> 2.7.1)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -15,7 +15,7 @@ class ContentItem
   end
 
   def beta?
-    @content_item_data["phase"] == "beta" 
+    @content_item_data["phase"] == "beta"
   end
 
   def details

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -20,7 +20,15 @@ class MainstreamBrowsePage
   end
 
   def second_level_browse_pages
-    linked_items("second_level_browse_pages")
+    links = linked_items("second_level_browse_pages")
+
+    if second_level_pages_curated?
+      links.sort_by do |link|
+        details["ordered_second_level_browse_pages"].index(link.content_id)
+      end
+    else
+      links
+    end
   end
 
   def second_level_pages_curated?

--- a/features/viewing_browse.feature
+++ b/features/viewing_browse.feature
@@ -7,31 +7,32 @@ Feature: Viewing browse
   Scenario: Browse to a browse page with Javascript
     Given there is an alphabetical browse page set up with links
     When I visit the main browse page
-    And I click on a top level browse page
+    Then I see the list of top level browse pages alphabetically ordered
+    When I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
     Then I should see the second level browse page
     Then I see the links tagged to the browse page
+    Then the A to Z label should be present
 
   Scenario: Browse to a browse page without Javascript
     Given there is an alphabetical browse page set up with links
     When I visit the main browse page
-    And I click on a top level browse page
+    Then I see the list of top level browse pages alphabetically ordered
+    When I click on a top level browse page
     Then I see the list of second level browse pages
     When I click on a second level browse page
     Then I should see the second level browse page
     Then I see the links tagged to the browse page
+    Then the A to Z label should be present
 
-  Scenario Outline: Browse to browse page and look for the A to Z label
-    Given there is a <child ordering> browse page set up with links
+  Scenario: Browse to a browse page without Javascript
+    Given that there are curated second level browse pages
     When I visit the main browse page
-    And I click on a top level browse page
-    Then the A to Z label should be <label presence>
-
-    Examples:
-      | child ordering | label presence |
-      |   alphabetical |        present |
-      |        curated |    not present |
+    Then I see the list of top level browse pages alphabetically ordered
+    When I click on a top level browse page
+    Then I see the curated list of second level browse pages
+    Then the A to Z label should not be present
 
   Scenario: Browse to browse page that has "Detailed guidance"
     Given there is an alphabetical browse page set up with links

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -49,6 +49,47 @@ describe MainstreamBrowsePage do
         refute @page.second_level_pages_curated?
       end
     end
+
+    describe "#second_level_browse_pages" do
+      before do
+        @second_level_browse_page_1 = {
+          "content_id" => "1",
+          "title" => "Foo",
+          "description" => "All about foo",
+          "base_path" => "/browse/foo",
+        }
+        @second_level_browse_page_2 = {
+          "content_id" => "2",
+          "title" => "Bar",
+          "description" => "All about bar",
+          "base_path" => "/browse/bar",
+        }
+        @api_data["details"]["ordered_second_level_browse_pages"] = [
+          "1",
+          "2",
+        ]
+        @api_data["links"]["second_level_browse_pages"] = [
+          @second_level_browse_page_2,
+          @second_level_browse_page_1,
+        ]
+      end
+
+      it "returns a curated set of links when second_level_ordering == curated" do
+        @api_data["details"]["second_level_ordering"] = "curated"
+        assert_equal [
+          @second_level_browse_page_1["content_id"],
+          @second_level_browse_page_2["content_id"],
+        ], @page.second_level_browse_pages.map(&:content_id)
+      end
+
+      it "returns an alphabetically ordered set of links when second_level_ordering == alphabetical" do
+        @api_data["details"]["second_level_ordering"] = "alphabetical"
+        assert_equal [
+          @second_level_browse_page_2["content_id"],
+          @second_level_browse_page_1["content_id"],
+        ], @page.second_level_browse_pages.map(&:content_id)
+      end
+    end
   end
 
   [


### PR DESCRIPTION
content-store does not retain the order of the items that are sent in the links hash, therefore in order to allow custom 2nd level browse pages ordering we have to read the links order from the details hash.

Extra: 
- Added a test to make sure that top-level-browse-pages are always alphabetically ordered
- Upgraded Slimmer

Depends on: https://github.com/alphagov/collections-publisher/pull/206

paired with @rubenarakelyan 