### PR TITLE
Add parenting and childcare document collections to guidance list

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -1083,5 +1083,90 @@
     "base_path": "/government/collections/ofsted-examples-of-good-practice-in-art-teaching",
     "surface_collection": false,
     "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/child-poverty-training-materials",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/childhood-neglect-training-resources",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/children-in-need-census",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/children-looked-after-return",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/childrens-social-care-registration-forms",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/early-years-business-sustainability",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/early-years-census",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/early-years-childcare-registering-with-ofsted",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/early-years-foundation-stage-profile-return",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/guidance-for-foster-carers",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/improvement-notices",
+    "surface_collection": true,
+    "surface_content": false
+  },
+  {
+    "base_path": "/government/collections/munro-review",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/national-minimum-standards",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/ofsteds-compliance-investigation-and-enforcement-handbooks",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/ofsteds-inspection-of-early-years-providers",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/open-as-a-childrens-social-care-provider-do-you-need-to-register",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/parental-responsibility-measures-attendance-census",
+    "surface_collection": true,
+    "surface_content": false
   }
 ]


### PR DESCRIPTION
This extends the existing list of education guidance document collections that dictates how collections are represented in the taxonomy navigation.

The display values have been extracted from [this spreadsheet](https://docs.google.com/spreadsheets/d/1pEyhjB8928KhSdH8mG-Mrd4fvlTpgNVlMGNa8QWNZZA/edit#gid=0)

### Trello

https://trello.com/c/CGHK9hH4/551-add-rules-to-the-collections-app-for-document-collections-on-parenting-and-childcare