### PR TITLE
Fix accordion for pages with no JS history object

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -225,10 +225,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
 
     function updateHash($subsectionElement) {
-      if (!GOVUK.support.history()) {
-        return;
-      }
-
       var subsectionView = new SubsectionView($subsectionElement);
       var hash = subsectionView.isOpen() && '#' + $subsectionElement.attr('id');
       setHash(hash)
@@ -236,6 +232,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     // Sets the hash for the page. If a falsy value is provided, the hash is cleared.
     function setHash(hash) {
+      if (!GOVUK.support.history()) {
+        return;
+      }
+
       var newLocation = hash || GOVUK.getCurrentLocation().pathname;
       history.replaceState({}, '', newLocation);
     }


### PR DESCRIPTION
In a previous refactor I missed moving the check for JavaScript `history` support. This caused a console error in older browsers which don't support `history.replaceState`.

### Trello

https://trello.com/c/Jj6bq3Sl/55-js-error-reported-in-ie8
