### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,77 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'collections'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'collections',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+  ])
+
+  try {
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Clean up workspace") {
+      govuk.cleanupGit()
+    }
+
+    stage("git merge") {
+      govuk.mergeMasterBranch()
+    }
+
+    stage("Configure Rails environment") {
+      govuk.setEnvar("RAILS_ENV", "test")
+    }
+
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage("bundle install") {
+      govuk.bundleApp()
+    }
+
+    stage("rubylinter") {
+      govuk.rubyLinter()
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    stage("Run tests") {
+      govuk.runRakeTask("default")
+      govuk.runRakeTask("spec:javascript")
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    }
+
+    govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
This adds the Jenkins configuration to allow pipeline builds on the Jenkins 2 CI server.

Currently blocked while we add phantomJS to the CI servers (alphagov/govuk-puppet#5273).