### PR TITLE
Upgrade navigation helpers and gds api adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'govuk_frontend_toolkit', '~> 4.3.0'
 gem 'unicorn', '~> 4.9.0'
 gem 'airbrake', '~> 4.3.1'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
-gem 'govuk_navigation_helpers', '~> 3.2'
+gem 'govuk_navigation_helpers', '~> 5.1'
 gem 'govuk_ab_testing', '~> 2.0'
 gem 'statsd-ruby', '1.3.0', require: 'statsd'
 
@@ -22,7 +22,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 40.1'
+  gem 'gds-api-adapters', '~> 41.0'
 end
 
 gem 'plek', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    gds-api-adapters (40.2.0)
+    gds-api-adapters (41.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -105,8 +105,8 @@ GEM
     govuk_frontend_toolkit (4.3.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (3.2.1)
-      gds-api-adapters (~> 40.1)
+    govuk_navigation_helpers (5.1.0)
+      gds-api-adapters (~> 41.0)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
     http-cookie (1.0.3)
@@ -283,12 +283,12 @@ DEPENDENCIES
   binding_of_caller
   capybara (~> 2.5.0)
   cucumber-rails (~> 1.4.2)
-  gds-api-adapters (~> 40.1)
+  gds-api-adapters (~> 41.0)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk-lint
   govuk_ab_testing (~> 2.0)
   govuk_frontend_toolkit (~> 4.3.0)
-  govuk_navigation_helpers (~> 3.2)
+  govuk_navigation_helpers (~> 5.1)
   govuk_schemas (~> 2.1)
   jasmine-rails (~> 0.12.1)
   logstasher (= 0.6.2)


### PR DESCRIPTION
This commit needs to upgrade both gems at the same time due to
dependencies between each other.

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type