### PR TITLE
Showing the practice materials collections in nav

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -1006,8 +1006,8 @@
   },
   {
     "base_path": "/government/collections/national-curriculum-assessments-practice-materials",
-    "surface_collection": false,
-    "surface_content": true
+    "surface_collection": true,
+    "surface_content": false
   },
   {
     "base_path": "/government/collections/higher-education-and-research-bill",


### PR DESCRIPTION
We should surface the document collection "National curriculum
assessments: practice materials" instead of its content items, otherwise
the accordion section is too long and confusing.

Change requested by Graeme.