### PR TITLE
Bump navigation helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
 gem 'appsignal', '~> 2.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
-gem 'govuk_navigation_helpers', '~> 2.1'
+gem 'govuk_navigation_helpers', '~> 2.4'
 gem 'govuk_ab_testing', '0.1.5' # Specify the minor version because API is unstable
 
 if ENV['SLIMMER_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (2.1.0)
+    govuk_navigation_helpers (2.4.0)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
     http-cookie (1.0.2)
@@ -292,7 +292,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 0.1.5)
   govuk_frontend_toolkit (~> 4.3.0)
-  govuk_navigation_helpers (~> 2.1)
+  govuk_navigation_helpers (~> 2.4)
   govuk_schemas (~> 2.1)
   jasmine-rails (~> 0.12.1)
   logstasher (= 0.6.2)

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -9,7 +9,7 @@ describe TaxonsController do
   describe "GET show" do
 
     before do
-      content_store_has_item("/education", content_id: "education-content-id")
+      content_store_has_item("/education", content_id: "education-content-id", title: "Education")
       stub_content_for_taxon("education-content-id", [])
     end
 


### PR DESCRIPTION
Bumping the navigation helpers gem version to display the current page in the breadcrumb list for the Education Navigation A/B test.

### Trello

https://trello.com/c/aZ8yAx6a/445-breadcrumbs-for-taxonomy-pages-missing-current-page