### PR TITLE
Remove nth selector from grid CSS

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -74,10 +74,10 @@
         padding-bottom: $gutter;
         min-height: (5 * $gutter);
       }
+    }
 
-      li:nth-child(3n+1) {
-        clear: left;
-      }
+    .leftmost-row-cell-clear-float {
+      clear: left;
     }
   }
 

--- a/app/views/taxons/_child_taxons_grid.html.erb
+++ b/app/views/taxons/_child_taxons_grid.html.erb
@@ -1,8 +1,8 @@
 <nav role="navigation" class="child-topics-list">
   <h2>In this section</h2>
   <ul>
-    <% child_taxons.each do |child_taxon| %>
-      <li>
+    <% child_taxons.each_with_index do |child_taxon, index| %>
+      <li class="<%= 'leftmost-row-cell' if index % 3 == 0%>">
         <h3>
           <%= link_to child_taxon.title, child_taxon.base_path %>
         </h3>


### PR DESCRIPTION
This change removes the usage of the `:nth-child` CSS selector in the Taxon grid. This selector is [not supported in IE8](http://caniuse.com/#feat=css-sel3).

In particular, the `clear: left` being applied is needed for very "uneven" content in the grid (ie if one of the descriptions is much longer than the others).

I've tested this in BrowserStack, and it looks fine.

Trello: https://trello.com/c/g8rg70Oa/359-find-a-way-of-making-sure-the-grid-doesn-t-break-without-using-nth-selectors-which-are-not-supported-in-ie8