### PR TITLE
Show new navigation pages regardless of variant

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,4 @@
 class TaxonsController < ApplicationController
-  before_action :return_404, unless: :new_navigation_enabled?
-
   helper_method :taxon_overview_and_child_taxons
 
   def show
@@ -27,14 +25,6 @@ private
 
       variant
     end
-  end
-
-  def new_navigation_enabled?
-    ab_variant.variant_b?
-  end
-
-  def return_404
-    head :not_found
   end
 
   def taxon

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -18,12 +18,12 @@ describe TaxonsController do
       assert_response 200
     end
 
-    it "returns 404 if the new navigation is disabled for variant 'A'" do
-      with_A_variant assert_meta_tag: false do
+    it "returns 200 if the new navigation is enabled in variant 'A'" do
+      with_A_variant do
         get :show, taxon_base_path: "education"
       end
 
-      assert_response 404
+      assert_response 200
     end
   end
 end


### PR DESCRIPTION
We should show the new navigation pages regardless of the variant. This
will prevent search engines to see 404s when crawling the pages.