### PR TITLE
Fix flaky integration test

### DIFF
--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -24,9 +24,11 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     end
 
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|
-      get content_item['base_path']
-      assert_response 200
-      assert page.has_selector?(shared_component_selector('breadcrumbs'))
+      visit content_item['base_path']
+
+      assert_equal 200, page.status_code
+      assert page.has_selector?(shared_component_selector('breadcrumbs')),
+        "Expected page at '#{content_item['base_path']}' to display breadcrumbs, but none found"
     end
   end
 end


### PR DESCRIPTION
MainstreamBrowsingTest was failing intermittently. It would pass if it happened to be run after one of the other integration tests, but would fail otherwise (example seed for failure case: 424).

I think the problem was that the test was using the Rails 'get' helper to get the page, rather than the Capybara 'visit' function. This meant that the Capybara 'page' variable was only defined if another integration test had already run. This means that the breadcrumb assertions were not testing the page they were intended to.