### PR TITLE
Use content store instead of Rummager in topic and browse pages

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -10,7 +10,7 @@ class ContentItem
     @content_item_data = content_item_data
   end
 
-  %i[base_path title description content_id].each do |field|
+  %i[base_path title description content_id document_type].each do |field|
     define_method field do
       @content_item_data[field.to_s]
     end

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -2,25 +2,10 @@ class ListSet
   include Enumerable
   delegate :each, to: :lists
 
-  BROWSE_FORMATS_TO_EXCLUDE = %w(
-    fatality_notice
-    news_article
-    speech
-    world_location_news_article
-    travel-advice
-  ).to_set
-
-  TOPIC_FORMATS_TO_EXCLUDE = %w(
-    fatality_notice
-    news_article
-    speech
-    world_location_news_article
-  ).to_set
-
-  def initialize(tag_type, tag_content_id, group_data = nil)
-    @tag_type = tag_type
-    @tag_content_id = tag_content_id
+  def initialize(linked_content, group_data, excluded_document_types = [])
+    @linked_content = linked_content || []
     @group_data = group_data || []
+    @excluded_document_types = excluded_document_types
   end
 
   def curated?
@@ -38,18 +23,19 @@ private
   end
 
   def a_to_z_list
-    [ListSet::List.new(
-      "A to Z",
-      content_tagged_to_tag
-        .reject { |content| excluded_formats.include? content.format }
-        .sort_by(&:title)
-    )]
+    az_list = @linked_content
+      .reject { |content| @excluded_document_types.include? content.document_type }
+      .map { |content| LinkedContent.new(content.title, content.base_path) }
+      .sort_by(&:title)
+
+    [ListSet::List.new("A to Z", az_list)]
   end
 
   def curated_list
     curated_data = @group_data.map do |group|
       contents = group["contents"].map do |base_path|
-        content_tagged_to_tag.find { |content| content.base_path == base_path }
+        link = @linked_content.find { |content| content.base_path == base_path }
+        link.nil? ? nil : LinkedContent.new(link.title, link.base_path)
       end
 
       ListSet::List.new(group["name"], contents.compact) if contents.any?
@@ -58,27 +44,8 @@ private
     curated_data.compact
   end
 
-  def content_tagged_to_tag
-    @content_tagged_to_tag ||= RummagerSearch.new(
-      :start => 0,
-      :count => RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
-      filter_name => [@tag_content_id],
-      :fields => %w(title link format))
-  end
-
-  def filter_name
-    if @tag_type == 'section'
-      :filter_mainstream_browse_page_content_ids
-    else
-      :filter_topic_content_ids
-    end
-  end
-
-  def excluded_formats
-    if @tag_type == 'section'
-      BROWSE_FORMATS_TO_EXCLUDE
-    else
-      TOPIC_FORMATS_TO_EXCLUDE
-    end
-  end
+  LinkedContent = Struct.new(
+    :title,
+    :base_path,
+  )
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -10,6 +10,14 @@ class MainstreamBrowsePage
     to: :content_item
   )
 
+  DOCUMENT_TYPES_TO_EXCLUDE = %w(
+    fatality_notice
+    news_article
+    speech
+    world_location_news_article
+    travel_advice
+  ).to_set
+
   def self.find(base_path)
     content_item = ContentItem.find!(base_path)
     new(content_item)
@@ -44,7 +52,10 @@ class MainstreamBrowsePage
   end
 
   def lists
-    @lists ||= ListSet.new("section", @content_item.content_id, details["groups"])
+    @lists ||= ListSet.new(
+      @content_item.linked_items("mainstream_browse_content"),
+      details["groups"],
+      DOCUMENT_TYPES_TO_EXCLUDE)
   end
 
   def related_topics

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -11,6 +11,13 @@ class Topic
     to: :content_item
   )
 
+  DOCUMENT_TYPES_TO_EXCLUDE = %w(
+    fatality_notice
+    news_article
+    speech
+    world_location_news_article
+  ).to_set
+
   def self.find(base_path, pagination_options = {})
     content_item = ContentItem.find!(base_path)
     new(content_item, pagination_options)
@@ -38,7 +45,10 @@ class Topic
   end
 
   def lists
-    ListSet.new("specialist_sector", content_item.content_id, details["groups"])
+    ListSet.new(
+      @content_item.linked_items("topic_content"),
+      details["groups"],
+      DOCUMENT_TYPES_TO_EXCLUDE)
   end
 
   def changed_documents

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -1,5 +1,5 @@
 Given(/^there is latest content for a subtopic$/) do
-  stub_topic_lookups
+  topic_content_id = stub_topic_lookups
 
   @stubbed_rummager_documents = %w(
     what-is-oil
@@ -24,7 +24,7 @@ Given(/^there is latest content for a subtopic$/) do
     has_entries(
       start: 0,
       count: 50,
-      filter_topic_content_ids: ['content-id-for-fields-and-wells'],
+      filter_topic_content_ids: [topic_content_id],
       order: "-public_timestamp",
     )
   ).returns("results" => @stubbed_rummager_documents,

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,10 +1,16 @@
+CRIME_AND_JUSTICE_CONTENT_ID = SecureRandom::uuid
+BENEFITS_CONTENT_ID = SecureRandom::uuid
+JUDGES_CONTENT_ID = SecureRandom::uuid
+COURTS_CONTENT_ID = SecureRandom::uuid
+
 Given(/^there is an alphabetical browse page set up with links$/) do
   stub_browse_lookups
 
   second_level_browse_pages = [{
-    content_id: 'judges-content-id',
+    content_id: JUDGES_CONTENT_ID,
     title: 'Judges',
-    base_path: '/browse/crime-and-justice/judges'
+    base_path: '/browse/crime-and-justice/judges',
+    locale: :en,
   }]
 
   add_browse_pages
@@ -12,15 +18,9 @@ Given(/^there is an alphabetical browse page set up with links$/) do
     child_pages: second_level_browse_pages,
     order_type: "alphabetical"
   )
-  add_second_level_browse_pages(second_level_browse_pages)
-
-  rummager_has_documents_for_browse_page(
-    "judges-content-id",
-    [
-      "judge-dredd",
-    ],
-    page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-  )
+  add_second_level_browse_pages(
+    second_level_browse_pages,
+    order_type: "alphabetical")
 end
 
 Given(/^that there are curated second level browse pages$/) do
@@ -28,14 +28,16 @@ Given(/^that there are curated second level browse pages$/) do
 
   second_level_browse_pages = [
     {
-      content_id: 'judges-content-id',
+      content_id: JUDGES_CONTENT_ID,
       title: 'Judges',
       base_path: '/browse/crime-and-justice/judges',
+      locale: :en,
     },
     {
-      content_id: 'courts-content-id',
+      content_id: COURTS_CONTENT_ID,
       title: 'Courts',
       base_path: '/browse/crime-and-justice/courts',
+      locale: :en,
     }
   ]
 
@@ -44,11 +46,13 @@ Given(/^that there are curated second level browse pages$/) do
     child_pages: second_level_browse_pages,
     order_type: "curated"
   )
-  add_second_level_browse_pages(second_level_browse_pages)
+  add_second_level_browse_pages(
+    second_level_browse_pages,
+    order_type: "curated")
 end
 
 Then(/^I see the links tagged to the browse page/) do
-  assert page.has_selector?('a', text: "Judge dredd")
+  assert page.has_selector?('a', text: "Judge Dredd")
 end
 
 When(/^I visit the main browse page$/) do
@@ -100,48 +104,82 @@ end
 def top_level_browse_pages
   [
     {
-      content_id: 'content-id-for-crime-and-justice',
+      content_id: CRIME_AND_JUSTICE_CONTENT_ID,
       title: 'Crime and justice',
-      base_path: '/browse/crime-and-justice'
+      base_path: '/browse/crime-and-justice',
+      locale: :en,
     },
     {
-      content_id: 'content-id-for-benefits',
+      content_id: BENEFITS_CONTENT_ID,
       title: 'Benefits',
-      base_path: '/browse/benefits'
+      base_path: '/browse/benefits',
+      locale: :en,
     },
   ]
 end
 
 def add_browse_pages
-  content_store_has_item '/browse', links: {
-    top_level_browse_pages: top_level_browse_pages
-  }
+  browse_root = GovukSchemas::RandomExample
+    .for_schema(frontend_schema: "mainstream_browse_page")
+    .merge_and_validate({
+      links: {
+        top_level_browse_pages: top_level_browse_pages
+      }
+    })
+  content_store_has_item("/browse", browse_root)
 end
 
 def add_first_level_browse_pages(child_pages:, order_type:)
-  content_store_has_item('/browse/crime-and-justice', base_path: '/browse/crime-and-justice',
-    links: {
-      top_level_browse_pages: top_level_browse_pages,
-      second_level_browse_pages: child_pages,
-    },
-    details: {
-      second_level_ordering: order_type,
-      ordered_second_level_browse_pages: child_pages.map { |page| page[:content_id] }
+  browse_page = GovukSchemas::RandomExample
+    .for_schema(frontend_schema: "mainstream_browse_page")
+    .merge_and_validate({
+      base_path: '/browse/crime-and-justice',
+      links: {
+        top_level_browse_pages: top_level_browse_pages,
+        second_level_browse_pages: child_pages,
+      },
+      details: {
+        "second_level_ordering" => order_type,
+        "ordered_second_level_browse_pages" => child_pages.map { |page| page[:content_id] }
+      },
     })
+
+  content_store_has_item("/browse/crime-and-justice", browse_page)
 end
 
-def add_second_level_browse_pages(second_level_browse_pages)
-  content_store_has_item '/browse/crime-and-justice/judges', content_id: 'judges-content-id',
-    title: 'Judges',
-    base_path: '/browse/crime-and-justice/judges',
-    links: {
-      top_level_browse_pages: top_level_browse_pages,
-      second_level_browse_pages: second_level_browse_pages,
-      active_top_level_browse_page: [{
-        content_id: 'content-id-for-crime-and-justice',
-        title: 'Crime and justice',
-        base_path: '/browse/crime-and-justice'
-      }],
-      related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
-    }
+def add_second_level_browse_pages(second_level_browse_pages, order_type:)
+  browse_page = GovukSchemas::RandomExample
+    .for_schema(frontend_schema: "mainstream_browse_page")
+    .merge_and_validate({
+      content_id: JUDGES_CONTENT_ID,
+      title: 'Judges',
+      base_path: '/browse/crime-and-justice/judges',
+      links: {
+        top_level_browse_pages: top_level_browse_pages,
+        second_level_browse_pages: second_level_browse_pages,
+        active_top_level_browse_page: [{
+          content_id: CRIME_AND_JUSTICE_CONTENT_ID,
+          title: 'Crime and justice',
+          base_path: '/browse/crime-and-justice',
+          locale: :en,
+        }],
+        related_topics: [{
+          content_id: SecureRandom::uuid,
+          title: 'A linked topic',
+          base_path: '/browse/linked-topic',
+          locale: :en,
+        }],
+        mainstream_browse_content: [{
+          content_id: SecureRandom::uuid,
+          title: 'Judge Dredd',
+          base_path: '/judge-dredd',
+          locale: :en,
+        }],
+      },
+      details: {
+        "second_level_ordering" => order_type,
+      },
+    })
+
+  content_store_has_item("/browse/crime-and-justice/judges", browse_page)
 end

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -14,26 +14,9 @@ module TopicHelper
       government/organisations/air-accidents-investigation-branch
     }
 
-    rummager_has_documents_for_subtopic(
-      'content-id-for-fields-and-wells',
-      %w{
-        what-is-oil
-        apply-for-an-oil-licence
-        environmental-policy
-        onshore-exploration-and-production
-        well-application-form
-        well-report-2014
-        oil-extraction-count-2013
-      },
-      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-    )
-
-    content_store_has_item("/topic/oil-and-gas/fields-and-wells",
-      content_id: 'content-id-for-fields-and-wells',
+    content_item = {
       base_path: "/topic/oil-and-gas/fields-and-wells",
-      title: "Fields and Wells",
       format: "topic",
-      public_updated_at: 10.days.ago.iso8601,
       details: {
         groups: [
           {
@@ -52,18 +35,45 @@ module TopicHelper
         ],
       },
       links: {
-        "parent" => [
-          "title" => "Oil and Gas",
-          "base_path" => "/oil-and-gas",
+        parent: [
+          content_link("Oil and Gas", "/oil-and-gas")
+        ],
+        topic_content: [
+          content_link("What is oil", "/what-is-oil"),
+          content_link("Apply for an oil licence", "/apply-for-an-oil-licence"),
+          content_link("Environmental policy", "/environmental-policy"),
+          content_link("Onshore exploration and production", "/onshore-exploration-and-production"),
+          content_link("Well application form", "/well-application-form"),
+          content_link("Well report 2014", "/well-report-2014"),
+          content_link("Oil extraction count 2013", "/oil-extraction-count-2013"),
         ]
-      })
+      }
+    }
+
+    topic = GovukSchemas::RandomExample
+      .for_schema(frontend_schema: 'topic')
+      .merge_and_validate(content_item)
+    content_store_has_item("/topic/oil-and-gas/fields-and-wells", topic)
 
     stub_topic_organisations(
       'oil-and-gas/fields-and-wells',
-      'content-id-for-fields-and-wells'
+      topic["content_id"]
     )
 
     stub_shared_component_locales
+
+    topic["content_id"]
+  end
+
+private
+
+  def content_link(title, base_path)
+    {
+      title: title,
+      base_path: base_path,
+      locale: "en",
+      content_id: SecureRandom::uuid
+    }
   end
 end
 

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 describe SecondLevelBrowsePageController do
-  include RummagerHelpers
   include GovukAbTesting::MinitestHelpers
 
   describe "GET second_level_browse_page" do
@@ -22,12 +21,6 @@ describe SecondLevelBrowsePageController do
             related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
           }
         )
-
-        rummager_has_documents_for_browse_page(
-          "entitlement-content-id",
-          ["entitlement"],
-          page_size: 1000
-        )
       end
 
       it "set correct expiry headers" do
@@ -46,12 +39,6 @@ describe SecondLevelBrowsePageController do
               title: 'Education and learning',
             }],
           }
-        )
-
-        rummager_has_documents_for_browse_page(
-          "student-finance-content-id",
-          ["student-finance"],
-          page_size: 1000
         )
       end
 
@@ -101,12 +88,6 @@ describe SecondLevelBrowsePageController do
             }
           )
 
-          rummager_has_documents_for_browse_page(
-            "school-life-content-id",
-            ["school-life"],
-            page_size: 1000
-          )
-
           with_new_navigation_enabled do
             with_variant EducationNavigation: "B", assert_meta_tag: false do
               get :show, top_level_slug: "education", second_level_slug: "school-life"
@@ -126,12 +107,6 @@ describe SecondLevelBrowsePageController do
                   title: 'Benefits',
                 }],
               }
-            )
-
-            rummager_has_documents_for_browse_page(
-              "entitlement-content-id",
-              ["entitlement"],
-              page_size: 1000
             )
 
             with_new_navigation_enabled do

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -8,19 +8,6 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     # request their parents and links.
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|
       content_store_has_item(content_item['base_path'], content_item)
-
-      rummager_has_documents_for_browse_page(
-        content_item['content_id'],
-        [
-          "employee-tax-codes",
-          "get-paye-forms-p45-p60",
-          "pay-paye-penalty",
-          "pay-paye-tax",
-          "pay-psa",
-          "payroll-annual-reporting",
-        ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-      )
     end
 
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -15,27 +15,19 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         groups: [],
       },
       links: {
-        "parent" => [
-          "title" => "Oil and Gas",
-          "base_path" => "/topic/oil-and-gas",
+        parent: [
+          { title: "Oil and Gas", base_path: "/topic/oil-and-gas" }
+        ],
+        topic_content: [
+          { title: "Oil rig safety requirements", base_path: "/oil-rig-safety-requirements" },
+          { title: "Oil rig staffing", base_path: "/oil-rig-staffing" },
+          { title: "North sea shipping lanes", base_path: "/north-sea-shipping-lanes" },
+          { title: "Undersea piping restrictions", base_path: "/undersea-piping-restrictions" },
         ]
       },
     }
     base[:details].merge!(params.delete(:details)) if params.has_key?(:details)
     base.merge(params)
-  end
-
-  before do
-    rummager_has_documents_for_subtopic(
-      'content-id-for-offshore',
-      [
-        'oil-rig-safety-requirements',
-        'oil-rig-staffing',
-        'north-sea-shipping-lanes',
-        'undersea-piping-restrictions'
-      ],
-      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-    )
   end
 
   it "renders a curated subtopic" do

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 describe ListSet do
-  include RummagerHelpers
-
   describe "for a curated subtopic" do
     setup do
       @group_data = [
@@ -24,20 +22,16 @@ describe ListSet do
         },
       ]
 
-      rummager_has_documents_for_subtopic(
-        "paye-content-id",
-        [
-          "employee-tax-codes",
-          "get-paye-forms-p45-p60",
-          "pay-paye-penalty",
-          "pay-paye-tax",
-          "pay-psa",
-          "payroll-annual-reporting",
-        ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-      )
+      topic_links = [
+        ContentItem.new("title" => "Employee tax codes", "base_path" => "/employee-tax-codes"),
+        ContentItem.new("title" => "Get PAYE forms P45 P60", "base_path" => "/get-paye-forms-p45-p60"),
+        ContentItem.new("title" => "Pay PAYE penalty", "base_path" => "/pay-paye-penalty"),
+        ContentItem.new("title" => "Pay PAYE tax", "base_path" => "/pay-paye-tax"),
+        ContentItem.new("title" => "Pay PSA", "base_path" => "/pay-psa"),
+        ContentItem.new("title" => "Payroll annlual reporting", "base_path" => "/payroll-annual-reporting"),
+      ]
 
-      @list_set = ListSet.new("specialist_sector", "paye-content-id", @group_data)
+      @list_set = ListSet.new(topic_links, @group_data)
     end
 
     it "returns the groups in the curated order" do
@@ -76,131 +70,122 @@ describe ListSet do
       refute list_titles.include?("Group with untagged items")
       refute list_titles.include?("Empty group")
     end
+
+    it "returns no groups if there is no linked content" do
+      list_set = ListSet.new(nil, @group_data)
+
+      assert_equal 0, list_set.count
+    end
   end
 
   describe "for a non-curated topic" do
-    setup do
-      rummager_has_documents_for_subtopic(
-        "paye-content-id",
-        [
-          "get-paye-forms-p45-p60",
-          "pay-paye-penalty",
-          "pay-paye-tax",
-          "pay-psa",
-          "employee-tax-codes",
-          "payroll-annual-reporting",
-        ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-      )
-      @list_set = ListSet.new("specialist_sector", "paye-content-id", [])
+    it "constructs a single A-Z group" do
+      list_set = ListSet.new([], [])
+
+      assert_equal 1, list_set.to_a.size
+      assert_equal "A to Z", list_set.first.title
     end
 
-    it "constructs a single A-Z group" do
-      assert_equal 1, @list_set.to_a.size
-      assert_equal "A to Z", @list_set.first.title
+    it "constructs a single A-Z group if group array is nil" do
+      list_set = ListSet.new([], nil)
+
+      assert_equal 1, list_set.to_a.size
+      assert_equal "A to Z", list_set.first.title
+    end
+
+    it "returns an empty A-Z group is no linked content" do
+      list_set = ListSet.new(nil, [])
+
+      assert_equal 1, list_set.to_a.size
+      assert_equal "A to Z", list_set.first.title
+      assert_equal 0, list_set.first.contents.size
     end
 
     it "includes content tagged to the topic in alphabetical order" do
+      topic_links = [
+        ContentItem.new("title" => "Pay PAYE tax"),
+        ContentItem.new("title" => "Get PAYE forms P45 P60"),
+        ContentItem.new("title" => "Pay PAYE penalty"),
+        ContentItem.new("title" => "Employee tax codes"),
+      ]
+      list_set = ListSet.new(topic_links, [])
+
       expected_titles = [
         "Employee tax codes",
-        "Get paye forms p45 p60",
-        "Pay paye penalty",
-        "Pay paye tax",
-        "Pay psa",
-        "Payroll annual reporting"
+        "Get PAYE forms P45 P60",
+        "Pay PAYE penalty",
+        "Pay PAYE tax",
       ]
-      assert_equal expected_titles, @list_set.first.contents.map(&:title)
+      assert_equal expected_titles, list_set.first.contents.map(&:title)
     end
 
-    it "includes the base_path for all items" do
-      assert_equal "/pay-paye-tax", @list_set.first.contents.to_a[3].base_path
-    end
-
-    it "handles nil data the same as empty array" do
-      @list_set = ListSet.new("specialist_sector", "paye-content-id", nil)
-      assert_equal 1, @list_set.to_a.size
-      assert_equal "A to Z", @list_set.first.title
-    end
-  end
-
-  describe "fetching content tagged to this tag" do
-    setup do
-      @subtopic_content_id = 'paye-content-id'
-      rummager_has_documents_for_subtopic(@subtopic_content_id, [
-        'pay-paye-penalty',
-        'pay-paye-tax',
-        'pay-psa',
-        'employee-tax-codes',
-        'payroll-annual-reporting',
-      ], page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING)
-    end
-
-    it "returns the content for the tag" do
-      expected_titles = [
-        'Pay paye penalty',
-        'Pay paye tax',
-        'Pay psa',
-        'Employee tax codes',
-        'Payroll annual reporting',
+    it "includes the base_path" do
+      topic_links = [
+        ContentItem.new("base_path" => "/some/base/path"),
       ]
 
-      assert_equal expected_titles.sort, ListSet.new("specialist_sector", @subtopic_content_id).first.contents.map(&:title).sort
-    end
+      list_set = ListSet.new(topic_links, [])
 
-    it "provides the title, base_path for each document" do
-      documents = ListSet.new("specialist_sector", @subtopic_content_id).first.contents
-
-      assert_equal "/pay-paye-tax", documents[2].base_path
-      assert_equal "Pay paye tax", documents[2].title
-    end
-  end
-
-  describe "handling missing fields in the search results" do
-    it "handles documents that don't contain the public_timestamp field" do
-      result = rummager_document_for_slug('pay-psa')
-      result.delete("public_timestamp")
-
-      Services.rummager.stubs(:search).with(
-        has_entries(filter_topic_content_ids: ['paye-content-id'])
-      ).returns("results" => [result],
-        "start" => 0,
-        "total" => 1)
-
-      documents = ListSet.new("specialist_sector", "paye-content-id").first.contents
-
-      assert_equal 1, documents.to_a.size
-      assert_equal 'Pay psa', documents.first.title
-      assert_nil documents.first.public_updated_at
+      assert_equal "/some/base/path", list_set.first.contents.first.base_path
     end
   end
 
   describe "filtering uncurated lists" do
-    before do
-      @list_set = ListSet.new("section", "content-id-for-living-abroad")
-    end
-
     it "shouldn't display a document if its format is excluded" do
-      rummager_has_documents_for_browse_page(
-        'content-id-for-living-abroad',
-        ['baz'],
-        ListSet::BROWSE_FORMATS_TO_EXCLUDE.to_a.last,
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-      )
+      topic_links = [
+        ContentItem.new(
+          "title" => "Living abroad",
+          "base_path" => "/living-abroad",
+          "document_type" => "some-excluded-doc-type")
+      ]
+      excluded_document_types = ["some-excluded-doc-type"]
 
-      assert_equal 0, @list_set.first.contents.length
+      list_set = ListSet.new(topic_links, [], excluded_document_types)
+
+      assert_equal 0, list_set.first.contents.length
     end
 
     it "should display a document if its format isn't excluded" do
-      rummager_has_documents_for_browse_page(
-        'content-id-for-living-abroad',
-        ['baz'],
-        'some-format-not-excluded',
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
-      )
+      topic_links = [
+        ContentItem.new(
+          "title" => "Living abroad",
+          "base_path" => "/living-abroad",
+          "document_type" => "some-doc-type-not-excluded")
+      ]
+      excluded_document_types = []
 
-      results = @list_set.first.contents
+      list_set = ListSet.new(topic_links, [], excluded_document_types)
+
+      results = list_set.first.contents
       assert_equal 1, results.length
-      assert_equal 'Baz', results.first.title
+      assert_equal 'Living abroad', results.first.title
+    end
+  end
+
+  describe "determining whether content is curated" do
+    it "should identify content with groups as curated" do
+      group_data = [
+        {
+          "name" => "Paying HMRC",
+          "contents" => ['/pay-paye-tax']
+        },
+      ]
+
+      list_set = ListSet.new([], group_data)
+
+      assert list_set.curated?
+    end
+
+    it "should identify content with no groups as not curated" do
+      list_set = ListSet.new([], [])
+
+      assert_not list_set.curated?
+    end
+
+    it "should identify content with missing group data as not curated" do
+      list_set = ListSet.new([], nil)
+
+      assert_not list_set.curated?
     end
   end
 end

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -2,6 +2,12 @@ require "test_helper"
 
 describe Topic do
   setup do
+    @topic_content = [
+      {
+        "title" => "Some browse page",
+        "base_path" => "/some-browse-page"
+      }
+    ]
     @api_data = {
       "base_path" => "/topic/business-tax/paye",
       "content_id" => "uuid-23",
@@ -15,6 +21,7 @@ describe Topic do
           "base_path" => "/topic/business-tax",
           "description" => "All about tax for businesses",
         }],
+        "topic_content" => @topic_content,
       },
     }
     @content_item = ContentItem.new(@api_data)
@@ -113,15 +120,28 @@ describe Topic do
   end
 
   describe "lists" do
-    it "passes the slug of the topic when constructing groups" do
-      ListSet.expects(:new).with("specialist_sector", @content_item.content_id, anything).returns(:a_lists_instance)
+    it "should create the content lists using topic content links" do
+      ListSet.expects(:new)
+        .with { |links| links.map(&:to_hash) == @topic_content }
+        .returns(:a_lists_instance)
 
       assert_equal :a_lists_instance, @topic.lists
     end
 
-    it "passes the groups data when constructing" do
-      ListSet.expects(:new).with(anything, anything, :some_data).returns(:a_lists_instance)
-      @api_data["details"]["groups"] = :some_data
+    it "should pass the groups data when constructing" do
+      ListSet.expects(:new)
+        .with(anything, :group_data, Topic::DOCUMENT_TYPES_TO_EXCLUDE)
+        .returns(:a_lists_instance)
+      @api_data["details"]["groups"] = :group_data
+
+      assert_equal :a_lists_instance, @topic.lists
+    end
+
+    it "should pass in nil if the group data is missing" do
+      ListSet.expects(:new)
+        .with(anything, nil, Topic::DOCUMENT_TYPES_TO_EXCLUDE)
+        .returns(:a_lists_instance)
+      @api_data.delete("details")
 
       assert_equal :a_lists_instance, @topic.lists
     end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -77,48 +77,4 @@ module RummagerHelpers
         "total" => results.size)
     end
   end
-
-  def rummager_has_documents_for_subtopic(subtopic_content_id, document_slugs, format = "guide", page_size: 50)
-    results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
-    end
-
-    results.each_slice(page_size).with_index do |results_page, page|
-      start = page * page_size
-      Services.rummager.stubs(:search).with(
-        has_entries(
-          start: start,
-          count: page_size,
-          filter_topic_content_ids: [subtopic_content_id],
-        )
-      ).returns("results" => results_page,
-        "start" => start,
-        "total" => results.size)
-    end
-  end
-
-  def rummager_has_documents_for_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 50)
-    results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
-    end
-
-    results.each_slice(page_size).with_index do |results_page, page|
-      start = page * page_size
-      Services.rummager.stubs(:search).with(
-        has_entries(
-          start: start,
-          count: page_size,
-          filter_mainstream_browse_page_content_ids: [browse_page_content_id],
-        )
-      ).returns("results" => results_page,
-        "start" => start,
-        "total" => results.size)
-    end
-  end
-
-  def expect_search_params(params)
-    GdsApi::Rummager.any_instance.expects(:search)
-      .with(has_entries(params))
-      .returns(:some_results)
-  end
 end


### PR DESCRIPTION
Content is linked to parent topics and mainstream browse pages in the publishing API and content store, so the content store can be used to populate the subtopic and second-level browse pages rather than Rummager.

This reduces the number of requests to Rummager from collections, and is a step towards removing it from collections entirely.

Dependencies:

- [x] Add `topic_content` and `mainstream_browse_content` to frontend schemas (alphagov/govuk-content-schemas#535)
- [x] Add `topic_content` and `mainstream_browse_content` reverse links to the publishing API (alphagov/publishing-api#793)
- [x] Re-present all topics and mainstream browse pages to the content store

Trello: https://trello.com/c/D8Heon8X/410-use-the-content-store-to-serve-pages-in-collections-frontend