### PR TITLE
Add associated taxons support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Collections serves the GOV.UK browse and topic pages.
   `child_taxons` links. None of those child taxons' links have `child_taxons`,
   in which case we display an accordion view:
   [gov.uk/education/school-governance](https://www-origin.integration.publishing.service.gov.uk/education/school-governance)
+- **Taxon with associated taxons**: a content item of type taxon that has
+  `associated_taxons` links. In this case the tagged content of the taxon will
+  include content that is directly tagged to it and also content that has been
+  tagged to any of the associated taxons.
+  
 
 ## Technical documentation
 

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -79,8 +79,6 @@ private
 
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
-    taxon_content_ids.inject([]) do |content, taxon_content_id|
-      content + TaggedContent.fetch(taxon_content_id)
-    end
+    TaggedContent.fetch(taxon_content_ids)
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -79,8 +79,8 @@ private
 
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
-    taxon_content_ids.inject([]) do |result, content_id|
-      result + TaggedContent.fetch(content_id)
+    taxon_content_ids.inject([]) do |content, taxon_content_id|
+      content + TaggedContent.fetch(taxon_content_id)
     end
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -17,7 +17,7 @@ class Taxon
   end
 
   def tagged_content
-    @tagged_content ||= TaggedContent.fetch(content_id)
+    @tagged_content ||= fetch_tagged_content
   end
 
   def most_popular_content
@@ -59,6 +59,12 @@ class Taxon
     end
   end
 
+  def associated_taxons
+    linked_items('associated_taxons').map do |associated_taxon|
+      self.class.new(associated_taxon)
+    end
+  end
+
   def merge(to_merge)
     Taxon.new(content_item.merge(to_merge))
   end
@@ -67,5 +73,14 @@ class Taxon
     return @can_subscribe if defined?(@can_subscribe)
 
     true
+  end
+
+private
+
+  def fetch_tagged_content
+    taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
+    taxon_content_ids.inject([]) do |result, content_id|
+      result + TaggedContent.fetch(content_id)
+    end
   end
 end

--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -1,12 +1,12 @@
 class TaggedContent
-  attr_reader :content_id
+  attr_reader :content_ids
 
-  def initialize(content_id)
-    @content_id = content_id
+  def initialize(content_ids)
+    @content_ids = Array(content_ids)
   end
 
-  def self.fetch(content_id)
-    new(content_id).fetch
+  def self.fetch(content_ids)
+    new(content_ids).fetch
   end
 
   def fetch
@@ -27,7 +27,7 @@ private
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
       filter_navigation_document_supertype: 'guidance',
-      filter_taxons: [content_id],
+      filter_taxons: content_ids,
       order: 'title',
     )
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,4 +34,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Enable context in tests
+  config.minitest_spec_rails.mini_shoulda = true
 end

--- a/test/fixtures/content_store/travelling_to_the_usa.json
+++ b/test/fixtures/content_store/travelling_to_the_usa.json
@@ -1,0 +1,27 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da501",
+  "title": "Travelling to the USA",
+  "description": "Includes travel advice and how to get married abroad.",
+  "base_path": "\/world\/usa\/travelling-to-the-usa",
+  "locale": "en",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da500",
+        "locale": "en",
+        "title": "USA",
+        "description": "USA worldwide taxon",
+        "base_path": "\/world\/usa"
+      }
+    ],
+    "associated_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da506",
+        "locale": "en",
+        "title": "Travelling Abroad",
+        "description": "General advice for travelling abroad",
+        "base_path": "\/world\/travelling-abroad"
+      }
+    ]
+  }
+}

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -267,19 +267,7 @@ private
     @taxon = Taxon.find(@base_path)
     @associated_taxon = Taxon.find(associate_base_path)
 
-    taxon_content = ["/taxon-slug-1", "/taxon-slug-2"].map do |slug|
-      rummager_document_for_slug(slug)
-    end
-
-    associate_content = [
-      "/associated-taxon-slug-3",
-      "/associated-taxon-slug-4"
-    ].map do |slug|
-      rummager_document_for_slug(slug)
-    end
-
-    stub_content_for_taxon(@taxon.content_id, taxon_content)
-    stub_content_for_taxon(associate_content_id, associate_content)
+    stub_content_for_taxon([@taxon.content_id, associate_content_id], search_results)
   end
 
   def and_that_taxon_has_few_content_items_tagged_to_it
@@ -426,23 +414,8 @@ private
     end
   end
 
-  def and_i_can_see_content_tagged_to_the_taxon_and_the_associate
-    expected_content = [
-      "/taxon-slug-1",
-      "/taxon-slug-2",
-      "/associated-taxon-slug-3",
-      "/associated-taxon-slug-4"
-    ].map do |slug|
-      rummager_document_for_slug(slug)
-    end
-
-    expected_content.each do |content_item|
-      assert page.has_link?(content_item['title'], href: /^.*#{content_item['link']}$/),
-        "expected page to have link with #{content_item['title']}"
-      assert page.has_content?(content_item['description']),
-        "expected page to have content #{content_item['description']}"
-    end
-  end
+  alias_method :and_i_can_see_content_tagged_to_the_taxon_and_the_associate,
+    :and_i_can_see_content_tagged_to_the_taxon
 
   def and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
     assert_leaf_tracking_attributes_present(

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -36,7 +36,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_title_and_description
     and_i_can_see_links_to_the_child_taxons_in_a_grid
     and_the_grid_has_tracking_attributes
-    and_i_can_see_tagged_content_to_the_taxon
+    and_i_can_see_content_tagged_to_the_taxon
     and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_grid
     and_i_can_see_an_email_signup_link
@@ -53,7 +53,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_general_information_section_in_the_accordion
     and_i_can_see_links_to_the_child_taxons_in_an_accordion
     and_the_accordion_has_tracking_attributes
-    and_i_can_see_tagged_content_to_the_taxon
+    and_i_can_see_content_tagged_to_the_taxon
     and_the_page_is_tracked_as_an_accordion
     and_i_can_see_an_email_signup_link
     and_all_sections_apart_from_general_information_have_an_email_signup_link
@@ -75,7 +75,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     then_i_can_see_the_meta_description
     then_i_can_see_the_breadcrumbs
     and_i_can_see_the_title_and_description
-    and_i_can_see_tagged_content_to_the_taxon
+    and_i_can_see_content_tagged_to_the_taxon
     and_the_content_tagged_to_the_leaf_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_leaf_node_taxon
     and_i_can_see_an_email_signup_link
@@ -379,7 +379,7 @@ private
     )
   end
 
-  def and_i_can_see_tagged_content_to_the_taxon
+  def and_i_can_see_content_tagged_to_the_taxon
     search_results.each do |search_result|
       assert page.has_link?(search_result['title'], href: /^.*#{search_result['link']}$/)
       assert page.has_content?(search_result['description'])

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -67,12 +67,8 @@ describe Taxon do
       associated_taxon_content_id = "36dd87da-4973-5490-ab00-72025b1da506"
 
       TaggedContent.expects(:fetch)
-        .with(own_content_id)
-        .returns(["own content"])
-
-      TaggedContent.expects(:fetch)
-        .with(associated_taxon_content_id)
-        .returns(["associated content"])
+        .with([own_content_id, associated_taxon_content_id])
+        .returns(["own content", "associated content"])
 
       assert_equal ["own content", "associated content"],
         @taxon.tagged_content

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -3,54 +3,79 @@ require 'test_helper'
 describe Taxon do
   include TaxonHelpers
 
-  setup do
-    content_item = ContentItem.new(student_finance_taxon)
-    @taxon = Taxon.new(content_item)
-  end
+  context "with associate_taxons" do
+    setup do
+      content_item = ContentItem.new(student_finance_taxon)
+      @taxon = Taxon.new(content_item)
+    end
 
-  it 'has a title' do
-    assert_equal @taxon.title, student_finance_taxon['title']
-  end
+    it 'has a title' do
+      assert_equal @taxon.title, student_finance_taxon['title']
+    end
 
-  it 'has a description' do
-    assert_equal @taxon.description, student_finance_taxon['description']
-  end
+    it 'has a description' do
+      assert_equal @taxon.description, student_finance_taxon['description']
+    end
 
-  it 'has a content id' do
-    assert_equal @taxon.content_id, student_finance_taxon['content_id']
-  end
+    it 'has a content id' do
+      assert_equal @taxon.content_id, student_finance_taxon['content_id']
+    end
 
-  it 'has a base path' do
-    assert_equal @taxon.base_path, student_finance_taxon['base_path']
-  end
+    it 'has a base path' do
+      assert_equal @taxon.base_path, student_finance_taxon['base_path']
+    end
 
-  it 'has two taxon children' do
-    assert_equal @taxon.child_taxons.length, 2
+    it 'has two taxon children' do
+      assert_equal @taxon.child_taxons.length, 2
 
-    @taxon.child_taxons.each do |child|
-      assert_instance_of Taxon, child
-      assert_includes ['Student sponsorship', 'Student loans'], child.title
+      @taxon.child_taxons.each do |child|
+        assert_instance_of Taxon, child
+        assert_includes ['Student sponsorship', 'Student loans'], child.title
+      end
+    end
+
+    it 'has grandchildren' do
+      taxon = stub(children?: true)
+      Taxon.stubs(:find).returns(taxon)
+
+      assert @taxon.grandchildren?
+    end
+
+    it 'does not have grandchildren' do
+      taxon = stub(children?: false)
+      Taxon.stubs(:find).returns(taxon)
+
+      assert not(@taxon.grandchildren?)
+    end
+
+    it 'knows about its most popular content items' do
+      results = [:result_1, :result_2]
+      MostPopularContent.stubs(:fetch).returns(results)
+
+      assert_equal(results, @taxon.most_popular_content)
     end
   end
 
-  it 'has grandchildren' do
-    taxon = stub(children?: true)
-    Taxon.stubs(:find).returns(taxon)
+  context "with associated_taxons" do
+    setup do
+      content_item = ContentItem.new(travelling_to_the_usa_taxon)
+      @taxon = Taxon.new(content_item)
+    end
 
-    assert @taxon.grandchildren?
-  end
+    it "retrieves content tagged to itself and associated_taxons" do
+      own_content_id = @taxon.content_id
+      associated_taxon_content_id = "36dd87da-4973-5490-ab00-72025b1da506"
 
-  it 'does not have grandchildren' do
-    taxon = stub(children?: false)
-    Taxon.stubs(:find).returns(taxon)
+      TaggedContent.expects(:fetch)
+        .with(own_content_id)
+        .returns(["own content"])
 
-    assert not(@taxon.grandchildren?)
-  end
+      TaggedContent.expects(:fetch)
+        .with(associated_taxon_content_id)
+        .returns(["associated content"])
 
-  it 'knows about its most popular content items' do
-    results = [:result_1, :result_2]
-    MostPopularContent.stubs(:fetch).returns(results)
-
-    assert_equal(results, @taxon.most_popular_content)
+      assert_equal ["own content", "associated content"],
+        @taxon.tagged_content
+    end
   end
 end

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -210,6 +210,12 @@ describe TaggedContent do
         tagged_content.fetch
       end
     end
+
+    it 'allows multiple content_ids' do
+      assert_includes_params(filter_taxons: ["test-content-id-one", "test-content-id-two"]) do
+        TaggedContent.fetch(["test-content-id-one", "test-content-id-two"])
+      end
+    end
   end
 
 private

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,11 +1,11 @@
 module RummagerHelpers
-  def stub_content_for_taxon(content_id, results)
+  def stub_content_for_taxon(content_ids, results)
     Services.rummager.stubs(:search).with(
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
       filter_navigation_document_supertype: 'guidance',
-      filter_taxons: [content_id],
+      filter_taxons: Array(content_ids),
       order: 'title',
     ).returns(
       "results" => results,

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -26,6 +26,11 @@ module TaxonHelpers
     fetch_and_validate_taxon(:world_usa, params)
   end
 
+  # This taxon has an associated_taxon
+  def travelling_to_the_usa_taxon(params = {})
+    fetch_and_validate_taxon(:travelling_to_the_usa, params)
+  end
+
 private
 
   def fetch_and_validate_taxon(basename, params = {})


### PR DESCRIPTION
We have added a new link type `associated_taxons` which allows a taxon to be associated with another. The effect of this association is that content tagged to the associated taxon(s) is included in the content of the taxon that declares the association.

e.g.

* `usa` taxon has `child_taxons` of `[travelling-in-the-usa]`
* `travelling-in-the-usa` has `associated_taxons` of `[travelling-abroad]`

The taxon page for `usa` would display a 'Travelling in the USA' heading. The 'Travelling in the USA' heading would contain content tagged to `travelling-in-the-usa` and also any content tagged to `travelling-abroad` .

This PR adds support for this feature.

[Trello](https://trello.com/c/r3jl4SE4/178-allow-contents-of-associated-taxons-to-be-displayed-on-a-taxon-navigation-page)

Discussed with @carvil how we can include this associated taxon content in the `#most_popular_content` results. We don't necessarily require this currently but it makes sense for it to be included in the results. Any suggestions welcome. 
