### PR TITLE
Add navigation page redirects for A/B test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.1'
+gem 'govuk_ab_testing', '0.1.4' # Specify the minor version because API is unstable
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.1'
-gem 'govuk_ab_testing', '0.1.4' # Specify the minor version because API is unstable
+gem 'govuk_ab_testing', '0.1.5' # Specify the minor version because API is unstable
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :test do
   gem 'minitest-spec-rails', '~> 5.3.0'
   gem 'mocha', '~> 1.1.0', require: false
   gem 'webmock', '~> 1.21.0', require: false
+  gem 'climate_control', '~> 0.1.0', require: false
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
   gem 'govuk_schemas', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
@@ -283,6 +284,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
+  climate_control (~> 0.1.0)
   cucumber-rails (~> 1.4.2)
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.1.4)
+    govuk_ab_testing (0.1.5)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -290,7 +290,7 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 0.1.4)
+  govuk_ab_testing (= 0.1.5)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.1)
   govuk_schemas (~> 2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_ab_testing (0.1.4)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -289,6 +290,7 @@ DEPENDENCIES
   gds-api-adapters (~> 34.1.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
+  govuk_ab_testing (= 0.1.4)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.1)
   govuk_schemas (~> 2.1)

--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -321,9 +321,16 @@
     },
     navigate: function(e){
       if(e.currentTarget.pathname.match(/^\/browse\/[^\/]+(\/[^\/]+)?$/)){
-        e.preventDefault();
 
         var $target = $(e.currentTarget);
+
+        if ($target.hasClass('ab-test-redirect')) {
+          // Allow browser to follow link, which will redirect to the correct page
+          return;
+        }
+
+        e.preventDefault();
+
         var state = this.parsePathname(e.currentTarget.pathname);
         state.title = $target.text();
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,10 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
+  def new_navigation_enabled?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -57,8 +57,4 @@ private
       "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}"
     )
   end
-
-  def redirects
-    Rails.application.config_for(:navigation_redirects)["second_level_browse_pages"]
-  end
 end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -6,31 +6,7 @@ class SecondLevelBrowsePageController < ApplicationController
 
     respond_to do |f|
       f.html do
-        dimension = Rails.application.config.navigation_ab_test_dimension
-        ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-        ab_variant = ab_test.requested_variant(request)
-
-        is_page_under_ab_test = false
-
-        if new_navigation_enabled? && params[:top_level_slug] == "education"
-          ab_variant.configure_response(response)
-          is_page_under_ab_test = true
-
-          if ab_variant.variant_b?
-            taxon = redirects["education"][params[:second_level_slug]]
-
-            return redirect_to controller: "taxons",
-              action: "show",
-              taxon_base_path: taxon
-          end
-        end
-
-        render :show, locals: {
-          page: page,
-          meta_section: meta_section,
-          ab_variant: ab_variant,
-          is_page_under_ab_test: is_page_under_ab_test
-        }
+        show_html
       end
       f.json do
         render json: {
@@ -42,6 +18,35 @@ class SecondLevelBrowsePageController < ApplicationController
   end
 
 private
+
+  def show_html
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda { params[:top_level_slug] == "education" },
+      map_to_taxon: lambda { redirects["education"][params[:second_level_slug]] }
+    )
+
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      render :show, locals: {
+        page: page,
+        meta_section: meta_section,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        ab_variant: taxon_resolver.ab_variant,
+      }
+    end
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["second_level_browse_pages"]
+  end
 
   def meta_section
     page.active_top_level_browse_page.title.downcase

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -6,9 +6,15 @@ class SecondLevelBrowsePageController < ApplicationController
 
     respond_to do |f|
       f.html do
+
+        dimension = Rails.application.config.navigation_ab_test_dimension
+        ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
+        ab_variant = ab_test.requested_variant(request)
+        
         render :show, locals: {
           page: page,
-          meta_section: meta_section
+          meta_section: meta_section,
+          ab_variant: ab_variant
         }
       end
       f.json do

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -6,15 +6,30 @@ class SecondLevelBrowsePageController < ApplicationController
 
     respond_to do |f|
       f.html do
-
         dimension = Rails.application.config.navigation_ab_test_dimension
         ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
         ab_variant = ab_test.requested_variant(request)
-        
+
+        is_page_under_ab_test = false
+
+        if new_navigation_enabled? && params[:top_level_slug] == "education"
+          ab_variant.configure_response(response)
+          is_page_under_ab_test = true
+
+          if ab_variant.variant_b?
+            taxon = redirects["education"][params[:second_level_slug]]
+
+            return redirect_to controller: "taxons",
+              action: "show",
+              taxon_base_path: taxon
+          end
+        end
+
         render :show, locals: {
           page: page,
           meta_section: meta_section,
-          ab_variant: ab_variant
+          ab_variant: ab_variant,
+          is_page_under_ab_test: is_page_under_ab_test
         }
       end
       f.json do
@@ -36,5 +51,9 @@ private
     MainstreamBrowsePage.find(
       "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}"
     )
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["second_level_browse_pages"]
   end
 end

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -2,11 +2,29 @@ class ServicesAndInformationController < ApplicationController
   def index
     setup_content_item_and_navigation_helpers(service_and_information)
 
-    render :index, locals: {
-      service_and_information: service_and_information,
-      organisation: service_and_information.organisation,
-      grouped_links: grouped_links
-    }
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda { params[:organisation_id] == "department-for-education" },
+      map_to_taxon: lambda { "education" }
+    )
+
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      render :index, locals: {
+        service_and_information: service_and_information,
+        organisation: service_and_information.organisation,
+        grouped_links: grouped_links,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        ab_variant: taxon_resolver.ab_variant,
+      }
+    end
   end
 
 private

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,12 +1,34 @@
 class SubtopicsController < ApplicationController
   def show
-    subtopic = Topic.find(request.path)
-    setup_content_item_and_navigation_helpers(subtopic)
 
-    render :show, locals: {
-      subtopic: subtopic,
-      meta_section: subtopic.parent.title.downcase
-    }
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda {
+        !redirects[params[:topic_slug]].nil? &&
+          !redirects[params[:topic_slug]][params[:subtopic_slug]].nil?
+      },
+      map_to_taxon: lambda { redirects[params[:topic_slug]][params[:subtopic_slug]] }
+    )
+
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      subtopic = Topic.find(request.path)
+      setup_content_item_and_navigation_helpers(subtopic)
+
+      render :show, locals: {
+        subtopic: subtopic,
+        meta_section: subtopic.parent.title.downcase,
+        ab_variant: taxon_resolver.ab_variant,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+      }
+    end
   end
 
 private
@@ -24,5 +46,9 @@ private
         facet_organisations: "1000",
       )["facets"]["organisations"]
     )
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["subtopics"]
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,5 @@
 class TaxonsController < ApplicationController
-  before_action :return_404, unless: :new_navigaton_enabled?
+  before_action :return_404, unless: :new_navigation_enabled?
 
   def show
     setup_content_item_and_navigation_helpers(taxon)
@@ -8,10 +8,6 @@ class TaxonsController < ApplicationController
   end
 
 private
-
-  def new_navigaton_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
 
   def return_404
     head :not_found

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -4,7 +4,16 @@ class TaxonsController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
-    render :show, locals: { taxon: taxon }
+    dimension = Rails.application.config.navigation_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
+    ab_variant = ab_test.requested_variant(request)
+
+    ab_variant.configure_response(response)
+
+    # Show the taxon page regardless of which variant is requested, because
+    # there is no straighforward mapping of taxons back to original navigation
+    # pages.
+    render :show, locals: { taxon: taxon, ab_variant: ab_variant }
   end
 
 private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,13 +3,37 @@ class TopicsController < ApplicationController
     topic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(topic)
 
-    render :index, locals: { topic: topic }
+    render :index, locals: { topic: topic, is_page_under_ab_test: false }
   end
 
   def show
-    topic = Topic.find(request.path)
-    setup_content_item_and_navigation_helpers(topic)
+    taxon_resolver = TaxonRedirectResolver.new(
+      request,
+      is_page_in_ab_test: lambda { !redirects[params[:topic_slug]].nil? },
+      map_to_taxon: lambda { redirects[params[:topic_slug]] }
+    )
 
-    render :index, locals: { topic: topic }
+    if taxon_resolver.page_ab_tested?
+      taxon_resolver.ab_variant.configure_response(response)
+    end
+
+    if taxon_resolver.taxon_base_path
+      redirect_to controller: "taxons",
+        action: "show",
+        taxon_base_path: taxon_resolver.taxon_base_path
+    else
+      topic = Topic.find(request.path)
+      setup_content_item_and_navigation_helpers(topic)
+
+      render :index, locals: {
+        topic: topic,
+        ab_variant: taxon_resolver.ab_variant,
+        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+      }
+    end
+  end
+
+  def redirects
+    Rails.application.config_for(:navigation_redirects)["topics"]
   end
 end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -1,0 +1,20 @@
+class TaxonRedirectResolver
+  attr_reader :ab_variant
+
+  def initialize(request, is_page_in_ab_test:, map_to_taxon:)
+    dimension = Rails.application.config.navigation_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
+    @ab_variant = ab_test.requested_variant(request)
+
+    @is_page_in_ab_test = is_page_in_ab_test
+    @map_to_taxon = map_to_taxon
+  end
+
+  def page_ab_tested?
+    ENV['ENABLE_NEW_NAVIGATION'] == 'yes' && @is_page_in_ab_test.call
+  end
+
+  def taxon_base_path
+    @map_to_taxon.call if page_ab_tested? && ab_variant.variant_b?
+  end
+end

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -3,7 +3,12 @@
   <ul>
     <% top_level_browse_pages.each do |page| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">
-        <%= link_to page.title, page.base_path %>
+        <% link_class = if ab_variant.variant_b? && page.base_path == "/browse/education"
+          "ab-test-redirect"
+        else
+          ""
+        end %>
+        <%= link_to page.title, page.base_path, class: link_class %>
       </li>
     <% end %>
   </ul>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -3,5 +3,6 @@
 
 <div class="browse-panes root">
   <%= render 'top_level_browse_pages',
-    top_level_browse_pages: page.top_level_browse_pages %>
+    top_level_browse_pages: page.top_level_browse_pages,
+    ab_variant: ab_variant %>
 </div>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_test_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 <% content_for :page_class, "browse" %>
 
 <div class="browse-panes section" data-state="section">

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -2,7 +2,7 @@
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>
-    <%= ab_test_variant.analytics_meta_tag.html_safe %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
   <% end %>
 <% end %>
 <% content_for :page_class, "browse" %>
@@ -16,5 +16,6 @@
   </div>
 
   <%= render 'browse/top_level_browse_pages',
-        top_level_browse_pages: page.top_level_browse_pages %>
+        top_level_browse_pages: page.top_level_browse_pages,
+        ab_variant: ab_variant %>
 </div>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 <% content_for :page_class, "browse" %>
 
 <% content_for :meta_section do %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -20,5 +20,6 @@
   </div>
 
   <%= render 'browse/top_level_browse_pages',
-    top_level_browse_pages: page.top_level_browse_pages %>
+    top_level_browse_pages: page.top_level_browse_pages,
+    ab_variant: ab_variant %>
 </div>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, "Services and information - #{organisation['title']} - GOV.UK" %>
 <% content_for :page_class, "topics-page" %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+<% end %>
 
 <header class="page-header group">
   <div class="full-width">

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, "#{subtopic.combined_title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: subtopic %>
+<% if is_page_under_ab_test %>
+  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% end %>
 <% content_for :page_title do %>
   <%- if subtopic.parent -%>
     <%= link_to subtopic.parent.title, subtopic.parent.base_path %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, taxon.title %>
 <% content_for :page_class, "taxon-page" %>
+<% content_for :meta_tags do %>
+  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% end %>
 
 <%= render partial: 'page_header', locals: { taxon: taxon } %>
 

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title do %><%= topic.title %> - GOV.UK<% end %>
 <%= render 'shared/tag_meta', tag: topic %>
+<% if is_page_under_ab_test %>
+  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% end %>
 <% content_for :page_class, "topics-page" %>
 
 <header class="page-header group">

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Collections
     config.action_dispatch.default_headers = {
       'X-Frame-Options' => 'ALLOWALL'
     }
+
+    # Google Analytics dimension assigned to the education navigation A/B test
+    config.navigation_ab_test_dimension = 41
   end
 end

--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -6,6 +6,10 @@ default: &default
       school-life: education
       student-finance: education/funding-and-finance-for-students
       universities-higher-education: education/further-and-higher-education-skills-and-vocational-training
+  topics:
+    schools-colleges-childrens-services: education
+    further-education-skills: education/further-and-higher-education-skills-and-vocational-training
+    higher-education: education/further-and-higher-education-skills-and-vocational-training
 
 production:
   <<: *default

--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -1,0 +1,17 @@
+default: &default
+  second_level_browse_pages:
+    education:
+      find-course: education/further-and-higher-education-skills-and-vocational-training
+      school-admissions-transport: education/running-and-managing-a-school
+      school-life: education
+      student-finance: education/funding-and-finance-for-students
+      universities-higher-education: education/further-and-higher-education-skills-and-vocational-training
+
+production:
+  <<: *default
+
+development:
+  <<: *default
+
+test:
+  <<: *default

--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -10,6 +10,30 @@ default: &default
     schools-colleges-childrens-services: education
     further-education-skills: education/further-and-higher-education-skills-and-vocational-training
     higher-education: education/further-and-higher-education-skills-and-vocational-training
+  subtopics:
+    schools-colleges-childrens-services:
+      curriculum-qualifications: education/school-curriculum
+      data-collection-statistical-returns: education/data-collection-for-pupil-data-and-school-censuses
+      exams-testing-assessment: education/school-curriculum
+      inspections: education/school-inspections-and-performance
+      opening-academy-free-school: education/setting-up-or-changing-the-status-of-a-school
+      running-school-college: education/running-and-managing-a-school
+      school-behaviour-attendance: education/pupil-wellbeing-behaviour-and-attendance
+      school-careers-employment: education/teaching-and-leadership
+      school-college-funding-finance: education/school-and-academy-funding-and-provision
+      special-educational-needs-disabilities: education/pupils-and-students-with-special-educational-needs-and-disability-send
+    further-education-skills:
+      administration: education/running-a-further-or-higher-education-institution
+      apprenticeships: education/apprenticeships-traineeships-and-internships
+      learning-records-service: education/learning-records-service-lrs
+      vocational-qualifications: education/apprenticeships-traineeships-and-internships
+    higher-education:
+      administration: education/running-a-further-or-higher-education-institution
+      scholarships-for-overseas-students: education/financial-help-for-international-students-in-the-uk
+
+
+
+
 
 production:
   <<: *default

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
+require "climate_control"
 
 describe BrowseController do
+
+  include GovukAbTesting::MinitestHelpers
+
   describe "GET index" do
     before do
       content_store_has_item("/browse",
@@ -29,10 +33,77 @@ describe BrowseController do
         )
       end
 
-      it "set correct expiry headers" do
+      it "sets correct expiry headers" do
         get :show, top_level_slug: "benefits"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+    end
+
+    describe "during the education navigation A/B test" do
+      before do
+        content_store_has_item("/browse/education", base_path: '/browse/education')
+        content_store_has_item("/browse/benefits", base_path: '/browse/benefits')
+      end
+
+      describe "with the new navigation not enabled" do
+        ["A", "B"].each do |variant|
+          it "returns the original version of the page for variant #{variant}" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            get :show, top_level_slug: "education"
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
+      end
+
+      describe "with the new navigation enabled" do
+        it "returns the original version of the page as the A variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "A" do
+              get :show, top_level_slug: "education"
+
+              assert_response 200
+            end
+          end
+        end
+
+        it "redirects to the taxonomy navigation as the B variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "B", assert_meta_tag: false do
+              get :show, top_level_slug: "education"
+
+              assert_response 302
+              assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
+            end
+          end
+        end
+
+        ["A", "B"].each do |variant|
+          it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, top_level_slug: "benefits"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+
+          it "does not redirect education when the #{variant} variant is requested in JSON format" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :show, format: :json, top_level_slug: "education"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
       end
     end
 
@@ -66,5 +137,9 @@ describe BrowseController do
       title: 'Entitlement',
       base_path: '/browse/benefits/entitlement'
     }]
+  end
+
+  def with_new_navigation_enabled(&block)
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
   end
 end

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "climate_control"
 
 describe BrowseController do
 

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -53,7 +53,7 @@ describe BrowseController do
             get :show, top_level_slug: "education"
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end
@@ -89,7 +89,7 @@ describe BrowseController do
             end
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
 
           it "does not redirect education when the #{variant} variant is requested in JSON format" do
@@ -100,7 +100,7 @@ describe BrowseController do
             end
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -138,8 +138,4 @@ describe BrowseController do
       base_path: '/browse/benefits/entitlement'
     }]
   end
-
-  def with_new_navigation_enabled(&block)
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
-  end
 end

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -63,7 +63,7 @@ describe SecondLevelBrowsePageController do
             get :show, top_level_slug: "education", second_level_slug: "student-finance"
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end
@@ -139,7 +139,7 @@ describe SecondLevelBrowsePageController do
               get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
 
               assert_response 200
-              assert_unaffected_by_ab_test
+              assert_response_not_modified_for_ab_test
             end
           end
 
@@ -151,7 +151,7 @@ describe SecondLevelBrowsePageController do
             end
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "climate_control"
 
 describe SecondLevelBrowsePageController do
   include RummagerHelpers

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -49,7 +49,7 @@ describe ServicesAndInformationController do
             get :index, organisation_id: "department-for-education"
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end
@@ -67,7 +67,7 @@ describe ServicesAndInformationController do
             end
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
 

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -1,8 +1,10 @@
 require_relative '../test_helper'
+require "climate_control"
 
 describe ServicesAndInformationController do
   include RummagerHelpers
   include ServicesAndInformationHelpers
+  include GovukAbTesting::MinitestHelpers
 
   describe "with a valid organisation slug" do
     it "sets expiry headers for 30 minutes" do
@@ -31,6 +33,65 @@ describe ServicesAndInformationController do
       get :index, organisation_id: "hm-revenue-customs"
 
       assert_equal 200, response.status
+    end
+
+    describe "A/B test" do
+      before do
+        stub_education_services_and_information_content_item
+        stub_services_and_information_links("department-for-education")
+      end
+
+      describe "new navigation is not enabled" do
+        ["A", "B"].each do |variant|
+          it "returns the original version of the page for variant #{variant}" do
+            setup_ab_variant("EducationNavigation", variant)
+
+            get :index, organisation_id: "department-for-education"
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
+      end
+
+      describe "new navigation is enabled" do
+        ["A", "B"].each do |variant|
+          it "does not redirect non-education organisations in the #{variant} variant" do
+            stub_services_and_information_content_item
+            stub_services_and_information_links("hm-revenue-customs")
+
+            setup_ab_variant("EducationNavigation", variant)
+
+            with_new_navigation_enabled do
+              get :index, organisation_id: "hm-revenue-customs"
+            end
+
+            assert_response 200
+            assert_unaffected_by_ab_test
+          end
+        end
+
+        it "shows the original page in the A variant" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "A" do
+              get :index, organisation_id: "department-for-education"
+
+              assert_response 200
+            end
+          end
+        end
+
+        it "redirects B variant of education" do
+          with_new_navigation_enabled do
+            with_variant EducationNavigation: "B", assert_meta_tag: false do
+              get :index, organisation_id: "department-for-education"
+
+              assert_response 302
+              assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -41,7 +41,7 @@ describe SubtopicsController do
             get :show, topic_slug: "further-education-skills", subtopic_slug: "apprenticeships"
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end
@@ -81,7 +81,7 @@ describe SubtopicsController do
             end
 
             assert_response 200
-            assert_unaffected_by_ab_test
+            assert_response_not_modified_for_ab_test
           end
         end
       end

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "climate_control"
+
+describe TaxonsController do
+
+  include RummagerHelpers
+  include GovukAbTesting::MinitestHelpers
+
+  describe "GET show" do
+
+    before do
+      content_store_has_item("/education", content_id: "education-content-id")
+      stub_content_for_taxon("education-content-id", [])
+    end
+
+    it "returns 200 if the new navigation is enabled" do
+      with_new_navigation_enabled do
+        get :show, taxon_base_path: "education"
+      end
+
+      assert_response 200
+    end
+
+    it "returns 404 if the new navigation is disabled" do
+      get :show, taxon_base_path: "education"
+
+      assert_response 404
+    end
+
+    %w(A B).each do |variant|
+      it "returns the taxon page in the #{variant} variant" do
+        with_new_navigation_enabled do
+          with_variant EducationNavigation: variant do
+            get :show, taxon_base_path: "education"
+
+            assert_response 200
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -41,7 +41,7 @@ describe TopicsController do
           get :show, topic_slug: "further-education-skills"
 
           assert_response 200
-          assert_unaffected_by_ab_test
+          assert_response_not_modified_for_ab_test
         end
       end
     end
@@ -80,7 +80,7 @@ describe TopicsController do
           end
 
           assert_response 200
-          assert_unaffected_by_ab_test
+          assert_response_not_modified_for_ab_test
         end
       end
     end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -4,6 +4,8 @@ describe TopicsController do
   include ContentSchemaHelpers
   include RummagerHelpers
 
+  include GovukAbTesting::MinitestHelpers
+
   describe "GET topic" do
     describe "with a valid topic slug" do
       before do
@@ -22,6 +24,65 @@ describe TopicsController do
       get :show, topic_slug: "oil-and-gas"
 
       assert_equal 404, response.status
+    end
+  end
+
+  describe "during the education navigation A/B test" do
+
+    before do
+      content_store_has_item('/topic/further-education-skills', content_schema_example(:topic, :topic))
+    end
+
+    describe "with the new navigation not enabled" do
+      ["A", "B"].each do |variant|
+        it "returns the original version of the page for variant #{variant}" do
+          setup_ab_variant("EducationNavigation", variant)
+
+          get :show, topic_slug: "further-education-skills"
+
+          assert_response 200
+          assert_unaffected_by_ab_test
+        end
+      end
+    end
+
+    describe "with the new navigation enabled" do
+      it "returns the original version of the page as the A variant" do
+        with_new_navigation_enabled do
+          with_variant EducationNavigation: "A" do
+            get :show, topic_slug: "further-education-skills"
+
+            assert_response 200
+          end
+        end
+      end
+
+      it "redirects to the taxonomy navigation as the B variant" do
+        with_new_navigation_enabled do
+          with_variant EducationNavigation: "B", assert_meta_tag: false do
+            get :show, topic_slug: "further-education-skills"
+
+            assert_response 302
+            assert_redirected_to controller: "taxons", 
+              action: "show",
+              taxon_base_path: "education/further-and-higher-education-skills-and-vocational-training"
+          end
+        end
+      end
+
+      ["A", "B"].each do |variant|
+        it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+          content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
+          setup_ab_variant("EducationNavigation", variant)
+
+          with_new_navigation_enabled do
+            get :show, topic_slug: "oil-and-gas"
+          end
+
+          assert_response 200
+          assert_unaffected_by_ab_test
+        end
+      end
     end
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,5 +1,6 @@
 require 'integration_test_helper'
 require 'slimmer/test_helpers/govuk_components'
+require "climate_control"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
@@ -46,7 +47,7 @@ private
   end
 
   def given_new_navigation_is_enabled
-    ENV['ENABLE_NEW_NAVIGATION'] = 'yes'
+    @enable_new_navigation = true
   end
 
   def given_there_is_a_taxon_with_grandchildren
@@ -110,7 +111,11 @@ private
   end
 
   def when_i_visit_the_taxon_page
-    visit @base_path
+    new_nav_environment_variable = @enable_new_navigation ? 'yes' : nil
+
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: new_nav_environment_variable) do
+      visit @base_path
+    end
   end
 
   def then_i_can_see_there_is_a_page_title

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,6 +1,5 @@
 require 'integration_test_helper'
 require 'slimmer/test_helpers/govuk_components'
-require "climate_control"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -9,4 +9,8 @@ class ActiveSupport::TestCase
       value
     end
   end
+
+  def with_new_navigation_enabled(&block)
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
+  end
 end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -1,3 +1,5 @@
+require "climate_control"
+
 class ActiveSupport::TestCase
   def build_ostruct_recursively(value)
     case value

--- a/test/support/services_and_information_helpers.rb
+++ b/test/support/services_and_information_helpers.rb
@@ -1,8 +1,20 @@
 module ServicesAndInformationHelpers
   def stub_services_and_information_content_item
-    content_store_has_item("/government/organisations/hm-revenue-customs/services-information",
-      base_path: "/government/organisations/hm-revenue-customs/services-information",
-      title: "Services and information - HM Revenue & Customs",
+    stub_content_item(
+      "/government/organisations/hm-revenue-customs/services-information",
+      "HM Revenue & Customs")
+  end
+
+  def stub_education_services_and_information_content_item
+    stub_content_item(
+      "/government/organisations/department-for-education/services-information",
+      "Department for Education")
+  end
+
+  def stub_content_item(base_path, organisation_title)
+    content_store_has_item(base_path,
+      base_path: base_path,
+      title: "S&I page title",
       description: "",
       document_type: "services_and_information",
       public_updated_at: 10.days.ago.iso8601,
@@ -10,9 +22,9 @@ module ServicesAndInformationHelpers
       links: {
         parent: [
           {
-            analytics_identifier: "D25",
-            base_path: "/government/organisations/hm-revenue-customs",
-            title: "HM Revenue & Customs",
+            analytics_identifier: "org_analytics_id",
+            base_path: "/organisation/base/path",
+            title: organisation_title,
           },
         ],
       },


### PR DESCRIPTION
- Redirect education pages to taxons when users are in the B bucket of the navigation A/B test:
  - Browse pages (including when JS is enabled)
  - Second-level browse pages
  - Topic pages
  - Subtopic pages
  - Service and information pages
- Add `meta` tag to taxon pages, so that it is reported as the B version in analytics

Trello:
- https://trello.com/c/D7QsJmAy/329-redirects-to-the-new-navigation
- https://trello.com/c/zqV4lkGv/375-redirect-from-topics-to-taxons-in-b-version-of-the-navigation
- https://trello.com/c/mXf7R9tk/391-redirect-from-second-level-browse-pages-to-taxons