### PR TITLE
Add summary description for News pages

### DIFF
--- a/app/helpers/taxon_helper.rb
+++ b/app/helpers/taxon_helper.rb
@@ -1,0 +1,22 @@
+module TaxonHelper
+  def taxon_description(taxon, presented_taxon)
+    return taxon.description if taxon.description.present?
+    worldwide_news_description(taxon, presented_taxon)
+  end
+
+private
+
+  # There is currently no good way to determine whether or not the taxon
+  #  is a worldwide news page from the results returned by rummager.
+  #  This is because worlwide news pages are just aggregates of publications
+  #  relating to a location and rendered by Whitheall.
+  #  Use the base_path to decide as follows:
+  #   If the taxon has a base_path that ends with the
+  #   "<presented_taxon base_path>/news", assume it is a worldwide news item
+  def worldwide_news_description(taxon, presented_taxon)
+    assumed_news_base_path = presented_taxon.base_path + "/news"
+    if taxon.base_path.present? && taxon.base_path.ends_with?(assumed_news_base_path)
+      "Updates, news and events from the UK government in #{presented_taxon.title}"
+    end
+  end
+end

--- a/app/views/taxons/_content_list_for_child_taxon.html.erb
+++ b/app/views/taxons/_content_list_for_child_taxon.html.erb
@@ -16,7 +16,7 @@
         }
       )%>
 
-      <p><%= content_item.description %></p>
+      <p><%= taxon_description(content_item, presented_taxon) %></p>
     </li>
   <% end %>
 </ol>

--- a/app/views/taxons/_tagged_content_list.html.erb
+++ b/app/views/taxons/_tagged_content_list.html.erb
@@ -29,7 +29,7 @@
                     }
                     ) %>
                 </h2>
-                <p><%= content_item.description %></p>
+                <p><%= taxon_description(content_item, presented_taxon) %></p>
               </li>
             <% end %>
           </ol>

--- a/app/views/taxons/accordion.html.erb
+++ b/app/views/taxons/accordion.html.erb
@@ -30,7 +30,7 @@
                 <div class="subsection-header js-subsection-header">
                   <h2 class="subsection-title js-subsection-title"><%= taxon.title %></h2>
                   <% if taxon.description.present? %>
-                    <p class="subsection-description"><%= taxon.description %></p>
+                    <p class="subsection-description"><%= taxon_description(taxon, presented_taxon) %></p>
                   <% end %>
                 </div>
 
@@ -41,6 +41,7 @@
                   <%= render partial: 'content_list_for_child_taxon', locals: {
                       section_index: index,
                       tagged_content: taxon.tagged_content,
+                      presented_taxon: presented_taxon,
                   } %>
                 </div>
               </div>

--- a/app/views/taxons/grid.html.erb
+++ b/app/views/taxons/grid.html.erb
@@ -29,7 +29,7 @@
             }
           )%>
         </h2>
-        <p><%= child_taxon.description %></p>
+        <p><%= taxon_description(child_taxon, presented_taxon) %></p>
       </li>
     <% end %>
   </ol>

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -45,6 +45,21 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     assert page.has_no_selector?('.feeds')
   end
 
+  it "displays the 'Updates, news and events from the UK government in [country]' for world location news pages tagged to a taxon" do
+    @base_path = '/world/usa'
+    world_usa = world_usa_taxon(base_path: @base_path)
+
+    content_store_has_item(@base_path, world_usa)
+
+    @taxon = Taxon.find(@base_path)
+    stub_content_for_taxon(@taxon.content_id, search_results_with_news)
+
+    visit @base_path
+
+    puts page.body
+    assert page.has_content?("Updates, news and events from the UK government in USA")
+  end
+
 private
 
   def search_results
@@ -58,6 +73,23 @@ private
         'title' => 'Content item 2',
         'description' => 'Description of content item 2',
         'link' => 'content-item-2'
+      },
+    ]
+  end
+
+  def search_results_with_news
+    [
+      {
+        "title" => "News about USA",
+        "description" => "",
+        "base_path" => "/government/world/usa/news",
+        "link" => "/government/world/usa/news"
+      },
+      {
+        "title" => "British Embassy Washington ",
+        "description" => "We develop and maintain relations between the UK and USA.",
+        "base_path" => "/government/world/organisations/british-embassy-washington",
+        "link" => "british-embassy-washington"
       },
     ]
   end


### PR DESCRIPTION
Worldwide News pages will be tagged to World Loctaions and as such
will display on World Location navigation pages. We want a specific hard
coded summary of "Updates, news and events from the UK government in
[country]" to display under these.

This commit adds a description helper to display the summary.

The only way to determine if a page is a worldwide news page is to test
the base path returned by Rummager.