### PR TITLE
[DO NOT MERGE] Enable A/B education redirects from JavaScript-powered browse pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'minitest-spec-rails', '~> 5.3.0'
   gem 'mocha', '~> 1.1.0', require: false
   gem 'webmock', '~> 1.21.0', require: false
+  gem 'climate_control', '~> 0.1.0', require: false
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
   gem 'govuk_schemas', '~> 2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.1'
+# TODO: Specify version number once gem is released
+gem 'govuk_ab_testing', github: 'alphagov/govuk_ab_testing', branch: 'master'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
@@ -283,6 +284,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
+  climate_control (~> 0.1.0)
   cucumber-rails (~> 1.4.2)
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/alphagov/govuk_ab_testing.git
+  revision: 95733140a397791d93a952f009f9b1a3bd13b50b
+  branch: master
+  specs:
+    govuk_ab_testing (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -289,6 +296,7 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
+  govuk_ab_testing!
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.1)
   govuk_schemas (~> 2.1)

--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -321,9 +321,16 @@
     },
     navigate: function(e){
       if(e.currentTarget.pathname.match(/^\/browse\/[^\/]+(\/[^\/]+)?$/)){
-        e.preventDefault();
 
         var $target = $(e.currentTarget);
+
+        if ($target.hasClass('ab-test-redirect')) {
+          // Allow browser to follow link, which will redirect to the correct page
+          return;
+        }
+
+        e.preventDefault();
+
         var state = this.parsePathname(e.currentTarget.pathname);
         state.title = $target.text();
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
+  def new_navigation_enabled?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -15,7 +15,26 @@ class BrowseController < ApplicationController
 
     respond_to do |f|
       f.html do
-        render :show, locals: { page: page }
+        is_page_under_ab_test = false
+        ab_test_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
+
+        if new_navigation_enabled? && params[:top_level_slug] == "education"
+          ab_test_variant.configure_response(response)
+
+          if ab_test_variant.variant_b?
+            return redirect_to controller: "taxons",
+              action: "show",
+              taxon_base_path: "education"
+          end
+
+          is_page_under_ab_test = true
+        end
+
+        render :show, locals: {
+          page: page,
+          is_page_under_ab_test: is_page_under_ab_test,
+          ab_test_variant: ab_test_variant,
+         }
       end
       f.json do
         render json: {

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -5,7 +5,9 @@ class BrowseController < ApplicationController
     page = MainstreamBrowsePage.find("/browse")
     setup_content_item_and_navigation_helpers(page)
 
-    render :index, locals: { page: page }
+    ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
+
+    render :index, locals: { page: page, ab_variant: ab_variant }
   end
 
   def show
@@ -16,12 +18,12 @@ class BrowseController < ApplicationController
     respond_to do |f|
       f.html do
         is_page_under_ab_test = false
-        ab_test_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
+        ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
 
         if new_navigation_enabled? && params[:top_level_slug] == "education"
-          ab_test_variant.configure_response(response)
+          ab_variant.configure_response(response)
 
-          if ab_test_variant.variant_b?
+          if ab_variant.variant_b?
             return redirect_to controller: "taxons",
               action: "show",
               taxon_base_path: "education"
@@ -33,7 +35,7 @@ class BrowseController < ApplicationController
         render :show, locals: {
           page: page,
           is_page_under_ab_test: is_page_under_ab_test,
-          ab_test_variant: ab_test_variant,
+          ab_variant: ab_variant,
          }
       end
       f.json do

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -6,9 +6,11 @@ class SecondLevelBrowsePageController < ApplicationController
 
     respond_to do |f|
       f.html do
+        ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
         render :show, locals: {
           page: page,
-          meta_section: meta_section
+          meta_section: meta_section,
+          ab_variant: ab_variant
         }
       end
       f.json do

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,5 @@
 class TaxonsController < ApplicationController
-  before_action :return_404, unless: :new_navigaton_enabled?
+  before_action :return_404, unless: :new_navigation_enabled?
 
   def show
     setup_content_item_and_navigation_helpers(taxon)
@@ -8,10 +8,6 @@ class TaxonsController < ApplicationController
   end
 
 private
-
-  def new_navigaton_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
 
   def return_404
     head :not_found

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -3,7 +3,12 @@
   <ul>
     <% top_level_browse_pages.each do |page| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">
-        <%= link_to page.title, page.base_path %>
+        <% link_class = if ab_variant.variant_b? && page.base_path == "/browse/education"
+          "ab-test-redirect"
+        else
+          ""
+        end %>
+        <%= link_to page.title, page.base_path, class: link_class %>
       </li>
     <% end %>
   </ul>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -3,5 +3,6 @@
 
 <div class="browse-panes root">
   <%= render 'top_level_browse_pages',
-    top_level_browse_pages: page.top_level_browse_pages %>
+    top_level_browse_pages: page.top_level_browse_pages,
+    ab_variant: ab_variant %>
 </div>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_test_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 <% content_for :page_class, "browse" %>
 
 <div class="browse-panes section" data-state="section">

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -2,7 +2,7 @@
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>
-    <%= ab_test_variant.analytics_meta_tag.html_safe %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
   <% end %>
 <% end %>
 <% content_for :page_class, "browse" %>
@@ -16,5 +16,6 @@
   </div>
 
   <%= render 'browse/top_level_browse_pages',
-        top_level_browse_pages: page.top_level_browse_pages %>
+        top_level_browse_pages: page.top_level_browse_pages,
+        ab_variant: ab_variant %>
 </div>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -20,5 +20,6 @@
   </div>
 
   <%= render 'browse/top_level_browse_pages',
-    top_level_browse_pages: page.top_level_browse_pages %>
+    top_level_browse_pages: page.top_level_browse_pages,
+    ab_variant: ab_variant %>
 </div>

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
+require "climate_control"
 
 describe BrowseController do
+
+  include GovukAbTesting::MinitestHelpers
+
   describe "GET index" do
     before do
       content_store_has_item("/browse",
@@ -29,10 +33,77 @@ describe BrowseController do
         )
       end
 
-      it "set correct expiry headers" do
+      it "sets correct expiry headers" do
         get :show, top_level_slug: "benefits"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+    end
+
+    describe "during the education navigation A/B test" do
+      before do
+        content_store_has_item("/browse/education", base_path: '/browse/education')
+        content_store_has_item("/browse/benefits", base_path: '/browse/benefits')
+      end
+
+      describe "with the new navigation not enabled" do
+        ["A", "B"].each do |variant|
+          it "returns the original version of the page for variant #{variant}" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            get :show, top_level_slug: "education"
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
+      end
+
+      describe "with the new navigation enabled" do
+        it "returns the original version of the page as the A variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "A" do
+              get :show, top_level_slug: "education"
+
+              assert_response 200
+            end
+          end
+        end
+
+        it "redirects to the taxonomy navigation as the B variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "B", assert_meta_tag: false do
+              get :show, top_level_slug: "education"
+
+              assert_response 302
+              assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
+            end
+          end
+        end
+
+        ["A", "B"].each do |variant|
+          it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, top_level_slug: "benefits"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+
+          it "does not redirect education when the #{variant} variant is requested in JSON format" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, format: :json, top_level_slug: "education"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
       end
     end
 
@@ -66,5 +137,9 @@ describe BrowseController do
       title: 'Entitlement',
       base_path: '/browse/benefits/entitlement'
     }]
+  end
+
+  def with_new_navigation_enabled(&block)
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,5 +1,6 @@
 require 'integration_test_helper'
 require 'slimmer/test_helpers/govuk_components'
+require "climate_control"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
@@ -48,7 +49,7 @@ private
   end
 
   def given_new_navigation_is_enabled
-    ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
+    @enable_new_navigation = true
   end
 
   def given_there_is_a_taxon_with_grandchildren
@@ -112,7 +113,11 @@ private
   end
 
   def when_i_visit_the_taxon_page
-    visit @base_path
+    new_nav_environment_variable = @enable_new_navigation ? 'yes' : nil
+
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: new_nav_environment_variable) do
+      visit @base_path
+    end
   end
 
   def then_i_can_see_there_is_a_page_title


### PR DESCRIPTION
Ensure that when a user clicks on 'Education and learning' from /browse, they are redirected to the new taxon page if they are in the B bucket.

https://trello.com/c/D7QsJmAy/329-redirects-to-the-new-navigation

Before merging:
- [ ] Use the [A/B testing gem](https://github.com/alphagov/govuk_ab_testing) to simplify the `HTTP_GOVUK_ABTEST_EDUCATIONNAVIGATION` checks
- [ ] Merge #232 and rebase this PR on master

I'm not very keen on all the hard-coded "education" strings in this code - even once the A/B test is removed, we'll (presumably?) be leaving the redirects in place from the old to the new navigation. At that point, it seems wrong for "education" to be hard-coded into the controller and "/browse/education" to be hard-coded into the JS which handles the browse page links.

Would it be better to add another type of link to the content store, named something like `new_navigation_redirect`? Then we could use it store the redirect from /browse/education to /education. @tijmenb and I talked about doing this for topic pages, but it might make sense here, too. It would make it simple to start redirecting other themes as they're added to the taxonomy, because we'd just make a config change and push it to the content store rather than updating hard-coded theme names in collections.