### PR TITLE
Handle linked items without a title

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -27,6 +27,6 @@ class ContentItem
 
     @content_item_data["links"][field].to_a.map { |item_hash|
       self.class.new(item_hash)
-    }.sort_by(&:title)
+    }.select(&:title).sort_by(&:title)
   end
 end

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -133,6 +133,26 @@ describe MainstreamBrowsePage do
     end
   end
 
+  it "filters items without title" do
+    @api_data["links"]["second_level_browse_pages"] = [
+      {
+        "description" => "All about foo",
+        "base_path"=>"/browse/foo",
+      },
+      {
+        "title"=>"Bar",
+        "description" => "All about bar",
+        "base_path"=>"/browse/bar",
+      },
+    ]
+
+    items = @page.second_level_browse_pages
+
+    assert_equal 'Bar', items[0].title
+    assert_equal 'All about bar', items[0].description
+    assert_equal '/browse/bar', items[0].base_path
+  end
+
   describe "active_top_level_browse_page" do
     it "returns the title, base_path and description for the linked item" do
       @api_data["links"]["active_top_level_browse_page"] = [{


### PR DESCRIPTION
Because of a bug in publishing-api there are currently redirect & gone items in the links hash that weren't there previously. This makes this application crash. Until the issue is fixed in the publishing-api we need to make this application more robust.

Fixes: https://errbit.publishing.service.gov.uk/apps/53440a5c0da115938404564b/problems/57b451b76578633253350200