### PR TITLE
Redirect Education browse page in B variant of navigation A/B test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.1'
+gem 'govuk_ab_testing', '0.1.4' # Specify the minor version because API is unstable
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'minitest-spec-rails', '~> 5.3.0'
   gem 'mocha', '~> 1.1.0', require: false
   gem 'webmock', '~> 1.21.0', require: false
+  gem 'climate_control', '~> 0.1.0', require: false
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
   gem 'govuk_schemas', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
@@ -283,6 +284,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
+  climate_control (~> 0.1.0)
   cucumber-rails (~> 1.4.2)
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_ab_testing (0.1.4)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -289,6 +290,7 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
+  govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.1)
   govuk_schemas (~> 2.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
+  def new_navigation_enabled?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,5 @@
 class TaxonsController < ApplicationController
-  before_action :return_404, unless: :new_navigaton_enabled?
+  before_action :return_404, unless: :new_navigation_enabled?
 
   def show
     setup_content_item_and_navigation_helpers(taxon)
@@ -8,10 +8,6 @@ class TaxonsController < ApplicationController
   end
 
 private
-
-  def new_navigaton_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
 
   def return_404
     head :not_found

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_test_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 <% content_for :page_class, "browse" %>
 
 <div class="browse-panes section" data-state="section">

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Collections
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'ALLOWALL'
     }
+
+    # Google Analytics dimension assigned to the education navigation A/B test
+    config.navigation_ab_test_dimension = 41
   end
 end

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
+require "climate_control"
 
 describe BrowseController do
+
+  include GovukAbTesting::MinitestHelpers
+
   describe "GET index" do
     before do
       content_store_has_item("/browse",
@@ -29,10 +33,77 @@ describe BrowseController do
         )
       end
 
-      it "set correct expiry headers" do
+      it "sets correct expiry headers" do
         get :show, top_level_slug: "benefits"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+    end
+
+    describe "during the education navigation A/B test" do
+      before do
+        content_store_has_item("/browse/education", base_path: '/browse/education')
+        content_store_has_item("/browse/benefits", base_path: '/browse/benefits')
+      end
+
+      describe "with the new navigation not enabled" do
+        ["A", "B"].each do |variant|
+          it "returns the original version of the page for variant #{variant}" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            get :show, top_level_slug: "education"
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
+      end
+
+      describe "with the new navigation enabled" do
+        it "returns the original version of the page as the A variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "A" do
+              get :show, top_level_slug: "education"
+
+              assert_response 200
+            end
+          end
+        end
+
+        it "redirects to the taxonomy navigation as the B variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "B", assert_meta_tag: false do
+              get :show, top_level_slug: "education"
+
+              assert_response 302
+              assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
+            end
+          end
+        end
+
+        ["A", "B"].each do |variant|
+          it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, top_level_slug: "benefits"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+
+          it "does not redirect education when the #{variant} variant is requested in JSON format" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, format: :json, top_level_slug: "education"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
       end
     end
 
@@ -66,5 +137,9 @@ describe BrowseController do
       title: 'Entitlement',
       base_path: '/browse/benefits/entitlement'
     }]
+  end
+
+  def with_new_navigation_enabled(&block)
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,5 +1,6 @@
 require 'integration_test_helper'
 require 'slimmer/test_helpers/govuk_components'
+require "climate_control"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
@@ -48,7 +49,7 @@ private
   end
 
   def given_new_navigation_is_enabled
-    ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
+    @enable_new_navigation = true
   end
 
   def given_there_is_a_taxon_with_grandchildren
@@ -112,7 +113,11 @@ private
   end
 
   def when_i_visit_the_taxon_page
-    visit @base_path
+    new_nav_environment_variable = @enable_new_navigation ? 'yes' : nil
+
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: new_nav_environment_variable) do
+      visit @base_path
+    end
   end
 
   def then_i_can_see_there_is_a_page_title


### PR DESCRIPTION
If the user has been assigned to the B variant of the Education Navigation A/B test, redirect them from /browse/education to the new navigation page at /education.

Ensure that this redirect response is cached separately from the original A version.

https://trello.com/c/D7QsJmAy/329-redirects-to-the-new-navigation

This doesn't cover second-level browse pages such as https://www.gov.uk/browse/education/student-finance. I've added that to the Trello card.

Dependencies:

- [x] alphagov/govuk_ab_testing#3