### PR TITLE
Remove the feature flag from collections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :test do
   gem 'minitest-spec-rails', '~> 5.3.0'
   gem 'mocha', '~> 1.1.0', require: false
   gem 'webmock', '~> 1.21.0', require: false
-  gem 'climate_control', '~> 0.1.0', require: false
   gem 'cucumber-rails', '~> 1.4.2', require: false
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
   gem 'govuk_schemas', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    climate_control (0.1.0)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
@@ -286,7 +285,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
-  climate_control (~> 0.1.0)
   cucumber-rails (~> 1.4.2)
   gds-api-adapters (~> 40.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
@@ -312,4 +310,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.13.5
+   1.14.5

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -28,7 +28,7 @@ private
   end
 
   def new_navigation_enabled?
-    ab_variant.variant_b? && ENV['ENABLE_NEW_NAVIGATION'] == 'yes'
+    ab_variant.variant_b?
   end
 
   def return_404

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -11,7 +11,7 @@ class TaxonRedirectResolver
   end
 
   def page_ab_tested?
-    ENV['ENABLE_NEW_NAVIGATION'] == 'yes' && @is_page_in_ab_test.call
+    @is_page_in_ab_test.call
   end
 
   def taxon_base_path

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "climate_control"
 
 describe TaxonsController do
   include RummagerHelpers

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -33,50 +33,33 @@ describe TopicsController do
       content_store_has_item('/topic/further-education-skills', content_schema_example(:topic, :topic))
     end
 
-    describe "with the feature flag off" do
-      ["A", "B"].each do |variant|
-        it "returns the original version of the page for variant #{variant}" do
-          setup_ab_variant("EducationNavigation", variant)
+    it "returns the original version of the page as the A variant" do
+      with_A_variant assert_meta_tag: false do
+        get :show, topic_slug: "further-education-skills"
 
-          get :show, topic_slug: "further-education-skills"
-
-          assert_response 200
-          assert_response_not_modified_for_ab_test
-        end
+        assert_response 200
       end
     end
 
-    describe "with the feature flag on" do
-      it "returns the original version of the page as the A variant" do
-        with_A_variant assert_meta_tag: false do
-          get :show, topic_slug: "further-education-skills"
+    it "redirects to the taxonomy navigation as the B variant" do
+      with_B_variant assert_meta_tag: false do
+        get :show, topic_slug: "further-education-skills"
 
-          assert_response 200
-        end
+        assert_redirected_to controller: "taxons",
+          action: "show",
+          taxon_base_path: "education/further-and-higher-education-skills-and-vocational-training"
       end
+    end
 
-      it "redirects to the taxonomy navigation as the B variant" do
-        with_B_variant assert_meta_tag: false do
-          get :show, topic_slug: "further-education-skills"
+    ["A", "B"].each do |variant|
+      it "does not change a page outside the A/B test when the #{variant} variant is requested" do
+        content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
+        setup_ab_variant("EducationNavigation", variant)
 
-          assert_redirected_to controller: "taxons",
-            action: "show",
-            taxon_base_path: "education/further-and-higher-education-skills-and-vocational-training"
-        end
-      end
+        get :show, topic_slug: "oil-and-gas"
 
-      ["A", "B"].each do |variant|
-        it "does not change a page outside the A/B test when the #{variant} variant is requested" do
-          ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
-            content_store_has_item('/topic/oil-and-gas', content_schema_example(:topic, :topic))
-            setup_ab_variant("EducationNavigation", variant)
-
-            get :show, topic_slug: "oil-and-gas"
-
-            assert_response 200
-            assert_response_not_modified_for_ab_test
-          end
-        end
+        assert_response 200
+        assert_response_not_modified_for_ab_test
       end
     end
   end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -1,5 +1,3 @@
-require "climate_control"
-
 class ActiveSupport::TestCase
   def build_ostruct_recursively(value)
     case value
@@ -18,10 +16,8 @@ class ActiveSupport::TestCase
       { EducationNavigation: 'A' }
       .merge(options)
 
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
-      with_variant variant_options do
-        yield
-      end
+    with_variant variant_options do
+      yield
     end
   end
 
@@ -30,10 +26,8 @@ class ActiveSupport::TestCase
       { EducationNavigation: 'B' }
       .merge(options)
 
-    ClimateControl.modify(ENABLE_NEW_NAVIGATION: 'yes') do
-      with_variant variant_options do
-        yield
-      end
+    with_variant variant_options do
+      yield
     end
   end
   # rubocop:enable Style/MethodName


### PR DESCRIPTION
This means we will be able to A/B test this in all environments. For
now, in production it's only possible to see the B variant with the
chrome extension.

Trello: https://trello.com/c/940kowVa/484-remove-enable-new-navigation-check-from-repos-and-from-puppet