### PR TITLE
Only show content for primary school teachers useful information

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -551,8 +551,8 @@
   },
   {
     "base_path": "/government/collections/primary-school-teachers-useful-information",
-    "surface_collection": true,
-    "surface_content": false
+    "surface_collection": false,
+    "surface_content": true
   },
   {
     "base_path": "/government/collections/teacher-misconduct",


### PR DESCRIPTION
A lot of the content in there is quite important, and needs to be
surfaced.

https://www.gov.uk/government/collections/primary-school-teachers-useful-information