### PR TITLE
Handle link groups with no title

### DIFF
--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -5,6 +5,8 @@ class ServicesAndInformationController < ApplicationController
     links_grouper = ServicesAndInformationLinksGrouper.new(params[:organisation_id])
     @navigation_helpers = GovukNavigationHelpers::NavigationHelper.new(@content_item)
     @organisation = @content_item.dig("links", "parent", 0)
-    @grouped_links = links_grouper.parsed_grouped_links
+    @grouped_links = links_grouper.parsed_grouped_links.reject do |group|
+      group["title"].nil?
+    end
   end
 end

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -4,13 +4,11 @@ describe ServicesAndInformationController do
   include RummagerHelpers
   include ServicesAndInformationHelpers
 
-  before do
-    stub_services_and_information_links("hm-revenue-customs")
-  end
-
   describe "with a valid organisation slug" do
     it "sets expiry headers for 30 minutes" do
       stub_services_and_information_content_item
+      stub_services_and_information_links("hm-revenue-customs")
+
       get :index, organisation_id: "hm-revenue-customs"
 
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
@@ -20,9 +18,19 @@ describe ServicesAndInformationController do
   describe "GET services and information page" do
     it "returns a 404 status for GET services and information with an invalid organisation id" do
       content_store_does_not_have_item("/government/organisations/hm-revenue-customs/services-information")
+
       get :index, organisation_id: "hm-revenue-customs"
 
       assert_equal 404, response.status
+    end
+
+    it "renders the page correctly when there are unexpanded links in the rummager results" do
+      stub_services_and_information_content_item
+      stub_services_and_information_links_with_missing_keys("hm-revenue-customs")
+
+      get :index, organisation_id: "hm-revenue-customs"
+
+      assert_equal 200, response.status
     end
   end
 end

--- a/test/fixtures/services_and_information_missing_keys_fixture.json
+++ b/test/fixtures/services_and_information_missing_keys_fixture.json
@@ -1,0 +1,69 @@
+{
+  "results": [ ],
+  "total": 3138,
+  "start": 0,
+  "facets": {
+    "specialist_sectors": {
+      "options": [
+      {
+        "value": {
+          "slug": "environmental-management/environmental-permits",
+          "example_info": {
+            "total": 47,
+            "examples": [
+            {
+              "title": "Check if you need an environmental permit",
+              "link": "/environmental-permit-check-if-you-need-one"
+            },
+            {
+              "title": "Environmental permit: how to apply",
+              "link": "/environmental-permit-how-to-apply"
+            },
+            {
+              "title": "Standard rules: environmental permitting",
+              "link": "/government/collections/standard-rules-environmental-permitting"
+            },
+            {
+              "title": "Environmental permitting (EP) charges scheme: April 2014 to March 2015",
+              "link": "/government/publications/environmental-permitting-ep-charges-scheme-april-2014-to-march-2015"
+            }
+            ]
+          }
+        },
+        "documents": 47
+      },
+      {
+        "value": {
+          "slug": "environmental-management/waste",
+          "example_info": {
+            "total": 49,
+            "examples": [
+            {
+              "title": "Register as a waste carrier, broker or dealer (England)",
+              "link": "/waste-carrier-or-broker-registration"
+            },
+            {
+              "title": "Hazardous waste producer registration (England and Wales)",
+              "link": "/hazardous-waste-producer-registration"
+            },
+            {
+              "title": "Check if you need an environmental permit",
+              "link": "/environmental-permit-check-if-you-need-one"
+            },
+            {
+              "title": "Classify different types of waste",
+              "link": "/how-to-classify-different-types-of-waste"
+            }
+            ]
+          }
+        },
+        "documents": 47
+      }
+      ],
+        "documents_with_no_value": 2900,
+        "total_options": 17,
+        "missing_options": 0
+    }
+  },
+  "suggested_queries": [ ]
+}

--- a/test/support/gds_api_rummager_test_helpers.rb
+++ b/test/support/gds_api_rummager_test_helpers.rb
@@ -1,0 +1,19 @@
+module GdsApi
+  module TestHelpers
+    module Rummager
+      def rummager_has_services_and_info_data_with_missing_keys_for_organisation
+        stub_request_for(search_results_found_with_missing_keys)
+        run_example_query
+      end
+
+      def search_results_found_with_missing_keys
+        File.read(
+          File.expand_path(
+            "../../fixtures/services_and_information_missing_keys_fixture.json",
+            __FILE__
+          )
+        )
+      end
+    end
+  end
+end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -19,6 +19,16 @@ module RummagerHelpers
     )
   end
 
+  def stub_services_and_information_links_with_missing_keys(organisation_id)
+    Services.rummager.stubs(:search).with(
+      count: "0",
+      filter_organisations: organisation_id,
+      facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
+    ).returns(
+      rummager_has_services_and_info_data_with_missing_keys_for_organisation
+    )
+  end
+
   def rummager_document_for_slug(slug, updated_at = 1.hour.ago, format = "guide")
     {
       "format" => format.to_s,


### PR DESCRIPTION
Currently, if the “services and information” controller encounters a link group without a title then it returns a 500 error. This usually happens when links are not expanded by rummager due to unsynced data between rummager and the publishing-api. This commit removes any such groups to prevent such issues from affecting the “services and information” pages.

Trello: https://trello.com/c/aDBf32Dl/363-fix-crash-on-collections