### PR TITLE
Update accordion tracking

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -212,6 +212,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var shouldUpdateHash = true;
 
       this.title = $subsectionElement.find('.js-subsection-title').text();
+      this.href = $titleLink.attr('href');
       this.element = $subsectionElement;
 
       this.open = open;
@@ -221,6 +222,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.isOpen = isOpen;
       this.isClosed = isClosed;
       this.preventHashUpdate = preventHashUpdate;
+      this.numberOfContentItems = numberOfContentItems;
 
       function open() {
         setIsOpen(true);
@@ -255,6 +257,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       function preventHashUpdate() {
         shouldUpdateHash = false;
       }
+
+      function numberOfContentItems() {
+        return $subsectionContent.find('li').length;
+      }
     }
 
     function updateHash($subsectionElement) {
@@ -278,6 +284,18 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function trackClick() {
         accordionTracker.track('pageElementInteraction', trackingAction(), {label: trackingLabel()});
+        
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(
+            'navAccordionLinkClicked',
+            String(subsectionIndex()),
+            {
+              label: subsectionView.href,
+              dimension28: String(subsectionView.numberOfContentItems()),
+              dimension29: subsectionView.title
+            }
+          )
+        }
       }
 
       function trackingLabel() {

--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -141,7 +141,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           var subsectionView = new SubsectionView($(this).closest('.js-subsection'));
           subsectionView.toggle();
 
-          var toggleClick = new SubsectionToggleClick(subsectionView, accordionTracker, event);
+          var toggleClick = new SubsectionToggleClick(subsectionView, $subsections, accordionTracker);
           toggleClick.track();
 
           setOpenCloseAllText();
@@ -212,6 +212,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       var shouldUpdateHash = true;
 
       this.title = $subsectionElement.find('.js-subsection-title').text();
+      this.element = $subsectionElement;
 
       this.open = open;
       this.close = close;
@@ -272,43 +273,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       history.replaceState({}, '', newLocation);
     }
 
-    // A constructor for an object that represents a click event on a subsection which
-    // handles the complexity of sending different tracking labels to Google Analytics
-    // depending on which part of the subsection the user clicked.
-    function SubsectionToggleClick(subsectionView, accordionTracker, event) {
-      var $target = $(event.target);
-
+    function SubsectionToggleClick(subsectionView, $subsections, accordionTracker) {
       this.track = trackClick;
 
       function trackClick() {
         accordionTracker.track('pageElementInteraction', trackingAction(), {label: trackingLabel()});
       }
 
+      function trackingLabel() {
+        return subsectionIndex() + '. ' + subsectionView.title;
+      }
+
+      function subsectionIndex() {
+        return $subsections.index(subsectionView.element) + 1;
+      }
+
       function trackingAction() {
         return (subsectionView.isClosed() ? 'accordionClosed' : 'accordionOpened');
-      }
-
-      function trackingLabel() {
-        if (clickedOnIcon()) {
-          return subsectionView.title + ' - ' + iconType() + ' Click';
-        } else if (clickedOnHeading()) {
-          return subsectionView.title + ' - Heading Click';
-        } else {
-          return subsectionView.title + ' - Click Elsewhere';
-        }
-      }
-
-      function clickedOnIcon() {
-        return $target.hasClass('subsection-icon');
-      }
-
-      function clickedOnHeading() {
-        return !!$target.parents('.js-subsection-title-link').length
-          || $target.hasClass('js-subsetion-title-link');
-      }
-
-      function iconType() {
-        return (subsectionView.isClosed() ? 'Minus' : 'Plus');
       }
     }
 


### PR DESCRIPTION
## Update accordion tracking label

When clicking an accordion heading, we send a tracking event. We
previously tracked where on the header we clicked:

- on the heading link
- on the +/- icon
- anywhere else (whitespace or description)

In analysis, this amount of information in the tracking label was too
verbose, so we are removing it.

Instead, we now return just the heading, and its position in the
accordion. For example, if we have a taxon entitled “Phonics” as the
fourth taxon in the accordion, if that section is expanded the tracking
label will be `4. Phonics`.

## Track extra event for accordion heading clicks

This change adds an extra event to accordion heading clicks that aligns
with the event submitted when a content item is clicked in an accordion
(see: https://github.com/alphagov/collections/blob/b8b3313abdd960f8ad6fa99eb7107a9fe12d8a94/app/views/taxons/_content_list_for_child_taxon.html.erb#L7-L14).

This behaviour is also more consistent with the taxonomy sidebar
tracking, where the sidebar heading is tracked as well as the listed
items.

## Trello

https://trello.com/c/udNckXa7/117-amend-accordion-analytics-tracking