### PR TITLE
Add email alert buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,7 +10,7 @@
 @import "helpers/pagination";
 
 @import "views/browse";
-@import "views/email-signups";
 @import "views/latest-changes";
 @import "views/topics";
 @import "views/taxons";
+@import "views/email-signups";

--- a/app/assets/stylesheets/views/_email-signups.scss
+++ b/app/assets/stylesheets/views/_email-signups.scss
@@ -38,3 +38,29 @@
     margin: 20px 0;
   }
 }
+
+.subscriptions {
+  @include bold-19;
+
+  a {
+    display: inline-block;
+    text-decoration: none;
+    margin: 3px;
+    padding-left: 28px;
+    background-repeat: no-repeat;
+    background-position: 0 20%;
+
+    @include media(tablet) {
+      background-position: 0 35%;
+    }
+  }
+
+  .email-alerts {
+    background-image: image-url("mail-icon.png");
+
+    @include device-pixel-ratio() {
+      background-image: image-url("mail-icon-x2.png");
+      background-size: 20px 14px;
+    }
+  }
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -31,6 +31,7 @@ private
           'title' => current_taxon_title,
           'description' => '',
           'base_path' => current_taxon_title.downcase.tr(' ', '-'),
+          'has_tagged_content?' => true,
         )
       )
     end

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -16,7 +16,9 @@
                 </div>
 
                 <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
-                  <%= render partial: 'email_alerts', locals: { taxon: taxon } %>
+                  <% unless taxon.to_hash['has_tagged_content?'] %>
+                    <%= render partial: 'email_alerts', locals: { taxon: taxon } %>
+                  <% end %>
                   <%= render partial: 'content_list_for_child_taxon', locals: {
                       section_index: index,
                       tagged_content: taxon.tagged_content,

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -16,6 +16,7 @@
                 </div>
 
                 <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
+                  <%= render partial: 'email_alerts', locals: { taxon: taxon } %>
                   <%= render partial: 'content_list_for_child_taxon', locals: {
                       section_index: index,
                       tagged_content: taxon.tagged_content,

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -1,5 +1,4 @@
 <ol class="subsection-list">
-  <%= render partial: 'email_alerts' %>
   <% tagged_content.each_with_index do |content_item, index| %>
     <li class="subsection-list-item">
       <%= link_to(

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -1,4 +1,5 @@
 <ol class="subsection-list">
+  <%= render partial: 'email_alerts' %>
   <% tagged_content.each_with_index do |content_item, index| %>
     <li class="subsection-list-item">
       <%= link_to(

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,7 +1,6 @@
 <div class='subscriptions'>
-  <%=
-    link_to 'Get email alerts for this topic',
-      "/email-signup/?topic=#{taxon.base_path}",
-      class: 'email-alerts'
-  %>
+  <a href="/email-signup/?topic=<%= taxon.base_path %>" class='email-alerts'>
+    Get email alerts for this topic
+    <span class='visuallyhidden'><%= taxon.title %></span>
+  </a>
 </div>

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,0 +1,7 @@
+<div class='subscriptions'>
+  <%=
+    link_to 'Get email alerts for this topic',
+      "/email-signup/?topic=#{taxon.base_path}",
+      class: 'email-alerts'
+  %>
+</div>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -5,7 +5,7 @@
         <%= taxon.title %>
       </h1>
       <p><%= taxon.description %></p>
-      <%= render partial: 'email_alerts' %>
+      <%= render partial: 'email_alerts', locals: { taxon: taxon } %>
     </div>
   </div>
 </div>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -5,6 +5,7 @@
         <%= taxon.title %>
       </h1>
       <p><%= taxon.description %></p>
+      <%= render partial: 'email_alerts' %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<img width="659" alt="pupil_wellbeing__behaviour_and_attendance_-_gov_uk" src="https://cloud.githubusercontent.com/assets/519250/24480986/7bab386e-14df-11e7-9a19-c28d6c140e42.png">


## Hiding signup link on General information and guidance

<img width="687" alt="education_and_funding_for_high_needs__special_educational_needs_and_disability__send__-_gov_uk" src="https://cloud.githubusercontent.com/assets/519250/24500832/f94ea1c0-153e-11e7-960b-beb01cb32465.png">


https://trello.com/c/YImQlqXa/152-1-add-the-email-link-to-navigation-pages
https://trello.com/c/lPlSbZnX/166-3-build-3-types-of-sign-up-pages-backend