### PR TITLE
Fix all Rubocop linter warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  TargetRubyVersion: 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,13 @@ gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.0'
 
 if ENV['SLIMMER_DEV']
-  gem 'slimmer', :path => '../slimmer'
+  gem 'slimmer', path: '../slimmer'
 else
   gem 'slimmer', '10.0.0'
 end
 
 if ENV['API_DEV']
-  gem 'gds-api-adapters', :path => '../gds-api-adapters'
+  gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
   gem 'gds-api-adapters', '~> 34.1.0'
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,7 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
-  private
+private
 
   def restrict_request_formats
     unless can_handle_format?(request.format)
@@ -45,7 +45,9 @@ class ApplicationController < ActionController::Base
   end
 
   def error_404; error 404; end
+
   def error_410; error 410; end
+
   def error_503(e); error(503, e); end
 
   def error(status_code, exception = nil)
@@ -55,7 +57,7 @@ class ApplicationController < ActionController::Base
 
   def set_expiry(duration = 30.minutes)
     unless Rails.env.development?
-      expires_in(duration, :public => true)
+      expires_in(duration, public: true)
     end
   end
 

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -27,7 +27,7 @@ class ListSet
     @group_data.any?
   end
 
-  private
+private
 
   def lists
     if @group_data.any?
@@ -40,31 +40,30 @@ class ListSet
   def a_to_z_list
     [ListSet::List.new(
       "A to Z",
-      content_tagged_to_tag.reject do |content|
-        excluded_formats.include? content.format
-      end.sort_by(&:title)
+      content_tagged_to_tag
+        .reject { |content| excluded_formats.include? content.format }
+        .sort_by(&:title)
     )]
   end
 
   def curated_list
-    @group_data.map do |group|
+    curated_data = @group_data.map do |group|
       contents = group["contents"].map do |base_path|
-        content_tagged_to_tag.find do |content|
-          content.base_path == base_path
-        end
-      end.compact
+        content_tagged_to_tag.find { |content| content.base_path == base_path }
+      end
 
-      ListSet::List.new(group["name"], contents) if contents.any?
-    end.compact
+      ListSet::List.new(group["name"], contents.compact) if contents.any?
+    end
+
+    curated_data.compact
   end
 
   def content_tagged_to_tag
-    @content_tagged_to_tag ||= RummagerSearch.new({
+    @content_tagged_to_tag ||= RummagerSearch.new(
       :start => 0,
       :count => RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       filter_name => [@tag_content_id],
-      :fields => %w(title link format),
-    })
+      :fields => %w(title link format))
   end
 
   def filter_name

--- a/app/models/topic/changed_documents.rb
+++ b/app/models/topic/changed_documents.rb
@@ -26,12 +26,10 @@ private
   end
 
   def rummager_search
-    @rummager_search ||= RummagerSearch.new({
-      start: start_param,
+    @rummager_search ||= RummagerSearch.new(start: start_param,
       count: page_size,
       order: "-public_timestamp",
       fields: %w(title link latest_change_note public_timestamp format),
-      filter_topic_content_ids: [@topic_content_id]
-    })
+      filter_topic_content_ids: [@topic_content_id])
   end
 end

--- a/app/presenters/changed_documents_pagination_presenter.rb
+++ b/app/presenters/changed_documents_pagination_presenter.rb
@@ -1,5 +1,4 @@
 class ChangedDocumentsPaginationPresenter
-
   def initialize(changed_documents, view_context)
     @changed_documents = changed_documents
     @view_context = view_context
@@ -11,7 +10,7 @@ class ChangedDocumentsPaginationPresenter
 
   def current_page_number
     # Add 1 because page numbers are 1-indexed
-    ( @changed_documents.start.to_f / @changed_documents.page_size.to_f ).ceil + 1
+    (@changed_documents.start.to_f / @changed_documents.page_size.to_f).ceil + 1
   end
 
   def next_page?

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby1.9.1
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Collections::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files  = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.

--- a/features/step_definitions/browsing_topics_steps.rb
+++ b/features/step_definitions/browsing_topics_steps.rb
@@ -1,12 +1,12 @@
-Given /^there are documents in a subtopic$/ do
+Given(/^there are documents in a subtopic$/) do
   stub_topic_lookups
 end
 
-When /^I view the browse page for that subtopic$/ do
+When(/^I view the browse page for that subtopic$/) do
   visit "/topic/oil-and-gas/fields-and-wells"
 end
 
-Then /^I see a list of organisations associated with content in the subtopic$/ do
+Then(/^I see a list of organisations associated with content in the subtopic$/) do
   @organisations.each do |slug|
     assert page.has_selector?("a[href='/#{slug}'][class='organisation-link']")
   end

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -12,8 +12,8 @@ Given(/^there is latest content for a subtopic$/) do
   ).map.with_index do |slug, i|
     {
       "latest_change_note" => "This has changed",
-      "public_timestamp" => (i+1).hours.ago.iso8601,
-      "title" => "#{slug.titleize}",
+      "public_timestamp" => (i + 1).hours.ago.iso8601,
+      "title" => slug.titleize.to_s,
       "link" => "/government/publications/#{slug}",
       "index" => "government",
       "_id" => "/government/publications/#{slug}",
@@ -27,11 +27,9 @@ Given(/^there is latest content for a subtopic$/) do
       filter_topic_content_ids: ['content-id-for-fields-and-wells'],
       order: "-public_timestamp",
     )
-  ).returns({
-    "results" => @stubbed_rummager_documents,
+  ).returns("results" => @stubbed_rummager_documents,
     "start" => 0,
-    "total" => @stubbed_rummager_documents.size,
-  })
+    "total" => @stubbed_rummager_documents.size)
 end
 
 When(/^I view the latest changes page for that subtopic$/) do
@@ -40,8 +38,8 @@ end
 
 Then(/^I see a date\-ordered list of content with change notes$/) do
   @stubbed_rummager_documents.each_with_index do |document, index|
-    within(".browse-container li:nth-of-type(#{index+1})") do
-      assert page.has_selector?("h3 a[href='#{document["link"]}']", text: document["title"])
+    within(".browse-container li:nth-of-type(#{index + 1})") do
+      assert page.has_selector?("h3 a[href='#{document['link']}']", text: document["title"])
       assert page.has_content?(document["latest_change_note"]) if document["latest_change_note"]
       assert page.has_selector?("time") if document["public_updated_at"]
     end

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -31,13 +31,11 @@ Given(/^that there are curated second level browse pages$/) do
       content_id: 'judges-content-id',
       title: 'Judges',
       base_path: '/browse/crime-and-justice/judges',
-      content_id: "2",
     },
     {
       content_id: 'courts-content-id',
       title: 'Courts',
       base_path: '/browse/crime-and-justice/courts',
-      content_id: "1",
     }
   ]
 
@@ -115,14 +113,13 @@ def top_level_browse_pages
 end
 
 def add_browse_pages
-  content_store_has_item '/browse', { links: {
+  content_store_has_item '/browse', links: {
     top_level_browse_pages: top_level_browse_pages
-  }}
+  }
 end
 
-def add_first_level_browse_pages(child_pages: second_level_browse_pages, order_type: order_type)
-  content_store_has_item('/browse/crime-and-justice', {
-    base_path: '/browse/crime-and-justice',
+def add_first_level_browse_pages(child_pages:, order_type:)
+  content_store_has_item('/browse/crime-and-justice', base_path: '/browse/crime-and-justice',
     links: {
       top_level_browse_pages: top_level_browse_pages,
       second_level_browse_pages: child_pages,
@@ -130,13 +127,11 @@ def add_first_level_browse_pages(child_pages: second_level_browse_pages, order_t
     details: {
       second_level_ordering: order_type,
       ordered_second_level_browse_pages: child_pages.map { |page| page[:content_id] }
-    },
-  })
+    })
 end
 
 def add_second_level_browse_pages(second_level_browse_pages)
-  content_store_has_item '/browse/crime-and-justice/judges', {
-    content_id: 'judges-content-id',
+  content_store_has_item '/browse/crime-and-justice/judges', content_id: 'judges-content-id',
     title: 'Judges',
     base_path: '/browse/crime-and-justice/judges',
     links: {
@@ -149,5 +144,4 @@ def add_second_level_browse_pages(second_level_browse_pages)
       }],
       related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
     }
-  }
 end

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -28,7 +28,7 @@ module TopicHelper
       page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
     )
 
-    content_store_has_item("/topic/oil-and-gas/fields-and-wells", {
+    content_store_has_item("/topic/oil-and-gas/fields-and-wells",
       content_id: 'content-id-for-fields-and-wells',
       base_path: "/topic/oil-and-gas/fields-and-wells",
       title: "Fields and Wells",
@@ -56,8 +56,7 @@ module TopicHelper
           "title" => "Oil and Gas",
           "base_path" => "/oil-and-gas",
         ]
-      },
-    })
+      })
 
     stub_topic_organisations(
       'oil-and-gas/fields-and-wells',

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -5,61 +5,61 @@
 # files.
 
 
-unless ARGV.any? {|a| a =~ /^gems/} # Don't load anything when running the gems:* tasks
+unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
-vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
-$LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
+  vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
+  $LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
 
-begin
-  require 'cucumber/rake/task'
+  begin
+    require 'cucumber/rake/task'
 
-  namespace :cucumber do
-    Cucumber::Rake::Task.new({:ok => 'test:prepare'}, 'Run features that should pass') do |t|
-      t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'default'
+    namespace :cucumber do
+      Cucumber::Rake::Task.new({ ok: 'test:prepare' }, 'Run features that should pass') do |t|
+        t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'default'
+      end
+
+      Cucumber::Rake::Task.new({ wip: 'test:prepare' }, 'Run features that are being worked on') do |t|
+        t.binary = vendored_cucumber_bin
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'wip'
+      end
+
+      Cucumber::Rake::Task.new({ rerun: 'test:prepare' }, 'Record failing features and run only them if any exist') do |t|
+        t.binary = vendored_cucumber_bin
+        t.fork = true # You may get faster startup if you set this to false
+        t.profile = 'rerun'
+      end
+
+      desc 'Run all features'
+      task all: [:ok, :wip]
+
+      task :statsetup do
+        require 'rails/code_statistics'
+        ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
+        ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+      end
+    end
+    desc 'Alias for cucumber:ok'
+    task cucumber: 'cucumber:ok'
+
+    task default: :cucumber
+
+    task features: :cucumber do
+      STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
     end
 
-    Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|
-      t.binary = vendored_cucumber_bin
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'wip'
+    # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
+    task 'test:prepare' do
     end
 
-    Cucumber::Rake::Task.new({:rerun => 'test:prepare'}, 'Record failing features and run only them if any exist') do |t|
-      t.binary = vendored_cucumber_bin
-      t.fork = true # You may get faster startup if you set this to false
-      t.profile = 'rerun'
-    end
-
-    desc 'Run all features'
-    task :all => [:ok, :wip]
-
-    task :statsetup do
-      require 'rails/code_statistics'
-      ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
-      ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+    task stats: 'cucumber:statsetup'
+  rescue LoadError
+    desc 'cucumber rake task not available (cucumber not installed)'
+    task :cucumber do
+      abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
     end
   end
-  desc 'Alias for cucumber:ok'
-  task :cucumber => 'cucumber:ok'
-
-  task :default => :cucumber
-
-  task :features => :cucumber do
-    STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
-  end
-
-  # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.
-  task 'test:prepare' do
-  end
-
-  task :stats => 'cucumber:statsetup'
-rescue LoadError
-  desc 'cucumber rake task not available (cucumber not installed)'
-  task :cucumber do
-    abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
-  end
-end
 
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ConcreteTestController < ApplicationController
   enable_request_formats json: :json, js_or_atom: [:js, :atom]
   protect_from_forgery except: :js_or_atom
-    
+
   def test
     render text: 'ok'
   end

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -15,7 +15,7 @@ describe BrowseController do
     it "set correct expiry headers" do
       get :index
 
-      assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+      assert_equal "max-age=1800, public", response.headers["Cache-Control"]
     end
   end
 
@@ -34,7 +34,7 @@ describe BrowseController do
       it "set correct expiry headers" do
         get :top_level_browse_page, top_level_slug: "benefits"
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
     end
 
@@ -76,7 +76,7 @@ describe BrowseController do
       it "set correct expiry headers" do
         get :second_level_browse_page, top_level_slug: "benefits", second_level_slug: "entitlement"
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
     end
 

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -5,14 +5,12 @@ describe EmailSignupsController do
     @valid_subtopic_params = { topic_slug: 'oil-and-gas', subtopic_slug: 'wells' }
     content_store_has_item(
       "/topic/oil-and-gas/wells",
-      content_item_for_base_path("/topic/oil-and-gas/wells").merge({
-        "links" => {
+      content_item_for_base_path("/topic/oil-and-gas/wells").merge("links" => {
           "parent" => [{
             "title" => "Oil and Gas",
             "base_path" => "/oil-and-gas",
           }],
-        },
-      }),
+        }),
     )
 
     @invalid_subtopic_params = { topic_slug: 'invalid', subtopic_slug: 'subtopic' }

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -13,7 +13,7 @@ describe TopicsController do
       it "sets expiry headers for 30 minutes" do
         get :topic, topic_slug: "oil-and-gas"
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
     end
 
@@ -30,15 +30,14 @@ describe TopicsController do
       setup do
         content_store_has_item(
           "/topic/oil-and-gas/wells",
-          content_item_for_base_path("/topic/oil-and-gas/wells").merge({
+          content_item_for_base_path("/topic/oil-and-gas/wells").merge(
             "content_id" => 'content-id-for-wells',
             "links" => {
               "parent" => [{
                 "title" => "Oil and Gas",
                 "base_path" => "/oil-and-gas",
               }],
-            },
-          }),
+            }),
         )
 
         ListSet.stubs(:new).returns(
@@ -59,7 +58,7 @@ describe TopicsController do
       it "sets expiry headers for 30 minutes" do
         get :subtopic, topic_slug: "oil-and-gas", subtopic_slug: "wells"
 
-        assert_equal "max-age=1800, public",  response.headers["Cache-Control"]
+        assert_equal "max-age=1800, public", response.headers["Cache-Control"]
       end
     end
 

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -78,9 +78,9 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     end
 
     # And I should see the curated content for the subtopic
-    assert page.has_link?("Oil rig staffing", :href => "/oil-rig-staffing")
-    assert page.has_link?("Oil rig safety requirements", :href => "/oil-rig-safety-requirements")
-    assert page.has_link?("Undersea piping restrictions", :href => "/undersea-piping-restrictions")
+    assert page.has_link?("Oil rig staffing", href: "/oil-rig-staffing")
+    assert page.has_link?("Oil rig safety requirements", href: "/oil-rig-safety-requirements")
+    assert page.has_link?("Undersea piping restrictions", href: "/undersea-piping-restrictions")
 
     refute page.has_link?("North sea shipping lanes")
 
@@ -110,16 +110,16 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     end
 
     # And I should see all content for the subtopic
-    assert page.has_link?("Oil rig staffing", :href => "/oil-rig-staffing")
-    assert page.has_link?("Oil rig safety requirements", :href => "/oil-rig-safety-requirements")
-    assert page.has_link?("North sea shipping lanes", :href => "/north-sea-shipping-lanes")
-    assert page.has_link?("Undersea piping restrictions", :href => "/undersea-piping-restrictions")
+    assert page.has_link?("Oil rig staffing", href: "/oil-rig-staffing")
+    assert page.has_link?("Oil rig safety requirements", href: "/oil-rig-safety-requirements")
+    assert page.has_link?("North sea shipping lanes", href: "/north-sea-shipping-lanes")
+    assert page.has_link?("Undersea piping restrictions", href: "/undersea-piping-restrictions")
 
     assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 
   it "renders a beta subtopic" do
-    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", { "phase" => "beta" }))
+    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", "phase" => "beta"))
     stub_topic_organisations('oil-and-gas/offshore', 'content-id-for-offshore')
 
     visit "/topic/oil-and-gas/offshore"

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -1,7 +1,6 @@
 require 'integration_test_helper'
 
 class TopicBrowsingTest < ActionDispatch::IntegrationTest
-
   def oil_and_gas_topic_item(params = {})
     base = {
       base_path: "/topic/oil-and-gas",
@@ -16,7 +15,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "is possible to visit the topic index page" do
-    content_store_has_item("/topic", {
+    content_store_has_item("/topic",
       base_path: "/topic",
       title: "Topics",
       format: "topic",
@@ -29,8 +28,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
             base_path: "/topic/oil-and-gas",
           },
         ],
-      }
-    })
+      })
 
     visit "/topic"
 
@@ -40,8 +38,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a topic tag page and list its subtopics" do
-    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge({
-      :links => {
+    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
         "children" => [
           {
             "title" => "Wells",
@@ -56,8 +53,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
             "base_path" => "/topic/oil-and-gas/offshore",
           },
         ],
-      }
-    }))
+      }))
 
     visit "/topic/oil-and-gas"
     assert page.has_title?("Oil and gas - GOV.UK")
@@ -82,9 +78,10 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a beta topic" do
-    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(
-      "phase" => "beta"
-    ))
+    content_store_has_item(
+      "/topic/oil-and-gas",
+      oil_and_gas_topic_item.merge("phase" => "beta")
+    )
 
     visit "/topic/oil-and-gas"
 

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -28,7 +28,7 @@ describe EmailSignup do
           "topics" => ["uuid-888"]
         },
       ).returns(OpenStruct.new(
-        subscriber_list: OpenStruct.new(subscription_url: "http://govdelivery_signup_url"))
+                  subscriber_list: OpenStruct.new(subscription_url: "http://govdelivery_signup_url"))
       )
 
       assert email_signup.save

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -162,11 +162,9 @@ describe ListSet do
 
       Services.rummager.stubs(:search).with(
         has_entries(filter_topic_content_ids: ['paye-content-id'])
-      ).returns({
-        "results" => [result],
+      ).returns("results" => [result],
         "start" => 0,
-        "total" => 1,
-      })
+        "total" => 1)
 
       documents = ListSet.new("specialist_sector", "paye-content-id").first.contents
 

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -29,7 +29,6 @@ describe MainstreamBrowsePage do
     end
 
     describe "#second_level_pages_curated?" do
-
       it "is true when second_level_ordering == curated" do
         @api_data["details"]["second_level_ordering"] = "curated"
         assert @page.second_level_pages_curated?
@@ -65,10 +64,7 @@ describe MainstreamBrowsePage do
           "description" => "All about bar",
           "base_path" => "/browse/bar",
         }
-        @api_data["details"]["ordered_second_level_browse_pages"] = [
-          "1",
-          "2",
-        ]
+        @api_data["details"]["ordered_second_level_browse_pages"] = %w(1 2)
         @api_data["links"]["second_level_browse_pages"] = [
           @second_level_browse_page_2,
           @second_level_browse_page_1,
@@ -93,22 +89,21 @@ describe MainstreamBrowsePage do
     end
   end
 
-  [
-    "top_level_browse_pages",
-    "second_level_browse_pages",
-  ].each do |link_type|
+  %w(
+top_level_browse_pages
+second_level_browse_pages).each do |link_type|
     describe link_type do
       it "returns the title, base_path and description for all linked items" do
         @api_data["links"][link_type] = [
           {
-            "title"=>"Foo",
+            "title" => "Foo",
             "description" => "All about foo",
-            "base_path"=>"/browse/foo",
+            "base_path" => "/browse/foo",
           },
           {
-            "title"=>"Bar",
+            "title" => "Bar",
             "description" => "All about bar",
-            "base_path"=>"/browse/bar",
+            "base_path" => "/browse/bar",
           },
         ]
 
@@ -138,12 +133,12 @@ describe MainstreamBrowsePage do
     @api_data["links"]["second_level_browse_pages"] = [
       {
         "description" => "All about foo",
-        "base_path"=>"/browse/foo",
+        "base_path" => "/browse/foo",
       },
       {
-        "title"=>"Bar",
+        "title" => "Bar",
         "description" => "All about bar",
-        "base_path"=>"/browse/bar",
+        "base_path" => "/browse/bar",
       },
     ]
 
@@ -157,9 +152,9 @@ describe MainstreamBrowsePage do
   describe "active_top_level_browse_page" do
     it "returns the title, base_path and description for the linked item" do
       @api_data["links"]["active_top_level_browse_page"] = [{
-        "title"=>"Foo",
+        "title" => "Foo",
         "description" => "All about foo",
-        "base_path"=>"/browse/foo",
+        "base_path" => "/browse/foo",
       }]
 
       assert_equal 'Foo', @page.active_top_level_browse_page.title
@@ -181,14 +176,14 @@ describe MainstreamBrowsePage do
     it "returns the title, base_path and description for all related topics" do
       @api_data["links"]["related_topics"] = [
         {
-          "title"=>"Foo",
+          "title" => "Foo",
           "description" => "All about foo",
-          "base_path"=>"/browse/foo",
+          "base_path" => "/browse/foo",
         },
         {
-          "title"=>"Bar",
+          "title" => "Bar",
           "description" => "All about bar",
-          "base_path"=>"/browse/bar",
+          "base_path" => "/browse/bar",
         },
       ]
 
@@ -200,14 +195,14 @@ describe MainstreamBrowsePage do
     it "returns related topics alphabetised" do
       @api_data["links"]["related_topics"] = [
         {
-          "title"=>"Foo",
+          "title" => "Foo",
         },
         {
-          "title"=>"Bar",
+          "title" => "Bar",
         },
       ]
 
-      assert_equal ['Bar', 'Foo'], @page.related_topics.map(&:title)
+      assert_equal %w(Bar Foo), @page.related_topics.map(&:title)
     end
 
     it "returns empty array with no items" do
@@ -240,7 +235,7 @@ describe MainstreamBrowsePage do
     end
 
     it "should pass the groups data when constructing" do
-      ListSet.expects(:new).with(anything(), anything(), :some_data).returns(:a_lists_instance)
+      ListSet.expects(:new).with(anything, anything, :some_data).returns(:a_lists_instance)
       @api_data["details"]["groups"] = :some_data
 
       assert_equal :a_lists_instance, @page.lists

--- a/test/models/topic/changed_documents_test.rb
+++ b/test/models/topic/changed_documents_test.rb
@@ -55,8 +55,8 @@ describe Topic::ChangedDocuments do
         'pay-psa',
         'employee-tax-codes',
         'payroll-annual-reporting',
-      ], :page_size => 3)
-      @pagination_options = {:count => 3}
+      ], page_size: 3)
+      @pagination_options = { count: 3 }
       @documents = Topic::ChangedDocuments.new(@subtopic_content_id, @pagination_options)
     end
 
@@ -86,11 +86,9 @@ describe Topic::ChangedDocuments do
 
       Services.rummager.stubs(:search).with(
         has_entries(filter_topic_content_ids: ['paye-content-id'])
-      ).returns({
-        "results" => [result],
+      ).returns("results" => [result],
         "start" => 0,
-        "total" => 1,
-      })
+        "total" => 1)
 
       documents = Topic::ChangedDocuments.new("paye-content-id")
 

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -11,9 +11,9 @@ describe Topic do
       },
       "links" => {
         "parent" => [{
-          "title"=>"Business tax",
-          "base_path"=>"/topic/business-tax",
-          "description"=>"All about tax for businesses",
+          "title" => "Business tax",
+          "base_path" => "/topic/business-tax",
+          "description" => "All about tax for businesses",
         }],
       },
     }
@@ -84,12 +84,12 @@ describe Topic do
     it "returns the title and base_path for all children" do
       @api_data["links"]["children"] = [
         {
-          "title"=>"Foo",
-          "base_path"=>"/topic/business-tax/foo",
+          "title" => "Foo",
+          "base_path" => "/topic/business-tax/foo",
         },
         {
-          "title"=>"Bar",
-          "base_path"=>"/topic/business-tax/bar",
+          "title" => "Bar",
+          "base_path" => "/topic/business-tax/bar",
         },
       ]
 

--- a/test/presenters/changed_documents_pagination_presenter_test.rb
+++ b/test/presenters/changed_documents_pagination_presenter_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 describe ChangedDocumentsPaginationPresenter do
-
   def mock_view_context
-    stub("View context", :latest_changes_path => "/somewhere")
+    stub("View context", latest_changes_path: "/somewhere")
   end
 
   def build_presenter_for_subtopic(total: 100, start: 0, page_size: 50, view_context: mock_view_context)
@@ -95,7 +94,7 @@ describe ChangedDocumentsPaginationPresenter do
     it 'returns a path to the next page' do
       presenter = build_presenter_for_subtopic(view_context: @view_context)
 
-      @view_context.expects(:latest_changes_path).with(:start => 50)
+      @view_context.expects(:latest_changes_path).with(start: 50)
         .returns("/a/path")
       assert_equal '/a/path', presenter.next_page_path
     end
@@ -104,7 +103,7 @@ describe ChangedDocumentsPaginationPresenter do
       presenter = build_presenter_for_subtopic(view_context: @view_context,
         page_size: 20)
 
-      @view_context.expects(:latest_changes_path).with(:count => 20, :start => 20)
+      @view_context.expects(:latest_changes_path).with(count: 20, start: 20)
         .returns("/a/path")
       assert_equal '/a/path', presenter.next_page_path
     end
@@ -119,7 +118,7 @@ describe ChangedDocumentsPaginationPresenter do
       presenter = build_presenter_for_subtopic(view_context: @view_context,
         start: 100, total: 150)
 
-      @view_context.expects(:latest_changes_path).with(:start => 50)
+      @view_context.expects(:latest_changes_path).with(start: 50)
         .returns("/a/path")
       assert_equal '/a/path', presenter.previous_page_path
     end
@@ -128,7 +127,7 @@ describe ChangedDocumentsPaginationPresenter do
       presenter = build_presenter_for_subtopic(view_context: @view_context,
         page_size: 20, start: 40)
 
-      @view_context.expects(:latest_changes_path).with(:count => 20, :start => 20)
+      @view_context.expects(:latest_changes_path).with(count: 20, start: 20)
         .returns("/a/path")
       assert_equal '/a/path', presenter.previous_page_path
     end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -21,10 +21,10 @@ module RummagerHelpers
 
   def rummager_document_for_slug(slug, updated_at = 1.hour.ago, format = "guide")
     {
-      "format" => "#{format}",
+      "format" => format.to_s,
       "latest_change_note" => "This has changed",
       "public_timestamp" => updated_at.iso8601,
-      "title" => "#{slug.titleize.humanize}",
+      "title" => slug.titleize.humanize.to_s,
       "link" => "/#{slug}",
       "index" => "/",
       "_id" => "/#{slug}",
@@ -46,11 +46,9 @@ module RummagerHelpers
           filter_topic_content_ids: [subtopic_content_id],
           order: "-public_timestamp",
         )
-      ).returns({
-        "results" => results_page,
+      ).returns("results" => results_page,
         "start" => start,
-        "total" => results.size,
-      })
+        "total" => results.size)
     end
   end
 
@@ -67,11 +65,9 @@ module RummagerHelpers
           count: page_size,
           filter_topic_content_ids: [subtopic_content_id],
         )
-      ).returns({
-        "results" => results_page,
+      ).returns("results" => results_page,
         "start" => start,
-        "total" => results.size,
-      })
+        "total" => results.size)
     end
   end
 
@@ -88,11 +84,9 @@ module RummagerHelpers
           count: page_size,
           filter_mainstream_browse_page_content_ids: [browse_page_content_id],
         )
-      ).returns({
-        "results" => results_page,
+      ).returns("results" => results_page,
         "start" => start,
-        "total" => results.size,
-      })
+        "total" => results.size)
     end
   end
 


### PR DESCRIPTION
This is in preparation for migrating the build to Jenkins 2. Jenkins 2 will require
us to add new build scripts which could optionally include Rubocop linting, so this
seems like a convenient point to add linting to this project.

Most of the Rubocop errors were trivial and could be fixed automatically.

One fix used Ruby's keyword arguments with no defaults, which are only supported by
Ruby 2.1 and above, so the Rubocop language level has been raised to 2.3 to be
consistent with the language level of the project.

I'll comment on the lines that needed manual updates, in case you want to review them in more detail.