### PR TITLE
[DO NOT MERGE] Redirect from second-level browse pages in the education nav A/B test

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -17,26 +17,7 @@ class BrowseController < ApplicationController
 
     respond_to do |f|
       f.html do
-        is_page_under_ab_test = false
-        ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
-
-        if new_navigation_enabled? && params[:top_level_slug] == "education"
-          ab_variant.configure_response(response)
-
-          if ab_variant.variant_b?
-            return redirect_to controller: "taxons",
-              action: "show",
-              taxon_base_path: "education"
-          end
-
-          is_page_under_ab_test = true
-        end
-
-        render :show, locals: {
-          page: page,
-          is_page_under_ab_test: is_page_under_ab_test,
-          ab_variant: ab_variant,
-         }
+        show_html(page)
       end
       f.json do
         render json: {
@@ -48,6 +29,30 @@ class BrowseController < ApplicationController
   end
 
 private
+
+  def show_html(page)
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda { params[:top_level_slug] == "education" },
+      map_to_taxon: lambda { "education" }
+    )
+
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      render :show, locals: {
+        page: page,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        ab_variant: taxon_resolver.ab_variant,
+      }
+    end
+  end
 
   def second_level_browse_pages_partial(page)
     render_partial('second_level_browse_page/_second_level_browse_pages',

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -7,10 +7,27 @@ class SecondLevelBrowsePageController < ApplicationController
     respond_to do |f|
       f.html do
         ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
+
+        is_page_under_ab_test = false
+
+        if new_navigation_enabled? && params[:top_level_slug] == "education"
+          ab_variant.configure_response(response)
+          is_page_under_ab_test = true
+
+          if ab_variant.variant_b?
+            taxon = redirects["education"][params[:second_level_slug]]
+
+            return redirect_to controller: "taxons",
+              action: "show",
+              taxon_base_path: taxon
+          end
+        end
+
         render :show, locals: {
           page: page,
           meta_section: meta_section,
-          ab_variant: ab_variant
+          ab_variant: ab_variant,
+          is_page_under_ab_test: is_page_under_ab_test
         }
       end
       f.json do
@@ -32,5 +49,9 @@ private
     MainstreamBrowsePage.find(
       "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}"
     )
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["second_level_browse_pages"]
   end
 end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -1,0 +1,17 @@
+class TaxonRedirectResolver
+  attr_reader :ab_variant
+
+  def initialize(request, is_page_in_ab_test:, map_to_taxon:)
+    @ab_variant = GovukAbTesting::AbTest.new("EducationNavigation").requested_variant(request)
+    @is_page_in_ab_test = is_page_in_ab_test
+    @map_to_taxon = map_to_taxon
+  end
+
+  def page_ab_tested?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes' && @is_page_in_ab_test.call
+  end
+
+  def taxon_base_path
+    @map_to_taxon.call if page_ab_tested? && ab_variant.variant_b?
+  end
+end

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 <% content_for :page_class, "browse" %>
 
 <% content_for :meta_section do %>

--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -1,0 +1,17 @@
+default: &default
+  second_level_browse_pages:
+    education:
+      find-course: education/further-and-higher-education-skills-and-vocational-training
+      school-admissions-transport: education/running-and-managing-a-school
+      school-life: education
+      student-finance: education/funding-and-finance-for-students
+      universities-higher-education: education/further-and-higher-education-skills-and-vocational-training
+
+production:
+  <<: *default
+
+development:
+  <<: *default
+
+test:
+  <<: *default

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -138,8 +138,4 @@ describe BrowseController do
       base_path: '/browse/benefits/entitlement'
     }]
   end
-
-  def with_new_navigation_enabled(&block)
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
-  end
 end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -9,4 +9,8 @@ class ActiveSupport::TestCase
       value
     end
   end
+
+  def with_new_navigation_enabled(&block)
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
+  end
 end


### PR DESCRIPTION
Configure redirects from all education second-level browse pages, such as /browse/education/school-life, to the equivalent taxon page.

Dependencies:

- [ ] Merge #235, and then rebase this on master

Trello: https://trello.com/c/mXf7R9tk/391-redirect-from-second-level-browse-pages-to-taxons