### PR TITLE
Track link clicks on browse pages

### DIFF
--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,14 +1,27 @@
 <div id="root" class="pane root-pane">
   <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
   <ul>
-    <% top_level_browse_pages.each do |page| %>
+    <% top_level_browse_pages.each_with_index do |page, index| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">
         <% link_class = if ab_variant.variant_b? && page.base_path == "/browse/education"
           "ab-test-redirect"
         else
           ""
         end %>
-        <%= link_to page.title, page.base_path, class: link_class %>
+        <%= link_to(
+          page.title,
+          page.base_path,
+          class: link_class,
+          data: {
+            track_category: 'firstLevelBrowseLinkClicked',
+            track_action: "#{index + 1}",
+            track_label: page.base_path,
+            track_options: {
+              dimension28: top_level_browse_pages.count.to_s,
+              dimension29: page.title,
+            },
+          },
+        ) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "All categories" %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes root">
+<div class="browse-panes root" data-module="track-click">
   <%= render 'top_level_browse_pages',
     top_level_browse_pages: page.top_level_browse_pages,
     ab_variant: ab_variant %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <% content_for :page_class, "browse" %>
 
-<div class="browse-panes section" data-state="section">
+<div class="browse-panes section" data-state="section" data-module="track-click">
   <div id="section" class="section-pane pane with-sort">
     <%= render 'second_level_browse_page/second_level_browse_pages',
           title: page.title,

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,7 +1,7 @@
 <div class="pane-inner <%= page.lists.curated? ? 'curated-list' : 'a-to-z' %>">
   <h1 tabindex="-1"><%= page.title %></h1>
 
-  <% page.lists.each do |list| %>
+  <% page.lists.each_with_index do |list, section_index| %>
     <% if page.lists.curated? %>
       <h2 class='list-header'><%= list.title %></h2>
     <% else %>
@@ -9,8 +9,22 @@
     <% end %>
 
     <ul>
-      <% list.contents.each do |list_item| %>
-        <li><%= link_to list_item.title, list_item.base_path %></li>
+      <% list.contents.each_with_index do |list_item, index| %>
+        <li>
+          <%= link_to(
+            list_item.title,
+            list_item.base_path,
+            data: {
+              track_category: 'thirdLevelBrowseLinkClicked',
+              track_action: "#{section_index + 1}.#{index + 1}",
+              track_label: list_item.base_path,
+              track_options: {
+                dimension28: list.contents.count.to_s,
+                dimension29: list_item.title,
+              },
+            },
+          ) %>
+        </li>
       <% end %>
     </ul>
   <% end %>
@@ -19,8 +33,22 @@
     <div class="detailed-guidance">
       <h2>Detailed guidance</h2>
       <ul>
-        <% page.related_topics.each do |related_topic| %>
-          <li><%= link_to related_topic.title, related_topic.base_path %></li>
+        <% page.related_topics.each_with_index do |related_topic, index| %>
+          <li>
+            <%= link_to(
+              related_topic.title,
+              related_topic.base_path,
+              data: {
+                track_category: 'thirdLevelBrowseLinkClicked',
+                track_action: "#{page.lists.count + 1}.#{index + 1}",
+                track_label: related_topic.base_path,
+                track_options: {
+                  dimension28: page.related_topics.count.to_s,
+                  dimension29: related_topic.title,
+                },
+              },
+            ) %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -4,9 +4,20 @@
     <p class="sort-order"><%= hairspace 'A to Z' %></p>
   <% end %>
   <ul>
-    <% second_level_browse_pages.each do |browse_page| %>
+    <% second_level_browse_pages.each_with_index do |browse_page, index| %>
       <li class='<%= browsing_in_second_level_page?(browse_page) ? 'active' : nil %>'>
-        <%= link_to browse_page.base_path do %>
+        <%= link_to(
+          browse_page.base_path,
+          data: {
+            track_category: 'secondLevelBrowseLinkClicked',
+            track_action: "#{index + 1}",
+            track_label: browse_page.base_path,
+            track_options: {
+              dimension28: second_level_browse_pages.count.to_s,
+              dimension29: browse_page.title,
+            },
+          },
+        ) do %>
           <h3><%= browse_page.title %></h3>
           <p><%= browse_page.description %></p>
         <% end %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -11,7 +11,7 @@
   <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
 
-<div class="browse-panes subsection" data-state="subsection">
+<div class="browse-panes subsection" data-state="subsection" data-module="track-click">
   <div id="subsection" class="subsection-pane pane with-sort">
     <%= render 'links', page: page %>
   </div>


### PR DESCRIPTION
This change introduces click event tracking identical to the tracking
already implemented on taxonomy navigation pages (grid, accordion, etc.),
where we track an event every time a link is clicked with:

- the title of the link
- the `href` of the link
- the position of the link in its list
- the number of other links in its list