### PR TITLE
Remove parent taxon link from taxon navigation pages

### DIFF
--- a/app/assets/images/back.svg
+++ b/app/assets/images/back.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="17.565px" height="30px" viewBox="0 0 17.565 30" enable-background="new 0 0 17.565 30" xml:space="preserve">
-<polygon fill="#6F777B" points="15,30 0,15 15,0 17.565,2.565 5.131,15 17.565,27.437 "/>
-</svg>

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -32,27 +32,6 @@
     margin-bottom: 6px;
   }
 
-  .sub-heading {
-    @include core-24;
-    margin-bottom: 0;
-
-    a {
-      color: $secondary-text-colour;
-      text-decoration: none;
-
-      &:before {
-        content: " ";
-        background-image: image-url("back.svg");
-        background-repeat: no-repeat;
-        background-size: auto 18px;
-        background-position: left bottom;
-        display: inline-block;
-        width: 20px;
-        height: 1em;
-      }
-    }
-  }
-
   .page-header {
     margin-top: $gutter * 3;
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -36,12 +36,6 @@ class Taxon
     new(content_item)
   end
 
-  def parent_taxon
-    return nil unless parent?
-
-    self.class.new(linked_items('parent_taxons').first)
-  end
-
   def child_taxons
     return [] unless children?
 

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,13 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="govuk-title length-long">
-      <span  role="link" tabindex="0" class="sub-heading">
-        <% if parent_taxon.present? %>
-          <%= link_to parent_taxon.title, parent_taxon.base_path %>
-        <% else %>
-          <%= link_to 'Home', Plek.find('www') %>
-        <% end %>
-      </span>
       <h1>
         <%= taxon.title %>
       </h1>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,10 +1,7 @@
 <% content_for :title, taxon.title %>
 <% content_for :page_class, "taxon-page" %>
 
-<%= render partial: 'page_header', locals: {
-  taxon: taxon,
-  parent_taxon: taxon.parent_taxon
-} %>
+<%= render partial: 'page_header', locals: { taxon: taxon } %>
 
 <% content_for :breadcrumbs do %>
   <%= render partial: 'govuk_component/beta_label' %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -12,7 +12,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
     then_i_can_see_the_breadcrumbs
-    and_i_can_see_a_link_to_the_parent_taxon
     and_i_can_see_the_title_and_description
     and_i_can_see_links_to_the_child_taxons_in_a_grid
     and_i_can_see_tagged_content_to_the_taxon
@@ -24,7 +23,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
     then_i_can_see_the_breadcrumbs
-    and_i_can_see_a_link_to_the_parent_taxon
     and_i_can_see_the_title_and_description
     and_i_can_see_links_to_the_child_taxons_in_an_accordion
     and_i_can_see_tagged_content_to_the_taxon
@@ -125,10 +123,6 @@ private
 
   def then_i_can_see_the_breadcrumbs
     assert_not_nil shared_component_selector('breadcrumbs')
-  end
-
-  def and_i_can_see_a_link_to_the_parent_taxon
-    assert page.has_link?(@parent['title'], @parent['description'])
   end
 
   def and_i_can_see_the_title_and_description

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -24,18 +24,6 @@ describe Taxon do
     assert_equal @taxon.base_path, student_finance_taxon['base_path']
   end
 
-  it 'has parent taxon' do
-    parent = @taxon.parent_taxon
-
-    assert_instance_of Taxon, parent
-    assert_equal parent.title,
-      student_finance_taxon['links']['parent_taxons'].first['title']
-    assert_equal parent.description,
-      student_finance_taxon['links']['parent_taxons'].first['description']
-    assert_equal parent.base_path,
-      student_finance_taxon['links']['parent_taxons'].first['base_path']
-  end
-
   it 'has two taxon children' do
     assert_equal @taxon.child_taxons.length, 2
 


### PR DESCRIPTION
In user research, this link helped some users but was completely misunderstood by others. Given that users can still navigate to the parent page using the breadcrumbs, we've decided to remove this link.

https://trello.com/c/A2mVxBwh/376-update-collections-to-show-the-latest-parent-taxon-link-styles-from-the-prototype