### PR TITLE
Update accordion styles to match prototype

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -133,7 +133,7 @@
 
    // When JavaScript is enabled, create accordion
   .js-accordion-with-descriptions {
-    padding-bottom: $gutter * 2;
+    padding-bottom: $gutter;
 
     // Wrapper for 'expand all / close all' button
     .subsection-controls {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -110,11 +110,6 @@
   .subsection,
   .subsection-is-open {
     width: 100%;
-    margin-bottom: $gutter;
-
-    @include media(tablet) {
-      margin-bottom: $gutter * 1.5;
-    }
 
     .subsection-description {
       @include core-19;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -170,7 +170,7 @@
       }
 
       margin-bottom: 0;
-      margin-right: $gutter;
+      margin-right: $gutter * 1.5;
     }
 
     .subsection-header {
@@ -188,7 +188,7 @@
 
     .subsection-description {
       margin-bottom: 0;
-      margin-right: $gutter;
+      margin-right: $gutter * 1.5;
     }
 
     .subsection-icon {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -130,10 +130,6 @@
       padding-left: 0;
       list-style-type: none;
     }
-
-    .subsection-list-item a {
-      text-decoration: none;
-    }
   }
 
 // Most of this is taken from the service manual and at some point needs to be


### PR DESCRIPTION
Four small changes:

- Under links inside the accordion sections
- Remove margin on subsections
- Update subsection title and description margins to 45px
- Reduce padding at bottom of accordion

cc @alextea 

https://trello.com/c/HvOu1E7e/469-style-changes-to-the-accordion-pages-in-collections