### PR TITLE
Include document collection in Guidance list

### DIFF
--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -5,6 +5,7 @@ class RummagerSearch
     answer
     contact
     detailed_guide
+    document_collection
     form
     guidance
     guide


### PR DESCRIPTION
We are in the process of converting some document collections into
taxons in order to better represent that data in navigation pages.

In the meantime, we would like to have visibility into what document
collections there are.

This commit makes sure they are surfaced in the new navigation pages.

Trello: https://trello.com/c/2KDTKdo6/413-only-show-collections-on-list-pages-not-content-tagged-to-them