### PR TITLE
Accordion behaviour fixes

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -116,7 +116,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function bindToggleForSubsections(accordionTracker) {
         $element.find('.js-subsection-header').click(function (event) {
-          event.preventDefault();
+          preventLinkFollowingForCurrentTab(event);
 
           var subsectionView = new SubsectionView($(this).closest('.js-subsection'));
           subsectionView.toggle();
@@ -126,6 +126,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
           setOpenCloseAllText();
         });
+      }
+
+      function preventLinkFollowingForCurrentTab(event) {
+        // If the user is holding the ⌘ or Ctrl key, they're trying
+        // to open the link in a new window, so let the click happen
+        if (event.metaKey || event.ctrlKey) {
+          return;
+        }
+
+        event.preventDefault();
       }
 
       function bindToggleOpenCloseAllButton(accordionTracker) {

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -22,6 +22,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.start = function ($element) {
 
+      $(window).unload(storeScrollPosition);
+
       // Indicate that js has worked
       $element.addClass('js-accordion-with-descriptions');
 
@@ -46,6 +48,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       bindToggleForSubsections(accordionTracker);
       bindToggleOpenCloseAllButton(accordionTracker);
+
+      // When navigating back in browser history to the accordion, the browser will try to be "clever" and return
+      // the user to their previous scroll position. However, since we collapse all but the currently-anchored
+      // subsection, the content length changes and the user is returned to the wrong position (often the footer).
+      // In order to correct this behaviour, as the user leaves the page, we anticipate the correct height we wish the
+      // user to return to by forcibly scrolling them to that height, which becomes the height the browser will return
+      // them to.
+      // If we can't find an element to return them to, then reset the scroll to the top of the page. This handles
+      // the case where the user has expanded all sections, so they are not returned to a particular section, but
+      // still could have scrolled a long way down the page.
+      function storeScrollPosition() {
+        closeAllSections();
+        var $subsection = getSubsectionForAnchor();
+
+        document.body.scrollTop = $subsection && $subsection.length
+          ? $subsection.offset().top
+          : 0;
+      }
 
       function addOpenCloseAllButton() {
         $element.prepend('<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">' + bulkActions.openAll.buttonText + '</button></div>');
@@ -78,20 +98,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function openLinkedSection() {
-        var anchor = getActiveAnchor(),
-          $subsection;
+        var $subsection = getSubsectionForAnchor();
 
-        if (!anchor.length) {
-          return;
-        }
-
-        anchor = '#' + escapeSelector(anchor.substr(1));
-        $subsection = $element.find(anchor);
-
-        if ($subsection.length) {
+        if ($subsection && $subsection.length) {
           var subsectionView = new SubsectionView($subsection);
           subsectionView.open();
         }
+      }
+
+      function getSubsectionForAnchor() {
+        var anchor = getActiveAnchor();
+
+        return anchor.length
+          ? $element.find('#' + escapeSelector(anchor.substr(1)))
+          : null;
       }
 
       function getActiveAnchor() {
@@ -187,7 +207,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     };
 
     function SubsectionView($subsectionElement) {
-      var $subsectionContent = $subsectionElement.find('.js-subsection-content');
       var $titleLink = $subsectionElement.find('.js-subsection-title-link');
       var shouldUpdateHash = true;
 
@@ -214,7 +233,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function setIsOpen(isOpen) {
-        $subsectionContent.toggleClass('js-hidden', !isOpen);
         $subsectionElement.toggleClass('subsection-is-open', isOpen);
         $titleLink.attr("aria-expanded", isOpen);
 
@@ -224,11 +242,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function isOpen() {
-        return !isClosed();
+        return $subsectionElement.hasClass('subsection-is-open');
       }
 
       function isClosed() {
-        return $subsectionContent.hasClass('js-hidden');
+        return !isOpen();
       }
 
       function preventHashUpdate() {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -243,4 +243,14 @@
       font-weight: bold;
     }
   }
+
+  .subsection-content {
+    display: none;
+  }
+
+  .subsection-is-open {
+    .subsection-content {
+      display: block;
+    }
+  }
 }

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -3,7 +3,7 @@
     <div class="column-two-thirds">
       <div class="topic-content">
 
-        <div data-module="accordion-with-descriptions">
+        <div data-module="accordion-with-descriptions" class="js-hidden">
           <div class="subsection-wrapper">
 
             <% accordion_content.each_with_index do |taxon, index| %>

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -81,8 +81,8 @@ describe('An accordion with descriptions module', function () {
   });
 
   it("ensures all subsection content is hidden", function () {
-    $.each($element.find('.subsection-content'), function (index, content) {
-      expect(content).toHaveClass('js-hidden');
+    $element.find('.subsection').each(function (index, $subsection) {
+      expect($subsection).not.toHaveClass('subsection-is-open');
     });
   });
 
@@ -107,10 +107,6 @@ describe('An accordion with descriptions module', function () {
 
     it('adds an aria-expanded attribute to each subsection link', function () {
       expect($element.find('.js-subsection-title-link[aria-expanded="true"]').length).toEqual(2);
-    });
-
-    it('removes the .js-hidden class from each subsection content to hide the list of links', function () {
-      expect($element.find('.js-subsection-content.js-hidden').length).toEqual(0);
     });
 
     it('changes the Open/Close all button text to "Close all"', function () {
@@ -146,11 +142,11 @@ describe('An accordion with descriptions module', function () {
   describe('Opening a section', function () {
 
     // When a section is open (testing: toggleSection, openSection)
-    it("does not have a class of js-hidden", function () {
+    it("has a class of subsection-is-open", function () {
       var $subsectionLink = $element.find('.subsection-header a:first');
-      var $subsectionContent = $element.find('.subsection-content:first');
+      var $subsection = $element.find('.subsection');
       $subsectionLink.click();
-      expect($subsectionContent).not.toHaveClass("js-hidden");
+      expect($subsection).toHaveClass("subsection-is-open");
     });
 
     // When a section is open (testing: toggleState, setExpandedState)
@@ -212,13 +208,13 @@ describe('An accordion with descriptions module', function () {
   describe('Closing a section', function () {
 
     // When a section is closed (testing: toggleSection, closeSection)
-    it("has a class of js-hidden", function () {
+    it("removes the subsection-is-open class", function () {
       var $subsectionLink = $element.find('.subsection-header a:first');
-      var $subsectionContent = $element.find('.subsection-content:first');
+      var $subsection = $element.find('.subsection');
       $subsectionLink.click();
-      expect($subsectionContent).not.toHaveClass("js-hidden");
+      expect($subsection).toHaveClass("subsection-is-open");
       $subsectionLink.click();
-      expect($subsectionContent).toHaveClass("js-hidden");
+      expect($subsection).not.toHaveClass("subsection-is-open");
     });
 
     // When a section is closed (testing: toggleState, setExpandedState)
@@ -294,13 +290,13 @@ describe('An accordion with descriptions module', function () {
     });
 
     it("opens the linked to topic section", function () {
-      var $subsectionContent = $element.find('#topic-section-one').find('.subsection-content');
-      expect($subsectionContent).not.toHaveClass('js-hidden');
+      var $subsection = $element.find('#topic-section-one');
+      expect($subsection).toHaveClass('subsection-is-open');
     });
 
     it("leaves other sections closed", function () {
-      var $subsectionContent = $element.find('#topic-section-two').find('.subsection-content');
-      expect($subsectionContent).toHaveClass('js-hidden');
+      var $subsection = $element.find('#topic-section-two');
+      expect($subsection).not.toHaveClass('subsection-is-open');
     });
   });
 


### PR DESCRIPTION
This Pull Request addresses the following issues with the accordion:
- The full content of the accordion is visible before it's collapsed by JavaScript (FOUC)
- Ctrl + click or Cmd + click didn't open accordion links in new tabs
- When using the browser history to navigate, the accordion scroll position is not set correctly

### Flash of unstyled content (FOUC)

There was a previous fix for FOUC in place that has been removed through refactoring. This was fixed by replacing the `js-hidden` class on the accordion.

### Ctrl + click / Cmd + click

Solution used from here: https://gist.github.com/andreaslof/4ef2935dee9a03267692

### Browser scroll position

When navigating back in browser history to the accordion, the browser will try to be "clever" and return the user to their previous scroll position. However, since we collapse all but the currently-anchored subsection, the content length changes and the user is returned to the wrong position (often the footer).

In order to correct this behaviour, as the user leaves the page, we anticipate the correct height we wish the user to return to by forcibly scrolling them to that height, which becomes the height the browser will return them to.

If we can't find an element to return them to, then reset the scroll to the top of the page. This handles the case where the user has expanded all sections, so they are not returned to a particular section, but still could have scrolled a long way down the page.

### Trello

https://trello.com/c/QPSaKsg3/12-when-navigating-via-the-back-button-from-content-back-to-the-accordion-sometimes-i-jumped-back-to-the-footer-not-the-expanded-le
