### PR TITLE
Fix topic redirect

### DIFF
--- a/config/navigation_redirects.yml
+++ b/config/navigation_redirects.yml
@@ -29,7 +29,7 @@ default: &default
       vocational-qualifications: education/apprenticeships-traineeships-and-internships
     higher-education:
       administration: education/running-a-further-or-higher-education-institution
-      scholarships-for-overseas-students: education/financial-help-for-international-students-in-the-uk
+      scholarships-for-overseas-students: education/funding-and-finance-for-students#/education/student-grants-bursaries-scholarships
 
 
 


### PR DESCRIPTION
The topic "Scholarships for overseas students" was redirecting to a
taxon that no longer exists. This commit fixes the redirect to an entry
in the expected accordion section.

This change was requested by Graeme.