### PR TITLE
Render alphabetical lists on taxon pages as ordered lists

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -62,7 +62,7 @@
   }
 
   .child-topics-list {
-    ul {
+    ol {
       list-style-type: none;
       @extend %grid-row;
 
@@ -82,7 +82,7 @@
     .topic-content {
       padding-bottom: $gutter;
 
-      ul {
+      ol {
         list-style-type: none;
         padding-bottom: $gutter-one-third;
       }
@@ -96,7 +96,7 @@
 
   .child-topic-contents {
     .topic-content {
-      ul {
+      ol {
         list-style-type: none;
       }
 

--- a/app/views/taxons/_child_taxons_grid.html.erb
+++ b/app/views/taxons/_child_taxons_grid.html.erb
@@ -1,6 +1,6 @@
 <nav role="navigation" class="child-topics-list">
   <h2>In this section</h2>
-  <ul>
+  <ol>
     <% child_taxons.each_with_index do |child_taxon, index| %>
       <li class="<%= 'leftmost-row-cell-clear-float' if index % 3 == 0 %>">
         <h3>
@@ -9,5 +9,5 @@
         <p><%= child_taxon.description %></p>
       </li>
     <% end %>
-  </ul>
+  </ol>
 </nav>

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -1,4 +1,4 @@
-<ul class="subsection-list">
+<ol class="subsection-list">
   <% tagged_content.each do |content_item| %>
     <li class="subsection-list-item">
       <%= link_to content_item.title, content_item.base_path %>
@@ -6,4 +6,4 @@
       <p><%= content_item.description %></p>
     </li>
   <% end %>
-</ul>
+</ol>

--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -7,7 +7,7 @@
           <p><%= taxon.description %></p>
         <% end %>
 
-        <ul>
+        <ol>
           <% tagged_content.each do |content_item| %>
             <li>
               <h3>
@@ -16,7 +16,7 @@
               <p><%= content_item.description %></p>
             </li>
           <% end %>
-        </ul>
+        </ol>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Mark the topic and taxon content lists as `ol` rather than `ul` to mark them as ordered (alphabetical) lists. This is more informative and can be used by browsers like screen readers to provide more navigation control.

This does not change the visual appearance of the lists in a standard browser.

Trello: https://trello.com/c/Tjj0CWJa/389-ensure-markup-is-semantic