### PR TITLE
Update govuk_navigation_helpers gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.1.0)
+    govuk_navigation_helpers (3.1.1)
       gds-api-adapters (~> 40.1)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)


### PR DESCRIPTION
Update gem to pick up the latest list of guidance document types

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list