### PR TITLE
Use GovukSchemas to validate taxon fixtures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'webmock', '~> 1.21.0', require: false
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
+  gem 'govuk_schemas', '~> 2.1'
   gem 'simplecov', '~> 0.10.0'
   gem 'simplecov-rcov', '~> 0.2.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_navigation_helpers (2.1.0)
+    govuk_schemas (2.1.0)
+      json-schema (~> 2.5.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -288,6 +290,7 @@ DEPENDENCIES
   govuk-lint
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.1)
+  govuk_schemas (~> 2.1)
   jasmine-rails (~> 0.12.1)
   logstasher (= 0.6.2)
   minitest-spec-rails (~> 5.3.0)

--- a/test/fixtures/content_store/funding_and_finance_for_students.json
+++ b/test/fixtures/content_store/funding_and_finance_for_students.json
@@ -1,0 +1,40 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da600",
+  "title": "Funding and finance for students",
+  "description": "Description for funding and finance for students",
+  "base_path": "\/alpha-taxonomy\/funding-and-finance-for-students",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da602",
+        "locale": "en",
+        "title": "Education and learning",
+        "description": "Education and learning description",
+        "base_path": "\/alpha-taxonomy\/education"
+      }
+    ],
+    "child_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da601",
+        "title": "Student finance",
+        "description": "Student finance content",
+        "base_path": "\/alpha-taxonomy\/student-finance",
+        "locale": "en",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "36dd87da-4973-5490-ab00-72025b1da603",
+              "locale": "en",
+              "title": "Funding and finance for students",
+              "description": "Description for funding and finance for students",
+              "base_path": "\/alpha-taxonomy\/funding-and-finance-for-students"
+            }
+          ],
+          "child_taxons": [
+            // child taxons are not expanded in the content store
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/content_store/student_finance.json
+++ b/test/fixtures/content_store/student_finance.json
@@ -1,0 +1,55 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da500",
+  "title": "Student finance",
+  "description": "Student finance content",
+  "base_path": "\/alpha-taxonomy\/student-finance",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da505",
+        "locale": "en",
+        "title": "Funding and finance for students",
+        "description": "Description for funding and finance for students",
+        "base_path": "\/alpha-taxonomy\/funding-and-finance-for-students"
+      }
+    ],
+    "child_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da501",
+        "title": "Student sponsorship",
+        "description": "Description of student sponsorship",
+        "base_path": "\/alpha-taxonomy\/student-sponsorship",
+        "locale": "en",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "36dd87da-4973-5490-ab00-72025b1da504",
+              "locale": "en",
+              "title": "Student finance",
+              "description": "Student finance content",
+              "base_path": "\/alpha-taxonomy\/student-finance"
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da502",
+        "title": "Student loans",
+        "description": "Description of student loans",
+        "base_path": "\/alpha-taxonomy\/student-loans",
+        "locale": "en",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "36dd87da-4973-5490-ab00-72025b1da503",
+              "locale": "en",
+              "title": "Student finance",
+              "description": "Student finance content",
+              "base_path": "\/alpha-taxonomy\/student-finance"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/content_store/student_loans.json
+++ b/test/fixtures/content_store/student_loans.json
@@ -1,0 +1,18 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da502",
+  "title": "Student loans",
+  "description": "Description of student loans",
+  "base_path": "\/alpha-taxonomy\/student-loans",
+  "locale": "en",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da503",
+        "locale": "en",
+        "title": "Student finance",
+        "description": "Student finance content",
+        "base_path": "\/alpha-taxonomy\/student-finance"
+      }
+    ]
+  }
+}

--- a/test/fixtures/content_store/student_sponsorship.json
+++ b/test/fixtures/content_store/student_sponsorship.json
@@ -1,0 +1,19 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da501",
+  "title": "Student sponsorship",
+  "description": "Description of student sponsorship",
+  "base_path": "\/alpha-taxonomy\/student-sponsorship",
+  "locale": "en",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da504",
+        "locale": "en",
+        "title": "Student finance",
+        "description": "Student finance content",
+        "base_path": "\/alpha-taxonomy\/student-finance"
+      }
+    ]
+  }
+}
+

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -6,21 +6,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include TaxonHelpers
   include Slimmer::TestHelpers::GovukComponents
 
-  def search_results
-    [
-      {
-        'title' => 'Content item 1',
-        'description' => 'Description of content item 1',
-        'link' => 'content-item-1'
-      },
-      {
-        'title' => 'Content item 2',
-        'description' => 'Description of content item 2',
-        'link' => 'content-item-2'
-      },
-    ]
-  end
-
   it 'is possible to browse a taxon page that has grandchildren' do
     given_there_is_a_taxon_with_grandchildren
     when_i_visit_the_taxon_page
@@ -41,14 +26,37 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_tagged_content_to_the_taxon
   end
 
+private
+
+  def search_results
+    [
+      {
+        'title' => 'Content item 1',
+        'description' => 'Description of content item 1',
+        'link' => 'content-item-1'
+      },
+      {
+        'title' => 'Content item 2',
+        'description' => 'Description of content item 2',
+        'link' => 'content-item-2'
+      },
+    ]
+  end
+
   def given_there_is_a_taxon_with_grandchildren
     @base_path = '/alpha-taxonomy/funding_and_finance_for_students'
-    funding_and_finance_for_students = funding_and_finance_for_students(base_path: @base_path)
+    funding_and_finance_for_students_taxon =
+      funding_and_finance_for_students_taxon(base_path: @base_path)
 
-    @parent = funding_and_finance_for_students['links']['parent_taxons'].first
-    @child_taxons = funding_and_finance_for_students['links']['child_taxons']
+    @parent =
+      funding_and_finance_for_students_taxon['links']['parent_taxons'].first
+    assert_not_nil @parent
 
-    content_store_has_item(@base_path, funding_and_finance_for_students)
+    @child_taxons =
+      funding_and_finance_for_students_taxon['links']['child_taxons']
+    assert @child_taxons.length > 0
+
+    content_store_has_item(@base_path, funding_and_finance_for_students_taxon)
     content_store_has_item(
       student_finance_taxon['base_path'],
       student_finance_taxon
@@ -74,7 +82,10 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     student_finance = student_finance_taxon(base_path: @base_path)
 
     @parent = student_finance['links']['parent_taxons'].first
+    assert_not_nil @parent
+
     @child_taxons = student_finance['links']['child_taxons']
+    assert @child_taxons.length > 0
 
     content_store_has_item(@base_path, student_finance)
     content_store_has_item(

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -9,28 +9,31 @@ describe Taxon do
   end
 
   it 'has a title' do
-    assert_equal @taxon.title, 'Student finance'
+    assert_equal @taxon.title, student_finance_taxon['title']
   end
 
   it 'has a description' do
-    assert_equal @taxon.description, 'Student finance content'
+    assert_equal @taxon.description, student_finance_taxon['description']
   end
 
   it 'has a content id' do
-    assert_equal @taxon.content_id, 'student-finance-content-id'
+    assert_equal @taxon.content_id, student_finance_taxon['content_id']
   end
 
   it 'has a base path' do
-    assert_equal @taxon.base_path, '/alpha-taxonomy/student-finance'
+    assert_equal @taxon.base_path, student_finance_taxon['base_path']
   end
 
   it 'has parent taxon' do
     parent = @taxon.parent_taxon
 
     assert_instance_of Taxon, parent
-    assert_equal parent.title, 'Funding and finance for students'
-    assert_equal parent.description, 'Description for funding and finance for students'
-    assert_equal parent.base_path, '/alpha-taxonomy/funding-and-finance-for-students'
+    assert_equal parent.title,
+      student_finance_taxon['links']['parent_taxons'].first['title']
+    assert_equal parent.description,
+      student_finance_taxon['links']['parent_taxons'].first['description']
+    assert_equal parent.base_path,
+      student_finance_taxon['links']['parent_taxons'].first['base_path']
   end
 
   it 'has two taxon children' do

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -1,82 +1,32 @@
 module TaxonHelpers
   # This taxon has grandchildren
-  def funding_and_finance_for_students(params = {})
-    {
-      'content_id' => 'funding-and-finance-for-students-content-id',
-      'title' => 'Funding and finance for students',
-      'description' => 'Description for funding and finance for students',
-      'base_path' => '/alpha-taxonomy/funding-and-finance-for-students',
-      'links' => {
-        'parent_taxons' => [
-          {
-            'title' => 'Education and learning',
-            'description' => 'Education and learning description',
-            'base_path' => '/alpha-taxonomy/education'
-          }
-        ],
-        'child_taxons' => [
-          student_finance_taxon
-        ]
-      }
-    }.merge(params)
+  def funding_and_finance_for_students_taxon(params = {})
+    fetch_and_validate_taxon(:funding_and_finance_for_students, params)
   end
 
   # This taxon does not have grandchildren
   def student_finance_taxon(params = {})
-    {
-      'content_id' => 'student-finance-content-id',
-      'title' => 'Student finance',
-      'description' => 'Student finance content',
-      'base_path' => '/alpha-taxonomy/student-finance',
-      'links' => {
-        'parent_taxons' => [
-          {
-            'title' => 'Funding and finance for students',
-            'description' => 'Description for funding and finance for students',
-            'base_path' => '/alpha-taxonomy/funding-and-finance-for-students'
-          }
-        ],
-        'child_taxons' => [
-          student_sponsorship_taxon,
-          student_loans_taxon
-        ]
-      }
-    }.merge(params)
+    fetch_and_validate_taxon(:student_finance, params)
   end
 
   def student_sponsorship_taxon(params = {})
-    {
-      'content_id' => 'student-sponsorship-content-id',
-      'title' => 'Student sponsorship',
-      'description' => 'Description of student sponsorship',
-      'base_path' => '/alpha-taxonomy/student-sponsorship',
-      'links' => {
-        'parent_taxons' => [
-          {
-            'title' => 'Student finance',
-            'description' => 'Student finance content',
-            'base_path' => '/alpha-taxonomy/student-finance'
-          }
-        ],
-      }
-    }.merge(params)
+    fetch_and_validate_taxon(:student_sponsorship, params)
   end
 
   def student_loans_taxon(params = {})
-    {
-      'content_id' => 'student-loans-content-id',
-      'title' => 'Student loans',
-      'description' => 'Description of student loans',
-      'base_path' => '/alpha-taxonomy/student-loans',
-      'links' => {
-        'parent_taxons' => [
-          {
-            'title' => 'Student finance',
-            'description' => 'Student finance content',
-            'base_path' => '/alpha-taxonomy/student-finance'
-          }
-        ],
-      }
-    }.merge(params)
+    fetch_and_validate_taxon(:student_loans, params)
+  end
+
+private
+
+  def fetch_and_validate_taxon(basename, params = {})
+    json = File.read(
+      Rails.root.join('test', 'fixtures', 'content_store', "#{basename}.json")
+    )
+    content_item = JSON.parse(json)
+
+    GovukSchemas::RandomExample
+      .for_schema(frontend_schema: 'taxon')
+      .merge_and_validate(content_item.merge(params))
   end
 end


### PR DESCRIPTION
This commit introduces GovukSchemas so that we can validate taxon
schemas in the tests. I've also moved the example taxons to JSON files
and updated them to be valid against the schema.

This is a follow up from this comment in another PR: https://github.com/alphagov/collections/pull/217#discussion_r96446991

cc/ @tijmenb 