### PR TITLE
Test email alert link and refactor logic

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -26,13 +26,18 @@ private
     current_taxon_title = 'General information and guidance'
 
     if taxon.tagged_content.count > 0
-      accordion_items.unshift(
-        taxon.merge(
+      general_information = Taxon.new(
+        ContentItem.new(
+          'content_id' => taxon.content_id,
           'title' => current_taxon_title,
-          'description' => '',
           'base_path' => current_taxon_title.downcase.tr(' ', '-'),
-          'has_tagged_content?' => true,
+          'description' => ''
         )
+      )
+      general_information.can_subscribe = false
+
+      accordion_items.unshift(
+        general_information
       )
     end
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,5 +1,7 @@
 class Taxon
   attr_reader :content_item
+  attr_accessor :can_subscribe, :tagged_content
+
   delegate(
     :content_id,
     :base_path,
@@ -53,5 +55,11 @@ class Taxon
 
   def merge(to_merge)
     Taxon.new(content_item.merge(to_merge))
+  end
+
+  def can_subscribe?
+    return @can_subscribe if defined?(@can_subscribe)
+
+    true
   end
 end

--- a/app/views/taxons/_child_taxons_list.html.erb
+++ b/app/views/taxons/_child_taxons_list.html.erb
@@ -16,7 +16,7 @@
                 </div>
 
                 <div class="subsection-content js-subsection-content" id="subsection_content_<%= index + 1 %>">
-                  <% unless taxon.to_hash['has_tagged_content?'] %>
+                  <% if taxon.can_subscribe? %>
                     <%= render partial: 'email_alerts', locals: { taxon: taxon } %>
                   <% end %>
                   <%= render partial: 'content_list_for_child_taxon', locals: {

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -33,6 +33,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_grid
+    and_i_can_see_an_email_signup_link
   end
 
   it 'is possible to browse a taxon page that does not have grandchildren' do
@@ -47,6 +48,8 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_the_accordion_has_tracking_attributes
     and_i_can_see_tagged_content_to_the_taxon
     and_the_page_is_tracked_as_an_accordion
+    and_i_can_see_an_email_signup_link
+    and_all_sections_apart_from_general_information_have_an_email_signup_link
   end
 
   it 'does not show the general information section when there is no content tagged' do
@@ -66,6 +69,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_tagged_content_to_the_taxon
     and_the_content_tagged_to_the_leaf_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_leaf_node_taxon
+    and_i_can_see_an_email_signup_link
   end
 
 private
@@ -316,6 +320,30 @@ private
 
   def and_the_page_is_tracked_as_a_leaf_node_taxon
     assert_navigation_page_type_tracking("leaf")
+  end
+
+  def and_i_can_see_an_email_signup_link
+    govuk_title = page.find('.govuk-title')
+
+    assert govuk_title.has_link?(
+      'Get email alerts for this topic',
+      href: "/email-signup/?topic=#{current_path}"
+    )
+  end
+
+  def and_all_sections_apart_from_general_information_have_an_email_signup_link
+    general_information, *subsections = page.all('.subsection').to_a
+
+    refute general_information.has_link?(
+      'Get email alerts for this topic'
+    )
+
+    subsections.each do |subsection|
+      assert subsection.has_link?(
+        'Get email alerts for this topic',
+        href: "/email-signup/?topic=#{subsection[:id]}"
+      )
+    end
   end
 
   def assert_navigation_page_type_tracking(expected_page_type)


### PR DESCRIPTION
This commit adds tests for the email subscription link on navigation
pages. It also refactors logic around when to show the email
subscription link on accordion pages so it's clearer. On accordion
pages, the "General Information and Guidance" section should not have
the email subscription link on it, so I've renamed the method to
indicate that.