### PR TITLE
Send extra accordion click tracking event on open only

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -284,9 +284,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       function trackClick() {
         accordionTracker.track('pageElementInteraction', trackingAction(), {label: trackingLabel()});
-        
-        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
-          GOVUK.analytics.trackEvent(
+
+        if (!subsectionView.isClosed()) {
+          accordionTracker.track(
             'navAccordionLinkClicked',
             String(subsectionIndex()),
             {
@@ -316,6 +316,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     function AccordionTracker(totalSubsections) {
       this.track = function(category, action, options) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          options = options || {};
           options["dimension28"] = totalSubsections.toString();
           GOVUK.analytics.trackEvent(category, action, options);
         }


### PR DESCRIPTION
When an accordion section heading is clicked, we fire two events:

- track a `pageElementInteraction` to record whether the accordion was
  opened or closed
- track a `navAccordionLinkClicked` similar to when clicking content
  items in an accordion section

In order to make our `navAccordionLinkClicked` tracking “cleaner”, we
only track a click if the accordion is being opened, which indicates
that the contents of that section have been exposed, and the number of
clicks on the accordion heading can be directly compared with the
number of clicks on a content item.

### Trello

https://trello.com/c/udNckXa7/117-amend-accordion-analytics-tracking