### PR TITLE
Add heatmap tracking for benchmarking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'govuk_navigation_helpers', '~> 3.2'
-gem 'govuk_ab_testing', '1.0.1'
+gem 'govuk_ab_testing', '~> 2.0'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 
 if ENV['SLIMMER_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_ab_testing (1.0.1)
+    govuk_ab_testing (2.0.0)
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -286,7 +286,7 @@ DEPENDENCIES
   gds-api-adapters (~> 40.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
-  govuk_ab_testing (= 1.0.1)
+  govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (~> 3.2)
   govuk_schemas (~> 2.1)

--- a/app/assets/javascripts/mouseflow.js
+++ b/app/assets/javascripts/mouseflow.js
@@ -1,0 +1,9 @@
+var _mfq = _mfq || [];
+
+(function() {
+  var mf = document.createElement("script");
+  mf.type = "text/javascript";
+  mf.async = true;
+  mf.src = "//cdn.mouseflow.com/projects/807ab5b2-3fe4-4b3b-b4d7-e83b8f6e71fe.js";
+  document.getElementsByTagName("head")[0].appendChild(mf);
+})();

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,14 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
+  def education_ab_test
+    @education_ab_test ||= begin
+      ab_test_request = EducationNavigationAbTestRequest.new(request)
+      ab_test_request.set_response_vary_header(response)
+      ab_test_request
+    end
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,24 @@ class ApplicationController < ActionController::Base
     @acceptable_formats ||= {}
   end
 
+  def benchmarking_ab_test
+    @benchmarking_ab_test ||= begin
+      benchmarking_test = BenchmarkingAbTestRequest.new(request)
+
+      if benchmarking_test.in_benchmarking?
+        benchmarking_test.set_response_vary_header(response)
+      end
+
+      benchmarking_test
+    end
+  end
+  helper_method :benchmarking_ab_test
+
+  def should_track_mouse_movements?
+    benchmarking_ab_test.in_benchmarking?
+  end
+  helper_method :should_track_mouse_movements?
+
   def education_ab_test
     @education_ab_test ||= begin
       ab_test_request = EducationNavigationAbTestRequest.new(request)

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -5,11 +5,10 @@ class BrowseController < ApplicationController
     page = MainstreamBrowsePage.find("/browse")
     setup_content_item_and_navigation_helpers(page)
 
-    dimension = Rails.application.config.navigation_ab_test_dimension
-    ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-    ab_variant = ab_test.requested_variant(request.headers)
-
-    render :index, locals: { page: page, ab_variant: ab_variant }
+    render :index, locals: {
+      page: page,
+      ab_variant: education_ab_test.requested_variant
+    }
   end
 
   def show

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -7,25 +7,13 @@ class TaxonsController < ApplicationController
     # Show the taxon page regardless of which variant is requested, because
     # there is no straighforward mapping of taxons back to original navigation
     # pages.
-    render :show, locals: { taxon: taxon, ab_variant: ab_variant }
+    render :show, locals: {
+      taxon: taxon,
+      ab_variant: education_ab_test.requested_variant
+    }
   end
 
 private
-
-  def dimension
-    Rails.application.config.navigation_ab_test_dimension
-  end
-
-  def ab_variant
-    @ab_variant ||= begin
-      ab_test =
-        GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-      variant = ab_test.requested_variant(request.headers)
-      variant.configure_response(response)
-
-      variant
-    end
-  end
 
   def taxon
     @taxon ||= Taxon.find(request.path)

--- a/app/models/benchmarking_ab_test_request.rb
+++ b/app/models/benchmarking_ab_test_request.rb
@@ -1,0 +1,22 @@
+class BenchmarkingAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    dimension = Rails.application.config.benchmarking_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new(
+      "Benchmarking",
+      dimension: dimension
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+  end
+
+  def in_benchmarking?
+    requested_variant.variant_b?
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/models/education_navigation_ab_test_request.rb
+++ b/app/models/education_navigation_ab_test_request.rb
@@ -1,0 +1,22 @@
+class EducationNavigationAbTestRequest
+  attr_accessor :requested_variant
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    dimension = Rails.application.config.navigation_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new(
+      "EducationNavigation",
+      dimension: dimension
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+  end
+
+  def should_present_new_navigation?
+    requested_variant.variant_b?
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,8 @@
   <%= yield :meta_tags %>
   <%= yield :meta_section %>
 
+  <%= benchmarking_ab_test.requested_variant.analytics_meta_tag.html_safe %>
+
   <%= render partial: 'govuk_component/analytics_meta_tags',
     locals: { content_item: @content_item } %>
 </head>
@@ -27,5 +29,9 @@
       <%= yield %>
     </main>
   </div>
+
+  <% if should_track_mouse_movements? %>
+    <%= javascript_include_tag 'mouseflow' %>
+  <% end %>
 </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,9 @@ module Collections
 
     # Google Analytics dimension assigned to the education navigation A/B test
     config.navigation_ab_test_dimension = 41
+
+
+    # Google Analytics dimension assigned to the benchmarking A/B test
+    config.benchmarking_ab_test_dimension = 49
   end
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -2,4 +2,5 @@ Rails.application.config.assets.precompile += %w(
   application-ie6.css
   application-ie7.css
   application-ie8.css
+  mouseflow.js
 )

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -64,7 +64,7 @@ describe BrowseController do
           get :show, top_level_slug: "benefits"
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
 
         it "does not redirect education when the #{variant} variant is requested in JSON format" do
@@ -73,7 +73,7 @@ describe BrowseController do
           get :show, format: :json, top_level_slug: "education"
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
       end
 

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -118,7 +118,7 @@ describe SecondLevelBrowsePageController do
           get :show, top_level_slug: "benefits", second_level_slug: "entitlement"
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
 
         it "does not redirect education when the #{variant} variant is requested in JSON format" do
@@ -127,7 +127,7 @@ describe SecondLevelBrowsePageController do
           get :show, top_level_slug: "education", second_level_slug: "student-finance", format: :json
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
       end
     end

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -50,7 +50,7 @@ describe ServicesAndInformationController do
           get :index, organisation_id: "hm-revenue-customs"
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
       end
 

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -61,7 +61,7 @@ describe SubtopicsController do
           get :show, topic_slug: "oil-and-gas", subtopic_slug: "wells"
 
           assert_response 200
-          assert_response_not_modified_for_ab_test
+          assert_response_not_modified_for_ab_test("EducationNavigation")
         end
       end
     end

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -59,7 +59,7 @@ describe TopicsController do
         get :show, topic_slug: "oil-and-gas"
 
         assert_response 200
-        assert_response_not_modified_for_ab_test
+        assert_response_not_modified_for_ab_test("EducationNavigation")
       end
     end
   end

--- a/test/integration/benchmarking_test.rb
+++ b/test/integration/benchmarking_test.rb
@@ -1,0 +1,97 @@
+require 'integration_test_helper'
+require 'slimmer/test_helpers/govuk_components'
+
+class BenchmarkingTest < ActionDispatch::IntegrationTest
+  include RummagerHelpers
+  include TaxonHelpers
+  include Slimmer::TestHelpers::GovukComponents
+  include GovukAbTesting::MinitestHelpers
+
+  before do
+    @existing_framework = GovukAbTesting.configuration.acceptance_test_framework
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = :capybara
+    end
+  end
+
+  after do
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = @existing_framework
+    end
+  end
+
+  it 'shows the mouseflow tag when on the benchmarking test' do
+    when_i_am_on_the_new_benchmarking_test
+    and_there_is_a_taxon
+    when_i_visit_the_taxon_page
+    then_there_is_a_mouseflow_tag_on_the_page
+    and_the_page_has_been_cached_by_variant
+  end
+
+  it 'does not show the mouseflow tag when outside of the benchmarking test' do
+    when_i_am_not_on_the_new_benchmarking_test
+    and_there_is_a_taxon
+    when_i_visit_the_taxon_page
+    then_there_is_no_mouseflow_tag_on_the_page
+  end
+
+  def when_i_am_on_the_new_benchmarking_test
+    setup_ab_variant('Benchmarking', 'B')
+  end
+
+  def when_i_am_not_on_the_new_benchmarking_test
+    setup_ab_variant('Benchmarking', 'A')
+  end
+
+  def when_i_visit_the_taxon_page
+    visit @base_path
+  end
+
+  def then_there_is_a_mouseflow_tag_on_the_page
+    all_script_tags = page.all('script', visible: false)
+
+    mouseflow_tags =
+      all_script_tags.select { |tag| tag[:src].match(/mouseflow-.*\.js/i) }
+
+    assert_equal(
+      1,
+      mouseflow_tags.count,
+      "Expected to find one script tag with the mouseflow js code on the page"
+    )
+  end
+
+  def and_the_page_has_been_cached_by_variant
+    assert_response_is_cached_by_variant('Benchmarking')
+  end
+
+  def then_there_is_no_mouseflow_tag_on_the_page
+    all_script_tags = page.all('script', visible: false)
+
+    mouseflow_tags =
+      all_script_tags.select { |tag| tag[:src].match(/mouseflow-.*\.js/i) }
+
+    assert_equal(
+      0,
+      mouseflow_tags.count,
+      "Did not expect to find a script tag with the mouseflow javascript code"
+    )
+  end
+
+  def and_there_is_a_taxon
+    @base_path = '/education/student-finance'
+
+    student_finance_taxon = student_finance_taxon(
+      base_path: @base_path,
+      links: {
+        parent_taxons: [],
+        child_taxons: []
+      }
+    )
+
+    content_store_has_item(@base_path, student_finance_taxon)
+
+    @taxon = Taxon.find(@base_path)
+    stub_content_for_taxon(@taxon.content_id, [])
+  end
+end


### PR DESCRIPTION
### Background

We are going to conduct a 2nd round of Benchmarking in GOV.UK. The idea is that we will try it with the new Education Navigation enabled across GOV.UK and see how it performs against the current navigation patterns (mainstream browse pages, topics, etc).

Besides checking if people actually complete the tasks, we would also like to know more details about how they use the new navigation pages and also about the new orientation in content pages. In order to do that, we will track mouse movements and gather the results in a heatmap. We are using a software called mouseflow to do this.

The tracking code will only be present for the people doing the benchmarking test (around 60 people). It will be behind a new A/B test so the tracking doesn't run for other GOV.UK users. These 60 users will be presented with a consent form where this will be explained.

### What this PR does

This PR adds the Mouseflow tracking code behind a new A/B test (`GOVUK-ABTest-Benchmarking`). With this new A/B test, we will be able to enable Mouseflow for all 60 users in the benchmarking round. This will allow us to collect data on how the navigation pages are used and generate a heatmap in the end in order to help us understand what areas of the site will be improved.

Trello: https://trello.com/c/NJ6O76BR/281-heatmap-tracking