### PR TITLE
Enable Heroku review apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/rails server -p $PORT -e $RAILS_ENV
+web: GOVUK_ASSET_ROOT=https://${HEROKU_APP_NAME}.herokuapp.com bin/rails server -p $PORT -e $RAILS_ENV

--- a/app.json
+++ b/app.json
@@ -1,0 +1,40 @@
+{
+  "name": "collections",
+  "repository": "https://github.com/alphagov/collections",
+  "env": {
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_ASSET_ROOT": {
+      "value": "https://govuk-collections.herokuapp.com"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_SEARCH_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_STATIC_URI": {
+      "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "RAILS_SERVE_STATIC_ASSETS": {
+      "value": "yes"
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    }
+  },
+  "image": "heroku/ruby",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": []
+}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,6 +35,10 @@ Collections::Application.configure do
   # Version of your assets, change this if you want to expire all your assets.
   config.assets.version = '1.0'
 
+  if ENV['RAILS_SERVE_STATIC_ASSETS'] == 'yes'
+    config.serve_static_assets = true
+  end
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx


### PR DESCRIPTION
This commit allows us to deploy the application to Heroku and therefore
enable review apps for each PR.

App is currently running on http://govuk-collections.herokuapp.com/education

With this in the repo I will be able enable review apps.