### PR TITLE
Add tracking attribute to accordion sections

### DIFF
--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -7,7 +7,7 @@
           <div class="subsection-wrapper">
 
             <% accordion_content.each_with_index do |taxon, index| %>
-              <div class="subsection js-subsection" id="<%= taxon.base_path %>">
+              <div class="subsection js-subsection" id="<%= taxon.base_path %>" data-track-count="accordionSection">
                 <div class="subsection-header js-subsection-header">
                   <h2 class="subsection-title js-subsection-title"><%= taxon.title %></h2>
                   <% if taxon.description.present? %>


### PR DESCRIPTION
It’s useful to have a handle on the accordion when trying to select
it or its descendants using CSS.

In particular, this will be used for tracking the number of links
inside an accordion, and the number of sections in it.

### Trello

https://trello.com/c/VS6HcoBS/556-track-the-total-number-of-links-and-sections-for-accordions-and-related-links