### PR TITLE
Delete all 'page is in beta' messages from topic pages

### DIFF
--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -160,15 +160,4 @@
       }
     }
   }
-
-  .govuk-beta-label {
-    padding-bottom: 10px;
-    border-bottom: 1px solid $border-colour;
-    margin: 10px 0;
-
-    @include media(mobile) {
-      margin: 5px 0;
-    }
-  }
-
 }

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -14,10 +14,6 @@ class ContentItem
     end
   end
 
-  def beta?
-    @content_item_data["phase"] == "beta"
-  end
-
   def details
     @content_item_data["details"] || {}
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,7 +1,6 @@
 class Topic
   attr_reader :content_item
-  delegate :base_path, :title, :description, :content_id, :linked_items, :details,
-    :beta?, to: :content_item
+  delegate :base_path, :title, :description, :content_id, :linked_items, :details, to: :content_item
 
   def self.find(base_path, pagination_options = {})
     content_item = ContentItem.find!(base_path)

--- a/app/views/topics/_subtopic.html.erb
+++ b/app/views/topics/_subtopic.html.erb
@@ -34,17 +34,6 @@
   </div>
 </header>
 
-<% if local_assigns[:beta_label] %>
-  <%= render partial: 'govuk_component/beta_label',
-             locals: {
-               message: "This part of #{link_to('GOV.UK', '/')} is new and being improved - #{link_to('find out what this means','/help/beta')}"
-             } %>
-<% end %>
-
-<% if !local_assigns[:beta_label] && subtopic.beta? %>
-  <%= render 'topic_beta', topic: subtopic %>
-<% end %>
-
 <div class="browse-container full-width">
   <%= yield %>
 </div>

--- a/app/views/topics/_topic_beta.html.erb
+++ b/app/views/topics/_topic_beta.html.erb
@@ -1,5 +1,0 @@
-<%= render 'govuk_component/beta_label',
-  message: %{
-    This page is in beta - it doesn’t include everything on '#{topic.title}'.
-    More content will be added in the next few months. You can also
-    #{link_to("search GOV.UK", "/search")} to find the information you need.} %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -20,14 +20,6 @@
   </div>
 </header>
 
-<% if @topic.beta? %>
-  <%= render 'govuk_component/beta_label',
-    message: %{
-      This page is in beta. It doesn’t cover the full range of content available on GOV.UK -
-      more will be added over the next few months. You can also
-      #{link_to("search GOV.UK", "/search")} to find the information you need.} %>
-<% end %>
-
 <div class="browse-container full-width topics-page">
   <nav class="topics">
     <ul>

--- a/app/views/topics/latest_changes.html.erb
+++ b/app/views/topics/latest_changes.html.erb
@@ -19,7 +19,6 @@
     subtopic: @subtopic,
     organisations: organisations(@subtopic.content_id),
     link_to_latest_feed: false,
-    beta_label: true
   }) do %>
   <ul class="changed-documents">
     <% @subtopic.changed_documents.each do |document| -%>

--- a/app/views/topics/subtopic.html.erb
+++ b/app/views/topics/subtopic.html.erb
@@ -23,7 +23,6 @@
     subtopic: @subtopic,
     organisations: organisations(@subtopic.content_id),
     link_to_latest_feed: true,
-    beta_label: false
   }) do %>
   <% @subtopic.lists.each do |list| -%>
     <nav class="index-list with-title" aria-labelledby="<%= list.title.parameterize %>">

--- a/app/views/topics/topic.html.erb
+++ b/app/views/topics/topic.html.erb
@@ -17,10 +17,6 @@
   </div>
 </header>
 
-<% if @topic.beta? %>
-  <%= render 'topic_beta', topic: @topic %>
-<% end %>
-
 <div class="browse-container full-width topics-page">
   <nav class="topics">
     <ul>

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -118,15 +118,6 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
 
-  it "renders a beta subtopic" do
-    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", "phase" => "beta"))
-    stub_topic_organisations('oil-and-gas/offshore', 'content-id-for-offshore')
-
-    visit "/topic/oil-and-gas/offshore"
-
-    assert page.has_content?("This page is in beta"), "has beta-label"
-  end
-
   describe "latest page for a subtopic" do
     setup do
       content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -76,15 +76,4 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
       end
     end
   end
-
-  it "renders a beta topic" do
-    content_store_has_item(
-      "/topic/oil-and-gas",
-      oil_and_gas_topic_item.merge("phase" => "beta")
-    )
-
-    visit "/topic/oil-and-gas"
-
-    assert page.has_content?("This page is in beta"), "has beta-label"
-  end
 end

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -37,13 +37,6 @@ describe Topic do
     it "returns the topic description" do
       assert_equal "Pay As You Earn", @topic.description
     end
-
-    it "returns the topic's beta status" do
-      refute @topic.beta?
-
-      @api_data["phase"] = "beta"
-      assert @topic.beta?
-    end
   end
 
   describe "parent" do


### PR DESCRIPTION
Topic pages are no longer in beta, and they will be deprecated soon when the new taxonomy-based navigation is added. This means that the 'BETA' tag is out-of-date, and can be deleted.

https://trello.com/c/oW7gSMoB/328-remove-beta-tags-from-topics-in-collections