### PR TITLE
Add govuk_navigation_helpers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'govuk_frontend_toolkit', '~> 4.3.0'
 gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
+gem 'govuk_navigation_helpers', '~> 2.0'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    govuk_navigation_helpers (2.0.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -281,6 +282,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
   govuk_frontend_toolkit (~> 4.3.0)
+  govuk_navigation_helpers (~> 2.0)
   jasmine-rails (~> 0.12.1)
   logstasher (= 0.6.2)
   minitest-spec-rails (~> 5.3.0)


### PR DESCRIPTION
Add the `govuk_navigation_helpers` gem to collections so that breadcrumbs can be shown correctly when services and information pages are moved from whitehall.

Trello: https://trello.com/c/5kK0YosJ/276-move-services-and-information-pages-to-collections