### PR TITLE
Convert taxon breadcrumbs to back link on mobile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'govuk_frontend_toolkit', '~> 4.3.0'
 gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
-gem 'govuk_navigation_helpers', '~> 3.1'
+gem 'govuk_navigation_helpers', '~> 3.2'
 gem 'govuk_ab_testing', '1.0.1'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.1.1)
+    govuk_navigation_helpers (3.2.1)
       gds-api-adapters (~> 40.1)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
@@ -288,7 +288,7 @@ DEPENDENCIES
   govuk-lint
   govuk_ab_testing (= 1.0.1)
   govuk_frontend_toolkit (~> 4.3.0)
-  govuk_navigation_helpers (~> 3.1)
+  govuk_navigation_helpers (~> 3.2)
   govuk_schemas (~> 2.1)
   jasmine-rails (~> 0.12.1)
   logstasher (= 0.6.2)


### PR DESCRIPTION
Upgrade the govuk_navigation_helpers gem to pick up the latest breadcrumb config. This adds the taxon back link on mobile.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link