### PR TITLE
Add govuk-title component classes

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -3,8 +3,6 @@
   h1 {
     box-sizing: border-box;
     display: block;
-    padding-top: 90px;
-    @include bold-48;
 
     +p {
       @include core-24;

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <div class="page-header">
+    <div class="govuk-title length-long">
       <span  role="link" tabindex="0" class="sub-heading">
         <% if parent_taxon.present? %>
           <%= link_to parent_taxon.title, parent_taxon.base_path %>


### PR DESCRIPTION
Add govuk-title component classes and remove redundant CSS.  The spacing around the sub-heading is being ignored for the moment as it may imminently not exist. 

Before:

<img width="1019" alt="screen shot 2017-02-08 at 17 36 30" src="https://cloud.githubusercontent.com/assets/11633362/22749456/51184af0-ee25-11e6-9fe5-80ed894a6acb.png">

After:

<img width="1041" alt="screen shot 2017-02-08 at 17 36 58" src="https://cloud.githubusercontent.com/assets/11633362/22749464/548a3b3a-ee25-11e6-9fcb-a8e5e1fd531a.png">

https://trello.com/c/AvwlbOfZ/383-fix-spacing-around-the-title-in-the-new-navigation-pages