### PR TITLE
Fix link check

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -303,7 +303,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function clickedOnHeading() {
-        return !!$target.parents('.js-subsection-title-link')
+        return !!$target.parents('.js-subsection-title-link').length
           || $target.hasClass('js-subsetion-title-link');
       }
 


### PR DESCRIPTION
We had previously removed `.length` from the check for where on the
accordion we clicked, but actually jQuery returns a non-falsy
Object with a `length` of `0`.

### Trello

https://trello.com/c/GwqSByOV/89-review-accordion-heading-click-event-tracking