### PR TITLE
Skip document validation for world content

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -77,7 +77,11 @@ private
 
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
-    TaggedContent.fetch(taxon_content_ids, filter_by_document_supertype: navigation_document_supertype)
+    TaggedContent.fetch(
+      taxon_content_ids,
+      filter_by_document_supertype: navigation_document_supertype,
+      validate: validate_tagged_content?
+    )
   end
 
   def fetch_most_popular_content
@@ -86,6 +90,12 @@ private
 
   def navigation_document_supertype
     'guidance' unless world_related?
+  end
+
+  def validate_tagged_content?
+    return false if world_related?
+
+    true
   end
 
   def world_related?

--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -1,19 +1,20 @@
 class TaggedContent
-  attr_reader :content_ids, :filter_by_document_supertype
+  attr_reader :content_ids, :filter_by_document_supertype, :validate
 
-  def initialize(content_ids, filter_by_document_supertype:)
+  def initialize(content_ids, filter_by_document_supertype:, validate:)
     @content_ids = Array(content_ids)
     @filter_by_document_supertype = filter_by_document_supertype
+    @validate = validate
   end
 
-  def self.fetch(content_ids, filter_by_document_supertype:)
-    new(content_ids, filter_by_document_supertype: filter_by_document_supertype).fetch
+  def self.fetch(content_ids, filter_by_document_supertype:, validate:)
+    new(content_ids, filter_by_document_supertype: filter_by_document_supertype, validate: validate).fetch
   end
 
   def fetch
-    search_response
-      .documents
-      .select { |document| tagged_content_validator.valid?(document) }
+    documents = search_response.documents
+    documents = documents.select { |document| tagged_content_validator.valid?(document) } if validate
+    documents
   end
 
 private

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -84,7 +84,7 @@ describe Taxon do
 
     it 'requests for guidance document supertype by default' do
       TaggedContent.expects(:fetch)
-        .with([@taxon.content_id], filter_by_document_supertype: 'guidance')
+        .with([@taxon.content_id], filter_by_document_supertype: 'guidance', validate: true)
         .returns(["guidance_content"])
 
       assert_equal ["guidance_content"], @taxon.tagged_content
@@ -94,7 +94,7 @@ describe Taxon do
       @taxon.stubs(base_path: "/world/brazil")
 
       TaggedContent.expects(:fetch)
-        .with([@taxon.content_id], filter_by_document_supertype: nil)
+        .with([@taxon.content_id], filter_by_document_supertype: nil, validate: false)
         .returns(["brazil_content"])
 
       assert_equal ["brazil_content"], @taxon.tagged_content
@@ -112,7 +112,7 @@ describe Taxon do
       associated_taxon_content_id = "36dd87da-4973-5490-ab00-72025b1da506"
 
       TaggedContent.expects(:fetch)
-        .with([own_content_id, associated_taxon_content_id], filter_by_document_supertype: nil)
+        .with([own_content_id, associated_taxon_content_id], filter_by_document_supertype: nil, validate: false)
         .returns(["own content", "associated content"])
 
       assert_equal ["own content", "associated content"],

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -67,6 +67,35 @@ describe TaggedContent do
       )
     end
 
+    it 'shows content tagged to an unknown document collection when validation is disabled' do
+      search_results = {
+        'results' => [{
+          'content_store_document_type' => 'guide',
+          'title' => 'Content in document collection',
+          'link' => '/content-in-document-collection',
+          'document_collections' => [{
+            'link' => '/a-new-document-collection'
+          }]
+        }]
+      }
+
+      Services.rummager.stubs(:search).returns(search_results)
+
+      results = tagged_content_without_validation.fetch
+      assert_equal(
+        1,
+        results.count,
+        'It should include the content tagged to a collection in the results'
+      )
+
+      result = results.first
+      assert_equal(
+        result.base_path,
+        '/content-in-document-collection',
+        'It should match the content item\'s base path'
+      )
+    end
+
     it 'does not include a collection that should not be surfaced' do
       search_results = {
         'results' => [{
@@ -81,6 +110,31 @@ describe TaggedContent do
       assert_empty(
         results,
         'It should not include the document collection in the results'
+      )
+    end
+
+    it 'should include a collection that should not be surfaced when validation is disabled' do
+      search_results = {
+        'results' => [{
+          'content_store_document_type' => 'document_collection',
+          'link' => '/government/collections/national-curriculum-assessments-information-for-parents'
+        }]
+      }
+
+      Services.rummager.stubs(:search).returns(search_results)
+
+      results = tagged_content_without_validation.fetch
+      assert_equal(
+        1,
+        results.count,
+        'It should include the document collection in the results'
+      )
+
+      result = results.first
+      assert_equal(
+        result.base_path,
+        '/government/collections/national-curriculum-assessments-information-for-parents',
+        'It should match the document collection\'s base path'
       )
     end
 
@@ -158,6 +212,35 @@ describe TaggedContent do
       )
     end
 
+    it 'should include content tagged to a collection that should not be surfaced when validation is disabled' do
+      search_results = {
+        'results' => [{
+          'content_store_document_type' => 'guide',
+          'title' => 'Content in document collection',
+          'link' => '/content-in-document-collection',
+          'document_collections' => [{
+            'link' => '/government/collections/send-pathfinders'
+          }]
+        }]
+      }
+
+      Services.rummager.stubs(:search).returns(search_results)
+
+      results = tagged_content_without_validation.fetch
+      assert_equal(
+        1,
+        results.count,
+        'It should include the content tagged to a collection in the results'
+      )
+
+      result = results.first
+      assert_equal(
+        result.base_path,
+        '/content-in-document-collection',
+        'It should match the content item\'s base path'
+      )
+    end
+
     it 'returns the results from search' do
       search_results = {
         'results' => [{
@@ -213,7 +296,7 @@ describe TaggedContent do
 
     it 'allows multiple content_ids' do
       assert_includes_params(filter_taxons: ["test-content-id-one", "test-content-id-two"]) do
-        TaggedContent.fetch(["test-content-id-one", "test-content-id-two"], filter_by_document_supertype: 'guidance')
+        TaggedContent.fetch(["test-content-id-one", "test-content-id-two"], filter_by_document_supertype: 'guidance', validate: true)
       end
     end
   end
@@ -225,6 +308,10 @@ private
   end
 
   def tagged_content
-    @tagged_content ||= TaggedContent.new(taxon_content_id, filter_by_document_supertype: 'guidance')
+    @tagged_content ||= TaggedContent.new(taxon_content_id, filter_by_document_supertype: 'guidance', validate: true)
+  end
+
+  def tagged_content_without_validation
+    @tagged_content ||= TaggedContent.new(taxon_content_id, filter_by_document_supertype: 'guidance', validate: false)
   end
 end


### PR DESCRIPTION
This commit adds a `validate` flag to `TaggedContent` to allow taxon tagged content validation to be skipped for world content. This is because we do not restrict the types of content that can be tagged to the worldwide taxonomy.