### PR TITLE
Update padding bottom of taxon grid elements

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -57,6 +57,7 @@
         padding-bottom: $gutter;
 
         @include media (tablet) {
+          padding-bottom: $gutter * 1.5;
           min-height: (5 * $gutter);
         }
       }


### PR DESCRIPTION
### Desktop

<img width="1293" alt="screen shot 2017-03-02 at 16 44 39" src="https://cloud.githubusercontent.com/assets/416701/23517273/c75c0a96-ff67-11e6-9f1d-7452d7963a0d.png">

### Tablet

<img width="1376" alt="screen shot 2017-03-02 at 16 45 25" src="https://cloud.githubusercontent.com/assets/416701/23517284/cde9db40-ff67-11e6-9a52-5015a22bd2dc.png">

### Mobile

<img width="1096" alt="screen shot 2017-03-02 at 16 45 46" src="https://cloud.githubusercontent.com/assets/416701/23517292/d214466a-ff67-11e6-967a-fc1047515782.png">

Trello: https://trello.com/c/yTDsFUrm/468-style-changes-to-taxon-grid-pages-in-collections