### PR TITLE
Fetch breadcrumbs from the server in browse pages

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -12,7 +12,7 @@
     this.$root = this.$el.find('#root');
     this.$section = this.$el.find('#section');
     this.$subsection = this.$el.find('#subsection');
-    this.$breadcrumbs = $('.govuk-breadcrumbs ol');
+    this.$breadcrumbs = $('.govuk-breadcrumbs');
     this.animateSpeed = 330;
 
     if(this.$section.length === 0){
@@ -335,23 +335,9 @@
         this.loadSectionFromState(state);
       }
     },
-    updateBreadcrumbs: function(state){
-      var $breadcrumbItems = this.$breadcrumbs.find('li');
-      if(state.subsection){
-        var sectionSlug = state.section;
-        var sectionTitle = this.$section.find('h1').text();
-
-        if($breadcrumbItems.length === 1){
-          var $sectionBreadcrumb = $('<li />');
-          this.$breadcrumbs.append($sectionBreadcrumb);
-        } else {
-          var $sectionBreadcrumb = $breadcrumbItems.slice(1);
-        }
-
-        $sectionBreadcrumb.html('<a href="/browse/'+sectionSlug+'">'+sectionTitle+'</a>');
-      } else {
-        this.$breadcrumbs.find('li').slice(1).remove();
-      }
+    updateBreadcrumbs: function(state) {
+      var $newBreadcrumbs = $(state.sectionData.breadcrumbs);
+      this.$breadcrumbs.html($newBreadcrumbs.html());
     },
     trackPageview: function(state){
       var sectionTitle = this.$section.find('h1').text();

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -14,7 +14,10 @@ class BrowseController < ApplicationController
     respond_to do |f|
       f.html
       f.json do
-        render json: { html: second_level_browse_pages_partial(@page) }
+        render json: {
+          breadcrumbs: render_partial('_breadcrumbs'),
+          html: second_level_browse_pages_partial(@page)
+        }
       end
     end
   end
@@ -27,7 +30,10 @@ class BrowseController < ApplicationController
     respond_to do |f|
       f.html
       f.json do
-        render json: { html: render_partial('_links') }
+        render json: {
+          breadcrumbs: render_partial('_breadcrumbs'),
+          html: render_partial('_links')
+        }
       end
     end
   end

--- a/app/views/browse/_breadcrumbs.html.erb
+++ b/app/views/browse/_breadcrumbs.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: 'govuk_component/breadcrumbs',
+  locals: @navigation_helpers.breadcrumbs %>
+
+<div class="header-context">
+  <%# Deliberately empty. %>
+  <%# This will prevent Static from adding a placeholder breadcrumb. %>
+</div>

--- a/app/views/browse/second_level_browse_page.html.erb
+++ b/app/views/browse/second_level_browse_page.html.erb
@@ -8,8 +8,7 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
-  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+  <%= render 'breadcrumbs' %>
 <% end %>
 
 <div class="browse-panes subsection" data-state="subsection">

--- a/app/views/browse/top_level_browse_page.html.erb
+++ b/app/views/browse/top_level_browse_page.html.erb
@@ -7,8 +7,7 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render partial: 'govuk_component/breadcrumbs', locals: @navigation_helpers.breadcrumbs %>
-  <div class="header-context"><!-- Deliberately empty. This will prevent Static from adding a placeholder breadcrumb. --></div>
+  <%= render 'breadcrumbs' %>
 <% end %>
 
 <div class="browse-panes section" data-state="section">

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -114,30 +114,20 @@ describe('browse-columns.js', function() {
     }
   });
 
-  it("should update breadcrumbs", function(){
+  it("should update breadcrumbs from cache", function(){
     var context;
 
-    // section to section
-    context = { $breadcrumbs: $('<ol><li>one</li></ol>') };
-    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, {});
-    expect(context.$breadcrumbs.find('li').length).toEqual(1);
+    context = {
+      $breadcrumbs: $('<div class="govuk-breadcrumbs"><ol><li>one</li></ol></div>')
+    };
 
-    // subsection to section
-    context = { $breadcrumbs: $('<ol><li>one</li><li>two</li></ol>') };
-    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, {});
-    expect(context.$breadcrumbs.find('li').length).toEqual(1);
-
-    // subsection to subsection
-    context = { $breadcrumbs: $('<ol><li>one</li><li>two</li></ol>'), $section: $('<div><h1>text</h1></div>') };
-    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, { subsection: "first/second", section: 'first' });
+    var cached_data = {
+      sectionData: {
+        breadcrumbs: '<div class="govuk-breadcrumbs"><ol><li>one</li><li>two</li></ol></div>'
+      }
+    }
+    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, cached_data);
     expect(context.$breadcrumbs.find('li').length).toEqual(2);
-    expect(context.$breadcrumbs.find('li a').attr('href')).toEqual('/browse/first');
-
-    // section to subsection
-    context = { $breadcrumbs: $('<ol><li>one</li></ol>'), $section: $('<div><h1>text</h1></div>') };
-    GOVUK.BrowseColumns.prototype.updateBreadcrumbs.call(context, { subsection: "first/second", section: 'first' });
-    expect(context.$breadcrumbs.find('li').length).toEqual(2);
-    expect(context.$breadcrumbs.find('li a').attr('href')).toEqual('/browse/first');
   });
 
   // http://stackoverflow.com/questions/9821166/error-accessing-jquerywindow-height-in-jasmine-while-running-tests-in-maven


### PR DESCRIPTION
We have recently enabled click tracking on breadcrumbs via data
attributes. These data attributes are added by `static` and are needed
to know where people click. The old functionality in `collections` meant
that we would be adding list items to the breadcrumbs ourselves in the
app and therefore not including any of the necessary data attributes.

This commit re-fetches the breadcrumbs from either cache or the server
rather than modifying it.

This way, we always render breadcrumbs that have the expected attributes
set.

The tests are now simpler as well, since the logic of fetching
components from the server is already tested.

Trello: https://trello.com/c/mShtuEW6/340-bug-add-correct-data-attributes-to-the-breadcrumbs-in-collections