### PR TITLE
Use govuk_components for analytics meta tags and breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'govuk_navigation_helpers', '~> 2.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', :path => '../slimmer'
 else
-  gem 'slimmer', '9.1.0'
+  gem 'slimmer', '10.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,13 +228,13 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (9.1.0)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (3.7.0)
@@ -294,10 +294,10 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 9.1.0)
+  slimmer (= 10.0.0)
   uglifier (~> 2.7.1)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -12,7 +12,7 @@
     this.$root = this.$el.find('#root');
     this.$section = this.$el.find('#section');
     this.$subsection = this.$el.find('#subsection');
-    this.$breadcrumbs = $('#global-breadcrumb ol');
+    this.$breadcrumbs = $('.govuk-breadcrumbs ol');
     this.animateSpeed = 330;
 
     if(this.$section.length === 0){

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::Template
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   slimmer_template 'header_footer_only'
 
@@ -58,5 +57,10 @@ class ApplicationController < ActionController::Base
     unless Rails.env.development?
       expires_in(duration, :public => true)
     end
+  end
+
+  def setup_content_item_and_navigation_helpers(page)
+    @content_item = page.content_item.to_hash
+    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
   end
 end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -4,12 +4,12 @@ class BrowseController < ApplicationController
 
   def index
     @page = MainstreamBrowsePage.find("/browse")
-    set_slimmer_artefact_headers
+    setup_content_item_and_navigation_helpers(@page)
   end
 
   def top_level_browse_page
     @page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
-    set_slimmer_artefact_headers
+    setup_content_item_and_navigation_helpers(@page)
 
     respond_to do |f|
       f.html
@@ -21,11 +21,8 @@ class BrowseController < ApplicationController
 
   def second_level_browse_page
     @page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}")
-    set_slimmer_artefact_headers({
-      title: "browse",
-      section_name: @page.active_top_level_browse_page.title,
-      section_link: @page.active_top_level_browse_page.base_path,
-    })
+    @meta_section = @page.active_top_level_browse_page.title.downcase
+    setup_content_item_and_navigation_helpers(@page)
 
     respond_to do |f|
       f.html
@@ -43,11 +40,6 @@ private
       second_level_browse_pages: page.second_level_browse_pages,
       curated_order: page.second_level_pages_curated?,
     )
-  end
-
-  def set_slimmer_artefact_headers(dummy_artefact={})
-    set_slimmer_headers(format: 'browse')
-    set_slimmer_dummy_artefact(dummy_artefact) unless dummy_artefact.empty?
   end
 
   def render_partial(partial_name, locals = {})

--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -2,17 +2,26 @@ class EmailSignupsController < ApplicationController
   protect_from_forgery except: [:create]
 
   def new
-    slimmer_artefact = {
-      section_name: subtopic.title,
-      section_link: subtopic.base_path,
+    @meta_section = subtopic.parent.title.downcase
+    # Breadcrumbs for this page are hardcoded because it doesn't have a
+    # content item with parents.
+    @hardcoded_breadcrumbs = {
+      breadcrumbs: [
+        {
+          title: "Home",
+          url: "/",
+        },
+        {
+          title: subtopic.parent.title,
+          url: subtopic.parent.base_path,
+        },
+        {
+          title: subtopic.title,
+          url: subtopic.base_path,
+        },
+      ]
     }
-    if subtopic.parent
-      slimmer_artefact[:parent] = {
-        section_name: subtopic.parent.title,
-        section_link: subtopic.parent.base_path,
-      }
-    end
-    set_slimmer_dummy_artefact(slimmer_artefact)
+    setup_content_item_and_navigation_helpers(subtopic)
   end
 
   def create

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -1,17 +1,10 @@
 class ServicesAndInformationController < ApplicationController
   def index
     base_path = "/government/organisations/#{params[:organisation_id]}/services-information"
-    content_item = Services.content_store.content_item!(base_path).to_hash
+    @content_item = Services.content_store.content_item!(base_path).to_hash
     links_grouper = ServicesAndInformationLinksGrouper.new(params[:organisation_id])
-    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(content_item)
-    @organisation = content_item.dig("links", "parent", 0)
+    @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
+    @organisation = @content_item.dig("links", "parent", 0)
     @grouped_links = links_grouper.parsed_grouped_links
-    set_slimmer_analytics_headers
-  end
-
-private
-
-  def set_slimmer_analytics_headers
-    set_slimmer_headers(organisations: "<#{@organisation['analytics_identifier']}>")
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -29,4 +29,8 @@ class ContentItem
       self.class.new(item_hash)
     }.select(&:title).sort_by(&:title)
   end
+
+  def to_hash
+    @content_item_data
+  end
 end

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,6 +1,15 @@
 <% content_for :title, "All categories - GOV.UK" %>
 <% content_for :page_class, "browse" %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <div class="browse-panes root">
   <%= render 'top_level_browse_pages', top_level_browse_pages: @page.top_level_browse_pages %>
 </div>

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -2,6 +2,16 @@
 <%= render 'shared/tag_meta', tag: @page %>
 <% content_for :page_class, "browse" %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+  <meta name="govuk:section" content="<%= @meta_section %>">
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <div class="browse-panes subsection" data-state="subsection">
   <div id="subsection" class="pane with-sort">
     <%= render 'links' %>

--- a/app/views/browse/top_level_browse_page.html.erb
+++ b/app/views/browse/top_level_browse_page.html.erb
@@ -2,6 +2,15 @@
 <%= render 'shared/tag_meta', tag: @page %>
 <% content_for :page_class, "browse" %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <div class="browse-panes section" data-state="section">
   <div id="section" class="pane with-sort">
     <%= render 'second_level_browse_pages',

--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -2,6 +2,15 @@
 <%= render 'shared/tag_meta', tag: subtopic, description: "Subscribe to get an email each time content is published or updated in the '#{subtopic.combined_title}' topic." %>
 <% content_for :page_class, "email-signup-new" %>
 
+<% content_for :extra_headers do %>
+  <meta name="govuk:section" content="<%= @meta_section %>">
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @hardcoded_breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <header>
   <h1>
     <span>Email alert subscription</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,10 +13,7 @@
 
 <body>
   <div id="wrapper">
-    <% if @navigation_helpers %>
-      <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
-      <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
-    <% end %>
+    <%= yield :breadcrumbs %>
     <main id="content" role="main" class="<%= yield :page_class %>">
       <%= yield %>
     </main>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -1,6 +1,15 @@
 <% content_for :title, "Services and information - #{@organisation['title']} - GOV.UK" %>
 <% content_for :page_class, "topics-page" %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <header class="page-header group">
   <div class="full-width">
     <div class="heading">

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -2,9 +2,14 @@
 <%= render 'shared/tag_meta', tag: @topic %>
 <% content_for :page_class, "topics-page" %>
 
-<div class="header-context">
-  <%# This empty div makes the breadcrumbs disappear. %>
-</div>
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
 
 <header class="page-header group">
   <div class="full-width">

--- a/app/views/topics/latest_changes.html.erb
+++ b/app/views/topics/latest_changes.html.erb
@@ -3,6 +3,16 @@
   <span><%= @subtopic.title %></span>: latest documents
 <% end %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+  <meta name="govuk:section" content="<%= @meta_section %>">
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @hardcoded_breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <%= render(
   layout: "subtopic",
   locals: {

--- a/app/views/topics/subtopic.html.erb
+++ b/app/views/topics/subtopic.html.erb
@@ -7,6 +7,16 @@
   <%= @subtopic.title %>
 <% end %>
 
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+  <meta name="govuk:section" content="<%= @meta_section %>">
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
+
 <%= render(
   layout: "subtopic",
   locals: {

--- a/app/views/topics/topic.html.erb
+++ b/app/views/topics/topic.html.erb
@@ -2,9 +2,14 @@
 <%= render 'shared/tag_meta', tag: @topic %>
 <% content_for :page_class, "topics-page" %>
 
-<div class="header-context">
-  <%# This empty div makes the breadcrumbs disappear. %>
-</div>
+<% content_for :extra_headers do %>
+  <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
+  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+<% end %>
 
 <header class="page-header group">
   <div class="full-width">

--- a/config/initializers/jasmine_rails.rb
+++ b/config/initializers/jasmine_rails.rb
@@ -1,6 +1,10 @@
 if defined?(JasmineRails)
+  require 'slimmer/headers'
+
   module JasmineRails
     class ApplicationController < ActionController::Base
+      include Slimmer::Headers
+
       before_filter :skip_slimmer
 
       def skip_slimmer

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,4 +1,6 @@
 Given(/^there is an alphabetical browse page set up with links$/) do
+  stub_browse_lookups
+
   second_level_browse_pages = [{
     content_id: 'judges-content-id',
     title: 'Judges',
@@ -22,6 +24,8 @@ Given(/^there is an alphabetical browse page set up with links$/) do
 end
 
 Given(/^that there are curated second level browse pages$/) do
+  stub_browse_lookups
+
   second_level_browse_pages = [
     {
       content_id: 'judges-content-id',

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -1,7 +1,13 @@
 require 'gds_api/test_helpers/content_store'
+require 'slimmer/test_helpers/govuk_components'
 
 module BrowseTestHelpers
   include GdsApi::TestHelpers::ContentStore
+  include Slimmer::TestHelpers::GovukComponents
+
+  def stub_browse_lookups
+    stub_shared_component_locales
+  end
 
   def assert_can_see_linked_item(name)
     assert page.has_selector?('a', text: name)

--- a/features/support/services_and_information_helper.rb
+++ b/features/support/services_and_information_helper.rb
@@ -1,10 +1,12 @@
 require 'gds_api/test_helpers/rummager'
+require 'slimmer/test_helpers/govuk_components'
 
 require_relative '../../test/support/rummager_helpers'
 
 module ServicesAndInformationHelpers
   include GdsApi::TestHelpers::Rummager
   include RummagerHelpers
+  include Slimmer::TestHelpers::GovukComponents
 
   def stub_services_and_information_lookups
     @services_and_information = %w{
@@ -29,6 +31,8 @@ module ServicesAndInformationHelpers
         ]
       },
     )
+
+    stub_shared_component_locales
   end
 end
 

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -1,10 +1,12 @@
 require 'gds_api/test_helpers/rummager'
+require 'slimmer/test_helpers/govuk_components'
 
 require_relative '../../test/support/rummager_helpers'
 
 module TopicHelper
   include GdsApi::TestHelpers::Rummager
   include RummagerHelpers
+  include Slimmer::TestHelpers::GovukComponents
 
   def stub_topic_lookups
     @organisations = %w{
@@ -61,6 +63,8 @@ module TopicHelper
       'oil-and-gas/fields-and-wells',
       'content-id-for-fields-and-wells'
     )
+
+    stub_shared_component_locales
   end
 end
 

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require "test_helper"
 
 describe TopicsController do
   include ContentSchemaHelpers
@@ -8,12 +8,6 @@ describe TopicsController do
     describe "with a valid topic slug" do
       before do
         content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
-      end
-
-      it "sets the correct slimmer headers" do
-        get :topic, topic_slug: "oil-and-gas"
-
-        assert_equal "specialist-sector", response.headers["X-Slimmer-Format"]
       end
 
       it "sets expiry headers for 30 minutes" do
@@ -60,16 +54,6 @@ describe TopicsController do
             "oil-and-gas/wells",
           )
          )
-      end
-
-      it "sets the correct slimmer headers" do
-        get :subtopic, topic_slug: "oil-and-gas", subtopic_slug: "wells"
-
-        artefact = JSON.parse(response.headers["X-Slimmer-Artefact"])
-        primary_tag = artefact["tags"][0]
-        assert_equal "/oil-and-gas", primary_tag["content_with_tag"]["web_url"]
-        assert_equal "Oil and Gas", primary_tag["title"]
-        assert_equal "specialist-sector", response.headers["X-Slimmer-Format"]
       end
 
       it "sets expiry headers for 30 minutes" do

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -26,6 +26,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|
       get content_item['base_path']
       assert_response 200
+      assert page.has_selector?(shared_component_selector('breadcrumbs'))
     end
   end
 end

--- a/test/integration/services_and_information_browsing_test.rb
+++ b/test/integration/services_and_information_browsing_test.rb
@@ -25,5 +25,7 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
     within "nav.index-list:nth-child(2) h1" do
       assert page.has_content?("Waste")
     end
+
+    assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 end

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -25,7 +25,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     base.merge(params)
   end
 
-  setup do
+  before do
     rummager_has_documents_for_subtopic(
       'content-id-for-offshore',
       [
@@ -83,6 +83,8 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Undersea piping restrictions", :href => "/undersea-piping-restrictions")
 
     refute page.has_link?("North sea shipping lanes")
+
+    assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 
   it "renders a non-curated subtopic" do
@@ -112,6 +114,8 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     assert page.has_link?("Oil rig safety requirements", :href => "/oil-rig-safety-requirements")
     assert page.has_link?("North sea shipping lanes", :href => "/north-sea-shipping-lanes")
     assert page.has_link?("Undersea piping restrictions", :href => "/undersea-piping-restrictions")
+
+    assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 
   it "renders a beta subtopic" do

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -35,6 +35,8 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     visit "/topic"
 
     assert page.has_content?("Oil and Gas")
+
+    assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 
   it "renders a topic tag page and list its subtopics" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,8 +3,14 @@ require_relative "support/content_schema_helpers"
 
 require 'capybara/rails'
 require 'slimmer/test'
+require 'slimmer/test_helpers/govuk_components'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include ContentSchemaHelpers
+  include Slimmer::TestHelpers::GovukComponents
+
+  before do
+    stub_shared_component_locales
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,15 +21,21 @@ WebMock.disable_net_connect!
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 require 'gds_api/test_helpers/content_store'
+require 'slimmer/test_helpers/govuk_components'
 require 'gds_api/test_helpers/rummager'
 
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
+  include Slimmer::TestHelpers::GovukComponents
   include GdsApi::TestHelpers::Rummager
 
   GovukContentSchemaTestHelpers.configure do |config|
     config.schema_type = 'frontend'
     config.project_root = Rails.root
+  end
+
+  before do
+    stub_shared_component_locales
   end
 
   after do


### PR DESCRIPTION
This commit replaces slimmer with govuk_components and govuk_navigation_helpers for rendering analytics meta tags and breadcrumbs across all pages.

Trello: https://trello.com/c/gZQn6ss2/336-upgrade-collections-frontend