### PR TITLE
Remove BEM syntax from accordion

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -13,9 +13,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // Prevent FOUC, remove class hiding content
       $element.removeClass('js-hidden');
 
-      var $subsectionButton = $element.find('.subsection__button');
-      var $subsectionHeader = $element.find('.subsection__header');
-      var totalSubsections = $element.find('.subsection__content').length;
+      var $subsectionButton = $element.find('.subsection-button');
+      var $subsectionHeader = $element.find('.subsection-header');
+      var totalSubsections = $element.find('.subsection-content').length;
 
       var $openOrCloseAllButton;
       var GOVUKServiceManualTopic = serviceManualTopicPrefix();
@@ -53,16 +53,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function addButtonsToSubsections() {
-        var $subsectionTitle = $element.find('.subsection__title');
+        var $subsectionTitle = $element.find('.subsection-title');
 
         // Wrap each title in a button, with aria controls matching the ID of the subsection
         $subsectionTitle.each(function(index) {
-          $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
+          $(this).wrapInner( '<button class="subsection-button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
         });
       }
 
       function addIconsToSubsections() {
-        $subsectionHeader.append( '<span class="subsection__icon"></span>' );
+        $subsectionHeader.append( '<span class="subsection-icon"></span>' );
       }
 
       function addAriaControlsAttrForOpenCloseAllButton() {
@@ -79,13 +79,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function closeOpenSections() {
-        var $subsectionContent = $element.find('.subsection__content');
+        var $subsectionContent = $element.find('.subsection-content');
         closeSection($subsectionContent);
       }
 
       function checkSessionStorage() {
 
-        var $subsectionContent = $element.find('.subsection__content');
+        var $subsectionContent = $element.find('.subsection-content');
 
         $subsectionContent.each(function(index) {
           var subsectionContentId = $(this).attr('id');
@@ -98,11 +98,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function setSessionStorage() {
-        var isOpenSubsections = $('.subsection--is-open').length;
+        var isOpenSubsections = $('.subsection-is-open').length;
         if (isOpenSubsections) {
-          var $openSubsections = $('.subsection--is-open');
+          var $openSubsections = $('.subsection-is-open');
           $openSubsections.each(function(index) {
-            var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
+            var subsectionOpenContentId = $(this).find('.subsection-content').attr('id');
             sessionStorage.setItem( GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
           });
         }
@@ -113,7 +113,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (isClosedSubsections) {
           var $closedSubsections = $('.subsection');
           $closedSubsections.each(function(index) {
-            var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
+            var subsectionClosedContentId = $(this).find('.subsection-content').attr('id');
             sessionStorage.removeItem( GOVUKServiceManualTopic+subsectionClosedContentId , subsectionClosedContentId);
           });
         }
@@ -124,7 +124,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $subsectionHeader.on('click', function(e) {
           toggleSection($(this).next());
           toggleIcon($(this));
-          toggleState($(this).find('.subsection__button'));
+          toggleState($(this).find('.subsection-button'));
           setOpenCloseAllText();
           setSessionStorage();
           removeSessionStorage();
@@ -191,12 +191,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       function openStoredSections($section) {
         toggleSection($section);
         toggleIcon($section);
-        toggleState($section.parent().find('.subsection__button'));
+        toggleState($section.parent().find('.subsection-button'));
         setOpenCloseAllText();
       }
 
       function setOpenCloseAllText() {
-        var openSubsections = $('.subsection--is-open').length;
+        var openSubsections = $('.subsection-is-open').length;
         // Find out if the number of is-opens == total number of sections
         if (openSubsections === totalSubsections) {
           $openOrCloseAllButton.text('Close all');
@@ -214,12 +214,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function toggleIcon($node) {
-        if ($($node).parent().hasClass('subsection--is-open')) {
-          $node.parent().removeClass('subsection--is-open');
+        if ($($node).parent().hasClass('subsection-is-open')) {
+          $node.parent().removeClass('subsection-is-open');
           $node.parent().addClass('subsection');
         } else {
           $node.parent().removeClass('subsection');
-          $node.parent().addClass('subsection--is-open');
+          $node.parent().addClass('subsection-is-open');
         }
       }
 
@@ -241,11 +241,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function showOpenIcon($node) {
         $node.parent().removeClass('subsection');
-        $node.parent().addClass('subsection--is-open');
+        $node.parent().addClass('subsection-is-open');
       }
 
       function showCloseIcon($node) {
-        $node.parent().removeClass('subsection--is-open');
+        $node.parent().removeClass('subsection-is-open');
         $node.parent().addClass('subsection');
       }
 

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -18,8 +18,7 @@
     margin-top: $gutter * 1.5;
     margin-bottom: $gutter;
 
-    // scss-lint:disable SelectorFormat
-    &.subsection__title {
+    &.subsection-title {
       margin: 0;
     }
   }
@@ -121,7 +120,7 @@
       margin-bottom: $gutter * 1.5;
     }
 
-    &__description {
+    .subsection-description {
       @include core-19;
       margin-bottom: $gutter-one-quarter;
 
@@ -130,20 +129,20 @@
       }
     }
 
-    &__list {
+    .subsection-list {
       @include core-19;
       padding-left: 0;
       list-style-type: none;
     }
 
-    &__list-item a {
+    .subsection-list-item a {
       text-decoration: none;
     }
   }
 
-// Most of this is taken from the service manual and at some point needs to be separated
-// out into a component.  We are currently holding off on this until it is tested more
-// within the current navigation changes.
+// Most of this is taken from the service manual and at some point needs to be
+// separated out into a component.  We are currently holding off on this until
+// it is tested more within the current navigation changes.
 
    // When JavaScript is enabled, create accordion
   .js-accordion-with-descriptions {
@@ -171,107 +170,100 @@
       border-bottom: 1px solid $border-colour;
     }
 
+    .subsection-title {
+      button {
+        color: $govuk-blue;
+        cursor: pointer;
+
+        @include bold-24;
+        background: none;
+        border: 0;
+        padding-left: 0;
+        text-align: left;
+      }
+
+      margin-bottom: 0;
+      margin-right: $gutter-half;
+
+      @include media(tablet) {
+        margin-right: $gutter;
+      }
+    }
+
+    .subsection-header {
+      position: relative;
+      padding-top: 14px;
+      padding-bottom: 12px;
+      border-top: 1px solid $border-colour;
+
+      // Change the background of the header on hover
+      &:hover {
+        cursor: pointer;
+        background: $highlight-colour;
+      }
+    }
+
+    .subsection-description {
+      margin-bottom: 0;
+      margin-right: $gutter-half;
+
+      @include media(tablet) {
+        margin-bottom: 0;
+        margin-right: $gutter;
+      }
+    }
+
+    .subsection-icon {
+      position: absolute;
+      top: 50%;
+      right: 0;
+
+      @include media (tablet) {
+        right: 15px;
+      }
+
+      height: 16px;
+      width: 16px;
+      margin-top: -8px;
+
+      // PNG fallback for SVG
+      background-image: image-url('icons-plus-minus.png');
+      // SVG sprite
+      background: image-url("icons-plus-minus.svg"), linear-gradient(transparent, transparent);
+      background-repeat: no-repeat;
+      background-position: 0 -16px;
+    }
+
+    .subsection-is-open {
+      .subsection-icon {
+        background-position: 0 0;
+      }
+
+      .subsection-content {
+        @include media(tablet) {
+          padding-top: 10px;
+          padding-bottom: $gutter;
+        }
+      }
+    }
+
+    .subsection-content {
+      padding-top: 5px;
+      padding-bottom: $gutter-half;
+    }
+
     .subsection {
       margin-bottom: 0;
 
       @include media(tablet) {
         margin-bottom: 0;
       }
-
-      &__header {
-        position: relative;
-        padding-top: 14px;
-        padding-bottom: 12px;
-        border-top: 1px solid $border-colour;
-
-        // Change the background of the header on hover
-        &:hover {
-          cursor: pointer;
-          background: $highlight-colour;
-        }
-      }
-
-      &__title {
-        button {
-          color: $govuk-blue;
-          cursor: pointer;
-
-          @include bold-24;
-          background: none;
-          border: 0;
-          padding-left: 0;
-          text-align: left;
-        }
-
-        margin-bottom: 0;
-        margin-right: $gutter-half;
-
-        @include media(tablet) {
-          margin-right: $gutter;
-        }
-      }
-
-      &__description {
-        margin-bottom: 0;
-        margin-right: $gutter-half;
-
-        @include media(tablet) {
-          margin-bottom: 0;
-          margin-right: $gutter;
-        }
-      }
-
-      &__icon {
-        position: absolute;
-        top: 50%;
-        right: 0;
-
-        @include media (tablet) {
-          right: 15px;
-        }
-
-        height: 16px;
-        width: 16px;
-        margin-top: -8px;
-
-        // PNG fallback for SVG
-        background-image: image-url('icons-plus-minus.png');
-        // SVG sprite
-        background: image-url("icons-plus-minus.svg"), linear-gradient(transparent, transparent);
-        background-repeat: no-repeat;
-        background-position: 0 -16px;
-      }
-
-      &--is-open {
-        // scss-lint:disable SelectorFormat
-        .subsection__icon {
-          background-position: 0 0;
-        }
-      }
-
-      &__content {
-        padding-top: 5px;
-        padding-bottom: $gutter-half;
-      }
-
-      &--is-open {
-        // scss-lint:disable SelectorFormat
-        .subsection__content {
-          @include media(tablet) {
-            padding-top: 10px;
-            padding-bottom: $gutter;
-          }
-        }
-      }
-
     }
   }
 
-  // scss-lint:disable SelectorFormat
-  .subsection__list-item {
+  .subsection-list-item {
     a {
       font-weight: bold;
     }
   }
-
 }

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -6,12 +6,12 @@
         <div class="subsection-wrapper">
           <% ([taxon] + child_taxons).each_with_index do |taxon_for_list, index| %>
             <div class="subsection">
-              <div class="subsection__header">
-                <h2 class="subsection__title"><%= taxon_for_list.title %></h2>
-                <p class="subsection__description"><%= taxon_for_list.description %></p>
+              <div class="subsection-header">
+                <h2 class="subsection-title"><%= taxon_for_list.title %></h2>
+                <p class="subsection-description"><%= taxon_for_list.description %></p>
               </div>
 
-              <div class="subsection__content" id="subsection_content_<%= index %>">
+              <div class="subsection-content" id="subsection_content_<%= index %>">
                 <%= render partial: 'tagged_content_list', locals: {
                   tagged_content: taxon_for_list.tagged_content
                 } %>

--- a/app/views/taxons/_tagged_content_list.html.erb
+++ b/app/views/taxons/_tagged_content_list.html.erb
@@ -1,6 +1,6 @@
-<ul class="subsection__list">
+<ul class="subsection-list">
   <% tagged_content.each do |content_item| %>
-    <li class="subsection__list-item">
+    <li class="subsection-list-item">
       <%= link_to content_item.title, content_item.base_path %>
 
       <p><%= content_item.description %></p>


### PR DESCRIPTION
This commit removes the BEM syntax from the accordion element. That
syntax isn't widely used in GOV.UK and it also causes linter issues.

Trello: https://trello.com/c/m9SRmrtq/332-refactor-css-and-js-that-has-been-copied-from-the-prototype