### PR TITLE
Differentiate between grid and leaf content clicks

### DIFF
--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -1,3 +1,5 @@
+<% is_grid ||= false %>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="parent-topic-contents">
@@ -15,7 +17,7 @@
                   content_item.title,
                   Plek.new.website_root + content_item.base_path,
                   data: {
-                    track_category: 'navLeafLinkClicked',
+                    track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
                     track_action: index + 1,
                     track_value: tagged_content.size,
                     track_label: content_item.base_path,

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -20,6 +20,7 @@
   <%= render partial: 'content_list_for_current_taxon', locals: {
   taxon: taxon,
   tagged_content: taxon.tagged_content,
+  is_grid: true,
   } %>
 <% else %>
   <% if taxon.children? %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -30,7 +30,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_links_to_the_child_taxons_in_a_grid
     and_the_grid_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
-    and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_grid
   end
 
@@ -61,7 +61,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     then_i_can_see_the_breadcrumbs
     and_i_can_see_the_title_and_description
     and_i_can_see_tagged_content_to_the_taxon
-    and_the_content_tagged_to_the_taxon_has_tracking_attributes
+    and_the_content_tagged_to_the_leaf_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_leaf_node_taxon
   end
 
@@ -283,29 +283,12 @@ private
     end
   end
 
-  def and_the_content_tagged_to_the_taxon_has_tracking_attributes
-    tracked_links = page.all(:css, "a[data-track-category='navLeafLinkClicked']")
-    tracked_links.size.must_equal search_results.size
+  def and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
+    assert_leaf_tracking_attributes_present('navGridLeafLinkClicked')
+  end
 
-    tracked_links.each_with_index do |link, index|
-      link[:'data-track-action'].must_equal "#{index + 1}"
-      link[:'data-track-label'].must_equal search_results[index]['link']
-      link[:'data-track-value'].must_equal "#{search_results.size}"
-      link[:'data-track-dimension'].must_equal search_results[index]['title']
-      link[:'data-track-dimension-index'].must_equal '29'
-      link[:'data-module'].must_equal 'track-click'
-    end
-
-    # Test an example free from logic
-    assert page.has_css?(
-      "a[data-track-category='navLeafLinkClicked']" +
-      "[data-track-action='2']" +
-      "[data-track-label='content-item-2']" +
-      "[data-track-value='2']" +
-      "[data-track-dimension='Content item 2']" +
-      "[data-track-dimension-index='29']" +
-      "[data-module='track-click']"
-    )
+  def and_the_content_tagged_to_the_leaf_taxon_has_tracking_attributes
+    assert_leaf_tracking_attributes_present('navLeafLinkClicked')
   end
 
   def and_the_page_is_tracked_as_a_grid
@@ -322,5 +305,30 @@ private
 
   def assert_navigation_page_type_tracking(expected_page_type)
     assert page.has_selector?("meta[name='govuk:navigation-page-type'][content='#{expected_page_type}']", visible: false)
+  end
+
+  def assert_leaf_tracking_attributes_present(tracking_category)
+    tracked_links = page.all(:css, "a[data-track-category='#{tracking_category}']")
+    tracked_links.size.must_equal search_results.size
+
+    tracked_links.each_with_index do |link, index|
+      link[:'data-track-action'].must_equal "#{index + 1}"
+      link[:'data-track-label'].must_equal search_results[index]['link']
+      link[:'data-track-value'].must_equal "#{search_results.size}"
+      link[:'data-track-dimension'].must_equal search_results[index]['title']
+      link[:'data-track-dimension-index'].must_equal '29'
+      link[:'data-module'].must_equal 'track-click'
+    end
+
+    # Test an example free from logic
+    assert page.has_css?(
+      "a[data-track-category='#{tracking_category}']" +
+      "[data-track-action='2']" +
+      "[data-track-label='content-item-2']" +
+      "[data-track-value='2']" +
+      "[data-track-dimension='Content item 2']" +
+      "[data-track-dimension-index='29']" +
+      "[data-module='track-click']"
+    )
   end
 end


### PR DESCRIPTION
Previously, there was no differentiation between clicks on content links on grid vs. those on a "leaf" taxon page.

This change will track all clicks on grid-level content items with a category of `navGridLeafLinkClicked`, and content items at the leaf level as `navLeafLinkClicked`.

Note that it is assumed that all content tagged at the accordion level will be contained within the accordion itself, and hence we don't need a separate tracking category for that case.

### Trello

https://trello.com/c/WJDdtMs4/430-track-click-events-in-taxon-leaf-pages
