### PR TITLE
Education navigation accessibility

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -55,18 +55,8 @@
       }
     }
 
-    a {
-      display: block;
-      text-decoration: none;
-    }
-
-    h3 {
-      text-decoration: underline;
-    }
-
     p {
       margin: 5px 0 20px 0;
-      color: $text-colour;
 
       &:last-child {
         margin-bottom: 0;
@@ -87,18 +77,8 @@
         padding-bottom: $gutter-one-third;
       }
 
-      a {
-        display: block;
-        text-decoration: none;
-      }
-
       h3 {
         padding-bottom: 0;
-        text-decoration: underline;
-      }
-
-      p {
-        color: $text-colour;
       }
 
     }
@@ -144,13 +124,8 @@
       list-style-type: none;
     }
 
-    a {
+    .subsection-list-item a {
       text-decoration: none;
-      display: block;
-    }
-
-    p {
-      color: $text-colour;
     }
   }
 

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -32,6 +32,13 @@
     margin-bottom: $gutter-two-thirds;
   }
 
+  a {
+    margin: -3px;
+    padding: 3px;
+    outline-color: transparent;
+    display: block;
+  }
+
   .page-header {
     margin-top: $gutter * 3;
 

--- a/app/views/taxons/_child_taxons_grid.html.erb
+++ b/app/views/taxons/_child_taxons_grid.html.erb
@@ -3,23 +3,22 @@
   <ol>
     <% child_taxons.each_with_index do |child_taxon, index| %>
       <li class="<%= 'leftmost-row-cell-clear-float' if index % 3 == 0 %>">
-        <%= link_to(
-          child_taxon.base_path,
-          data: {
-            track_category: 'navGridLinkClicked',
-            track_action: index + 1,
-            track_value: child_taxons.size,
-            track_label: child_taxon.base_path,
-            track_dimension: child_taxon.title,
-            track_dimension_index: 29,
-            module: 'track-click',
-          }
-        ) do %>
-          <h3>
-            <%= child_taxon.title %>
-          </h3>
-          <p><%= child_taxon.description %></p>
-        <% end %>
+        <h3>
+          <%= link_to(
+            child_taxon.title,
+            child_taxon.base_path,
+            data: {
+              track_category: 'navGridLinkClicked',
+              track_action: index + 1,
+              track_value: child_taxons.size,
+              track_label: child_taxon.base_path,
+              track_dimension: child_taxon.title,
+              track_dimension_index: 29,
+              module: 'track-click',
+            }
+          )%>
+        </h3>
+        <p><%= child_taxon.description %></p>
       </li>
     <% end %>
   </ol>

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -2,6 +2,7 @@
   <% tagged_content.each_with_index do |content_item, index| %>
     <li class="subsection-list-item">
       <%= link_to(
+        content_item.title,
         content_item.base_path,
         data: {
           track_category: 'navAccordionLinkClicked',
@@ -12,13 +13,9 @@
           track_dimension_index: '29',
           module: 'track-click',
         }
-      ) do %>
-        <h3>
-          <%= content_item.title %>
-        </h3>
+      )%>
 
-        <p><%= content_item.description %></p>
-      <% end %>
+      <p><%= content_item.description %></p>
     </li>
   <% end %>
 </ol>

--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -10,23 +10,22 @@
         <ol>
           <% tagged_content.each_with_index do |content_item, index| %>
             <li>
-              <%= link_to(
-                Plek.new.website_root + content_item.base_path,
-                data: {
-                  track_category: 'navLeafLinkClicked',
-                  track_action: index + 1,
-                  track_value: tagged_content.size,
-                  track_label: content_item.base_path,
-                  track_dimension: content_item.title,
-                  track_dimension_index: 29,
-                  module: 'track-click',
-                }
-              ) do %>
-                <h3>
-                  <%= content_item.title %>
-                </h3>
-                <p><%= content_item.description %></p>
-              <% end %>
+              <h3>
+                <%= link_to(
+                  content_item.title,
+                  Plek.new.website_root + content_item.base_path,
+                  data: {
+                    track_category: 'navLeafLinkClicked',
+                    track_action: index + 1,
+                    track_value: tagged_content.size,
+                    track_label: content_item.base_path,
+                    track_dimension: content_item.title,
+                    track_dimension_index: 29,
+                    module: 'track-click',
+                  }
+                ) %>
+              </h3>
+              <p><%= content_item.description %></p>
             </li>
           <% end %>
         </ol>


### PR DESCRIPTION
After a review with the Accessibility team, we decided that [wrapping both headings and descriptions in a link](https://github.com/alphagov/collections/pull/259) could be too verbose on a screen-reader, which could counter the potential benefit gained on touch devices.

This Pull Request:

- Reverts that clickable description change
- Enlarges the clickable area of links to improve touch experience

The links have been turned into `block` elements (so their bounding box is all clickable), and their padding has been increased to match the orange outline you get when focusing the link, similarly to [what we've already done with breadcrumbs](https://github.com/alphagov/static/pull/911).

# Screenshots

## After the revert

![links-before](https://cloud.githubusercontent.com/assets/12036746/23411069/2fec35c2-fdc9-11e6-887b-2c09dbee6b7d.png)

## With larger clickable area

![links-after](https://cloud.githubusercontent.com/assets/12036746/23411083/39571b90-fdc9-11e6-8bb9-4580d57aa632.png)

# Trello

https://trello.com/c/EiVQamBN/446-don-t-link-the-description-on-the-grid

