### PR TITLE
Track all nav pages as navigation pages in Google Analytics

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,5 +1,8 @@
 <% content_for :title, "All categories - GOV.UK" %>
 <% content_for :page_class, "browse" %>
+<% content_for :meta_tags do %>
+  <%= render 'shared/tag_meta_nav_ab_tracking' %>
+<% end %>
 
 <div class="browse-panes root">
   <%= render 'top_level_browse_pages',

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
+  <%= render 'shared/tag_meta_nav_ab_tracking' %>
   <% if is_page_under_ab_test %>
     <%= ab_variant.analytics_meta_tag.html_safe %>
   <% end %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "#{page.title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
+  <%= render 'shared/tag_meta_nav_ab_tracking' %>
   <% if is_page_under_ab_test %>
     <%= ab_variant.analytics_meta_tag.html_safe %>
   <% end %>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "Services and information - #{organisation['title']} - GOV.UK" %>
 <% content_for :page_class, "topics-page" %>
 <% content_for :meta_tags do %>
+  <%= render 'shared/tag_meta_nav_ab_tracking' %>
   <% if is_page_under_ab_test %>
     <%= ab_variant.analytics_meta_tag.html_safe %>
   <% end %>

--- a/app/views/shared/_tag_meta_nav_ab_tracking.html.erb
+++ b/app/views/shared/_tag_meta_nav_ab_tracking.html.erb
@@ -1,0 +1,1 @@
+<meta name="govuk:user-journey-stage" content="finding" />

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "#{subtopic.combined_title} - GOV.UK" %>
 <%= render 'shared/tag_meta', tag: subtopic %>
+<%= render 'shared/tag_meta_nav_ab_tracking' %>
 <% if is_page_under_ab_test %>
   <%= ab_variant.analytics_meta_tag.html_safe %>
 <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -2,6 +2,7 @@
 <% content_for :page_class, "taxon-page" %>
 <% content_for :meta_tags do %>
   <%= ab_variant.analytics_meta_tag.html_safe %>
+  <%= render 'shared/tag_meta_nav_ab_tracking' %>
   <meta name="govuk:navigation-page-type" content="<%=taxon_page_rendering_type(taxon)%>" />
 <% end %>
 

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title do %><%= topic.title %> - GOV.UK<% end %>
 <%= render 'shared/tag_meta', tag: topic %>
+<%= render 'shared/tag_meta_nav_ab_tracking' %>
 <% if is_page_under_ab_test %>
   <%= ab_variant.analytics_meta_tag.html_safe %>
 <% end %>

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 describe BrowseController do
-
   include GovukAbTesting::MinitestHelpers
+  include NavigationAbTestHelpers
 
   describe "GET index" do
     before do
@@ -17,6 +17,12 @@ describe BrowseController do
       get :index
 
       assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+    end
+
+    it "tracks the page as a 'finding' page type" do
+      get :index
+
+      assert_user_journey_stage_tracked_as_finding_page
     end
   end
 
@@ -36,6 +42,12 @@ describe BrowseController do
         get :show, top_level_slug: "benefits"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      it "tracks the page as a 'finding' page type" do
+        get :show, top_level_slug: "benefits"
+
+        assert_user_journey_stage_tracked_as_finding_page
       end
     end
 

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe SecondLevelBrowsePageController do
   include RummagerHelpers
   include GovukAbTesting::MinitestHelpers
+  include NavigationAbTestHelpers
 
   describe "GET second_level_browse_page" do
     describe "for a valid browse page" do
@@ -34,6 +35,12 @@ describe SecondLevelBrowsePageController do
         get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      it "tracks the page as a 'finding' page type" do
+        get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
+
+        assert_user_journey_stage_tracked_as_finding_page
       end
     end
 

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -5,6 +5,7 @@ describe ServicesAndInformationController do
   include RummagerHelpers
   include ServicesAndInformationHelpers
   include GovukAbTesting::MinitestHelpers
+  include NavigationAbTestHelpers
 
   describe "with a valid organisation slug" do
     it "sets expiry headers for 30 minutes" do
@@ -18,6 +19,15 @@ describe ServicesAndInformationController do
   end
 
   describe "GET services and information page" do
+    it "tracks the page as a 'finding' page type" do
+      stub_services_and_information_content_item
+      stub_services_and_information_links("hm-revenue-customs")
+
+      get :index, organisation_id: "hm-revenue-customs"
+
+      assert_user_journey_stage_tracked_as_finding_page
+    end
+
     it "returns a 404 status for GET services and information with an invalid organisation id" do
       content_store_does_not_have_item("/government/organisations/hm-revenue-customs/services-information")
 

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 describe SubtopicsController do
-
   include GovukAbTesting::MinitestHelpers
+  include NavigationAbTestHelpers
 
   describe "GET subtopic" do
     describe "with a valid topic and subtopic slug" do
@@ -14,6 +14,12 @@ describe SubtopicsController do
         get :show, topic_slug: "oil-and-gas", subtopic_slug: "wells"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      it "tracks the page as a 'finding' page type" do
+        get :show, topic_slug: "oil-and-gas", subtopic_slug: "wells"
+
+        assert_user_journey_stage_tracked_as_finding_page
       end
     end
 

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe TopicsController do
   include ContentSchemaHelpers
   include RummagerHelpers
+  include NavigationAbTestHelpers
 
   include GovukAbTesting::MinitestHelpers
 
@@ -16,6 +17,12 @@ describe TopicsController do
         get :show, topic_slug: "oil-and-gas"
 
         assert_equal "max-age=1800, public", response.headers["Cache-Control"]
+      end
+
+      it "tracks the page as a 'finding' page type" do
+        get :show, topic_slug: "oil-and-gas"
+
+        assert_user_journey_stage_tracked_as_finding_page
       end
     end
 

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -31,6 +31,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_grid_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_a_navigation_page
     and_the_page_is_tracked_as_a_grid
   end
 
@@ -44,6 +45,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_accordion_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_a_navigation_page
     and_the_page_is_tracked_as_an_accordion
   end
 
@@ -55,6 +57,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_title_and_description
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_page_is_tracked_as_a_navigation_page
     and_the_page_is_tracked_as_a_leaf_node_taxon
   end
 
@@ -290,5 +293,9 @@ private
 
   def assert_navigation_page_type_tracking(expected_page_type)
     assert page.has_selector?("meta[name='govuk:navigation-page-type'][content='#{expected_page_type}']", visible: false)
+  end
+
+  def and_the_page_is_tracked_as_a_navigation_page
+    assert page.has_selector?("meta[name='govuk:user-journey-stage'][content='finding']", visible: false)
   end
 end

--- a/test/support/navigation_ab_test_helpers.rb
+++ b/test/support/navigation_ab_test_helpers.rb
@@ -1,0 +1,6 @@
+module NavigationAbTestHelpers
+  def assert_user_journey_stage_tracked_as_finding_page
+    assert_select "meta[name='govuk:user-journey-stage'][content='finding']", 1,
+      "Expected a Google Analytics meta tag for tracking that the user has visited a navigation page"
+  end
+end


### PR DESCRIPTION
Add meta tag which marks taxon, browse, topic and services & information pages as being in the navigation stage of a user journey, as opposed to the content stage.

This will enable us to analyse how users navigate the site so that we can work out whether the new navigation pages are helping users find what they need.

The JS for converting the meta tags to the GA dimension was added in alphagov/static#910.

Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages