### PR TITLE
Show new navigation based on A/B testing variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 2.4.1'
-gem 'govuk_ab_testing', '0.1.5' # Specify the minor version because API is unstable
+gem 'govuk_ab_testing', '1.0.1'
 
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (0.1.5)
+    govuk_ab_testing (1.0.1)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -291,7 +291,7 @@ DEPENDENCIES
   gds-api-adapters (~> 40.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 0.1.5)
+  govuk_ab_testing (= 1.0.1)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 2.4.1)
   govuk_schemas (~> 2.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,10 +29,6 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
-  def new_navigation_enabled?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
-  end
-
 private
 
   def restrict_request_formats

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -7,7 +7,7 @@ class BrowseController < ApplicationController
 
     dimension = Rails.application.config.navigation_ab_test_dimension
     ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-    ab_variant = ab_test.requested_variant(request)
+    ab_variant = ab_test.requested_variant(request.headers)
 
     render :index, locals: { page: page, ab_variant: ab_variant }
   end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -4,7 +4,7 @@ class TaxonRedirectResolver
   def initialize(request, is_page_in_ab_test:, map_to_taxon:)
     dimension = Rails.application.config.navigation_ab_test_dimension
     ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-    @ab_variant = ab_test.requested_variant(request)
+    @ab_variant = ab_test.requested_variant(request.headers)
 
     @is_page_in_ab_test = is_page_in_ab_test
     @map_to_taxon = map_to_taxon

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -55,7 +55,7 @@ describe SecondLevelBrowsePageController do
         )
       end
 
-      describe "with the new navigation not enabled" do
+      describe "with the feature flag off" do
         %w(A, B).each do |variant|
           it "returns the original version of the page for variant #{variant}" do
             setup_ab_variant("EducationNavigation", variant)
@@ -68,26 +68,22 @@ describe SecondLevelBrowsePageController do
         end
       end
 
-      describe "with the new navigation enabled" do
+      describe "with the feature flag on" do
         it "returns the original version of education pages as the A variant" do
-          with_new_navigation_enabled do
-            with_variant EducationNavigation: "A" do
-              get :show, top_level_slug: "education", second_level_slug: "student-finance"
+          with_A_variant do
+            get :show, top_level_slug: "education", second_level_slug: "student-finance"
 
-              assert_response 200
-            end
+            assert_response 200
           end
         end
 
         it "redirects to the taxonomy navigation as the B variant" do
-          with_new_navigation_enabled do
-            with_variant EducationNavigation: "B", assert_meta_tag: false do
-              get :show, top_level_slug: "education", second_level_slug: "student-finance"
+          with_B_variant assert_meta_tag: false do
+            get :show, top_level_slug: "education", second_level_slug: "student-finance"
 
-              assert_response 302
-              assert_redirected_to controller: "taxons", action: "show",
-                taxon_base_path: "education/funding-and-finance-for-students"
-            end
+            assert_response 302
+            assert_redirected_to controller: "taxons", action: "show",
+              taxon_base_path: "education/funding-and-finance-for-students"
           end
         end
 
@@ -107,13 +103,11 @@ describe SecondLevelBrowsePageController do
             page_size: 1000
           )
 
-          with_new_navigation_enabled do
-            with_variant EducationNavigation: "B", assert_meta_tag: false do
-              get :show, top_level_slug: "education", second_level_slug: "school-life"
+          with_B_variant assert_meta_tag: false do
+            get :show, top_level_slug: "education", second_level_slug: "school-life"
 
-              assert_response 302
-              assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
-            end
+            assert_response 302
+            assert_redirected_to controller: "taxons", action: "show", taxon_base_path: "education"
           end
         end
 
@@ -134,21 +128,17 @@ describe SecondLevelBrowsePageController do
               page_size: 1000
             )
 
-            with_new_navigation_enabled do
-              setup_ab_variant("EducationNavigation", variant)
-              get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
+            setup_ab_variant("EducationNavigation", variant)
+            get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
 
-              assert_response 200
-              assert_response_not_modified_for_ab_test
-            end
+            assert_response 200
+            assert_response_not_modified_for_ab_test
           end
 
           it "does not redirect education when the #{variant} variant is requested in JSON format" do
             setup_ab_variant("EducationNavigation", variant)
 
-            with_new_navigation_enabled do
-              get :show, top_level_slug: "education", second_level_slug: "student-finance", format: :json
-            end
+            get :show, top_level_slug: "education", second_level_slug: "student-finance", format: :json
 
             assert_response 200
             assert_response_not_modified_for_ab_test

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -33,7 +33,7 @@ describe SubtopicsController do
           "apprenticeships")
       end
 
-      describe "with the new navigation not enabled" do
+      describe "with the feature flag off" do
         ["A", "B"].each do |variant|
           it "returns the original version of the page for variant #{variant}" do
             setup_ab_variant("EducationNavigation", variant)
@@ -46,42 +46,38 @@ describe SubtopicsController do
         end
       end
 
-      describe "with the new navigation enabled" do
+      describe "with the feature flag on" do
         it "returns the original version of the page as the A variant" do
-          with_new_navigation_enabled do
-            with_variant EducationNavigation: "A" do
-              get :show, topic_slug: "further-education-skills", subtopic_slug: "apprenticeships"
+          with_A_variant do
+            get :show, topic_slug: "further-education-skills", subtopic_slug: "apprenticeships"
 
-              assert_response 200
-            end
+            assert_response 200
           end
         end
 
         it "redirects to the taxonomy navigation as the B variant" do
-          with_new_navigation_enabled do
-            with_variant EducationNavigation: "B", assert_meta_tag: false do
-              get :show, topic_slug: "further-education-skills", subtopic_slug: "apprenticeships"
+          with_B_variant assert_meta_tag: false do
+            get :show, topic_slug: "further-education-skills", subtopic_slug: "apprenticeships"
 
-              assert_response 302
-              assert_redirected_to controller: "taxons",
-                action: "show",
-                taxon_base_path: "education/apprenticeships-traineeships-and-internships"
-            end
+            assert_response 302
+            assert_redirected_to controller: "taxons",
+              action: "show",
+              taxon_base_path: "education/apprenticeships-traineeships-and-internships"
           end
         end
 
         ["A", "B"].each do |variant|
           it "does not change a page outside the A/B test when the #{variant} variant is requested" do
-            stub_services_for_subtopic("content-id-for-wells", "oil-and-gas", "wells")
+            ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
+              stub_services_for_subtopic("content-id-for-wells", "oil-and-gas", "wells")
 
-            setup_ab_variant("EducationNavigation", variant)
+              setup_ab_variant("EducationNavigation", variant)
 
-            with_new_navigation_enabled do
               get :show, topic_slug: "oil-and-gas", subtopic_slug: "wells"
-            end
 
-            assert_response 200
-            assert_response_not_modified_for_ab_test
+              assert_response 200
+              assert_response_not_modified_for_ab_test
+            end
           end
         end
       end

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -2,41 +2,29 @@ require "test_helper"
 require "climate_control"
 
 describe TaxonsController do
-
   include RummagerHelpers
   include GovukAbTesting::MinitestHelpers
 
   describe "GET show" do
-
     before do
       content_store_has_item("/education", content_id: "education-content-id", title: "Education")
       stub_content_for_taxon("education-content-id", [])
     end
 
-    it "returns 200 if the new navigation is enabled" do
-      with_new_navigation_enabled do
+    it "returns 200 if the new navigation is enabled in variant 'B'" do
+      with_B_variant do
         get :show, taxon_base_path: "education"
       end
 
       assert_response 200
     end
 
-    it "returns 404 if the new navigation is disabled" do
-      get :show, taxon_base_path: "education"
+    it "returns 404 if the new navigation is disabled for variant 'A'" do
+      with_A_variant assert_meta_tag: false do
+        get :show, taxon_base_path: "education"
+      end
 
       assert_response 404
-    end
-
-    %w(A B).each do |variant|
-      it "returns the taxon page in the #{variant} variant" do
-        with_new_navigation_enabled do
-          with_variant EducationNavigation: variant do
-            get :show, taxon_base_path: "education"
-
-            assert_response 200
-          end
-        end
-      end
     end
   end
 end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -5,9 +5,23 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
   include TaxonHelpers
   include Slimmer::TestHelpers::GovukComponents
+  include GovukAbTesting::MinitestHelpers
+
+  before do
+    @existing_framework = GovukAbTesting.configuration.acceptance_test_framework
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = :capybara
+    end
+  end
+
+  after do
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = @existing_framework
+    end
+  end
 
   it 'is possible to browse a taxon page that has grandchildren' do
-    given_new_navigation_is_enabled
     given_there_is_a_taxon_with_grandchildren
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
@@ -21,7 +35,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it 'is possible to browse a taxon page that does not have grandchildren' do
-    given_new_navigation_is_enabled
     given_there_is_a_taxon_without_grandchildren
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
@@ -35,7 +48,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it 'is possible to browse a taxon page that does not have child taxons' do
-    given_new_navigation_is_enabled
     given_there_is_a_taxon_without_child_taxons
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
@@ -61,10 +73,6 @@ private
         'link' => 'content-item-2'
       },
     ]
-  end
-
-  def given_new_navigation_is_enabled
-    @enable_new_navigation = true
   end
 
   def given_there_is_a_taxon_with_grandchildren
@@ -143,9 +151,7 @@ private
   end
 
   def when_i_visit_the_taxon_page
-    new_nav_environment_variable = @enable_new_navigation ? 'yes' : nil
-
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: new_nav_environment_variable) do
+    with_B_variant do
       visit @base_path
     end
   end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -12,7 +12,29 @@ class ActiveSupport::TestCase
     end
   end
 
-  def with_new_navigation_enabled(&block)
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes', &block)
+  # rubocop:disable Style/MethodName
+  def with_A_variant(options = {})
+    variant_options =
+      { EducationNavigation: 'A' }
+      .merge(options)
+
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
+      with_variant variant_options do
+        yield
+      end
+    end
   end
+
+  def with_B_variant(options = {})
+    variant_options =
+      { EducationNavigation: 'B' }
+      .merge(options)
+
+    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
+      with_variant variant_options do
+        yield
+      end
+    end
+  end
+  # rubocop:enable Style/MethodName
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,13 @@ require 'gds_api/test_helpers/content_store'
 require 'slimmer/test_helpers/govuk_components'
 require 'gds_api/test_helpers/rummager'
 
+# Most tests use ActiveSupport TestCase behaviour, so we configure this here.
+# For integration tests that use capybara, we configure GovukAbTesting
+# accordingly before/after the tests.
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
   include Slimmer::TestHelpers::GovukComponents


### PR DESCRIPTION
This change makes sure collections behaves like any other repos that use the new navigation by allowing us to switch between A/B variants.