### PR TITLE
Bugfix class name

### DIFF
--- a/app/views/taxons/_child_taxons_grid.html.erb
+++ b/app/views/taxons/_child_taxons_grid.html.erb
@@ -2,7 +2,7 @@
   <h2>In this section</h2>
   <ul>
     <% child_taxons.each_with_index do |child_taxon, index| %>
-      <li class="<%= 'leftmost-row-cell' if index % 3 == 0%>">
+      <li class="<%= 'leftmost-row-cell-clear-float' if index % 3 == 0 %>">
         <h3>
           <%= link_to child_taxon.title, child_taxon.base_path %>
         </h3>


### PR DESCRIPTION
Fix left clear.  The class name had been changed but not updated on the markup.  This should provide a grid of a list that works on ie8 as well.