### PR TITLE
Use new analytics JavaScript interface

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -349,9 +349,15 @@
     trackPageview: function(state){
       var sectionTitle = this.$section.find('h1').text();
       sectionTitle = sectionTitle ? sectionTitle.toLowerCase() : 'browse';
-      if (GOVUK.analytics && GOVUK.analytics.trackPageview && GOVUK.analytics.setSectionDimension) {
-        GOVUK.analytics.setSectionDimension(sectionTitle);
-        GOVUK.analytics.trackPageview(state.path);
+
+      if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
+        GOVUK.analytics.trackPageview(
+          state.path,
+          null,
+          {
+            dimension1: sectionTitle
+          }
+        );
       }
     }
   };


### PR DESCRIPTION
We are making the Analytics tracking interface more explicit in which
methods are used external to the module. This involves:

- removing the methods that set custom dimensions at a session level,
  and instead explicitly setting custom dimensions on the pageview
- removing the `callOnNextPage` method, which allowed arbitrary running
  of any public methods on the analytics interface, where we just need
  to set options for the next page

## Trello

https://trello.com/c/5dIbwHvU/120-tidy-up-tracking-changes