### PR TITLE
Fix Google Analytics warning about using numbers rather than strings

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -316,7 +316,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function AccordionTracker(totalSubsections) {
       this.track = function(category, action, options) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          options["dimension28"] = totalSubsections;
+          options["dimension28"] = totalSubsections.toString();
           GOVUK.analytics.trackEvent(category, action, options);
         }
       }

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -116,7 +116,7 @@ describe('An accordion with descriptions module', function () {
     it("triggers a google analytics custom event", function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionAllOpened', {
         label: 'Open All',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
   });
@@ -134,7 +134,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionAllClosed', {
         label: 'Close All',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
   });
@@ -168,7 +168,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: 'Topic Section One - Heading Click',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
 
@@ -184,7 +184,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: 'Topic Section One - Plus Click',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
 
@@ -200,7 +200,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: 'Topic Section One - Click Elsewhere',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
   });
@@ -239,7 +239,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: 'Topic Section One - Heading Click',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
 
@@ -256,7 +256,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: 'Topic Section One - Minus Click',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
 
@@ -274,7 +274,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: 'Topic Section One - Click Elsewhere',
-        dimension28: expectedAccordionSectionCount
+        dimension28: expectedAccordionSectionCount.toString()
       });
     });
   });


### PR DESCRIPTION
Update the accordion tracking which tracks the total number of accordion sections against dimension 28. Convert the count to a string, which gets rid of the Google Analytics JavaScript warning: `Expected a string value for field: "dimension28". but found: "number"`.

https://trello.com/c/JffDJtJ5/500-track-the-number-of-items-in-accordions-breadcrumbs-and-related-links