### PR TITLE
Remove browse page from breadcrumbs

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -4,11 +4,7 @@ class BrowseController < ApplicationController
 
   def index
     @page = MainstreamBrowsePage.find("/browse")
-    set_slimmer_artefact_headers({
-      title: "browse",
-      section_name: @page.title,
-      section_link: @page.base_path,
-    })
+    set_slimmer_artefact_headers
   end
 
   def top_level_browse_page


### PR DESCRIPTION
The browse index page at /browse currently displays a breadcrumb as “Home > Browse”, thereby linking back to itself. For consistency with breadcrumbs elsewhere on GOV.UK, this commit removes this link, so that the breadcrumb on the index page is simply “Home”.

The decision was taken not to display the breadcrumb as "Home > Browse" when a user clicks on a top-level browse page, because direct visits to the browse index page are very low and most users end up on browse pages from the GOV.UK home page, by clicking a link to go directly to a top level browse page. Therefore, the breadcrumb only changes once a user clicks on a second level browse page link.

Trello: https://trello.com/c/LCUGEogs/47-fix-breadcrumbs-on-browse-pages

With @jackscotti 

Before:
![screen shot 2016-08-10 at 10 25 14](https://cloud.githubusercontent.com/assets/444232/17548679/cf2fcfd8-5ee4-11e6-9745-3fdc5691c3e9.png)

After:
![screen shot 2016-08-10 at 10 25 30](https://cloud.githubusercontent.com/assets/444232/17548682/d3a78e16-5ee4-11e6-9740-c2a20e1b2f35.png)
