### PR TITLE
Rename Open all to Expand all

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -49,7 +49,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function addOpenCloseAllButton() {
-        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>' );
+        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Expand all</button></div>' );
       }
 
       function addButtonsToSubsections() {
@@ -148,12 +148,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var action = '';
 
           // update button text
-          if ($openOrCloseAllButton.text() == "Open all") {
+          if ($openOrCloseAllButton.text() == "Expand all") {
             $openOrCloseAllButton.text("Close all");
             $openOrCloseAllButton.attr("aria-expanded", "true");
             action = 'open';
           } else {
-            $openOrCloseAllButton.text("Open all");
+            $openOrCloseAllButton.text("Expand all");
             $openOrCloseAllButton.attr("aria-expanded", "false");
             action = 'close';
           }
@@ -201,7 +201,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         if (openSubsections === totalSubsections) {
           $openOrCloseAllButton.text('Close all');
         } else {
-          $openOrCloseAllButton.text('Open all');
+          $openOrCloseAllButton.text('Expand all');
         }
       }
 


### PR DESCRIPTION
The toggle of the accordion has been renamed in the prototype based on
user feedback. This commit makes sure we use the new copy in the new
navigation pages.

Trello: https://trello.com/c/kFvjCgDX/306-as-a-developer-i-want-to-start-implementing-navigation-pages-in-production-to-understand-and-prepare-for-the-process-of-building