### PR TITLE
Fix JavaScript-disabled accordion

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -208,6 +208,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     function SubsectionView($subsectionElement) {
       var $titleLink = $subsectionElement.find('.js-subsection-title-link');
+      var $subsectionContent = $subsectionElement.find('.js-subsection-content');
       var shouldUpdateHash = true;
 
       this.title = $subsectionElement.find('.js-subsection-title').text();
@@ -234,6 +235,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function setIsOpen(isOpen) {
         $subsectionElement.toggleClass('subsection-is-open', isOpen);
+        $subsectionContent.toggleClass('js-hidden', !isOpen);
         $titleLink.attr("aria-expanded", isOpen);
 
         if (shouldUpdateHash) {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -101,8 +101,7 @@
     }
   }
 
-  .subsection,
-  .subsection-is-open {
+  .subsection {
     width: 100%;
 
     .subsection-description {
@@ -241,16 +240,6 @@
   .subsection-list-item {
     a {
       font-weight: bold;
-    }
-  }
-
-  .subsection-content {
-    display: none;
-  }
-
-  .subsection-is-open {
-    .subsection-content {
-      display: block;
     }
   }
 }


### PR DESCRIPTION
The use of display: none in the CSS prevents browsers without
JavaScript enabled from seeing any content under accordion
sections. This fix removes the use of this styling to hide
the content, and instead toggles the js-hidden class