### PR TITLE
Remove OpenStruct from email signups

### DIFF
--- a/app/models/email_signup.rb
+++ b/app/models/email_signup.rb
@@ -13,7 +13,7 @@ class EmailSignup
 
   def save
     if valid?
-      @subscription_url = find_or_create_subscription.subscriber_list.subscription_url
+      @subscription_url = find_or_create_subscription.dig('subscriber_list', 'subscription_url')
       true
     end
   end


### PR DESCRIPTION
We [recently bumped `gds-api-adapters`](https://github.com/alphagov/collections/pull/270), which dropped support for `OpenStruct`.

This change fixes that for email signups.