### PR TITLE
Properly create subscriberlists

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -28,13 +28,10 @@ private
 
   def subscription_params
     {
-      title: subtopic.combined_title,
-      tags: {
-        topics: [subtopic.slug]
-      },
-      links: {
-        topics: [subtopic.content_id]
+      'title' => subtopic.combined_title,
+      'links' => {
+        'topics' => [subtopic.content_id]
       }
-    }.deep_stringify_keys
+    }
   end
 end

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -24,9 +24,6 @@ describe EmailSignup do
 
       Services.email_alert_api.expects(:find_or_create_subscriber_list).with(
         "title" => "Oil and gas: Wells",
-        "tags" => {
-          "topics" => ["oil-and-gas/wells"]
-        },
         "links" => {
           "topics" => ["uuid-888"]
         },


### PR DESCRIPTION
These parameters tell email-alert-api to create a "subscriberlist" with certain parameters. The parameters determine when the user receives an email. This used to be done by saying specifying the URL of a topic the user wants to subscribe to. Because URLs always change, this is being moved to be based on `content_id` in the `links` hash.

This app was still sending both `links` and `tags`, when email-alert-api only accepts one of these. Since a deploy this morning email-alert-api has been suddenly rejecting the payloads (as if the validation just got introduced) - we don't know why.

https://trello.com/c/Nmyl1NkF