### PR TITLE
Update all executable in the bin folder

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
-#!/usr/bin/env ruby1.9.1
+#!/usr/bin/env ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby1.9.1
+#!/usr/bin/env ruby
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby1.9.1
+#!/usr/bin/env ruby
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require 'pathname'
+
+# path to your application root.
+APP_ROOT = Pathname.new File.expand_path('../../',  __FILE__)
+
+Dir.chdir APP_ROOT do
+  # This script is a starting point to setup your application.
+  # Add necessary setup steps to this file:
+
+  puts "== Installing dependencies =="
+  system "gem install bundler --conservative"
+  system "bundle check || bundle install"
+
+  # puts "\n== Copying sample files =="
+  # unless File.exist?("config/database.yml")
+  #   system "cp config/database.yml.sample config/database.yml"
+  # end
+
+  puts "\n== Preparing database =="
+  system "bin/rake db:setup"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system "rm -f log/*"
+  system "rm -rf tmp/cache"
+
+  puts "\n== Restarting application server =="
+  system "touch tmp/restart.txt"
+end


### PR DESCRIPTION
Currently, we can't run `govuk_app_console collections` anywhere. The error is:

```
$ sudo -u deploy govuk_setenv collections bundle exec ./bin/rails console
Could not find rake-11.2.2 in any of the sources
Run `bundle install` to install missing gems.
```

The reason is we were pointing to the incorrect ruby version in all executables
in bin/.

This change was achieved by running:

```
bundle exec rake rails:update:bin
```

More details here:
http://guides.rubyonrails.org/4_0_release_notes.html

In particular:

```
Your app's executables now live in the bin/ directory. Run rake rails:update:bin
to get bin/bundle, bin/rails, and bin/rake.
```