### PR TITLE
WIP - Rework css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,6 @@
 
 @import "helpers/layouts";
 @import "helpers/pagination";
-@import "helpers/govuk-component-helpers";
 
 @import "views/browse";
 @import "views/email-signups";

--- a/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
+++ b/app/assets/stylesheets/helpers/_govuk-component-helpers.scss
@@ -1,6 +1,0 @@
-// GOV.UK components expect to live in a world with a global reset. This CSS
-// might be pushed up to static at some point.
-.govuk-breadcrumbs {
-  max-width: 960px;
-  margin: 0 auto;
-}

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -38,6 +38,7 @@
   .sub-heading {
     @include core-24;
     margin-bottom: 0;
+
     a {
       color: $secondary-text-colour;
       text-decoration: none;
@@ -56,6 +57,8 @@
   }
 
   .page-header {
+    margin-top: $gutter * 3;
+
     h1 {
       padding-top: 0;
     }
@@ -82,13 +85,16 @@
   .parent-topic-contents {
     .topic-content {
       padding-bottom: $gutter;
+
       ul {
         list-style-type: none;
         padding-bottom: $gutter-one-third;
       }
+
       h3 {
-          padding-bottom: 0;
+        padding-bottom: 0;
       }
+
     }
   }
 
@@ -97,9 +103,11 @@
       ul {
         list-style-type: none;
       }
+
       li {
-          margin-bottom: $gutter-one-third;
+        margin-bottom: $gutter-one-third;
       }
+
       h3 {
         padding-bottom: 0;
       }
@@ -134,7 +142,9 @@
     }
   }
 
-/*  Most of this is taken from the service manual and at some point needs to be separated out into a component.  We are currently holding off on this until it is tested more within the current navigation changes */
+//  Most of this is taken from the service manual and at some point needs to be separated
+// out into a component.  We are currently holding off on this until it is tested more
+// within the current navigation changes.
 
    // When JavaScript is enabled, create accordion
   .js-accordion-with-descriptions {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -36,11 +36,9 @@
     margin-bottom: 6px;
   }
 
-//Should this sub-heading be marked up as a span, and then displayed as a block?  Doesn't seem like it should be.
   .sub-heading {
     @include core-24;
-    display: block;
-
+    margin-bottom: 0;
     a {
       color: $secondary-text-colour;
       text-decoration: none;
@@ -58,9 +56,16 @@
     }
   }
 
+  .page-header {
+    h1 {
+      padding-top: 0;
+    }
+  }
+
   .child-topics-list {
     ul {
       list-style-type: none;
+      //should this be extended?
       @extend %grid-row;
 
       li {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -15,7 +15,6 @@
 
   h2 {
     @include bold-24;
-
     margin-top: $gutter * 1.5;
     margin-bottom: $gutter;
 
@@ -115,11 +114,6 @@
       margin-bottom: $gutter * 1.5;
     }
 
-    &__title {
-      @include bold-24;
-      margin-bottom: 5px;
-    }
-
     &__description {
       @include core-19;
       margin-bottom: $gutter-one-quarter;
@@ -144,9 +138,11 @@
     }
   }
 
-///////////////////////////////////////////////////////////////////////////////////
+/*  Most of this is taken from the service manual and at some point needs to be separated out into a component.  We are currently holding off on this until it is tested more within the current navigation changes */
+
    // When JavaScript is enabled, create accordion
   .js-accordion-with-descriptions {
+    padding-bottom: $gutter * 2;
 
     // Wrapper for 'open all / close all' button
     .subsection-controls {
@@ -273,7 +269,4 @@
     }
   }
 
-  .js-accordion-with-descriptions {
-    padding-bottom: $gutter * 2;
-  }
 }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -47,7 +47,6 @@
   }
 
   .page-header {
-    min-height: 45vh;
     margin-bottom: 0;
 
     div {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -114,6 +114,11 @@
       margin-bottom: $gutter * 1.5;
     }
 
+    &__title {
+      @include bold-24;
+      margin-bottom: 5px;
+    }
+
     &__description {
       @include core-19;
       margin-bottom: $gutter-one-quarter;
@@ -127,10 +132,6 @@
       @include core-19;
       padding-left: 0;
       list-style-type: none;
-    }
-
-    &__list-item {
-      margin-bottom: 0.5em;
     }
 
     &__list-item a {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -34,16 +34,11 @@
     @include bold-19;
     padding-bottom: $gutter-one-third;
   }
-
+  //this needs work for different break points
   p {
     @include core-19;
-    margin-top: em(5, 16);
-    margin-bottom: em(20, 16);
-
-    @include media(tablet) {
-      margin-top: em(5);
-      margin-bottom: em(20);
-    }
+    margin-top: 2px;
+    margin-bottom: 6px;
   }
 
   .page-header {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,10 +1,5 @@
 .taxon-page {
 
-  // Where has this come from?  Alex's code or somewhere else?  Search for this in case.  Don't think this should be being used though,
-  @function em($px, $base: 19) {
-    @return ($px / $base) + em;
-  }
-
   h1 {
     box-sizing: border-box;
     display: block;
@@ -41,35 +36,24 @@
     margin-bottom: 6px;
   }
 
-  .page-header {
-    margin-bottom: 0;
+//Should this sub-heading be marked up as a span, and then displayed as a block?  Doesn't seem like it should be.
+  .sub-heading {
+    @include core-24;
+    display: block;
 
-    div {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
+    a {
+      color: $secondary-text-colour;
+      text-decoration: none;
 
-    .sub-heading {
-      font-weight: normal;
-      font-size: 24px;
-      padding-bottom: 10px;
-
-      display: block;
-
-      a {
-        color: $secondary-text-colour;
-        text-decoration: none;
-
-        &:before {
-          content: " ";
-          background-image: image-url("back.svg");
-          background-repeat: no-repeat;
-          background-size: auto 18px;
-          background-position: left bottom;
-          display: inline-block;
-          width: 20px;
-          height: 1em;
-        }
+      &:before {
+        content: " ";
+        background-image: image-url("back.svg");
+        background-repeat: no-repeat;
+        background-size: auto 18px;
+        background-position: left bottom;
+        display: inline-block;
+        width: 20px;
+        height: 1em;
       }
     }
   }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -114,11 +114,6 @@
       margin-bottom: $gutter * 1.5;
     }
 
-    &__title {
-      @include bold-24;
-      margin-bottom: 5px;
-    }
-
     &__description {
       @include core-19;
       margin-bottom: $gutter-one-quarter;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,5 +1,6 @@
 .taxon-page {
 
+  //Where has this come from?  Alex's code or somewhere else?  Search for this in case.  Don't think this should be being used though,
   @function em($px, $base: 19) {
     @return ($px / $base) + em;
   }
@@ -7,15 +8,11 @@
   h1 {
     box-sizing: border-box;
     display: block;
-    min-height: 30vh;
-    padding-top: 12.5vh;
-    font-size: 48px;
-    line-height: 50px;
-    font-weight: bold;
+    padding-top: 90px;
+    @include bold-48;
 
     +p {
-      font-size: 24px;
-      line-height: 30px;
+      @include core-24;
       padding-bottom: 30px;
     }
   }
@@ -65,6 +62,7 @@
     .sub-heading {
       font-weight: normal;
       font-size: 24px;
+      padding-bottom: 10px;
 
       display: block;
 

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -78,14 +78,12 @@
   .parent-topic-contents {
     .topic-content {
       padding-bottom: $gutter;
-
       ul {
         list-style-type: none;
         padding-bottom: $gutter-one-third;
-
-        h3 {
+      }
+      h3 {
           padding-bottom: 0;
-        }
       }
     }
   }
@@ -94,15 +92,12 @@
     .topic-content {
       ul {
         list-style-type: none;
-
-        li {
+      }
+      li {
           margin-bottom: $gutter-one-third;
-
-          // scss-lint:disable NestingDepth
-          h3 {
-            padding-bottom: 0;
-          }
-        }
+      }
+      h3 {
+        padding-bottom: 0;
       }
     }
   }
@@ -144,7 +139,7 @@
     }
   }
 
-
+///////////////////////////////////////////////////////////////////////////////////
    // When JavaScript is enabled, create accordion
   .js-accordion-with-descriptions {
 

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,6 +1,6 @@
 .taxon-page {
 
-  //Where has this come from?  Alex's code or somewhere else?  Search for this in case.  Don't think this should be being used though,
+  // Where has this come from?  Alex's code or somewhere else?  Search for this in case.  Don't think this should be being used though,
   @function em($px, $base: 19) {
     @return ($px / $base) + em;
   }
@@ -13,14 +13,13 @@
 
     +p {
       @include core-24;
+      padding-top: 10px;
       padding-bottom: 30px;
     }
   }
 
   h2 {
-    font-size: 24px;
-    line-height: 30px;
-    font-weight: bold;
+    @include bold-24;
 
     margin-top: $gutter * 1.5;
     margin-bottom: $gutter;
@@ -32,15 +31,12 @@
   }
 
   h3 {
-    font-size: 19px;
-    font-weight: bold;
-
+    @include bold-19;
     padding-bottom: $gutter-one-third;
   }
 
   p {
     @include core-19;
-    -webkit-font-smoothing: antialiased;
     margin-top: em(5, 16);
     margin-bottom: em(20, 16);
 

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,17 +1,16 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="page-header">
+      <span  role=”link” tabindex=”0″ class="sub-heading">
+        <% if parent_taxon.present? %>
+          <%= link_to parent_taxon.title, parent_taxon.base_path %>
+        <% else %>
+          <%= link_to 'Home', Plek.find('www') %>
+        <% end %>
+      </h2>
       <h1>
-        <span class="sub-heading">
-          <% if parent_taxon.present? %>
-            <%= link_to parent_taxon.title, parent_taxon.base_path %>
-          <% else %>
-            <%= link_to 'Home', Plek.find('www') %>
-          <% end %>
-          </span>
         <%= taxon.title %>
       </h1>
-
       <p><%= taxon.description %></p>
     </div>
   </div>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -7,7 +7,7 @@
         <% else %>
           <%= link_to 'Home', Plek.find('www') %>
         <% end %>
-      </h2>
+      </span>
       <h1>
         <%= taxon.title %>
       </h1>


### PR DESCRIPTION
WIP  - This isn't ready for review.  I'm also closing this as I don't agree with the WIP pull requests as an approach.  I haven't seen any other team do this, and I find them really confusing and that they act as noise, as you can't really review them, but they are there as if they are a pull request to be merged.

I'm going to put this on a trello card, and put down the branch this is on instead.  This is how I have worked in the past in other teams, and I thought this was how git was supposed to work.

Done:
- Using frontend toolkit mixins and fonts where possible.
-  Making measurements more consistent and remove measurements unsupported by older browsers.
-  Unnesting CSS
-  Remove unused CSS from collections for breadcrumbs.
-  Cut down CSS and unused selectors.
-  Added tab index for now to subheading, but I'm not sure about the markup around this currently.

Still to do:
- Ensure markup is semantic - I'm not sure the subheading is being handled the best way.  I'm not even sure if it should be referred to as a subheading as it is kind of a subheading/navigation element and breadcrumb/orientation element at the same time.  Added in a tab index to the span for the time being, apparently this helps with screenreaders but isn't completely ideal so I want to rethink this.
- Make sure images are supported by older browsers - We are using SVGs but don't have png fallbacks currently which are required for ie8.
- Stop the grid from breaking without nth selectors - Nth selectors are not supported by ie 8, so I need to find another way of making sure the grid doesn't break..
-  Check with Alex how the spacing should be now, as this has changed recently in the prototype.
-  Work needs to go into this on different viewports.