### PR TITLE
Fix all linter errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,10 @@ node {
       govuk.rubyLinter()
     }
 
+    stage("sasslinter") {
+      govuk.sassLinter()
+    }
+
     stage("Precompile assets") {
       govuk.precompileAssets()
     }

--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -16,7 +16,7 @@
     this.animateSpeed = 330;
 
     if(this.$section.length === 0){
-      this.$section = $('<div id="section" class="pane with-sort" />');
+      this.$section = $('<div id="section" class="section-pane pane with-sort" />');
       this.$el.prepend(this.$section);
       this.$el.addClass('section');
     }

--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -22,7 +22,7 @@
     }
 
     if(this.$subsection.length === 0){
-      this.$subsection = $('<div id="subsection" class="pane" />').hide();
+      this.$subsection = $('<div id="subsection" class="subsection-pane pane" />').hide();
       this.$el.prepend(this.$subsection);
     } else {
       this.$subsection.show();

--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -1,4 +1,4 @@
-#wrapper {
+.wrapper {
   border-bottom: 10px solid $govuk-blue;
 
   #content {

--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -1,7 +1,7 @@
 .wrapper {
   border-bottom: 10px solid $govuk-blue;
 
-  #content {
+  .content {
     display: block;
     @include outer-block;
   }

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -67,7 +67,7 @@ $gutter-one-sixth: $gutter / 6;
         }
       }
 
-      #subsection {
+      .subsection-pane {
         @include media(tablet) {
           float: right;
           width: 50%;
@@ -212,7 +212,7 @@ $gutter-one-sixth: $gutter / 6;
       }
     }
 
-    #subsection {
+    .subsection-pane {
       @include media(tablet) {
         .pane-inner {
           &.a-to-z {

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -12,7 +12,7 @@ main.browse {
     }
 
     &.section {
-      #root {
+      .root-pane {
         display: none; // hide on mobile
 
         @include media(tablet) {
@@ -37,7 +37,7 @@ main.browse {
     }
 
     &.subsection {
-      #root,
+      .root-pane,
       #section {
         display: none; // hide on mobile
 
@@ -104,7 +104,7 @@ main.browse {
 
 
 
-    #root,
+    .root-pane,
     #section {
       min-height: 20px;
 

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -22,7 +22,7 @@ $gutter-one-sixth: $gutter / 6;
         }
       }
 
-      #section {
+      .section-pane {
         @include media(tablet) {
           float: right;
           width: 30%;
@@ -38,7 +38,7 @@ $gutter-one-sixth: $gutter / 6;
 
     &.subsection {
       .root-pane,
-      #section {
+      .section-pane {
         display: none; // hide on mobile
 
         @include media(tablet) {
@@ -55,7 +55,7 @@ $gutter-one-sixth: $gutter / 6;
         }
       }
 
-      #section {
+      .section-pane {
         @include media(tablet) {
           margin-left: -18%;
           width: 30%;
@@ -105,7 +105,7 @@ $gutter-one-sixth: $gutter / 6;
 
 
     .root-pane,
-    #section {
+    .section-pane {
       min-height: 20px;
 
       h1,
@@ -185,7 +185,7 @@ $gutter-one-sixth: $gutter / 6;
       }
     }
 
-    #section {
+    .section-pane {
       z-index: 2;
       background: $white;
       position: relative;

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -1,6 +1,6 @@
 $gutter-one-sixth: $gutter / 6;
 
-main.browse {
+.browse {
   .browse-panes {
     @extend %contain-floats;
     @include inner-block;
@@ -170,7 +170,7 @@ main.browse {
           }
         }
 
-        li.active a {
+        .active a {
           background: $link-colour;
           color: $white;
 

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -102,8 +102,6 @@ $gutter-one-sixth: $gutter / 6;
       }
     }
 
-
-
     .root-pane,
     .section-pane {
       min-height: 20px;
@@ -119,68 +117,66 @@ $gutter-one-sixth: $gutter / 6;
         display: none;
       }
 
-      ul {
-        li {
-          list-style: none;
-          position: relative;
+      ul li {
+        list-style: none;
+        position: relative;
+      }
+
+      ul a {
+        position: relative;
+        display: block;
+        @include core-19;
+        text-decoration: none;
+        padding: 12px 25px 8px 0;
+
+        @include media(tablet) {
+          padding: 12px $gutter 8px $gutter-half;
+          @include core-16;
         }
 
-        a {
-          position: relative;
-          display: block;
-          @include core-19;
-          text-decoration: none;
-          padding: 12px 25px 8px 0;
+        &:hover {
+          background: $panel-colour;
+          color: $link-colour;
+        }
 
-          @include media(tablet) {
-            padding: 12px $gutter 8px $gutter-half;
-            @include core-16;
-          }
+        &:after {
+          position: absolute;
+          top: 50%;
+          margin-top: -8px;
+          right: $gutter-one-third;
+          float: right;
+          content: "\203A";
+        }
 
-          &:hover {
-            background: $panel-colour;
-            color: $link-colour;
-          }
+        &.loading {
+          cursor: default;
+          background: transparent image-url("loading.gif") 95% 50% no-repeat;
 
           &:after {
-            position: absolute;
-            top: 50%;
-            margin-top: -8px;
-            right: $gutter-one-third;
-            float: right;
-            content: "\203A";
-          }
-
-          &.loading {
-            cursor: default;
-            background: transparent image-url("loading.gif") 95% 50% no-repeat;
-
-            &:after {
-              content: "";
-            }
-          }
-
-          h3 {
-            font-weight: bold;
-          }
-
-          p {
-            color: $text-colour;
-            @include core-14;
+            content: "";
           }
         }
 
-        .active a {
+        h3 {
+          font-weight: bold;
+        }
+
+        p {
+          color: $text-colour;
+          @include core-14;
+        }
+      }
+
+      ul .active a {
+        background: $link-colour;
+        color: $white;
+
+        &:hover {
           background: $link-colour;
+        }
+
+        p {
           color: $white;
-
-          &:hover {
-            background: $link-colour;
-          }
-
-          p {
-            color: $white;
-          }
         }
       }
     }
@@ -256,27 +252,23 @@ $gutter-one-sixth: $gutter / 6;
       ul {
         padding: 0;
         list-style: none;
+      }
 
-        li {
-          padding: 0;
-          margin: 0;
+      ul li {
+        padding: 0;
+        margin: 0;
+      }
 
-          a {
-            @include bold-19;
-            display: block;
-            text-decoration: none;
-            padding: $gutter-one-third $gutter $gutter-one-third 0;
-          }
-        }
+      ul li a {
+        @include bold-19;
+        display: block;
+        text-decoration: none;
+        padding: $gutter-one-third $gutter $gutter-one-third 0;
       }
 
       .curated-list {
-        ul {
-          li {
-            a {
-              padding: $gutter-one-sixth $gutter $gutter-one-sixth 0;
-            }
-          }
+        ul li a {
+          padding: $gutter-one-sixth $gutter $gutter-one-sixth 0;
         }
       }
 

--- a/app/assets/stylesheets/views/_email-signups.scss
+++ b/app/assets/stylesheets/views/_email-signups.scss
@@ -1,4 +1,4 @@
-#wrapper #content.email-signup-new {
+.wrapper #content.email-signup-new {
   @extend %site-width-container;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/views/_email-signups.scss
+++ b/app/assets/stylesheets/views/_email-signups.scss
@@ -1,4 +1,4 @@
-.wrapper #content.email-signup-new {
+.wrapper .content.email-signup-new {
   @extend %site-width-container;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -90,25 +90,25 @@
             // align with the left edge of the search box
             margin-left: 18px;
           }
+        }
 
-          li {
-            display: block;
+        ul li {
+          display: block;
+        }
 
-            &.primary {
-              border-bottom: 1px solid $border-colour;
-              padding-bottom: 10px;
-              margin-bottom: 14px;
-            }
+        .primary {
+          border-bottom: 1px solid $border-colour;
+          padding-bottom: 10px;
+          margin-bottom: 14px;
+        }
 
-            &.email a {
-              background: image-url('mail-icon.png') 0 40% no-repeat;
-              padding-left: 28px;
+        .email a {
+          background: image-url('mail-icon.png') 0 40% no-repeat;
+          padding-left: 28px;
 
-              @include device-pixel-ratio() {
-                background-image: image-url('mail-icon-x2.png');
-                background-size: 20px 14px;
-              }
-            }
+          @include device-pixel-ratio() {
+            background-image: image-url('mail-icon-x2.png');
+            background-size: 20px 14px;
           }
         }
 

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,4 +1,4 @@
-<div id="root" class="pane">
+<div id="root" class="pane root-pane">
   <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
   <ul>
     <% top_level_browse_pages.each do |page| %>

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -18,7 +18,7 @@
   </div>
 
 
-  <div id="section" class="pane">
+  <div id="section" class="section-pane pane">
     <%= render 'second_level_browse_pages',
       title: @page.active_top_level_browse_page.title,
       second_level_browse_pages: @page.second_level_browse_pages,

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <div class="browse-panes subsection" data-state="subsection">
-  <div id="subsection" class="pane with-sort">
+  <div id="subsection" class="subsection-pane pane with-sort">
     <%= render 'links' %>
   </div>
 

--- a/app/views/browse/top_level_browse_page.html.erb
+++ b/app/views/browse/top_level_browse_page.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <div class="browse-panes section" data-state="section">
-  <div id="section" class="pane with-sort">
+  <div id="section" class="section-pane pane with-sort">
     <%= render 'second_level_browse_pages',
           title: @page.title,
           second_level_browse_pages: @page.second_level_browse_pages,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 <body>
   <div class="wrapper" id="wrapper">
     <%= yield :breadcrumbs %>
-    <main id="content" role="main" class="<%= yield :page_class %>">
+    <main id="content" role="main" class="content <%= yield :page_class %>">
       <%= yield %>
     </main>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 </head>
 
 <body>
-  <div id="wrapper">
+  <div class="wrapper" id="wrapper">
     <%= yield :breadcrumbs %>
     <main id="content" role="main" class="<%= yield :page_class %>">
       <%= yield %>


### PR DESCRIPTION
This PR fixes the remaining SASS linting issues in the repo. It's a follow up from https://github.com/alphagov/collections/pull/206

These changes are more substantial, so I used [wraith](http://bbc-news.github.io/wraith/) to make sure the pages aren't affected.

Here is the configuration file in case someone wants to test it out:

```
browser: "phantomjs"

directory: "shots"

domains:
  dev: "http://www.dev.gov.uk"
  live: "https://www.gov.uk"

screen_widths:
  - 1280

paths:
  topics: /topic
  topic_page: /topic/oil-and-gas
  subtopic_page: /topic/oil-and-gas/carbon-capture-and-storage
  latest: /topic/animal-welfare/pets/latest
  browse: /browse
  browse_page: /browse/benefits
  browse_subpage: /browse/benefits/entitlement
  email_signup: /topic/oil-and-gas/carbon-capture-and-storage/email-signup
  org_services_info: /government/organisations/department-for-environment-food-rural-affairs/services-information
```