### PR TITLE
Add meta descriptions to taxon pages

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, taxon.title %>
 <% content_for :page_class, "taxon-page" %>
 <% content_for :meta_tags do %>
+  <meta name="description" content="<%= taxon.description %>">
   <%= ab_variant.analytics_meta_tag.html_safe %>
   <meta name="govuk:navigation-page-type" content="<%=taxon_page_rendering_type(taxon)%>" />
 <% end %>

--- a/test/fixtures/content_store/running_education_institution.json
+++ b/test/fixtures/content_store/running_education_institution.json
@@ -2,6 +2,7 @@
   "base_path": "/education/running-a-further-or-higher-education-institution",
   "content_id": "27c5c52b-3b36-4119-b461-976197d929bf",
   "title": "Running a further or higher education institution",
+  "description": "Running a further or higher education institution - description",
   "links": {
     "parent_taxons": [
       {

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -25,6 +25,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     given_there_is_a_taxon_with_grandchildren
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
+    then_i_can_see_the_meta_description
     then_i_can_see_the_breadcrumbs
     and_i_can_see_the_title_and_description
     and_i_can_see_links_to_the_child_taxons_in_a_grid
@@ -38,6 +39,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     given_there_is_a_taxon_without_grandchildren
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
+    then_i_can_see_the_meta_description
     then_i_can_see_the_breadcrumbs
     and_i_can_see_the_title_and_description
     and_i_can_see_the_general_information_section_in_the_accordion
@@ -58,6 +60,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     given_there_is_a_taxon_without_child_taxons
     when_i_visit_the_taxon_page
     then_i_can_see_there_is_a_page_title
+    then_i_can_see_the_meta_description
     then_i_can_see_the_breadcrumbs
     and_i_can_see_the_title_and_description
     and_i_can_see_tagged_content_to_the_taxon
@@ -165,6 +168,16 @@ private
     with_B_variant do
       visit @base_path
     end
+  end
+
+  def then_i_can_see_the_meta_description
+    content = page.find('meta[name="description"]', visible: false)['content']
+
+    assert_equal(
+      @taxon.description,
+      content,
+      "The content of the meta description should be the taxon description"
+    )
   end
 
   def then_i_can_see_there_is_a_page_title


### PR DESCRIPTION
The meta description is the same as the taxon description.

This is needed because otherwise it's defaulting to the banner text re Brexit.