### PR TITLE
Fix the accordion heading tracking

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -303,7 +303,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function clickedOnHeading() {
-        return $target.hasClass('js-subsection-title-link');
+        return !!$target.parents('.js-subsection-title-link')
+          || $target.hasClass('js-subsetion-title-link');
       }
 
       function iconType() {


### PR DESCRIPTION
When we click on an accordion section to expand it, we send a tracking
event to Google Analytics (GA), including where on the accordion section
the user clicked. This may be one of:

- Heading
- Plus/Minus icon
- “Elsewhere” (basically the whitespace or the description)

However, heading clicks were previously being recorded as “elsewhere”
for many cases. This is because we consider the click to be on the
heading if the target of the click event is the link. However, some
browsers target the `<h2>` (child of the link) as the receiver of the
click event, which then registers as “elsewhere”.

So now we check if the target is, or has a parent that is the link.

### Trello

https://trello.com/c/GwqSByOV/89-review-accordion-heading-click-event-tracking