### PR TITLE
Enable taxonomy breadcrumb back link on mobile

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -25,7 +25,10 @@
     )
   %>
   <%= render partial: 'govuk_component/breadcrumbs',
-    locals: @navigation_helpers.taxon_breadcrumbs %>
+    locals: {
+      breadcrumbs: @navigation_helpers.taxon_breadcrumbs[:breadcrumbs],
+      collapse_on_mobile: true
+    } %>
 <% end %>
 
 <% if taxon.grandchildren? %>


### PR DESCRIPTION
Pass `collapse_on_mobile` parameter to enable the collapse of the taxonomy breadcrumbs to a single back link.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link