### PR TITLE
Fetch all document types for world taxons

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ one to create an atom link and one to create an email link.
 Once email subscriptions for World Locations have been completely ported to use
 Email Alert Api, this functionality can be removed.
 
+### Content for taxon pages
+
+Content for taxon pages is returned by a search in Rummager based on content_ids. By default this content is filtered by `filter_navigation_document_supertype: 'guidance'`. However for content tagged to the `/world` taxon, this restriction is lifted so that _all_ content is returned from Rummager.
+
 ### Dependencies
 
 - [content-store](https://github.com/alphagov/content-store), provides:

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -21,9 +21,7 @@ class Taxon
   end
 
   def most_popular_content
-    @most_popular_content ||= MostPopularContent.fetch(
-      content_id: content_id,
-    )
+    @most_popular_content ||= fetch_most_popular_content
   end
 
   def self.find(base_path)
@@ -80,6 +78,10 @@ private
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
     TaggedContent.fetch(taxon_content_ids, filter_by_document_supertype: navigation_document_supertype)
+  end
+
+  def fetch_most_popular_content
+    MostPopularContent.fetch(content_id: content_id, filter_by_document_supertype: navigation_document_supertype)
   end
 
   def navigation_document_supertype

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -79,6 +79,14 @@ private
 
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
-    TaggedContent.fetch(taxon_content_ids)
+    TaggedContent.fetch(taxon_content_ids, filter_by_document_supertype: navigation_document_supertype)
+  end
+
+  def navigation_document_supertype
+    'guidance' unless world_related?
+  end
+
+  def world_related?
+    base_path.starts_with?("/world")
   end
 end

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,13 +1,14 @@
 class MostPopularContent
-  attr_reader :content_id, :number_of_links
+  attr_reader :content_id, :filter_by_document_supertype, :number_of_links
 
-  def initialize(content_id:, number_of_links: 5)
+  def initialize(content_id:, filter_by_document_supertype:, number_of_links: 5)
     @content_id = content_id
+    @filter_by_document_supertype = filter_by_document_supertype
     @number_of_links = number_of_links
   end
 
-  def self.fetch(content_id:)
-    new(content_id: content_id).fetch
+  def self.fetch(content_id:, filter_by_document_supertype:)
+    new(content_id: content_id, filter_by_document_supertype: filter_by_document_supertype).fetch
   end
 
   def fetch
@@ -19,13 +20,15 @@ class MostPopularContent
 private
 
   def search_response
-    RummagerSearch.new(
+    params = {
       start: 0,
       count: number_of_links,
       fields: %w(title link),
-      filter_navigation_document_supertype: 'guidance',
       filter_part_of_taxonomy_tree: content_id,
       order: '-popularity',
-    )
+    }
+    params[:filter_navigation_document_supertype] = filter_by_document_supertype if filter_by_document_supertype.present?
+
+    RummagerSearch.new(params)
   end
 end

--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -1,12 +1,13 @@
 class TaggedContent
-  attr_reader :content_ids
+  attr_reader :content_ids, :filter_by_document_supertype
 
-  def initialize(content_ids)
+  def initialize(content_ids, filter_by_document_supertype:)
     @content_ids = Array(content_ids)
+    @filter_by_document_supertype = filter_by_document_supertype
   end
 
-  def self.fetch(content_ids)
-    new(content_ids).fetch
+  def self.fetch(content_ids, filter_by_document_supertype:)
+    new(content_ids, filter_by_document_supertype: filter_by_document_supertype).fetch
   end
 
   def fetch
@@ -22,13 +23,15 @@ private
   end
 
   def search_response
-    RummagerSearch.new(
+    params = {
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
-      filter_navigation_document_supertype: 'guidance',
       filter_taxons: content_ids,
       order: 'title',
-    )
+    }
+    params[:filter_navigation_document_supertype] = filter_by_document_supertype if filter_by_document_supertype.present?
+
+    RummagerSearch.new(params)
   end
 end

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -6,7 +6,10 @@ describe TaxonsController do
 
   describe "GET show" do
     before do
-      content_store_has_item("/education", content_id: "education-content-id", title: "Education")
+      content_store_has_item("/education",
+                             content_id: "education-content-id",
+                             base_path: "/education",
+                             title: "Education")
       stub_content_for_taxon("education-content-id", [])
     end
 

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -267,7 +267,7 @@ private
     @taxon = Taxon.find(@base_path)
     @associated_taxon = Taxon.find(associate_base_path)
 
-    stub_content_for_taxon([@taxon.content_id, associate_content_id], search_results)
+    stub_content_for_taxon([@taxon.content_id, associate_content_id], search_results, filter_navigation_document_supertype: nil)
   end
 
   def and_that_taxon_has_few_content_items_tagged_to_it

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -14,7 +14,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     content_store_has_item(@base_path, world_usa)
 
     @taxon = Taxon.find(@base_path)
-    stub_content_for_taxon(@taxon.content_id, search_results)
+    stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
 
     visit @base_path
     govuk_feeds = page.find('.feeds')
@@ -38,7 +38,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     content_store_has_item(@base_path, student_finance)
 
     @taxon = Taxon.find(@base_path)
-    stub_content_for_taxon(@taxon.content_id, search_results)
+    stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
 
     visit @base_path
 

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -55,6 +55,33 @@ describe Taxon do
       assert_equal(results, @taxon.most_popular_content)
     end
 
+    it 'knows about its most popular content items' do
+      results = [:result_1, :result_2]
+      MostPopularContent.stubs(:fetch).returns(results)
+
+      assert_equal(results, @taxon.most_popular_content)
+    end
+
+    it "requests popular content of document supertype 'guidance' by default" do
+      results = [:result_1, :result_2]
+      MostPopularContent.stubs(:fetch)
+        .with(content_id: @taxon.content_id, filter_by_document_supertype: 'guidance')
+        .returns(results)
+
+      assert_equal(results, @taxon.most_popular_content)
+    end
+
+    it "does not request popular content of document supertype 'guidance' for world related content" do
+      @taxon.stubs(base_path: "/world/brazil")
+
+      results = [:result_1, :result_2]
+      MostPopularContent.stubs(:fetch)
+        .with(content_id: @taxon.content_id, filter_by_document_supertype: nil)
+        .returns(results)
+
+      assert_equal(results, @taxon.most_popular_content)
+    end
+
     it 'requests for guidance document supertype by default' do
       TaggedContent.expects(:fetch)
         .with([@taxon.content_id], filter_by_document_supertype: 'guidance')

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Taxon do
   include TaxonHelpers
 
-  context "with associate_taxons" do
+  context "without associate_taxons" do
     setup do
       content_item = ContentItem.new(student_finance_taxon)
       @taxon = Taxon.new(content_item)
@@ -54,6 +54,24 @@ describe Taxon do
 
       assert_equal(results, @taxon.most_popular_content)
     end
+
+    it 'requests for guidance document supertype by default' do
+      TaggedContent.expects(:fetch)
+        .with([@taxon.content_id], filter_by_document_supertype: 'guidance')
+        .returns(["guidance_content"])
+
+      assert_equal ["guidance_content"], @taxon.tagged_content
+    end
+
+    it 'does not request guidance document supertype for world related content' do
+      @taxon.stubs(base_path: "/world/brazil")
+
+      TaggedContent.expects(:fetch)
+        .with([@taxon.content_id], filter_by_document_supertype: nil)
+        .returns(["brazil_content"])
+
+      assert_equal ["brazil_content"], @taxon.tagged_content
+    end
   end
 
   context "with associated_taxons" do
@@ -67,7 +85,7 @@ describe Taxon do
       associated_taxon_content_id = "36dd87da-4973-5490-ab00-72025b1da506"
 
       TaggedContent.expects(:fetch)
-        .with([own_content_id, associated_taxon_content_id])
+        .with([own_content_id, associated_taxon_content_id], filter_by_document_supertype: nil)
         .returns(["own content", "associated content"])
 
       assert_equal ["own content", "associated content"],

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -4,7 +4,8 @@ require './test/support/custom_assertions.rb'
 describe MostPopularContent do
   def most_popular_content
     @most_popular_content ||= MostPopularContent.new(
-      content_id: taxon_content_id
+      content_id: taxon_content_id,
+      filter_by_document_supertype: 'guidance'
     )
   end
 
@@ -59,7 +60,7 @@ describe MostPopularContent do
       end
     end
 
-    it 'filters guidance content only' do
+    it 'filters content by the requested filter_by_document_supertype only' do
       assert_includes_params(filter_navigation_document_supertype: 'guidance') do
         most_popular_content.fetch
       end

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -205,7 +205,7 @@ describe TaggedContent do
       end
     end
 
-    it 'filters guidance content only' do
+    it 'filters content by the requested filter_by_document_supertype only' do
       assert_includes_params(filter_navigation_document_supertype: 'guidance') do
         tagged_content.fetch
       end
@@ -213,7 +213,7 @@ describe TaggedContent do
 
     it 'allows multiple content_ids' do
       assert_includes_params(filter_taxons: ["test-content-id-one", "test-content-id-two"]) do
-        TaggedContent.fetch(["test-content-id-one", "test-content-id-two"])
+        TaggedContent.fetch(["test-content-id-one", "test-content-id-two"], filter_by_document_supertype: 'guidance')
       end
     end
   end
@@ -225,6 +225,6 @@ private
   end
 
   def tagged_content
-    @tagged_content ||= TaggedContent.new(taxon_content_id)
+    @tagged_content ||= TaggedContent.new(taxon_content_id, filter_by_document_supertype: 'guidance')
   end
 end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,17 +1,21 @@
 module RummagerHelpers
-  def stub_content_for_taxon(content_ids, results)
-    Services.rummager.stubs(:search).with(
+  def stub_content_for_taxon(content_ids, results, filter_navigation_document_supertype: 'guidance')
+    params = {
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w(title description link document_collections content_store_document_type),
-      filter_navigation_document_supertype: 'guidance',
       filter_taxons: Array(content_ids),
       order: 'title',
-    ).returns(
-      "results" => results,
-      "start" => 0,
-      "total" => results.size,
-    )
+    }
+    params[:filter_navigation_document_supertype] = filter_navigation_document_supertype if filter_navigation_document_supertype.present?
+
+    Services.rummager.stubs(:search)
+      .with(params)
+      .returns(
+        "results" => results,
+        "start" => 0,
+        "total" => results.size,
+      )
   end
 
   def stub_most_popular_content_for_taxon(content_id, results)


### PR DESCRIPTION
For https://trello.com/c/UEj3Q4PL/217-enable-non-guidance-content-to-be-rendered-on-taxonomy-navigation-pages

By default, the taxon pages were only showing content of type 'guidance'. This PR removes that filtering for any taxons with base_paths starting with `/world`.