### PR TITLE
Add Overview section with content to accordion

### DIFF
--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -5,6 +5,22 @@
 
         <div data-module="accordion-with-descriptions">
           <div class="subsection-wrapper">
+
+            <% if taxon.tagged_content.count > 0 %>
+              <div class="subsection js-subsection">
+                <div class="subsection-header">
+                  <h2 class="subsection-title">Overview</h2>
+                </div>
+
+                <div class="subsection-content js-subsection-content" id="subsection_content_0">
+                  <%= render partial: 'content_list_for_child_taxon', locals: {
+                    section_index: 0,
+                    tagged_content: taxon.tagged_content,
+                  } %>
+                </div>
+              </div>
+            <% end %>
+
             <% child_taxons.each_with_index do |taxon, index| %>
               <div class="subsection js-subsection">
                 <div class="subsection-header">
@@ -12,9 +28,9 @@
                   <p class="subsection-description"><%= taxon.description %></p>
                 </div>
 
-                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index %>">
+                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
                   <%= render partial: 'content_list_for_child_taxon', locals: {
-                    section_index: index,
+                    section_index: index + 1,
                     tagged_content: taxon.tagged_content,
                   } %>
                 </div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,15 +16,22 @@
 <% if taxon.grandchildren? %>
   <%= render partial: 'child_taxons_grid',
     locals: { child_taxons: taxon.child_taxons } %>
-<% else %>
-  <%= render partial: 'child_taxons_list', locals: {
-    taxon: taxon,
-    child_taxons: taxon.child_taxons,
-    tagged_content: taxon.tagged_content
-  } %>
-<% end %>
 
-<%= render partial: 'content_list_for_current_taxon', locals: {
+  <%= render partial: 'content_list_for_current_taxon', locals: {
   taxon: taxon,
   tagged_content: taxon.tagged_content,
-} %>
+  } %>
+<% else %>
+  <% if taxon.children? %>
+    <%= render partial: 'child_taxons_list', locals: {
+      taxon: taxon,
+      child_taxons: taxon.child_taxons,
+      tagged_content: taxon.tagged_content
+    } %>
+  <% else %>
+    <%= render partial: 'content_list_for_current_taxon', locals: {
+      taxon: taxon,
+      tagged_content: taxon.tagged_content,
+    } %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This commit makes sure the first section of the accordion view is an
Overview section with content tagged to the accordion taxon level.

When there is no content, we omit this section and only show child
taxons and their content.

The copy might change, but for now we should go ahead with this one.

Trello: https://trello.com/c/xSvrtvcG/467-move-content-tagged-at-an-accordion-level-to-the-first-position-in-the-accordion