### PR TITLE
Reword "Open all" button to "Expand all" in accordion

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -9,6 +9,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Modules.AccordionWithDescriptions = function() {
 
+    var bulkActions = {
+      openAll: {
+        buttonText: "Expand all",
+        eventLabel: "Open All"
+      },
+      closeAll: {
+        buttonText: "Close all",
+        eventLabel: "Close All"
+      }
+    }
+
     this.start = function($element) {
 
       // Indicate that js has worked
@@ -52,7 +63,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function addOpenCloseAllButton() {
-        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>' );
+        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">' + bulkActions.openAll.buttonText + '</button></div>' );
       }
 
       function addButtonsToSubsections() {
@@ -168,21 +179,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var action = '';
 
           // update button text
-          if ($openOrCloseAllButton.text() == "Open all") {
-            $openOrCloseAllButton.text("Close all");
+          if ($openOrCloseAllButton.text() == bulkActions.openAll.buttonText) {
+            $openOrCloseAllButton.text(bulkActions.closeAll.buttonText);
             $openOrCloseAllButton.attr("aria-expanded", "true");
             action = 'open';
 
             track('pageElementInteraction', 'accordionAllOpened', {
-              label: 'Open All'
+              label: bulkActions.openAll.eventLabel
             });
           } else {
-            $openOrCloseAllButton.text("Open all");
+            $openOrCloseAllButton.text(bulkActions.openAll.buttonText);
             $openOrCloseAllButton.attr("aria-expanded", "false");
             action = 'close';
 
             track('pageElementInteraction', 'accordionAllClosed', {
-              label: 'Close All'
+              label: bulkActions.closeAll.eventLabel
             });
           }
 
@@ -226,9 +237,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var openSubsections = $element.find('.subsection-is-open').length;
         // Find out if the number of is-opens == total number of sections
         if (openSubsections === totalSubsections) {
-          $openOrCloseAllButton.text('Close all');
+          $openOrCloseAllButton.text(bulkActions.closeAll.buttonText);
         } else {
-          $openOrCloseAllButton.text('Open all');
+          $openOrCloseAllButton.text(bulkActions.openAll.buttonText);
         }
       }
 

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -125,7 +125,7 @@
   .js-accordion-with-descriptions {
     padding-bottom: $gutter * 2;
 
-    // Wrapper for 'open all / close all' button
+    // Wrapper for 'expand all / close all' button
     .subsection-controls {
       @extend %contain-floats;
 

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -63,7 +63,7 @@ describe('An accordion with descriptions module', function () {
     var $openCloseAllButton = $element.find('.js-subsection-controls button');
 
     expect($openCloseAllButton).toExist();
-    expect($openCloseAllButton).toHaveText("Open all");
+    expect($openCloseAllButton).toHaveText("Expand all");
     // It has an aria-expanded false attribute as all subsections are closed
     expect($openCloseAllButton).toHaveAttr("aria-expanded", "false");
     // It has an aria-controls attribute that includes all the subsection_content IDs
@@ -106,7 +106,7 @@ describe('An accordion with descriptions module', function () {
     expect($subsectionHeader).toContainElement('.subsection-icon');
   });
 
-  describe('Clicking the "Open all" button', function () {
+  describe('Clicking the "Expand all" button', function () {
 
     it('adds a .subsection-is-open class to each subsection to hide the icon', function () {
       accordion.start($element);


### PR DESCRIPTION
User research has shown that "Expand all" is better understood.

I've left the analytics label as "Open All" to be consistent with the analytics for service-manual-frontend. I've also left all the "open" variables and functions as they are so that we stay consistent with the duplicate code in service-manual-frontend until we can extract a shared module. This is a bit messy, but I think it's better than the alternative - rename everything, and make it really hard to commonise later. What do other people think?

cc @carvil 