### PR TITLE
Accordion hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ There is no underlying persistence layer and all content is retrieved from exter
 
 ### Running the test suite
 
-Use `bundle exec rake` to run the full test suite
+Use `bundle exec rake` to run the test suite, excluding JavaScript
+
+#### Javascript tests
+
+Use `bundle exec rake spec:javascript` to run Jasmine tests  
+Alternatively, visit [`collections.dev.gov.uk/specs`](http://collections.dev.gov.uk/specs)
+for a live debugger in your browser
 
 ## License
 

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -7,7 +7,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   "use strict";
 
-  Modules.AccordionWithDescriptions = function() {
+  Modules.AccordionWithDescriptions = function () {
 
     var bulkActions = {
       openAll: {
@@ -18,9 +18,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         buttonText: "Close all",
         eventLabel: "Close All"
       }
-    }
+    };
 
-    this.start = function($element) {
+    this.start = function ($element) {
 
       // Indicate that js has worked
       $element.addClass('js-accordion-with-descriptions');
@@ -28,13 +28,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // Prevent FOUC, remove class hiding content
       $element.removeClass('js-hidden');
 
+      var $subsections = $element.find('.js-subsection');
       var $subsectionHeaders = $element.find('.subsection-header');
       var totalSubsections = $element.find('.subsection-content').length;
 
       var $openOrCloseAllButton;
 
+      wrapHeadersInLinks();
       addOpenCloseAllButton();
-      addButtonsToSubsections();
       addIconsToSubsections();
       addAriaControlsAttrForOpenCloseAllButton();
 
@@ -45,51 +46,45 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       bindToggleOpenCloseAllButton();
 
       function addOpenCloseAllButton() {
-        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">' + bulkActions.openAll.buttonText + '</button></div>' );
-      }
-
-      function addButtonsToSubsections() {
-        var $subsectionTitle = $element.find('.subsection-title');
-
-        // Wrap each title in a button, with aria controls matching the ID of the subsection
-        $subsectionTitle.each(function(index) {
-          $(this).wrapInner( '<button class="subsection-button js-subsection-button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></button>' );
-        });
+        $element.prepend('<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">' + bulkActions.openAll.buttonText + '</button></div>');
       }
 
       function addIconsToSubsections() {
-        $subsectionHeaders.append( '<span class="subsection-icon"></span>' );
+        $subsectionHeaders.append('<span class="subsection-icon"></span>');
       }
 
       function addAriaControlsAttrForOpenCloseAllButton() {
-        // For each of the sections, create a string with all the subsection content IDs
         var ariaControlsValue = "";
         for (var i = 0; i < totalSubsections; i++) {
-          ariaControlsValue += "subsection_content_"+i+" ";
+          ariaControlsValue += "subsection_content_" + i + " ";
         }
 
         $openOrCloseAllButton = $element.find('.js-subsection-controls button');
-
-        // Set the aria controls for the open/close all button value for all content items
         $openOrCloseAllButton.attr('aria-controls', ariaControlsValue);
       }
 
       function closeAllSections() {
-        $.each($element.find('.js-subsection'), function () {
+        setAllSectionsOpenState(false);
+      }
+
+      function setAllSectionsOpenState(isOpen) {
+        $.each($subsections, function () {
           var subsectionView = new SubsectionView($(this));
-          subsectionView.close();
+          subsectionView.preventHashUpdate();
+          subsectionView.setIsOpen(isOpen);
         });
       }
 
       function openLinkedSection() {
         var anchor = getActiveAnchor(),
-            $subsection;
+          $subsection;
 
         if (!anchor.length) {
           return;
         }
 
-        $subsection = $element.find(anchor).parents('.js-subsection');
+        anchor = '#' + escapeSelector(anchor.substr(1));
+        $subsection = $element.find(anchor);
 
         if ($subsection.length) {
           var subsectionView = new SubsectionView($subsection);
@@ -101,63 +96,61 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return GOVUK.getCurrentLocation().hash;
       }
 
+      function wrapHeadersInLinks() {
+        $.each($subsections, function () {
+          var $subsection = $(this);
+          var id = $subsection.attr('id');
+          var $title = $subsection.find('.js-subsection-title');
+          var contentId = $subsection.find('.js-subsection-content').first().attr('id');
+
+          $title.wrap(
+            '<a ' +
+            'class="subsection-title-link js-subsection-title-link" ' +
+            'href="#' + id + '" ' +
+            'aria-controls="' + contentId + '"></a>'
+          )
+        });
+      }
+
       function bindToggleForSubsections() {
-        $element.find('.subsection-header').on('click', function(event) {
-          var $subsectionHeader = $(this);
-          var $subsection = $subsectionHeader.parent('.js-subsection');
-          var subsectionView = new SubsectionView($subsection);
+        $element.find('.js-subsection-header').click(function (event) {
+          event.preventDefault();
 
+          var subsectionView = new SubsectionView($(this).closest('.js-subsection'));
           subsectionView.toggle();
+
+          var toggleClick = new SubsectionToggleClick(subsectionView, event);
+          toggleClick.track();
+
           setOpenCloseAllText();
-
-          var subsectionToggleClick = new SubsectionToggleClick(subsectionView, event);
-          subsectionToggleClick.track();
-
-          return false;
         });
       }
 
       function bindToggleOpenCloseAllButton() {
         $openOrCloseAllButton = $element.find('.js-subsection-controls button');
-        $openOrCloseAllButton.on('click', function(e) {
-          var action = '';
+        $openOrCloseAllButton.on('click', function () {
+          var shouldOpenAll;
 
-          // update button text
           if ($openOrCloseAllButton.text() == bulkActions.openAll.buttonText) {
             $openOrCloseAllButton.text(bulkActions.closeAll.buttonText);
-            $openOrCloseAllButton.attr("aria-expanded", "true");
-            action = 'open';
+            shouldOpenAll = true;
 
             track('pageElementInteraction', 'accordionAllOpened', {
               label: bulkActions.openAll.eventLabel
             });
           } else {
             $openOrCloseAllButton.text(bulkActions.openAll.buttonText);
-            $openOrCloseAllButton.attr("aria-expanded", "false");
-            action = 'close';
+            shouldOpenAll = false;
 
             track('pageElementInteraction', 'accordionAllClosed', {
               label: bulkActions.closeAll.eventLabel
             });
           }
 
-          $element.find('.js-subsection').each(function() {
-            var $subsection = $(this);
-            var $button = $subsection.find('.js-subsection-button');
-            var $subsectionContent = $subsection.find('.js-subsection-content');
-
-            if (action == 'open') {
-              $button.attr("aria-expanded", "true");
-              $subsectionContent.removeClass('js-hidden');
-              $subsection.removeClass('subsection');
-              $subsection.addClass('subsection-is-open');
-            } else {
-              $button.attr("aria-expanded", "false");
-              $subsectionContent.addClass('js-hidden');
-              $subsection.addClass('subsection');
-              $subsection.removeClass('subsection-is-open');
-            }
-          });
+          setAllSectionsOpenState(shouldOpenAll);
+          $openOrCloseAllButton.attr('aria-expanded', shouldOpenAll);
+          setOpenCloseAllText();
+          setHash(null);
 
           return false;
         });
@@ -173,87 +166,115 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       }
 
-    }
+      // Ideally we'd use jQuery.escapeSelector, but this is only available from v3
+      // See https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/selector-native.js#L46
+      function escapeSelector(s) {
+        var cssMatcher = /([\x00-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g;
+        return s.replace(cssMatcher, "\\$&");
+      }
+    };
 
-    function SubsectionView ($subsectionElement) {
-      var that = this;
+    function SubsectionView($subsectionElement) {
+      var $subsectionContent = $subsectionElement.find('.js-subsection-content');
+      var $titleLink = $subsectionElement.find('.js-subsection-title-link');
+      var shouldUpdateHash = true;
 
-      // The 'Content' is the container of links to guides
-      this.$subsectionContent = $subsectionElement.find('.js-subsection-content');
-      // The 'Button' is a button element that is wrapped around the title for
-      // accessibility reasons
-      this.$subsectionButton = $subsectionElement.find('.js-subsection-button');
+      this.title = $subsectionElement.find('.js-subsection-title').text();
 
-      this.title = that.$subsectionButton.text();
+      this.open = open;
+      this.close = close;
+      this.toggle = toggle;
+      this.setIsOpen = setIsOpen;
+      this.isOpen = isOpen;
+      this.isClosed = isClosed;
+      this.preventHashUpdate = preventHashUpdate;
 
-      this.toggle = function () {
-        if (that.isClosed()) {
-          that.open();
-        } else {
-          that.close();
+      function open() {
+        setIsOpen(true);
+      }
+
+      function close() {
+        setIsOpen(false);
+      }
+
+      function toggle() {
+        setIsOpen(isClosed());
+      }
+
+      function setIsOpen(isOpen) {
+        $subsectionContent.toggleClass('js-hidden', !isOpen);
+        $subsectionElement.toggleClass('subsection-is-open', isOpen);
+        $titleLink.attr("aria-expanded", isOpen);
+
+        if (shouldUpdateHash) {
+          updateHash($subsectionElement);
         }
       }
 
-      this.open = function () {
-        // Show the subsection content
-        that.$subsectionContent.removeClass('js-hidden');
-        // Swap the plus and minus sign
-        $subsectionElement.removeClass('subsection');
-        $subsectionElement.addClass('subsection-is-open');
-        // Tell impaired users that the section is open
-        that.$subsectionButton.attr("aria-expanded", "true");
+      function isOpen() {
+        return !isClosed();
       }
 
-      this.close = function () {
-        // Hide the subsection content
-        that.$subsectionContent.addClass('js-hidden');
-        // Swap the plus and minus sign
-        $subsectionElement.removeClass('subsection-is-open');
-        $subsectionElement.addClass('subsection');
-        // Tell impaired users that the section is closed
-        that.$subsectionButton.attr("aria-expanded", "false");
+      function isClosed() {
+        return $subsectionContent.hasClass('js-hidden');
       }
 
-      this.isClosed = function () {
-        return that.$subsectionContent.hasClass('js-hidden');
+      function preventHashUpdate() {
+        shouldUpdateHash = false;
       }
     }
 
-    // A contructor for an object that represents a click event on a subsection which
-    // handles the complexity of sending different tracking labels to Google Analytics
-    // depending on which part of the subsection the user clicked.
-    function SubsectionToggleClick (subsectionView, event) {
-      var that = this;
-
-      this.$target = $(event.target);
-
-      this.track = function () {
-        track('pageElementInteraction', that._trackingAction(), { label: that._trackingLabel() });
+    function updateHash($subsectionElement) {
+      if (!GOVUK.support.history()) {
+        return;
       }
 
-      this._trackingAction = function () {
+      var subsectionView = new SubsectionView($subsectionElement);
+      var hash = subsectionView.isOpen() && '#' + $subsectionElement.attr('id');
+      setHash(hash)
+    }
+
+    // Sets the hash for the page. If a falsy value is provided, the hash is cleared.
+    function setHash(hash) {
+      var newLocation = hash || GOVUK.getCurrentLocation().pathname;
+      history.replaceState({}, '', newLocation);
+    }
+
+    // A constructor for an object that represents a click event on a subsection which
+    // handles the complexity of sending different tracking labels to Google Analytics
+    // depending on which part of the subsection the user clicked.
+    function SubsectionToggleClick(subsectionView, event) {
+      var $target = $(event.target);
+
+      this.track = trackClick;
+
+      function trackClick() {
+        track('pageElementInteraction', trackingAction(), {label: trackingLabel()});
+      }
+
+      function trackingAction() {
         return (subsectionView.isClosed() ? 'accordionClosed' : 'accordionOpened');
       }
 
-      this._trackingLabel = function () {
-        if (that._clickedOnIcon()) {
-          return subsectionView.title + ' - ' + that._iconType() + ' Click';
-        } else if (that._clickedOnHeading()) {
+      function trackingLabel() {
+        if (clickedOnIcon()) {
+          return subsectionView.title + ' - ' + iconType() + ' Click';
+        } else if (clickedOnHeading()) {
           return subsectionView.title + ' - Heading Click';
         } else {
           return subsectionView.title + ' - Click Elsewhere';
         }
       }
 
-      this._clickedOnIcon = function () {
-        return that.$target.hasClass('subsection-icon');
+      function clickedOnIcon() {
+        return $target.hasClass('subsection-icon');
       }
 
-      this._clickedOnHeading = function () {
-        return that.$target.hasClass('js-subsection-button');
+      function clickedOnHeading() {
+        return $target.hasClass('js-subsection-title-link');
       }
 
-      this._iconType = function () {
+      function iconType() {
         return (subsectionView.isClosed() ? 'Minus' : 'Plus');
       }
     }

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -32,7 +32,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var totalSubsections = $element.find('.subsection-content').length;
 
       var $openOrCloseAllButton;
-      var sessionStorePrefix = getSessionStorePrefix();
 
       addOpenCloseAllButton();
       addButtonsToSubsections();
@@ -40,27 +39,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       addAriaControlsAttrForOpenCloseAllButton();
 
       closeAllSections();
-      checkSessionStorage();
       openLinkedSection();
 
       bindToggleForSubsections();
       bindToggleOpenCloseAllButton();
-
-      function getTaxonName() {
-        return $element.find('h1').text();
-      }
-
-      function replaceSpacesWithUnderscores(str) {
-        return str.replace(/\s+/g,"_");
-      }
-
-      function getSessionStorePrefix() {
-        var topic = getTaxonName();
-        topic = replaceSpacesWithUnderscores(topic);
-        topic = topic.toLowerCase();
-
-        return "GOVUK_navigation_for_taxon_" + topic + "_";
-      }
 
       function addOpenCloseAllButton() {
         $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">' + bulkActions.openAll.buttonText + '</button></div>' );
@@ -119,42 +101,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         return GOVUK.getCurrentLocation().hash;
       }
 
-      function checkSessionStorage() {
-
-        var $subsectionContent = $element.find('.subsection-content');
-
-        $subsectionContent.each(function(index) {
-          var subsectionContentId = $(this).attr('id');
-          if(sessionStorage.getItem(sessionStorePrefix+subsectionContentId)){
-            openStoredSections($element.find("#"+subsectionContentId));
-          }
-        });
-
-        setOpenCloseAllText();
-      }
-
-      function setSessionStorage() {
-        var isOpenSubsections = $element.find('.subsection-is-open').length;
-        if (isOpenSubsections) {
-          var $openSubsections = $element.find('.subsection-is-open');
-          $openSubsections.each(function(index) {
-            var subsectionOpenContentId = $(this).find('.subsection-content').attr('id');
-            sessionStorage.setItem( sessionStorePrefix+subsectionOpenContentId , 'Opened');
-          });
-        }
-      }
-
-      function removeSessionStorage() {
-        var isClosedSubsections = $element.find('.subsection').length;
-        if (isClosedSubsections) {
-          var $closedSubsections = $element.find('.subsection');
-          $closedSubsections.each(function(index) {
-            var subsectionClosedContentId = $(this).find('.subsection-content').attr('id');
-            sessionStorage.removeItem( sessionStorePrefix+subsectionClosedContentId , subsectionClosedContentId);
-          });
-        }
-      }
-
       function bindToggleForSubsections() {
         $element.find('.subsection-header').on('click', function(event) {
           var $subsectionHeader = $(this);
@@ -163,8 +109,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
           subsectionView.toggle();
           setOpenCloseAllText();
-          setSessionStorage();
-          removeSessionStorage();
 
           var subsectionToggleClick = new SubsectionToggleClick(subsectionView, event);
           subsectionToggleClick.track();
@@ -215,22 +159,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             }
           });
 
-          // Add any open sections to Session Storage
-          setSessionStorage();
-
-          // Remove any closed sections from Session Storage
-          removeSessionStorage();
-
           return false;
         });
-      }
-
-      function openStoredSections($sectionContent) {
-        var $subsection = $sectionContent.parent('.js-subsection');
-        var subsectionView = new SubsectionView($subsection);
-        subsectionView.open();
-
-        setOpenCloseAllText();
       }
 
       function setOpenCloseAllText() {
@@ -241,12 +171,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         } else {
           $openOrCloseAllButton.text(bulkActions.openAll.buttonText);
         }
-      }
-
-      function isSubsectionClosed($subsection) {
-        var $subsectionContent = $subsection.find('.js-subsection-content');
-
-        return $subsectionContent.hasClass('js-hidden');
       }
 
     }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -171,6 +171,11 @@
       }
 
       margin-bottom: 0;
+    }
+
+    .subsection-title-link {
+      text-decoration: none;
+      display: inline-block;
       margin-right: $gutter * 1.5;
     }
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,8 @@
 class TaxonsController < ApplicationController
   before_action :return_404, unless: :new_navigation_enabled?
 
+  helper_method :taxon_overview_and_child_taxons
+
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
@@ -37,5 +39,21 @@ private
 
   def taxon
     @taxon ||= Taxon.find(request.path)
+  end
+
+  def taxon_overview_and_child_taxons(taxon)
+    accordion_items = taxon.child_taxons
+    return [] if taxon.child_taxons.empty?
+
+    if taxon.tagged_content.count > 0
+      accordion_items.unshift(
+        taxon.merge(
+          'title' => 'Overview',
+          'description' => '',
+        )
+      )
+    end
+
+    accordion_items
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -50,6 +50,7 @@ private
         taxon.merge(
           'title' => 'Overview',
           'description' => '',
+          'base_path' => 'overview',
         )
       )
     end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -31,4 +31,8 @@ class ContentItem
   def to_hash
     @content_item_data
   end
+
+  def merge(to_merge)
+    ContentItem.new(content_item_data.merge(to_merge))
+  end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -50,4 +50,8 @@ class Taxon
       Taxon.find(child_taxon.base_path).children?
     end
   end
+
+  def merge(to_merge)
+    Taxon.new(content_item.merge(to_merge))
+  end
 end

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -7,18 +7,18 @@
           <div class="subsection-wrapper">
 
             <% accordion_content.each_with_index do |taxon, index| %>
-              <div class="subsection js-subsection">
-                <div class="subsection-header">
-                  <h2 class="subsection-title"><%= taxon.title %></h2>
+              <div class="subsection js-subsection" id="<%= taxon.base_path %>">
+                <div class="subsection-header js-subsection-header">
+                  <h2 class="subsection-title js-subsection-title"><%= taxon.title %></h2>
                   <% if taxon.description.present? %>
                     <p class="subsection-description"><%= taxon.description %></p>
                   <% end %>
                 </div>
 
-                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index %>">
+                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
                   <%= render partial: 'content_list_for_child_taxon', locals: {
-                    section_index: index,
-                    tagged_content: taxon.tagged_content,
+                      section_index: index,
+                      tagged_content: taxon.tagged_content,
                   } %>
                 </div>
               </div>

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -1,4 +1,4 @@
-<% if child_taxons.present? %>
+<% if accordion_content.present? %>
   <div class="grid-row child-topic-contents">
     <div class="column-two-thirds">
       <div class="topic-content">
@@ -6,36 +6,24 @@
         <div data-module="accordion-with-descriptions">
           <div class="subsection-wrapper">
 
-            <% if taxon.tagged_content.count > 0 %>
-              <div class="subsection js-subsection">
-                <div class="subsection-header">
-                  <h2 class="subsection-title">Overview</h2>
-                </div>
-
-                <div class="subsection-content js-subsection-content" id="subsection_content_0">
-                  <%= render partial: 'content_list_for_child_taxon', locals: {
-                    section_index: 0,
-                    tagged_content: taxon.tagged_content,
-                  } %>
-                </div>
-              </div>
-            <% end %>
-
-            <% child_taxons.each_with_index do |taxon, index| %>
+            <% accordion_content.each_with_index do |taxon, index| %>
               <div class="subsection js-subsection">
                 <div class="subsection-header">
                   <h2 class="subsection-title"><%= taxon.title %></h2>
-                  <p class="subsection-description"><%= taxon.description %></p>
+                  <% if taxon.description.present? %>
+                    <p class="subsection-description"><%= taxon.description %></p>
+                  <% end %>
                 </div>
 
-                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
+                <div class="subsection-content js-subsection-content" id="subsection_content_<%= index %>">
                   <%= render partial: 'content_list_for_child_taxon', locals: {
-                    section_index: index + 1,
+                    section_index: index,
                     tagged_content: taxon.tagged_content,
                   } %>
                 </div>
               </div>
             <% end %>
+
           </div>
         </div>
       </div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -25,9 +25,7 @@
 <% else %>
   <% if taxon.children? %>
     <%= render partial: 'child_taxons_list', locals: {
-      taxon: taxon,
-      child_taxons: taxon.child_taxons,
-      tagged_content: taxon.tagged_content
+      accordion_content: taxon_overview_and_child_taxons(taxon),
     } %>
   <% else %>
     <%= render partial: 'content_list_for_current_taxon', locals: {

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -42,7 +42,6 @@ describe('An accordion with descriptions module', function () {
 
   afterEach(function() {
     $(document).off();
-    sessionStorage.clear();
   });
 
   it("has a class of js-accordion-with-descriptions to indicate the js has loaded", function () {
@@ -186,20 +185,6 @@ describe('An accordion with descriptions module', function () {
       expect($subsectionButton).toHaveAttr('aria-expanded','true');
     });
 
-    it("has its state saved in session storage", function () {
-      accordion.start($element);
-
-      var $subsectionButton = $element.find('.subsection-title button');
-      $subsectionButton.click();
-
-      var $openSubsections = $element.find('.subsection-is-open');
-      var subsectionOpenContentId = $openSubsections.find('.subsection-content').attr('id');
-
-      var expectedSessionStorePrefix = "GOVUK_navigation_for_taxon__";
-      var storedItem = sessionStorage.getItem(expectedSessionStorePrefix+subsectionOpenContentId);
-      expect(storedItem).toEqual('Opened');
-    });
-
     it("triggers a google analytics custom event when clicking on the title", function () {
       GOVUK.analytics = {trackEvent: function() {}};
       spyOn(GOVUK.analytics, 'trackEvent');
@@ -264,22 +249,6 @@ describe('An accordion with descriptions module', function () {
       expect($subsectionButton).toHaveAttr('aria-expanded','true');
       $subsectionButton.click();
       expect($subsectionButton).toHaveAttr('aria-expanded','false');
-    });
-
-    it("has its state removed in session storage", function () {
-      accordion.start($element);
-
-      var $subsection = $element.find('.subsection');
-      var $subsectionButton = $subsection.find('.subsection-title button');
-
-      // Open and close the subsection
-      $subsectionButton.click();
-      $subsectionButton.click();
-
-      var subsectionContentId = $subsection.find('.subsection-content').attr('id');
-      var expectedSessionStorePrefix = "GOVUK_navigation_for_taxon__";
-      var storedItem = sessionStorage.getItem(expectedSessionStorePrefix+subsectionContentId);
-      expect(storedItem).toBeNull();
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -6,9 +6,9 @@ describe('An accordion with descriptions module', function () {
   var html = '\
     <div class="subsections js-hidden" data-module="accordion-with-descriptions">\
       <div class="subsection-wrapper">\
-        <div class="subsection js-subsection">\
-          <div class="subsection-header">\
-            <h2 class="subsection-title" id="topic-section-one">Topic Section One</h2>\
+        <div class="subsection js-subsection" id="topic-section-one">\
+          <div class="subsection-header js-subsection-header">\
+            <h2 class="subsection-title js-subsection-title">Topic Section One</h2>\
             <p class="subsection-description">Subsection description in here</p>\
           </div>\
           <div class="subsection-content js-subsection-content" id="subsection_content_0">\
@@ -19,9 +19,9 @@ describe('An accordion with descriptions module', function () {
             </ul>\
           </div>\
         </div>\
-        <div class="subsection js-subsection">\
-          <div class="subsection-header">\
-            <h2 class="subsection-title" id="topic-section-two">Topic Section Two</h2>\
+        <div class="subsection js-subsection" id="topic-section-two">\
+          <div class="subsection-header js-subsection-header">\
+            <h2 class="subsection-title js-subsection-title">Topic Section Two</h2>\
             <p class="subsection-description">Subsection description in here</p>\
           </div>\
           <div class="subsection-content js-subsection-content" id="subsection_content_1">\
@@ -38,27 +38,23 @@ describe('An accordion with descriptions module', function () {
   beforeEach(function () {
     accordion = new GOVUK.Modules.AccordionWithDescriptions();
     $element = $(html);
+    accordion.start($element);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $(document).off();
+    location.hash = "#";
   });
 
   it("has a class of js-accordion-with-descriptions to indicate the js has loaded", function () {
-    accordion.start($element);
-
     expect($element).toHaveClass("js-accordion-with-descriptions");
   });
 
   it("is not hidden", function () {
-    accordion.start($element);
-
     expect($element).not.toHaveClass("js-hidden");
   });
 
   it("has an open/close all button", function () {
-    accordion.start($element);
-
     var $openCloseAllButton = $element.find('.js-subsection-controls button');
 
     expect($openCloseAllButton).toExist();
@@ -66,82 +62,61 @@ describe('An accordion with descriptions module', function () {
     // It has an aria-expanded false attribute as all subsections are closed
     expect($openCloseAllButton).toHaveAttr("aria-expanded", "false");
     // It has an aria-controls attribute that includes all the subsection_content IDs
-    expect($openCloseAllButton).toHaveAttr('aria-controls','subsection_content_0 subsection_content_1 ');
+    expect($openCloseAllButton).toHaveAttr('aria-controls', 'subsection_content_0 subsection_content_1 ');
   });
 
   it("has no subsections which have an open state", function () {
-    accordion.start($element);
-
     var openSubsections = $element.find('.subsection-is-open').length;
-
     expect(openSubsections).toEqual(0);
   });
 
-  it("inserts a button into each subsection to show/hide content", function () {
-    accordion.start($element);
+  it("inserts a link into each subsection to show/hide content", function () {
+    var $titleLink = $element.find('.subsection-header a');
 
-    var $subsectionButton = $element.find('.subsection-title button');
-
-    expect($subsectionButton).toHaveClass('subsection-button');
-    // It has an aria-expanded false attribute as it is closed
-    expect($subsectionButton).toHaveAttr('aria-expanded','false');
-    // It has an aria-controls attribute to store the subsection_content ID
-    expect($subsectionButton).toHaveAttr('aria-controls','subsection_content_0');
+    expect($titleLink).toHaveClass('subsection-title-link');
+    expect($titleLink).toHaveAttr('aria-expanded', 'false');
+    expect($titleLink[0]).toHaveAttr('aria-controls', 'subsection_content_0');
+    expect($titleLink[1]).toHaveAttr('aria-controls', 'subsection_content_1');
   });
 
   it("ensures all subsection content is hidden", function () {
-    accordion.start($element);
-
-    $.each($element.find('.subsection-content'), function(index, content) {
+    $.each($element.find('.subsection-content'), function (index, content) {
       expect(content).toHaveClass('js-hidden');
     });
   });
 
   it("adds an open/close icon to each subsection", function () {
-    accordion.start($element);
-
     var $subsectionHeader = $element.find('.subsection-header');
-
     expect($subsectionHeader).toContainElement('.subsection-icon');
   });
 
   describe('Clicking the "Expand all" button', function () {
+    beforeEach(function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+      clickOpenCloseAll();
+    });
 
     it('adds a .subsection-is-open class to each subsection to hide the icon', function () {
-      accordion.start($element);
-      clickOpenCloseAll();
-
       expect($element.find('.subsection-is-open').length).toEqual(2);
     });
 
-    it('adds an aria-expanded attribute to each subsection button', function () {
-      accordion.start($element);
-      clickOpenCloseAll();
-
-      expect($element.find('.js-subsection-button[aria-expanded="true"]').length).toEqual(2);
+    it('adds an aria-expanded attribute to each subsection link', function () {
+      expect($element.find('.js-subsection-title-link[aria-expanded="true"]').length).toEqual(2);
     });
 
     it('removes the .js-hidden class from each subsection content to hide the list of links', function () {
-      accordion.start($element);
-      clickOpenCloseAll();
-
       expect($element.find('.js-subsection-content.js-hidden').length).toEqual(0);
     });
 
     it('changes the Open/Close all button text to "Close all"', function () {
-      accordion.start($element);
-      clickOpenCloseAll();
-
       expect($element.find('.js-subsection-controls button')).toContainText("Close all");
     });
 
     it("triggers a google analytics custom event", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      accordion.start($element);
-      clickOpenCloseAll();
-
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionAllOpened', {
         label: 'Open All'
       });
@@ -151,10 +126,12 @@ describe('An accordion with descriptions module', function () {
 
   describe('Clicking the "Close all" button', function () {
     it("triggers a google analytics custom event", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
       clickOpenCloseAll();
       clickOpenCloseAll();
 
@@ -168,30 +145,28 @@ describe('An accordion with descriptions module', function () {
 
     // When a section is open (testing: toggleSection, openSection)
     it("does not have a class of js-hidden", function () {
-      accordion.start($element);
-
-      var $subsectionButton = $element.find('.subsection-title button:first');
+      var $subsectionLink = $element.find('.subsection-header a:first');
       var $subsectionContent = $element.find('.subsection-content:first');
-      $subsectionButton.click();
+      $subsectionLink.click();
       expect($subsectionContent).not.toHaveClass("js-hidden");
     });
 
     // When a section is open (testing: toggleState, setExpandedState)
     it("has a an aria-expanded attribute and the value is true", function () {
-      accordion.start($element);
-
-      var $subsectionButton = $element.find('.subsection-title button:first');
-      $subsectionButton.click();
-      expect($subsectionButton).toHaveAttr('aria-expanded','true');
+      var $subsectionLink = $element.find('.subsection-header a:first');
+      $subsectionLink.click();
+      expect($subsectionLink).toHaveAttr('aria-expanded', 'true');
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
-      var $subsectionButton = $element.find('.subsection-title button:first');
-      $subsectionButton.click();
+      var $subsectionLink = $element.find('.subsection-header a:first');
+      $subsectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: 'Topic Section One - Heading Click'
@@ -199,10 +174,12 @@ describe('An accordion with descriptions module', function () {
     });
 
     it("triggers a google analytics custom event when clicking on the icon", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
       var $subsectionIcon = $element.find('.subsection-icon');
       $subsectionIcon.click();
 
@@ -212,10 +189,12 @@ describe('An accordion with descriptions module', function () {
     });
 
     it("triggers a google analytics custom event when clicking in space in the header", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
       var $subsectionHeader = $element.find('.subsection-header');
       $subsectionHeader.click();
 
@@ -229,36 +208,33 @@ describe('An accordion with descriptions module', function () {
 
     // When a section is closed (testing: toggleSection, closeSection)
     it("has a class of js-hidden", function () {
-      accordion.start($element);
-
-      var $subsectionButton = $element.find('.subsection-title button:first');
+      var $subsectionLink = $element.find('.subsection-header a:first');
       var $subsectionContent = $element.find('.subsection-content:first');
-      $subsectionButton.click();
+      $subsectionLink.click();
       expect($subsectionContent).not.toHaveClass("js-hidden");
-      $subsectionButton.click();
+      $subsectionLink.click();
       expect($subsectionContent).toHaveClass("js-hidden");
     });
 
     // When a section is closed (testing: toggleState, setExpandedState)
     it("has a an aria-expanded attribute and the value is false", function () {
-      accordion.start($element);
-
-      var $subsectionButton = $element.find('.subsection-title button:first');
-      var $subsectionContent = $element.find('.subsection-content');
-      $subsectionButton.click();
-      expect($subsectionButton).toHaveAttr('aria-expanded','true');
-      $subsectionButton.click();
-      expect($subsectionButton).toHaveAttr('aria-expanded','false');
+      var $subsectionLink = $element.find('.subsection-header a:first');
+      $subsectionLink.click();
+      expect($subsectionLink).toHaveAttr('aria-expanded', 'true');
+      $subsectionLink.click();
+      expect($subsectionLink).toHaveAttr('aria-expanded', 'false');
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
-      var $subsectionButton = $element.find('.subsection-title button:first');
-      $subsectionButton.click();
-      $subsectionButton.click();
+      var $subsectionLink = $element.find('.subsection-header a:first');
+      $subsectionLink.click();
+      $subsectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: 'Topic Section One - Heading Click'
@@ -266,10 +242,12 @@ describe('An accordion with descriptions module', function () {
     });
 
     it("triggers a google analytics custom event when clicking on the icon", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      accordion.start($element);
       var $subsectionIcon = $element.find('.subsection-icon');
       $subsectionIcon.click();
       $subsectionIcon.click();
@@ -280,7 +258,10 @@ describe('An accordion with descriptions module', function () {
     });
 
     it("triggers a google analytics custom event when clicking in space in the header", function () {
-      GOVUK.analytics = {trackEvent: function() {}};
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
       spyOn(GOVUK.analytics, 'trackEvent');
 
       accordion.start($element);
@@ -295,27 +276,22 @@ describe('An accordion with descriptions module', function () {
   });
 
   describe('When linking to a topic section', function () {
-    beforeEach(function() {
+    beforeEach(function () {
       spyOn(GOVUK, 'getCurrentLocation').and.returnValue({
         hash: '#topic-section-one'
       });
+
+      // Restart accordion after setting up mock location provider
+      accordion.start($element);
     });
 
     it("opens the linked to topic section", function () {
-      accordion.start($element);
-
-      var $subsectionContent = $element.find('#topic-section-one')
-        .parents('.subsection').find('.subsection-content');
-
+      var $subsectionContent = $element.find('#topic-section-one').find('.subsection-content');
       expect($subsectionContent).not.toHaveClass('js-hidden');
     });
 
     it("leaves other sections closed", function () {
-      accordion.start($element);
-
-      var $subsectionContent = $element.find('#topic-section-two')
-        .parents('.subsection').find('.subsection-content');
-
+      var $subsectionContent = $element.find('#topic-section-two').find('.subsection-content');
       expect($subsectionContent).toHaveClass('js-hidden');
     });
   });


### PR DESCRIPTION
This change is primarily to update the accordion element to store (some of) its state in the URL, rather than in [`sessionStorage`](https://developer.mozilla.org/en/docs/Web/API/Window/sessionStorage). This is to address the following observations from user research:

- When expanding an accordion, then continuing their journey and (much later) coming back to the accordion, users were confused as to why parts of it were expanded
- When navigating "back" in their browser from content to the accordion, users expect the section they came from to still be expanded

`sessionStorage` addressed the second issue, but gave rise to the first issue, since the state lingered long after a user has navigated away from the page.

As an alternative approach, state is instead stored in the URL hash, using [`history.replaceState`](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to avoid clobbering browser history.

For example, when a user expands "Section 1", their address bar looks like `gov.uk/some-taxon#section-1`. If they then collapse the section, the hash is removed. If they open another section, the hash is **replaced** rather than appended.

Notably, this JavaScript has [some limitations on compatibility](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Browser_compatibility), so a fallback of not storing state in the URL has also been added. In this case, when navigating back to the accordion, users will find the accordion completely collapsed, but this was deemed to be less confusing than coming back to a pre-expanded accordion after an unrelated journey.

The following edge cases have been identified, but will not be addressed in advance of an identified user need:

- Opening "Section 1", then opening "Section 2" will make my hash `#section-2`. If I click on content from Section 1, and then click "back" in my browser, I see Section 1 expanded and **not** Section 2 (where I came from)
- Clicking "expand all" will clear the hash, so when a user clicks content, then clicks "back", they will be returned to a collapsed accordion

### Trello

- https://trello.com/c/ZBbVh8r0/480-add-a-url-fragment-when-you-open-an-accordion-section
- https://trello.com/c/MLMgltu5/475-switching-off-the-option-that-keeps-the-accordion-open-when-moving-from-a-piece-of-content-selected-from-one-of-the-topic-child-
