### PR TITLE
Add padding bottom to the grid

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -46,6 +46,7 @@
   .child-topics-list {
     ol {
       list-style-type: none;
+      padding-bottom: $gutter-half;
       @extend %grid-row;
 
       li {


### PR DESCRIPTION
This is to ensure the spacing between the `ol` and the "is there something
wrong with this page" link or tagged content is always at 60px.

cc/ @alextea 


### Before

<img width="1382" alt="screen shot 2017-03-08 at 16 40 37" src="https://cloud.githubusercontent.com/assets/416701/23713919/61dc16cc-041f-11e7-861a-d4eb1b8a94c3.png">

### After

<img width="1367" alt="screen shot 2017-03-08 at 16 40 25" src="https://cloud.githubusercontent.com/assets/416701/23713927/647d173c-041f-11e7-907b-7a7459b5390e.png">
