### PR TITLE
Highlight Jenkins release stages more clearly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,11 +90,15 @@ node {
       step([$class: 'RcovPublisher', reportDir: "coverage/rcov"])
     }
 
-    stage("Push release tag") {
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-    }
+    if (env.BRANCH_NAME == "master") {
+      stage("Push release tag") {
+        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
 
-    govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+      stage("Deploy to integration") {
+        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+      }
+    }
 
   } catch (e) {
     currentBuild.result = "FAILED"


### PR DESCRIPTION
- Add extra master branch check. This is redundant, but it stops the release tag and deployment stages from being logged confusingly on branch builds.
- Wrap Integration deployment in a stage because this is no longer done by the govuk Jenkins helper.