### PR TITLE
Add rcov to Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,8 +60,13 @@ node {
     }
 
     stage("Run tests") {
+      govuk.setEnvar("USE_SIMPLECOV", "1")
       govuk.runRakeTask("default")
       govuk.runRakeTask("spec:javascript")
+    }
+
+    stage("Publish reports") {
+      step([$class: 'RcovPublisher', reportDir: "coverage/rcov"])
     }
 
     stage("Push release tag") {


### PR DESCRIPTION
The old Jenkins build used to publish the rcov reports, but this was missed when migrating to Jenkins 2. This commit configures rcov report publishing as part of the pipeline build.

The old Jenkins build used to publish the rcov reports, but this was missed when migrating to Jenkins 2. This commit configures rcov report publishing as part of the pipeline build.
    
The default coverage metrics are used, which means that the build does not fail if coverage is low, so rcov is really just being used to generate a graph of coverage over time.
