### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, "Email alert subscription for #{subtopic.combined_title} - GOV.UK" %>
+<%= render 'shared/tag_meta', tag: subtopic, description: "Subscribe to get an email each time content is published or updated in the '#{subtopic.combined_title}' topic." %>
 <% content_for :page_class, "email-signup-new" %>
 
 <header>

--- a/app/views/shared/_tag_meta.html.erb
+++ b/app/views/shared/_tag_meta.html.erb
@@ -1,5 +1,7 @@
 <% content_for :extra_headers do %>
-  <%- if tag.description.present? -%>
+  <%- if defined?(description) -%>
+    <meta name="description" content="<%= description %>">
+  <%- elsif tag.description.present? -%>
     <meta name="description" content="<%= tag.description %>">
   <%- end -%>
   <link rel="alternate" type="application/json" href="/api/content<%= tag.base_path %>">


### PR DESCRIPTION
This commit adds meta description tags to all email alert pages, the contents of which are set to the summary associated with the relevant alert. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them