### PR TITLE
Hide title & description under grid if nothing tagged to that level

### DIFF
--- a/app/views/taxons/_content_list_for_current_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_current_taxon.html.erb
@@ -1,38 +1,40 @@
 <% is_grid ||= false %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <div class="parent-topic-contents">
-      <div class="topic-content">
-        <% if taxon.child_taxons.present? %>
-          <h2><%= taxon.title %> guidance</h2>
-          <p><%= taxon.description %></p>
-        <% end %>
-
-        <ol>
-          <% tagged_content.each_with_index do |content_item, index| %>
-            <li>
-              <h2>
-                <%= link_to(
-                  content_item.title,
-                  Plek.new.website_root + content_item.base_path,
-                  data: {
-                    track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
-                    track_action: index + 1,
-                    track_label: content_item.base_path,
-                    track_options: {
-                      dimension28: tagged_content.size.to_s,
-                      dimension29: content_item.title,
-                    },
-                    module: 'track-click',
-                  }
-                ) %>
-              </h2>
-              <p><%= content_item.description %></p>
-            </li>
+<% if tagged_content.any? || !is_grid %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="parent-topic-contents">
+        <div class="topic-content">
+          <% if taxon.child_taxons.present? %>
+            <h2><%= taxon.title %> guidance</h2>
+            <p><%= taxon.description %></p>
           <% end %>
-        </ol>
+
+          <ol>
+            <% tagged_content.each_with_index do |content_item, index| %>
+              <li>
+                <h2>
+                  <%= link_to(
+                    content_item.title,
+                    Plek.new.website_root + content_item.base_path,
+                    data: {
+                      track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
+                      track_action: index + 1,
+                      track_label: content_item.base_path,
+                      track_options: {
+                          dimension28: tagged_content.size.to_s,
+                          dimension29: content_item.title,
+                      },
+                      module: 'track-click',
+                    }
+                    ) %>
+                </h2>
+                <p><%= content_item.description %></p>
+              </li>
+            <% end %>
+          </ol>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -18,9 +18,9 @@
     locals: { child_taxons: taxon.child_taxons } %>
 
   <%= render partial: 'content_list_for_current_taxon', locals: {
-  taxon: taxon,
-  tagged_content: taxon.tagged_content,
-  is_grid: true,
+    taxon: taxon,
+    tagged_content: taxon.tagged_content,
+    is_grid: true,
   } %>
 <% else %>
   <% if taxon.children? %>


### PR DESCRIPTION
When content is not tagged to a taxon grid, it should not display the taxon heading/description again underneath the grid.

## Screenshot

### Before

![before](https://cloud.githubusercontent.com/assets/12036746/23664203/cf005804-034c-11e7-95ba-ec8bb66a86fc.png)

### After

![after](https://cloud.githubusercontent.com/assets/12036746/23664205/d241b210-034c-11e7-93a5-9d361ceec624.png)

## Trello

https://trello.com/c/Cd0jdbth/504-remove-title-description-from-tagged-content-section-in-taxon-grid-pages-in-collections
