### PR TITLE
Move "- GOV.UK" suffix to application template

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "All categories - GOV.UK" %>
+<% content_for :title, "All categories" %>
 <% content_for :page_class, "browse" %>
 
 <div class="browse-panes root">

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{page.title} - GOV.UK" %>
+<% content_for :title, page.title %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>

--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Email alert subscription for #{subtopic.combined_title} - GOV.UK" %>
+<% content_for :title, "Email alert subscription for #{subtopic.combined_title}" %>
 <%= render 'shared/tag_meta', tag: subtopic, description: "Subscribe to get an email each time content is published or updated in the '#{subtopic.combined_title}' topic." %>
 <% content_for :page_class, "email-signup-new" %>
 

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{subtopic.title}: latest documents - GOV.UK" %>
+<% content_for :title, "#{subtopic.title}: latest documents" %>
 <% content_for :page_title do %>
   <span><%= subtopic.title %></span>: latest documents
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title><%= yield :title %></title>
+  <title><%= yield :title %> - GOV.UK</title>
   <%= javascript_include_tag "application" %>
   <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
   <!--[if IE 6]><%= stylesheet_link_tag "application-ie6" %><script>var ieVersion = 6;</script><![endif]-->

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{page.title} - GOV.UK" %>
+<% content_for :title, page.title %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Services and information - #{organisation['title']} - GOV.UK" %>
+<% content_for :title, "Services and information - #{organisation['title']}" %>
 <% content_for :page_class, "topics-page" %>
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{subtopic.combined_title} - GOV.UK" %>
+<% content_for :title, subtopic.combined_title %>
 <%= render 'shared/tag_meta', tag: subtopic %>
 <% if is_page_under_ab_test %>
   <%= ab_variant.analytics_meta_tag.html_safe %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= topic.title %> - GOV.UK<% end %>
+<% content_for :title, topic.title %>
 <%= render 'shared/tag_meta', tag: topic %>
 <% if is_page_under_ab_test %>
   <%= ab_variant.analytics_meta_tag.html_safe %>


### PR DESCRIPTION
The new navigation pages are currently missing the "- GOV.UK" suffix in the title. This fixes that by moving the suffix to the application template, which will add it for all pages from now on.