### PR TITLE
Remove redundant tag for removing breadcrumb

### DIFF
--- a/app/views/browse/_breadcrumbs.html.erb
+++ b/app/views/browse/_breadcrumbs.html.erb
@@ -1,7 +1,2 @@
 <%= render partial: 'govuk_component/breadcrumbs',
   locals: @navigation_helpers.breadcrumbs %>
-
-<div class="header-context">
-  <%# Deliberately empty. %>
-  <%# This will prevent Static from adding a placeholder breadcrumb. %>
-</div>


### PR DESCRIPTION
This app uses the GOV.UK Component to render the breadcrumb. The tag removed in this was previously necessary to instruct Slimmer to hide the old breadcrumb. We no longer need it because the CSS and HTML have been completely removed from static in https://github.com/alphagov/static/pull/879.

https://trello.com/c/7wohUbyo