### PR TITLE
Filter taxon content for Guidance material, sort by title

### DIFF
--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -1,6 +1,29 @@
 class RummagerSearch
   PAGE_SIZE_TO_GET_EVERYTHING = 1000
 
+  GUIDANCE_DOCUMENT_TYPES = %w[
+    answer
+    contact
+    detailed_guide
+    form
+    guidance
+    guide
+    licence
+    local_transaction
+    manual
+    map
+    notice
+    place
+    programme
+    promotional
+    regulation
+    simple_smart_answer
+    smart_answer
+    statutory_guidance
+    transaction
+    travel_advice
+  ].freeze
+
   include Enumerable
   delegate :each, to: :documents
 

--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -10,12 +10,13 @@ class TaggedContent
   end
 
   def fetch
-    # TODO: this should return only guidance content, sorted alphabetically
     RummagerSearch.new(
       filter_taxons: [content_id],
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
-      fields: %w(title description link)
+      fields: %w(title description link),
+      filter_content_store_document_type: RummagerSearch::GUIDANCE_DOCUMENT_TYPES,
+      order: 'title',
     ).documents
   end
 end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -4,7 +4,9 @@ module RummagerHelpers
       filter_taxons: [content_id],
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
-      fields: %w(title description link)
+      fields: %w(title description link),
+      filter_content_store_document_type: RummagerSearch::GUIDANCE_DOCUMENT_TYPES,
+      order: 'title',
     ).returns(
       "results" => results,
       "start" => 0,


### PR DESCRIPTION
Only show Guidance content tagged to a given taxon. Also adds a sort by title.

Note that this change is dependent upon the completion of https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager

Trello: https://trello.com/c/oVNYKzBl/325-fetch-only-guidance-content-from-rummager-in-collections-when-populating-the-tagged-content-for-a-taxon