### PR TITLE
Allow for fragments for taxon redirects

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -43,9 +43,12 @@ private
     end
 
     if taxon_resolver.taxon_base_path
-      redirect_to controller: "taxons",
+      redirect_to(
+        controller: "taxons",
         action: "show",
-        taxon_base_path: taxon_resolver.taxon_base_path
+        taxon_base_path: taxon_resolver.taxon_base_path,
+        anchor: taxon_resolver.fragment
+      )
     else
       render :show, locals: {
         page: page,

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -31,9 +31,12 @@ private
     end
 
     if taxon_resolver.taxon_base_path
-      redirect_to controller: "taxons",
+      redirect_to(
+        controller: "taxons",
         action: "show",
-        taxon_base_path: taxon_resolver.taxon_base_path
+        taxon_base_path: taxon_resolver.taxon_base_path,
+        anchor: taxon_resolver.fragment
+      )
     else
       render :show, locals: {
         page: page,

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -13,9 +13,12 @@ class ServicesAndInformationController < ApplicationController
     end
 
     if taxon_resolver.taxon_base_path
-      redirect_to controller: "taxons",
+      redirect_to(
+        controller: "taxons",
         action: "show",
-        taxon_base_path: taxon_resolver.taxon_base_path
+        taxon_base_path: taxon_resolver.taxon_base_path,
+        anchor: taxon_resolver.fragment
+      )
     else
       render :index, locals: {
         service_and_information: service_and_information,

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,6 +1,5 @@
 class SubtopicsController < ApplicationController
   def show
-
     taxon_resolver = TaxonRedirectResolver.new(
       request,
       is_page_in_ab_test: lambda {
@@ -15,9 +14,12 @@ class SubtopicsController < ApplicationController
     end
 
     if taxon_resolver.taxon_base_path
-      redirect_to controller: "taxons",
+      redirect_to(
+        controller: "taxons",
         action: "show",
-        taxon_base_path: taxon_resolver.taxon_base_path
+        taxon_base_path: taxon_resolver.taxon_base_path,
+        anchor: taxon_resolver.fragment
+      )
     else
       subtopic = Topic.find(request.path)
       setup_content_item_and_navigation_helpers(subtopic)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -18,9 +18,12 @@ class TopicsController < ApplicationController
     end
 
     if taxon_resolver.taxon_base_path
-      redirect_to controller: "taxons",
+      redirect_to(
+        controller: "taxons",
         action: "show",
-        taxon_base_path: taxon_resolver.taxon_base_path
+        taxon_base_path: taxon_resolver.taxon_base_path,
+        anchor: taxon_resolver.fragment
+      )
     else
       topic = Topic.find(request.path)
       setup_content_item_and_navigation_helpers(topic)

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -1,5 +1,5 @@
 class TaxonRedirectResolver
-  attr_reader :ab_variant
+  attr_reader :ab_variant, :taxon_base_path, :fragment
 
   def initialize(request, is_page_in_ab_test:, map_to_taxon:)
     dimension = Rails.application.config.navigation_ab_test_dimension
@@ -8,13 +8,13 @@ class TaxonRedirectResolver
 
     @is_page_in_ab_test = is_page_in_ab_test
     @map_to_taxon = map_to_taxon
+
+    if page_ab_tested? && ab_variant.variant_b?
+      @taxon_base_path, @fragment = @map_to_taxon.call.split('#')
+    end
   end
 
   def page_ab_tested?
     @is_page_in_ab_test.call
-  end
-
-  def taxon_base_path
-    @map_to_taxon.call if page_ab_tested? && ab_variant.variant_b?
   end
 end

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -52,6 +52,20 @@ describe SubtopicsController do
         end
       end
 
+      it "redirects to the taxonomy navigation as the B variant preserving the fragment" do
+        with_B_variant assert_meta_tag: false do
+          get :show, topic_slug: "higher-education", subtopic_slug: "scholarships-for-overseas-students"
+
+          assert_response 302
+          assert_redirected_to(
+            controller: "taxons",
+            action: "show",
+            taxon_base_path: "education/funding-and-finance-for-students",
+            anchor: "/education/student-grants-bursaries-scholarships"
+          )
+        end
+      end
+
       ["A", "B"].each do |variant|
         it "does not change a page outside the A/B test when the #{variant} variant is requested" do
           stub_services_for_subtopic("content-id-for-wells", "oil-and-gas", "wells")


### PR DESCRIPTION
This commit fixes an issue related to redirecting to a taxon page with a
fragment. Commit 7529768e00b75dfbaf80e2a92508c46f13785a96 added a
redirect with a fragment, however the resulting URL is:

```
/education/funding-and-finance-for-students%23/education/student-grants-bursaries-scholarships
```

By passing in an `anchor` param to `redirect_to`, we allow the redirect
to work and also make sure the user will be positioned in the expected
fragment.