### PR TITLE
Remove content in collections from nav pages

### DIFF
--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -11,11 +11,12 @@ class TaggedContent
 
   def fetch
     RummagerSearch.new(
-      filter_taxons: [content_id],
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link),
       filter_content_store_document_type: RummagerSearch::GUIDANCE_DOCUMENT_TYPES,
+      filter_taxons: [content_id],
+      filter_document_collections: '_MISSING',
       order: 'title',
     ).documents
   end

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -38,6 +38,10 @@ describe TaggedContent do
         filter_content_store_document_type: guidance_document_types
       )
     end
+
+    it 'filters out content that belongs to a document collection' do
+      assert_includes_params(filter_document_collections: '_MISSING')
+    end
   end
 
 private

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+require './test/support/custom_assertions.rb'
+
+describe TaggedContent do
+  describe '#fetch' do
+    it 'returns the documents from search' do
+      search_results = mock(documents: ['doc1'])
+
+      RummagerSearch.stubs(:new).returns(search_results)
+
+      assert(tagged_content.fetch, ['doc1'])
+    end
+
+    it 'starts from the first page' do
+      assert_includes_params(start: 0)
+    end
+
+    it 'requests all results' do
+      assert_includes_params(count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+    end
+
+    it 'requests a limited number of fields' do
+      assert_includes_params(fields: %w(title description link))
+    end
+
+    it 'orders the results by title' do
+      assert_includes_params(order: 'title')
+    end
+
+    it 'filters the results by taxon' do
+      assert_includes_params(filter_taxons: [taxon_content_id])
+    end
+
+    it 'filters out non-guidance content' do
+      guidance_document_types = RummagerSearch::GUIDANCE_DOCUMENT_TYPES
+
+      assert_includes_params(
+        filter_content_store_document_type: guidance_document_types
+      )
+    end
+  end
+
+private
+
+  def assert_includes_params(expected_params)
+    search_results = mock(documents: %w(doc1 doc2))
+
+    RummagerSearch.
+      stubs(:new).
+      with { |params| params.including?(expected_params) }.
+      returns(search_results)
+
+    assert_equal(tagged_content.fetch, %w(doc1 doc2))
+  end
+
+  def taxon_content_id
+    'c3c860fc-a271-4114-b512-1c48c0f82564'
+  end
+
+  def tagged_content
+    @tagged_content ||= TaggedContent.new(taxon_content_id)
+  end
+end

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -3,12 +3,18 @@ require './test/support/custom_assertions.rb'
 
 describe TaggedContent do
   describe '#fetch' do
-    it 'returns the documents from search' do
-      search_results = mock(documents: ['doc1'])
+    it 'returns the results from search' do
+      search_results = {
+        'results' => [{
+          'title' => 'Doc 1'
+        }]
+      }
 
-      RummagerSearch.stubs(:new).returns(search_results)
+      Services.rummager.stubs(:search).returns(search_results)
 
-      assert(tagged_content.fetch, ['doc1'])
+      results = tagged_content.fetch
+      assert_equal(results.count, 1)
+      assert_equal(results.first.title, 'Doc 1')
     end
 
     it 'starts from the first page' do
@@ -47,14 +53,28 @@ describe TaggedContent do
 private
 
   def assert_includes_params(expected_params)
-    search_results = mock(documents: %w(doc1 doc2))
+    search_results = {
+      'results' => [
+        {
+          'title' => 'Doc 1'
+        },
+        {
+          'title' => 'Doc 2'
+        }
+      ]
+    }
 
-    RummagerSearch.
-      stubs(:new).
+    Services.
+      rummager.
+      stubs(:search).
       with { |params| params.including?(expected_params) }.
       returns(search_results)
 
-    assert_equal(tagged_content.fetch, %w(doc1 doc2))
+    results = tagged_content.fetch
+    assert_equal(results.count, 2)
+
+    assert_equal(results.first.title, 'Doc 1')
+    assert_equal(results.last.title, 'Doc 2')
   end
 
   def taxon_content_id

--- a/test/support/custom_assertions.rb
+++ b/test/support/custom_assertions.rb
@@ -4,10 +4,13 @@ module MiniTest::Assertions
   # includes the sub-hash given. Useful when testing partial arguments/params to
   # methods.
   def assert_includes_subhash(expected_sub_hash, hash)
-    assert_equal(
-      expected_sub_hash.values,
-      hash.slice(*expected_sub_hash.keys).values
-    )
+    expected_sub_hash.each do |key, value|
+      assert_equal(
+        value,
+        hash[key],
+        "Expected #{hash} to include #{key}=#{value}"
+      )
+    end
   end
 end
 

--- a/test/support/custom_assertions.rb
+++ b/test/support/custom_assertions.rb
@@ -1,0 +1,14 @@
+module MiniTest::Assertions
+  # Behaves a bit like `hash_including`.
+  # Given a slice of the original hash, it verifies that the original hash
+  # includes the sub-hash given. Useful when testing partial arguments/params to
+  # methods.
+  def assert_includes_subhash(expected_sub_hash, hash)
+    assert_equal(
+      expected_sub_hash.values,
+      hash.slice(*expected_sub_hash.keys).values
+    )
+  end
+end
+
+Hash.infect_an_assertion :assert_includes_subhash, :including?

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,11 +1,12 @@
 module RummagerHelpers
   def stub_content_for_taxon(content_id, results)
     Services.rummager.stubs(:search).with(
-      filter_taxons: [content_id],
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link),
       filter_content_store_document_type: RummagerSearch::GUIDANCE_DOCUMENT_TYPES,
+      filter_taxons: [content_id],
+      filter_document_collections: '_MISSING',
       order: 'title',
     ).returns(
       "results" => results,


### PR DESCRIPTION
Document collections should be surfaced on navigation pages, but not the content tagged to them.

We have seen from lab research that surfacing all the content makes the list view harder to navigate.

Some document collections will be removed as they are now covered by taxons, but other that group the same type of thing will remain.

This PR makes sure we filter out all content that already belongs to a document collection.

Trello: https://trello.com/c/2KDTKdo6/413-only-show-collections-on-list-pages-not-content-tagged-to-them