### PR TITLE
Hide Buying for Schools collection

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -581,8 +581,8 @@
   },
   {
     "base_path": "/government/collections/buying-for-schools",
-    "surface_collection": true,
-    "surface_content": false
+    "surface_collection": false,
+    "surface_content": true
   },
   {
     "base_path": "/government/collections/school-building-design-and-maintenance",


### PR DESCRIPTION
We want to hide the School Procurement collection, and just surface its contents, because the [School Procurement](https://www.gov.uk/education/school-procurement) taxon exists.