### PR TITLE
Use document supertype to fetch guidance content

### DIFF
--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -26,7 +26,7 @@ private
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
-      filter_content_store_document_type: GovukNavigationHelpers::Guidance::DOCUMENT_TYPES,
+      filter_navigation_document_supertype: 'guidance',
       filter_taxons: [content_id],
       order: 'title',
     )

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -194,11 +194,9 @@ describe TaggedContent do
       assert_includes_params(filter_taxons: [taxon_content_id])
     end
 
-    it 'filters out non-guidance content' do
-      guidance_document_types = GovukNavigationHelpers::Guidance::DOCUMENT_TYPES
-
+    it 'filters guidance content only' do
       assert_includes_params(
-        filter_content_store_document_type: guidance_document_types
+        filter_navigation_document_supertype: 'guidance'
       )
     end
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -4,7 +4,7 @@ module RummagerHelpers
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
-      filter_content_store_document_type: GovukNavigationHelpers::Guidance::DOCUMENT_TYPES,
+      filter_navigation_document_supertype: 'guidance',
       filter_taxons: [content_id],
       order: 'title',
     ).returns(


### PR DESCRIPTION
This commit switches from using a hard-coded list of document types that
describe guidance content, to using a new field recently added to
search. This new field encapsulates the same logic and is being
populated during indexing in rummager and will be always present.

I deployed this branch to integration and ran wraith on all navigation pages against production to see if the content shown on each of the pages would change. There were no major changes between both environments.

Trello: https://trello.com/c/PtQXkimK/520-switch-from-using-hardcoded-guidance-document-types-into-using-document-supertypes