### PR TITLE
Taxon accessibility

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -87,8 +87,18 @@
         padding-bottom: $gutter-one-third;
       }
 
+      a {
+        display: block;
+        text-decoration: none;
+      }
+
       h3 {
         padding-bottom: 0;
+        text-decoration: underline;
+      }
+
+      p {
+        color: $text-colour;
       }
 
     }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -55,8 +55,18 @@
       }
     }
 
+    a {
+      display: block;
+      text-decoration: none;
+    }
+
+    h3 {
+      text-decoration: underline;
+    }
+
     p {
       margin: 5px 0 20px 0;
+      color: $text-colour;
 
       &:last-child {
         margin-bottom: 0;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -144,8 +144,13 @@
       list-style-type: none;
     }
 
-    .subsection-list-item a {
+    a {
       text-decoration: none;
+      display: block;
+    }
+
+    p {
+      color: $text-colour;
     }
   }
 

--- a/app/views/taxons/_child_taxons_grid.html.erb
+++ b/app/views/taxons/_child_taxons_grid.html.erb
@@ -3,10 +3,12 @@
   <ol>
     <% child_taxons.each_with_index do |child_taxon, index| %>
       <li class="<%= 'leftmost-row-cell-clear-float' if index % 3 == 0 %>">
-        <h3>
-          <%= link_to child_taxon.title, child_taxon.base_path %>
-        </h3>
-        <p><%= child_taxon.description %></p>
+        <%= link_to child_taxon.base_path do %>
+          <h3>
+            <%= child_taxon.title %>
+          </h3>
+          <p><%= child_taxon.description %></p>
+        <% end %>
       </li>
     <% end %>
   </ol>

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -1,9 +1,13 @@
 <ol class="subsection-list">
   <% tagged_content.each do |content_item| %>
     <li class="subsection-list-item">
-      <%= link_to content_item.title, content_item.base_path %>
+      <%= link_to content_item.base_path do %>
+        <h3>
+          <%= content_item.title %>
+        </h3>
 
-      <p><%= content_item.description %></p>
+        <p><%= content_item.description %></p>
+      <% end %>
     </li>
   <% end %>
 </ol>

--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -10,10 +10,12 @@
         <ol>
           <% tagged_content.each do |content_item| %>
             <li>
-              <h3>
-                <%= link_to content_item.title, Plek.new.website_root + content_item.base_path %>
-              </h3>
-              <p><%= content_item.description %></p>
+              <%= link_to Plek.new.website_root + content_item.base_path do %>
+                <h3>
+                  <%= content_item.title %>
+                </h3>
+                <p><%= content_item.description %></p>
+              <% end %>
             </li>
           <% end %>
         </ol>


### PR DESCRIPTION
This change applies to the new education navigation changes. It makes descriptions clickable as well as taxon/content item titles.

This is particularly useful on mobile, which makes it easier to click a link. It also improves consistency on the accordion, where it was possible to click on both the title and description to expand an accordion section.

# Screenshots

## Grid

![grid](https://cloud.githubusercontent.com/assets/12036746/23209445/25bb7fae-f8f1-11e6-87ab-8a5894ec7702.png)

## Accordion

![accordion](https://cloud.githubusercontent.com/assets/12036746/23209449/29489576-f8f1-11e6-8a50-dae0ccb877ae.png)

## List

![list](https://cloud.githubusercontent.com/assets/12036746/23209451/2b2eac40-f8f1-11e6-9db1-8f6255e9187a.png)

# Dependencies

- [x] Built on top of this Pull Request: https://github.com/alphagov/collections/pull/254

# Trello

https://trello.com/c/kSRKSoI2/326-review-styles-on-tablet-and-mobile-viewports-on-the-new-navigation-pages