### PR TITLE
[DO NOT MERGE] Redirect from topics to taxons in education navigation A/B test

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,13 +3,37 @@ class TopicsController < ApplicationController
     topic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(topic)
 
-    render :index, locals: { topic: topic }
+    render :index, locals: { topic: topic, is_page_under_ab_test: false }
   end
 
   def show
-    topic = Topic.find(request.path)
-    setup_content_item_and_navigation_helpers(topic)
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda { !redirects[params[:topic_slug]].nil? },
+      map_to_taxon: lambda { redirects[params[:topic_slug]] }
+    )
 
-    render :index, locals: { topic: topic }
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      topic = Topic.find(request.path)
+      setup_content_item_and_navigation_helpers(topic)
+
+      render :index, locals: {
+        topic: topic,
+        ab_variant: taxon_resolver.ab_variant,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+      }
+    end
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["topics"]
   end
 end

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title do %><%= topic.title %> - GOV.UK<% end %>
 <%= render 'shared/tag_meta', tag: topic %>
+<% if is_page_under_ab_test %>
+  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% end %>
 <% content_for :page_class, "topics-page" %>
 
 <header class="page-header group">

--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -6,6 +6,10 @@ default: &default
       school-life: education
       student-finance: education/funding-and-finance-for-students
       universities-higher-education: education/further-and-higher-education-skills-and-vocational-training
+  topics:
+    schools-colleges-childrens-services: education
+    further-education-skills: education/further-and-higher-education-skills-and-vocational-training
+    higher-education: education/further-and-higher-education-skills-and-vocational-training
 
 production:
   <<: *default

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "climate_control"
 
 describe BrowseController do
 

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "climate_control"
 
 describe SecondLevelBrowsePageController do
   include RummagerHelpers

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -4,6 +4,8 @@ describe TopicsController do
   include ContentSchemaHelpers
   include RummagerHelpers
 
+  include GovukAbTesting::MinitestHelpers
+
   describe "GET topic" do
     describe "with a valid topic slug" do
       before do
@@ -22,6 +24,65 @@ describe TopicsController do
       get :show, topic_slug: "oil-and-gas"
 
       assert_equal 404, response.status
+    end
+  end
+
+  describe "during the education navigation A/B test" do
+
+    before do
+      content_store_has_item('/topic/further-education-skills', content_schema_example(:topic, :topic))
+    end
+
+    describe "with the new navigation not enabled" do
+      ["A", "B"].each do |variant|
+        it "returns the original version of the page for variant #{variant}" do
+          setup_ab_variant("EducationNavigation", variant)
+
+          get :show, topic_slug: "further-education-skills"
+
+          assert_response 200
+          assert_unaffected_by_ab_test
+        end
+      end
+    end
+
+    describe "with the new navigation enabled" do
+      it "returns the original version of the page as the A variant" do
+        with_new_navigation_enabled do
+          with_variant EducationNavigation: "A" do
+            get :show, topic_slug: "further-education-skills"
+
+            assert_response 200
+          end
+        end
+      end
+
+      it "redirects to the taxonomy navigation as the B variant" do
+        with_new_navigation_enabled do
+          with_variant EducationNavigation: "B", assert_meta_tag: false do
+            get :show, topic_slug: "further-education-skills"
+
+            assert_response 302
+            assert_redirected_to controller: "taxons", 
+              action: "show",
+              taxon_base_path: "education/further-and-higher-education-skills-and-vocational-training"
+          end
+        end
+      end
+
+      ["A", "B"].each do |variant|
+        it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+          content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
+          setup_ab_variant("EducationNavigation", variant)
+
+          with_new_navigation_enabled do
+            get :show, topic_slug: "oil-and-gas"
+          end
+
+          assert_response 200
+          assert_unaffected_by_ab_test
+        end
+      end
     end
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,6 +1,5 @@
 require 'integration_test_helper'
 require 'slimmer/test_helpers/govuk_components'
-require "climate_control"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -1,3 +1,5 @@
+require "climate_control"
+
 class ActiveSupport::TestCase
   def build_ostruct_recursively(value)
     case value


### PR DESCRIPTION
Configure redirects from all education second-level browse pages like /topic/higher-education to the equivalent taxon page.

Dependencies:

- [ ] #232 

Trello: https://trello.com/c/zqV4lkGv/375-redirect-from-topics-to-taxons-in-b-version-of-the-navigation