### PR TITLE
Set specific order for world taxonomy accordion content

### DIFF
--- a/app/lib/world_taxonomy_sorter.rb
+++ b/app/lib/world_taxonomy_sorter.rb
@@ -1,0 +1,26 @@
+class WorldTaxonomySorter
+  WORLD_TAXONOMY_ORDER = [
+    "Emergency help for British nationals",
+    "Brexit",
+    "Passports and emergency travel documents",
+    "Travelling to",
+    "Coming to the UK",
+    "Living in",
+    "Tax, benefits, pensions and working abroad",
+    "Birth, death and marriage abroad",
+    "News and events",
+    "Trade and invest",
+    "British embassy or high commission",
+  ].freeze
+
+  def self.call(child_taxons)
+    ordered_taxons = WORLD_TAXONOMY_ORDER.map do |title|
+      # Using `starts_with?` as opposed to `==` here as we do not know the name
+      # the COUNTRY for 'Travelling to COUNTRY' or 'Living in COUNTRY'
+      child_taxons.find { |taxon| taxon.title.starts_with?(title) }
+    end
+
+    # remove nils and append the taxons with titles not in the order list
+    ordered_taxons.compact.concat(child_taxons - ordered_taxons)
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -73,6 +73,10 @@ class Taxon
     true
   end
 
+  def world_related?
+    base_path.starts_with?("/world")
+  end
+
 private
 
   def fetch_tagged_content
@@ -96,9 +100,5 @@ private
     return false if world_related?
 
     true
-  end
-
-  def world_related?
-    base_path.starts_with?("/world")
   end
 end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -41,7 +41,7 @@ class TaxonPresenter
 
   def accordion_content
     return [] unless renders_as_accordion?
-    accordion_items = taxon.child_taxons.map { |taxon| TaxonPresenter.new(taxon) }
+    accordion_items = ordered_child_taxons.map { |taxon| TaxonPresenter.new(taxon) }
 
     general_information_title = 'General information and guidance'
 
@@ -62,5 +62,11 @@ class TaxonPresenter
     end
 
     accordion_items
+  end
+
+private
+
+  def ordered_child_taxons
+    taxon.world_related? ? WorldTaxonomySorter.call(taxon.child_taxons) : taxon.child_taxons
   end
 end

--- a/test/lib/world_taxonomy_sorter_test.rb
+++ b/test/lib/world_taxonomy_sorter_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class FakeTaxon
+  attr_reader :title
+
+  def initialize(title)
+    @title = title
+  end
+end
+
+describe WorldTaxonomySorter do
+  setup do
+    child_taxon_titles = [
+     "Birth, death and marriage abroad",
+     "Brexit",
+     "British embassy or high commission",
+     "Coming to the UK",
+     "Emergency help for British nationals",
+     "News and events",
+     "Passports and emergency travel documents",
+     "Living in",
+     "Tax, benefits, pensions and working abroad",
+     "Trade and invest",
+     "Travelling to",
+    ]
+    @child_taxons = child_taxon_titles.map { |title| FakeTaxon.new(title) }
+
+    @expected_ordered_taxon_titles = [
+      "Emergency help for British nationals",
+      "Brexit",
+      "Passports and emergency travel documents",
+      "Travelling to",
+      "Coming to the UK",
+      "Living in",
+      "Tax, benefits, pensions and working abroad",
+      "Birth, death and marriage abroad",
+      "News and events",
+      "Trade and invest",
+      "British embassy or high commission",
+    ]
+  end
+
+  describe '#call' do
+    it 'sorts the given child taxons by the specified sorting order' do
+      sorted_child_taxon_titles = WorldTaxonomySorter.call(@child_taxons).map(&:title)
+
+      assert_equal(@expected_ordered_taxon_titles, sorted_child_taxon_titles)
+    end
+
+    it 'appends any child taxons which did not match to a title in the specified sorting order' do
+      child_taxons = @child_taxons.concat(
+        [
+          FakeTaxon.new("Another taxon"),
+          FakeTaxon.new("And another taxon"),
+        ]
+      )
+
+      expected_ordered_taxon_titles = @expected_ordered_taxon_titles.concat(
+        [
+          "Another taxon",
+          "And another taxon",
+        ]
+      )
+
+      sorted_child_taxon_titles = WorldTaxonomySorter.call(child_taxons).map(&:title)
+
+      assert_equal(expected_ordered_taxon_titles, sorted_child_taxon_titles)
+    end
+  end
+end

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -35,4 +35,18 @@ describe TaxonPresenter do
       )
     end
   end
+
+  describe '#accordion_content' do
+    it "calls the WorldTaxonomySorter class to sort accordion content for world related taxons" do
+      taxon = mock
+      taxon.stubs(grandchildren?: false,
+                  children?: true,
+                  world_related?: true,
+                  child_taxons: %w(a b c),
+                  tagged_content: [])
+
+      WorldTaxonomySorter.expects(:call).returns(%w(c b a))
+      TaxonPresenter.new(taxon).accordion_content
+    end
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/A5XJMJzD/265-fix-ordering-issue-for-world-taxon-pages

For the new world taxon pages (eg /world/germany), we require the child taxons to be displayed in a specific order. This commit adds short-term solution. Ideally we would like to be determine the order somewhere else in the publishing platform, but given the time constraints, this might be the best solution at the moment.

We rely on the title of the taxons so that's quite brittle, but not sure if there's anything better?