### PR TITLE
Delete TODO which has already been done

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -14,7 +14,6 @@ class Taxon
     @content_item = content_item
   end
 
-  # TODO: needs to be guidance content only
   def tagged_content
     @tagged_content ||= TaggedContent.fetch(content_id)
   end


### PR DESCRIPTION
The TODO is about only showing guidance content on a taxon page. This was fixed in #225, which added a document type filter to the rummager search.