### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'govuk_frontend_toolkit', '~> 4.3.0'
 
 gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
+gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,9 @@ GEM
     airbrake (4.3.8)
       builder
       multi_json
+    appsignal (2.0.5)
+      rack
+      thread_safe
     arel (6.0.3)
     ast (2.3.0)
     better_errors (2.1.1)
@@ -280,6 +283,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.3.1)
+  appsignal (~> 2.0)
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,10 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_API_KEY'] %>"
+  name: "Collections"
+  active: <%= ENV['APPSIGNAL_API_KEY'] ? true : false %>
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
This adds Appsignal to the app. We're evaluating to see if it is a good
replacement for Errbit, while also adding performance tracking.

It's only activated if APPSIGNAL_API_KEY is set, which is currently only in
integration (alphagov/govuk-puppet#5376
https://github.gds/gds/deployment/pull/1215).

https://trello.com/c/J3kDeZD7

cc/ @tijmenb 