### PR TITLE
Track the type of taxon page being visited in Google Analytics

### DIFF
--- a/app/helpers/taxon_helper.rb
+++ b/app/helpers/taxon_helper.rb
@@ -1,0 +1,11 @@
+module TaxonHelper
+  def taxon_page_rendering_type(taxon)
+    if taxon.grandchildren?
+      "grid"
+    elsif taxon.children?
+      "accordion"
+    else
+      "leaf"
+    end
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -14,18 +14,6 @@ class Taxon
     @content_item = content_item
   end
 
-  def has_grandchildren?
-    return false unless children?
-
-    # The Publishing API doesn't expand child taxons, which means
-    # we can't use the child_taxons method for each of the child
-    # taxons of this taxon. We have to do an API call to know if
-    # the children also have children.
-    child_taxons.any? do |child_taxon|
-      Taxon.find(child_taxon.base_path).children?
-    end
-  end
-
   # TODO: needs to be guidance content only
   def tagged_content
     @tagged_content ||= TaggedContent.fetch(content_id)
@@ -50,5 +38,17 @@ class Taxon
 
   def children?
     linked_items('child_taxons').present?
+  end
+
+  def grandchildren?
+    return false unless children?
+
+    # The Publishing API doesn't expand child taxons, which means
+    # we can't use the child_taxons method for each of the child
+    # taxons of this taxon. We have to do an API call to know if
+    # the children also have children.
+    child_taxons.any? do |child_taxon|
+      Taxon.find(child_taxon.base_path).children?
+    end
   end
 end

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -12,7 +12,7 @@
     locals: @navigation_helpers.taxon_breadcrumbs %>
 <% end %>
 
-<% if taxon.has_grandchildren? %>
+<% if taxon.grandchildren? %>
   <%= render partial: 'child_taxons_grid',
     locals: { child_taxons: taxon.child_taxons } %>
 <% else %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_class, "taxon-page" %>
 <% content_for :meta_tags do %>
   <%= ab_variant.analytics_meta_tag.html_safe %>
+  <meta name="govuk:navigation-page-type" content="<%=taxon_page_rendering_type(taxon)%>" />
 <% end %>
 
 <%= render partial: 'page_header', locals: { taxon: taxon } %>

--- a/test/fixtures/content_store/running_education_institution.json
+++ b/test/fixtures/content_store/running_education_institution.json
@@ -1,0 +1,28 @@
+{
+  "base_path": "/education/running-a-further-or-higher-education-institution",
+  "content_id": "27c5c52b-3b36-4119-b461-976197d929bf",
+  "title": "Running a further or higher education institution",
+  "links": {
+    "parent_taxons": [
+      {
+        "base_path": "/education/further-and-higher-education-skills-and-vocational-training",
+        "content_id": "dd767840-363e-43ad-8835-c9ab516633de",
+        "description": "Funding for further education providers, apprenticeships, inspections and performance.",
+        "locale": "en",
+        "title": "Further and higher education, skills and vocational training",
+        "links": {
+          "parent_taxons": [
+            {
+              "base_path": "/education",
+              "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+              "description": "Early years learning, schools and academies, further and higher education, skills and vocational training, student funding.",
+              "locale": "en",
+              "title": "Education, training and skills",
+              "links": {}
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -17,6 +17,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_grid_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_a_grid
   end
 
   it 'is possible to browse a taxon page that does not have grandchildren' do
@@ -30,6 +31,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_accordion_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_an_accordion
   end
 
   it 'is possible to browse a taxon page that does not have child taxons' do
@@ -41,6 +43,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_title_and_description
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_a_leaf_node_taxon
   end
 
 private
@@ -265,5 +268,21 @@ private
       "[data-track-dimension-index='29']" +
       "[data-module='track-click']"
     )
+  end
+
+  def and_the_page_is_tracked_as_a_grid
+    assert_navigation_page_type_tracking("grid")
+  end
+
+  def and_the_page_is_tracked_as_an_accordion
+    assert_navigation_page_type_tracking("accordion")
+  end
+
+  def and_the_page_is_tracked_as_a_leaf_node_taxon
+    assert_navigation_page_type_tracking("leaf")
+  end
+
+  def assert_navigation_page_type_tracking(expected_page_type)
+    assert page.has_selector?("meta[name='govuk:navigation-page-type'][content='#{expected_page_type}']", visible: false)
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -32,6 +32,17 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
   end
 
+  it 'is possible to browse a taxon page that does not have child taxons' do
+    given_new_navigation_is_enabled
+    given_there_is_a_taxon_without_child_taxons
+    when_i_visit_the_taxon_page
+    then_i_can_see_there_is_a_page_title
+    then_i_can_see_the_breadcrumbs
+    and_i_can_see_the_title_and_description
+    and_i_can_see_tagged_content_to_the_taxon
+    and_the_content_tagged_to_the_taxon_has_tracking_attributes
+  end
+
 private
 
   def search_results
@@ -54,7 +65,7 @@ private
   end
 
   def given_there_is_a_taxon_with_grandchildren
-    @base_path = '/alpha-taxonomy/funding_and_finance_for_students'
+    @base_path = '/education/funding_and_finance_for_students'
     funding_and_finance_for_students_taxon =
       funding_and_finance_for_students_taxon(base_path: @base_path)
 
@@ -88,7 +99,7 @@ private
   end
 
   def given_there_is_a_taxon_without_grandchildren
-    @base_path = '/alpha-taxonomy/student-finance'
+    @base_path = '/education/student-finance'
     student_finance = student_finance_taxon(base_path: @base_path)
 
     @parent = student_finance['links']['parent_taxons'].first
@@ -111,6 +122,21 @@ private
     stub_content_for_taxon(@taxon.content_id, search_results)
     stub_content_for_taxon(student_sponsorship_taxon['content_id'], search_results)
     stub_content_for_taxon(student_loans_taxon['content_id'], search_results)
+  end
+
+  def given_there_is_a_taxon_without_child_taxons
+    @base_path = '/education/running-a-further-or-higher-education-institution'
+    running_an_institution = running_an_education_institution_taxon(base_path: @base_path)
+
+    @parent = running_an_institution['links']['parent_taxons'].first
+    assert_not_nil @parent
+
+    assert_nil running_an_institution['links']['child_taxons']
+
+    content_store_has_item(@base_path, running_an_institution)
+
+    @taxon = Taxon.find(@base_path)
+    stub_content_for_taxon(@taxon.content_id, search_results)
   end
 
   def when_i_visit_the_taxon_page

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -37,13 +37,13 @@ describe Taxon do
     taxon = stub(children?: true)
     Taxon.stubs(:find).returns(taxon)
 
-    assert @taxon.has_grandchildren?
+    assert @taxon.grandchildren?
   end
 
   it 'does not have grandchildren' do
     taxon = stub(children?: false)
     Taxon.stubs(:find).returns(taxon)
 
-    assert not(@taxon.has_grandchildren?)
+    assert not(@taxon.grandchildren?)
   end
 end

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -9,6 +9,11 @@ module TaxonHelpers
     fetch_and_validate_taxon(:student_finance, params)
   end
 
+  # This taxon does not have any child taxons
+  def running_an_education_institution_taxon(params = {})
+    fetch_and_validate_taxon(:running_education_institution, params)
+  end
+
   def student_sponsorship_taxon(params = {})
     fetch_and_validate_taxon(:student_sponsorship, params)
   end


### PR DESCRIPTION
- Add integration test of leaf node taxon page in preparation for testing new `meta` tag on all versions of the taxon page
- Make taxon `grandchildren?` and `children?` methods consistent
- Add meta tag to taxon pages which identifies whether the page is a grid, an accordion or a leaf node. This will help us analyse whether users are able to find what they need quickly, or if they navigate in circles because they are struggling to find content in the new navigation.

This won't actually report anything to Google Analytics until alphagov/static#910 is merged.

Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages