### PR TITLE
Fix the taxonomy breadcrumbs for taxon pages

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -6,6 +6,11 @@
   parent_taxon: taxon.parent_taxon
 } %>
 
+<% content_for :breadcrumbs do %>
+  <%= render partial: 'govuk_component/breadcrumbs',
+    locals: @navigation_helpers.taxon_breadcrumbs %>
+<% end %>
+
 <% if taxon.has_grandchildren? %>
   <%= render partial: 'child_taxons_grid',
     locals: { child_taxons: taxon.child_taxons } %>


### PR DESCRIPTION
The taxonomy breadcrumbs use a different method from the navigation
helpers and therefore can't rely on the default breadcrumb data.

This commit re-adds the taxonomy breadcrumbs.