### PR TITLE
Remove duplicate entries for document collection

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -10,11 +10,6 @@
     "surface_content": true
   },
   {
-    "base_path": "/government/collections/further-education-commissioner-intervention-reports",
-    "surface_collection": true,
-    "surface_content": false
-  },
-  {
     "base_path": "/government/collections/fe-choices-information-for-providers",
     "surface_collection": true,
     "surface_content": false
@@ -876,11 +871,6 @@
   },
   {
     "base_path": "/government/collections/hmcis-monthly-commentaries",
-    "surface_collection": false,
-    "surface_content": true
-  },
-  {
-    "base_path": "/government/collections/further-education-commissioner-intervention-reports",
     "surface_collection": false,
     "surface_content": true
   },


### PR DESCRIPTION
We should not show the document collection, and instead show the
content tagged to it. This commit makes sure that's the only entry left
in the file.

Trello: https://trello.com/c/mXa55bSX/507-document-collections-showing-as-false-but-still-appearing-2-examples