### PR TITLE
Taxon styling tweaks

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -105,7 +105,8 @@
     }
   }
 
-  .subsection {
+  .subsection,
+  .subsection-is-open {
     width: 100%;
     margin-bottom: $gutter;
 
@@ -115,7 +116,7 @@
 
     .subsection-description {
       @include core-19;
-      margin-bottom: $gutter-one-quarter;
+      margin-bottom: $gutter;
 
       @include media(tablet) {
         margin-bottom: $gutter-half;
@@ -176,11 +177,7 @@
       }
 
       margin-bottom: 0;
-      margin-right: $gutter-half;
-
-      @include media(tablet) {
-        margin-right: $gutter;
-      }
+      margin-right: $gutter;
     }
 
     .subsection-header {
@@ -198,12 +195,7 @@
 
     .subsection-description {
       margin-bottom: 0;
-      margin-right: $gutter-half;
-
-      @include media(tablet) {
-        margin-bottom: 0;
-        margin-right: $gutter;
-      }
+      margin-right: $gutter;
     }
 
     .subsection-icon {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -28,13 +28,8 @@
 
   p {
     @include core-19;
-    margin-top: #{(5 / 16)}em;
-    margin-bottom: #{(20 / 16)}em;
-
-    @include media(tablet) {
-      margin-top: #{(5 / 19)}em;
-      margin-bottom: #{(20 / 19)}em;
-    }
+    margin-top: $gutter-one-third / 2;
+    margin-bottom: $gutter-two-thirds;
   }
 
   .page-header {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -28,8 +28,13 @@
 
   p {
     @include core-19;
-    margin-top: 2px;
-    margin-bottom: 6px;
+    margin-top: #{(5 / 16)}em;
+    margin-bottom: #{(20 / 16)}em;
+
+    @include media(tablet) {
+      margin-top: #{(5 / 19)}em;
+      margin-bottom: #{(20 / 19)}em;
+    }
   }
 
   .page-header {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -6,8 +6,6 @@
 
     +p {
       @include core-24;
-      padding-top: 10px;
-      padding-bottom: 30px;
     }
   }
 
@@ -23,7 +21,9 @@
 
   h3 {
     @include bold-19;
-    padding-bottom: $gutter-one-third;
+    @include media (tablet) {
+      padding-bottom: $gutter-one-third;
+    }
   }
 
   p {
@@ -48,7 +48,18 @@
       li {
         @include grid-column(1 / 3);
         padding-bottom: $gutter;
-        min-height: (5 * $gutter);
+
+        @include media (tablet) {
+          min-height: (5 * $gutter);
+        }
+      }
+    }
+
+    p {
+      margin: 5px 0 20px 0;
+
+      &:last-child {
+        margin-bottom: 0;
       }
     }
 


### PR DESCRIPTION
These styling changes bring `collections` better in-line with the current Education Navigation prototype.

Some paragraph styling has been adopted from `govuk_elements`, which is used in the prototype but not (currently) in `collections`.

## Accordion expanded subsection styling


### Before

![accordion-expanded-styling-before](https://cloud.githubusercontent.com/assets/12036746/23020661/036e4d7e-f440-11e6-856c-f63670a1097f.png)

### After

![accordion-expanded-styling-after](https://cloud.githubusercontent.com/assets/12036746/23020664/071b352c-f440-11e6-9b63-fd315bd87966.png)

## Accordion spacing on mobile with no JavaScript

### Before

![accordion-no-js-mobile-before](https://cloud.githubusercontent.com/assets/12036746/23020709/3a3541d2-f440-11e6-810f-90b78c045f2f.png)


### After

![accordion-no-js-mobile-after](https://cloud.githubusercontent.com/assets/12036746/23020714/3faea130-f440-11e6-94cc-0698ae3c7a24.png)

## Content spacing


### Before

![content-spacing-before](https://cloud.githubusercontent.com/assets/12036746/23020722/4acfa654-f440-11e6-924f-8d028a5937fc.png)

### After

![content-spacing-after](https://cloud.githubusercontent.com/assets/12036746/23020725/50fd6002-f440-11e6-9824-66c89267c830.png)

## Spacing on mobile

### Before

![content-spacing-mobile-before](https://cloud.githubusercontent.com/assets/12036746/23020741/64503080-f440-11e6-9961-46f6a1dfe8a3.png)


### After

![content-spacing-mobile-after](https://cloud.githubusercontent.com/assets/12036746/23020746/69ad6b1a-f440-11e6-8e2c-ef53cb1c0a7e.png)

## Taxon description spacing


### Before

![taxon-description-spacing-before](https://cloud.githubusercontent.com/assets/12036746/23020751/739ea47c-f440-11e6-95e7-bbab1aca3c3e.png)


### After

![taxon-description-spacing-after](https://cloud.githubusercontent.com/assets/12036746/23020753/794ef156-f440-11e6-8344-ae6ebc398634.png)


Trello: https://trello.com/c/kSRKSoI2/326-review-styles-on-tablet-and-mobile-viewports-on-the-new-navigation-pages 