### PR TITLE
Document Whitehall bound email and feed links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ Collections serves the GOV.UK browse and topic pages.
 This is a public facing Ruby on Rails application that retrieves browse content from APIs and presents it.
 There is no underlying persistence layer and all content is retrieved from external sources.
 
+### Whitehall email and feed links for World Locations
+
+A special case exists within Collections to allow email links on Taxon pages to be generated
+such that they point to the email subscription logic in Whitehall. This is
+currently implemented in `app/helpers/email_helper.rb` with the branching logic
+sitting in `app/views/taxons/_email_alerts.html`.
+
+The intention is to migrate rendering of World Location pages from Whitehall to
+Collections. Whitehall serves these from `/government/world/{world_location}`.
+Collections will serve these from `/world/{world_location}`.
+
+The helper currently tests for `base_path` starting with `/world` and provides two methods;
+one to create an atom link and one to create an email link.
+
+Once email subscriptions for World Locations have been completely ported to use
+Email Alert Api, this functionality can be removed.
+
 ### Dependencies
 
 - [content-store](https://github.com/alphagov/content-store), provides:


### PR DESCRIPTION
Add documentation for functionality added in https://github.com/alphagov/collections/pull/347

[Trello](https://trello.com/c/2Xk5rE3k/197-add-whitehall-email-and-atom-links-to-taxonomy-views)