### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'govuk_ab_testing', '0.1.5' # Specify the minor version because API is unsta
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '10.0.0'
+  gem 'slimmer', '~> 10.1.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   simplecov (~> 0.10.0)
   simplecov-rcov (~> 0.2.3)
-  slimmer (= 10.0.0)
+  slimmer (~> 10.1.1)
   uglifier (~> 2.7.1)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,10 +1,6 @@
 Collections::Application.configure do
   config.slimmer.logger = Rails.logger
 
-  if Rails.env.production?
-    config.slimmer.use_cache = true
-  end
-
   if Rails.env.development?
     config.slimmer.asset_host = Plek.current.find('static')
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI