### PR TITLE
Revert "Use content store instead of Rummager in topic and browse pages"

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -10,7 +10,7 @@ class ContentItem
     @content_item_data = content_item_data
   end
 
-  %i[base_path title description content_id document_type].each do |field|
+  %i[base_path title description content_id].each do |field|
     define_method field do
       @content_item_data[field.to_s]
     end

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -2,10 +2,25 @@ class ListSet
   include Enumerable
   delegate :each, to: :lists
 
-  def initialize(linked_content, group_data, excluded_document_types = [])
-    @linked_content = linked_content || []
+  BROWSE_FORMATS_TO_EXCLUDE = %w(
+    fatality_notice
+    news_article
+    speech
+    world_location_news_article
+    travel-advice
+  ).to_set
+
+  TOPIC_FORMATS_TO_EXCLUDE = %w(
+    fatality_notice
+    news_article
+    speech
+    world_location_news_article
+  ).to_set
+
+  def initialize(tag_type, tag_content_id, group_data = nil)
+    @tag_type = tag_type
+    @tag_content_id = tag_content_id
     @group_data = group_data || []
-    @excluded_document_types = excluded_document_types
   end
 
   def curated?
@@ -23,19 +38,18 @@ private
   end
 
   def a_to_z_list
-    az_list = @linked_content
-      .reject { |content| @excluded_document_types.include? content.document_type }
-      .map { |content| LinkedContent.new(content.title, content.base_path) }
-      .sort_by(&:title)
-
-    [ListSet::List.new("A to Z", az_list)]
+    [ListSet::List.new(
+      "A to Z",
+      content_tagged_to_tag
+        .reject { |content| excluded_formats.include? content.format }
+        .sort_by(&:title)
+    )]
   end
 
   def curated_list
     curated_data = @group_data.map do |group|
       contents = group["contents"].map do |base_path|
-        link = @linked_content.find { |content| content.base_path == base_path }
-        link.nil? ? nil : LinkedContent.new(link.title, link.base_path)
+        content_tagged_to_tag.find { |content| content.base_path == base_path }
       end
 
       ListSet::List.new(group["name"], contents.compact) if contents.any?
@@ -44,8 +58,27 @@ private
     curated_data.compact
   end
 
-  LinkedContent = Struct.new(
-    :title,
-    :base_path,
-  )
+  def content_tagged_to_tag
+    @content_tagged_to_tag ||= RummagerSearch.new(
+      :start => 0,
+      :count => RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      filter_name => [@tag_content_id],
+      :fields => %w(title link format))
+  end
+
+  def filter_name
+    if @tag_type == 'section'
+      :filter_mainstream_browse_page_content_ids
+    else
+      :filter_topic_content_ids
+    end
+  end
+
+  def excluded_formats
+    if @tag_type == 'section'
+      BROWSE_FORMATS_TO_EXCLUDE
+    else
+      TOPIC_FORMATS_TO_EXCLUDE
+    end
+  end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -10,14 +10,6 @@ class MainstreamBrowsePage
     to: :content_item
   )
 
-  DOCUMENT_TYPES_TO_EXCLUDE = %w(
-    fatality_notice
-    news_article
-    speech
-    world_location_news_article
-    travel_advice
-  ).to_set
-
   def self.find(base_path)
     content_item = ContentItem.find!(base_path)
     new(content_item)
@@ -52,10 +44,7 @@ class MainstreamBrowsePage
   end
 
   def lists
-    @lists ||= ListSet.new(
-      @content_item.linked_items("mainstream_browse_content"),
-      details["groups"],
-      DOCUMENT_TYPES_TO_EXCLUDE)
+    @lists ||= ListSet.new("section", @content_item.content_id, details["groups"])
   end
 
   def related_topics

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -11,13 +11,6 @@ class Topic
     to: :content_item
   )
 
-  DOCUMENT_TYPES_TO_EXCLUDE = %w(
-    fatality_notice
-    news_article
-    speech
-    world_location_news_article
-  ).to_set
-
   def self.find(base_path, pagination_options = {})
     content_item = ContentItem.find!(base_path)
     new(content_item, pagination_options)
@@ -45,10 +38,7 @@ class Topic
   end
 
   def lists
-    ListSet.new(
-      @content_item.linked_items("topic_content"),
-      details["groups"],
-      DOCUMENT_TYPES_TO_EXCLUDE)
+    ListSet.new("specialist_sector", content_item.content_id, details["groups"])
   end
 
   def changed_documents

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -1,5 +1,5 @@
 Given(/^there is latest content for a subtopic$/) do
-  topic_content_id = stub_topic_lookups
+  stub_topic_lookups
 
   @stubbed_rummager_documents = %w(
     what-is-oil
@@ -24,7 +24,7 @@ Given(/^there is latest content for a subtopic$/) do
     has_entries(
       start: 0,
       count: 50,
-      filter_topic_content_ids: [topic_content_id],
+      filter_topic_content_ids: ['content-id-for-fields-and-wells'],
       order: "-public_timestamp",
     )
   ).returns("results" => @stubbed_rummager_documents,

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,16 +1,10 @@
-CRIME_AND_JUSTICE_CONTENT_ID = SecureRandom::uuid
-BENEFITS_CONTENT_ID = SecureRandom::uuid
-JUDGES_CONTENT_ID = SecureRandom::uuid
-COURTS_CONTENT_ID = SecureRandom::uuid
-
 Given(/^there is an alphabetical browse page set up with links$/) do
   stub_browse_lookups
 
   second_level_browse_pages = [{
-    content_id: JUDGES_CONTENT_ID,
+    content_id: 'judges-content-id',
     title: 'Judges',
-    base_path: '/browse/crime-and-justice/judges',
-    locale: :en,
+    base_path: '/browse/crime-and-justice/judges'
   }]
 
   add_browse_pages
@@ -18,9 +12,15 @@ Given(/^there is an alphabetical browse page set up with links$/) do
     child_pages: second_level_browse_pages,
     order_type: "alphabetical"
   )
-  add_second_level_browse_pages(
-    second_level_browse_pages,
-    order_type: "alphabetical")
+  add_second_level_browse_pages(second_level_browse_pages)
+
+  rummager_has_documents_for_browse_page(
+    "judges-content-id",
+    [
+      "judge-dredd",
+    ],
+    page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+  )
 end
 
 Given(/^that there are curated second level browse pages$/) do
@@ -28,16 +28,14 @@ Given(/^that there are curated second level browse pages$/) do
 
   second_level_browse_pages = [
     {
-      content_id: JUDGES_CONTENT_ID,
+      content_id: 'judges-content-id',
       title: 'Judges',
       base_path: '/browse/crime-and-justice/judges',
-      locale: :en,
     },
     {
-      content_id: COURTS_CONTENT_ID,
+      content_id: 'courts-content-id',
       title: 'Courts',
       base_path: '/browse/crime-and-justice/courts',
-      locale: :en,
     }
   ]
 
@@ -46,13 +44,11 @@ Given(/^that there are curated second level browse pages$/) do
     child_pages: second_level_browse_pages,
     order_type: "curated"
   )
-  add_second_level_browse_pages(
-    second_level_browse_pages,
-    order_type: "curated")
+  add_second_level_browse_pages(second_level_browse_pages)
 end
 
 Then(/^I see the links tagged to the browse page/) do
-  assert page.has_selector?('a', text: "Judge Dredd")
+  assert page.has_selector?('a', text: "Judge dredd")
 end
 
 When(/^I visit the main browse page$/) do
@@ -104,82 +100,48 @@ end
 def top_level_browse_pages
   [
     {
-      content_id: CRIME_AND_JUSTICE_CONTENT_ID,
+      content_id: 'content-id-for-crime-and-justice',
       title: 'Crime and justice',
-      base_path: '/browse/crime-and-justice',
-      locale: :en,
+      base_path: '/browse/crime-and-justice'
     },
     {
-      content_id: BENEFITS_CONTENT_ID,
+      content_id: 'content-id-for-benefits',
       title: 'Benefits',
-      base_path: '/browse/benefits',
-      locale: :en,
+      base_path: '/browse/benefits'
     },
   ]
 end
 
 def add_browse_pages
-  browse_root = GovukSchemas::RandomExample
-    .for_schema(frontend_schema: "mainstream_browse_page")
-    .merge_and_validate({
-      links: {
-        top_level_browse_pages: top_level_browse_pages
-      }
-    })
-  content_store_has_item("/browse", browse_root)
+  content_store_has_item '/browse', links: {
+    top_level_browse_pages: top_level_browse_pages
+  }
 end
 
 def add_first_level_browse_pages(child_pages:, order_type:)
-  browse_page = GovukSchemas::RandomExample
-    .for_schema(frontend_schema: "mainstream_browse_page")
-    .merge_and_validate({
-      base_path: '/browse/crime-and-justice',
-      links: {
-        top_level_browse_pages: top_level_browse_pages,
-        second_level_browse_pages: child_pages,
-      },
-      details: {
-        "second_level_ordering" => order_type,
-        "ordered_second_level_browse_pages" => child_pages.map { |page| page[:content_id] }
-      },
+  content_store_has_item('/browse/crime-and-justice', base_path: '/browse/crime-and-justice',
+    links: {
+      top_level_browse_pages: top_level_browse_pages,
+      second_level_browse_pages: child_pages,
+    },
+    details: {
+      second_level_ordering: order_type,
+      ordered_second_level_browse_pages: child_pages.map { |page| page[:content_id] }
     })
-
-  content_store_has_item("/browse/crime-and-justice", browse_page)
 end
 
-def add_second_level_browse_pages(second_level_browse_pages, order_type:)
-  browse_page = GovukSchemas::RandomExample
-    .for_schema(frontend_schema: "mainstream_browse_page")
-    .merge_and_validate({
-      content_id: JUDGES_CONTENT_ID,
-      title: 'Judges',
-      base_path: '/browse/crime-and-justice/judges',
-      links: {
-        top_level_browse_pages: top_level_browse_pages,
-        second_level_browse_pages: second_level_browse_pages,
-        active_top_level_browse_page: [{
-          content_id: CRIME_AND_JUSTICE_CONTENT_ID,
-          title: 'Crime and justice',
-          base_path: '/browse/crime-and-justice',
-          locale: :en,
-        }],
-        related_topics: [{
-          content_id: SecureRandom::uuid,
-          title: 'A linked topic',
-          base_path: '/browse/linked-topic',
-          locale: :en,
-        }],
-        mainstream_browse_content: [{
-          content_id: SecureRandom::uuid,
-          title: 'Judge Dredd',
-          base_path: '/judge-dredd',
-          locale: :en,
-        }],
-      },
-      details: {
-        "second_level_ordering" => order_type,
-      },
-    })
-
-  content_store_has_item("/browse/crime-and-justice/judges", browse_page)
+def add_second_level_browse_pages(second_level_browse_pages)
+  content_store_has_item '/browse/crime-and-justice/judges', content_id: 'judges-content-id',
+    title: 'Judges',
+    base_path: '/browse/crime-and-justice/judges',
+    links: {
+      top_level_browse_pages: top_level_browse_pages,
+      second_level_browse_pages: second_level_browse_pages,
+      active_top_level_browse_page: [{
+        content_id: 'content-id-for-crime-and-justice',
+        title: 'Crime and justice',
+        base_path: '/browse/crime-and-justice'
+      }],
+      related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
+    }
 end

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -14,9 +14,26 @@ module TopicHelper
       government/organisations/air-accidents-investigation-branch
     }
 
-    content_item = {
+    rummager_has_documents_for_subtopic(
+      'content-id-for-fields-and-wells',
+      %w{
+        what-is-oil
+        apply-for-an-oil-licence
+        environmental-policy
+        onshore-exploration-and-production
+        well-application-form
+        well-report-2014
+        oil-extraction-count-2013
+      },
+      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+    )
+
+    content_store_has_item("/topic/oil-and-gas/fields-and-wells",
+      content_id: 'content-id-for-fields-and-wells',
       base_path: "/topic/oil-and-gas/fields-and-wells",
+      title: "Fields and Wells",
       format: "topic",
+      public_updated_at: 10.days.ago.iso8601,
       details: {
         groups: [
           {
@@ -35,45 +52,18 @@ module TopicHelper
         ],
       },
       links: {
-        parent: [
-          content_link("Oil and Gas", "/oil-and-gas")
-        ],
-        topic_content: [
-          content_link("What is oil", "/what-is-oil"),
-          content_link("Apply for an oil licence", "/apply-for-an-oil-licence"),
-          content_link("Environmental policy", "/environmental-policy"),
-          content_link("Onshore exploration and production", "/onshore-exploration-and-production"),
-          content_link("Well application form", "/well-application-form"),
-          content_link("Well report 2014", "/well-report-2014"),
-          content_link("Oil extraction count 2013", "/oil-extraction-count-2013"),
+        "parent" => [
+          "title" => "Oil and Gas",
+          "base_path" => "/oil-and-gas",
         ]
-      }
-    }
-
-    topic = GovukSchemas::RandomExample
-      .for_schema(frontend_schema: 'topic')
-      .merge_and_validate(content_item)
-    content_store_has_item("/topic/oil-and-gas/fields-and-wells", topic)
+      })
 
     stub_topic_organisations(
       'oil-and-gas/fields-and-wells',
-      topic["content_id"]
+      'content-id-for-fields-and-wells'
     )
 
     stub_shared_component_locales
-
-    topic["content_id"]
-  end
-
-private
-
-  def content_link(title, base_path)
-    {
-      title: title,
-      base_path: base_path,
-      locale: "en",
-      content_id: SecureRandom::uuid
-    }
   end
 end
 

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 describe SecondLevelBrowsePageController do
+  include RummagerHelpers
   include GovukAbTesting::MinitestHelpers
 
   describe "GET second_level_browse_page" do
@@ -21,6 +22,12 @@ describe SecondLevelBrowsePageController do
             related_topics: [{ title: 'A linked topic', base_path: '/browse/linked-topic' }]
           }
         )
+
+        rummager_has_documents_for_browse_page(
+          "entitlement-content-id",
+          ["entitlement"],
+          page_size: 1000
+        )
       end
 
       it "set correct expiry headers" do
@@ -39,6 +46,12 @@ describe SecondLevelBrowsePageController do
               title: 'Education and learning',
             }],
           }
+        )
+
+        rummager_has_documents_for_browse_page(
+          "student-finance-content-id",
+          ["student-finance"],
+          page_size: 1000
         )
       end
 
@@ -88,6 +101,12 @@ describe SecondLevelBrowsePageController do
             }
           )
 
+          rummager_has_documents_for_browse_page(
+            "school-life-content-id",
+            ["school-life"],
+            page_size: 1000
+          )
+
           with_new_navigation_enabled do
             with_variant EducationNavigation: "B", assert_meta_tag: false do
               get :show, top_level_slug: "education", second_level_slug: "school-life"
@@ -107,6 +126,12 @@ describe SecondLevelBrowsePageController do
                   title: 'Benefits',
                 }],
               }
+            )
+
+            rummager_has_documents_for_browse_page(
+              "entitlement-content-id",
+              ["entitlement"],
+              page_size: 1000
             )
 
             with_new_navigation_enabled do

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -8,6 +8,19 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     # request their parents and links.
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|
       content_store_has_item(content_item['base_path'], content_item)
+
+      rummager_has_documents_for_browse_page(
+        content_item['content_id'],
+        [
+          "employee-tax-codes",
+          "get-paye-forms-p45-p60",
+          "pay-paye-penalty",
+          "pay-paye-tax",
+          "pay-psa",
+          "payroll-annual-reporting",
+        ],
+        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+      )
     end
 
     content_schema_examples_for(:mainstream_browse_page).each do |content_item|

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -15,19 +15,27 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         groups: [],
       },
       links: {
-        parent: [
-          { title: "Oil and Gas", base_path: "/topic/oil-and-gas" }
-        ],
-        topic_content: [
-          { title: "Oil rig safety requirements", base_path: "/oil-rig-safety-requirements" },
-          { title: "Oil rig staffing", base_path: "/oil-rig-staffing" },
-          { title: "North sea shipping lanes", base_path: "/north-sea-shipping-lanes" },
-          { title: "Undersea piping restrictions", base_path: "/undersea-piping-restrictions" },
+        "parent" => [
+          "title" => "Oil and Gas",
+          "base_path" => "/topic/oil-and-gas",
         ]
       },
     }
     base[:details].merge!(params.delete(:details)) if params.has_key?(:details)
     base.merge(params)
+  end
+
+  before do
+    rummager_has_documents_for_subtopic(
+      'content-id-for-offshore',
+      [
+        'oil-rig-safety-requirements',
+        'oil-rig-staffing',
+        'north-sea-shipping-lanes',
+        'undersea-piping-restrictions'
+      ],
+      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
+    )
   end
 
   it "renders a curated subtopic" do

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 describe MainstreamBrowsePage do
   setup do
-    @mainstream_browse_content = [
-      {
-        "title" => "Some browse page",
-        "base_path" => "/some-browse-page"
-      }
-    ]
     @api_data = {
       "base_path" => "/browse/benefits/child",
       "title" => "Child Benefit",
@@ -15,7 +9,6 @@ describe MainstreamBrowsePage do
       "details" => {
       },
       "links" => {
-        "mainstream_browse_content" => @mainstream_browse_content
       },
     }
     @content_item = ContentItem.new(@api_data)
@@ -235,27 +228,21 @@ second_level_browse_pages).each do |link_type|
   end
 
   describe "lists" do
-    it "should create the content lists using mainstream browse content links" do
-      ListSet.expects(:new)
-        .with { |links| links.map(&:to_hash) == @mainstream_browse_content }
-        .returns(:a_lists_instance)
+    it "should pass the content id of the browse page when constructing groups" do
+      ListSet.expects(:new).with("section", @content_item.content_id, anything).returns(:a_lists_instance)
 
       assert_equal :a_lists_instance, @page.lists
     end
 
     it "should pass the groups data when constructing" do
-      ListSet.expects(:new)
-        .with(anything, :group_data, MainstreamBrowsePage::DOCUMENT_TYPES_TO_EXCLUDE)
-        .returns(:a_lists_instance)
-      @api_data["details"]["groups"] = :group_data
+      ListSet.expects(:new).with(anything, anything, :some_data).returns(:a_lists_instance)
+      @api_data["details"]["groups"] = :some_data
 
       assert_equal :a_lists_instance, @page.lists
     end
 
-    it "should pass in nil if the group data is missing" do
-      ListSet.expects(:new)
-        .with(anything, nil, MainstreamBrowsePage::DOCUMENT_TYPES_TO_EXCLUDE)
-        .returns(:a_lists_instance)
+    it "should pass in nil if the data is missing" do
+      ListSet.expects(:new).with(anything, anything, nil).returns(:a_lists_instance)
       @api_data.delete("details")
 
       assert_equal :a_lists_instance, @page.lists

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -2,12 +2,6 @@ require "test_helper"
 
 describe Topic do
   setup do
-    @topic_content = [
-      {
-        "title" => "Some browse page",
-        "base_path" => "/some-browse-page"
-      }
-    ]
     @api_data = {
       "base_path" => "/topic/business-tax/paye",
       "content_id" => "uuid-23",
@@ -21,7 +15,6 @@ describe Topic do
           "base_path" => "/topic/business-tax",
           "description" => "All about tax for businesses",
         }],
-        "topic_content" => @topic_content,
       },
     }
     @content_item = ContentItem.new(@api_data)
@@ -120,28 +113,15 @@ describe Topic do
   end
 
   describe "lists" do
-    it "should create the content lists using topic content links" do
-      ListSet.expects(:new)
-        .with { |links| links.map(&:to_hash) == @topic_content }
-        .returns(:a_lists_instance)
+    it "passes the slug of the topic when constructing groups" do
+      ListSet.expects(:new).with("specialist_sector", @content_item.content_id, anything).returns(:a_lists_instance)
 
       assert_equal :a_lists_instance, @topic.lists
     end
 
-    it "should pass the groups data when constructing" do
-      ListSet.expects(:new)
-        .with(anything, :group_data, Topic::DOCUMENT_TYPES_TO_EXCLUDE)
-        .returns(:a_lists_instance)
-      @api_data["details"]["groups"] = :group_data
-
-      assert_equal :a_lists_instance, @topic.lists
-    end
-
-    it "should pass in nil if the group data is missing" do
-      ListSet.expects(:new)
-        .with(anything, nil, Topic::DOCUMENT_TYPES_TO_EXCLUDE)
-        .returns(:a_lists_instance)
-      @api_data.delete("details")
+    it "passes the groups data when constructing" do
+      ListSet.expects(:new).with(anything, anything, :some_data).returns(:a_lists_instance)
+      @api_data["details"]["groups"] = :some_data
 
       assert_equal :a_lists_instance, @topic.lists
     end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -77,4 +77,48 @@ module RummagerHelpers
         "total" => results.size)
     end
   end
+
+  def rummager_has_documents_for_subtopic(subtopic_content_id, document_slugs, format = "guide", page_size: 50)
+    results = document_slugs.map.with_index do |slug, i|
+      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+    end
+
+    results.each_slice(page_size).with_index do |results_page, page|
+      start = page * page_size
+      Services.rummager.stubs(:search).with(
+        has_entries(
+          start: start,
+          count: page_size,
+          filter_topic_content_ids: [subtopic_content_id],
+        )
+      ).returns("results" => results_page,
+        "start" => start,
+        "total" => results.size)
+    end
+  end
+
+  def rummager_has_documents_for_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 50)
+    results = document_slugs.map.with_index do |slug, i|
+      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+    end
+
+    results.each_slice(page_size).with_index do |results_page, page|
+      start = page * page_size
+      Services.rummager.stubs(:search).with(
+        has_entries(
+          start: start,
+          count: page_size,
+          filter_mainstream_browse_page_content_ids: [browse_page_content_id],
+        )
+      ).returns("results" => results_page,
+        "start" => start,
+        "total" => results.size)
+    end
+  end
+
+  def expect_search_params(params)
+    GdsApi::Rummager.any_instance.expects(:search)
+      .with(has_entries(params))
+      .returns(:some_results)
+  end
 end


### PR DESCRIPTION
This reverts commit 119cf5c5a02e9b1c7cdea9c685d88bf881794276.

This change introduced a bug where redirected and removed content was appearing on topic and browse pages because it was still present in the content store. It is being reverted while we investigate the issue.