### PR TITLE
Remove /government from Whitehall email subscription links

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -16,7 +16,6 @@ module EmailHelper
 private
 
   WHITEHALL_EMAIL_SIGNUP_PATH = "/government/email-signup/new?email_signup[feed]=".freeze
-  GOVERNMENT_PATH = "/government".freeze
 
   def root
     Plek.new.website_root
@@ -27,6 +26,6 @@ private
   end
 
   def equivalent_whitehall_url
-    root + GOVERNMENT_PATH + request.fullpath
+    root + request.fullpath
   end
 end

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -19,7 +19,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     visit @base_path
     govuk_feeds = page.find('.feeds')
 
-    expected_atom_url = Plek.new.website_root + "/government/world/usa.atom"
+    expected_atom_url = Plek.new.website_root + "/world/usa.atom"
     expected_url = Plek.new.website_root + "/government/email-signup/new?email_signup%5Bfeed%5D=#{expected_atom_url}"
 
     assert govuk_feeds.has_link?(

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -17,7 +17,7 @@ class EmailHelperTest < ActionView::TestCase
       return OpenStruct.new(fullpath: "/world/blefuscu")
     end
 
-    expected_atom_url = Plek.new.website_root + "/government/world/blefuscu.atom"
+    expected_atom_url = Plek.new.website_root + "/world/blefuscu.atom"
 
     assert_equal expected_atom_url, whitehall_atom_url
   end
@@ -27,7 +27,7 @@ class EmailHelperTest < ActionView::TestCase
       return OpenStruct.new(fullpath: "/world/blefuscu")
     end
 
-    atom_url = Plek.new.website_root + "/government/world/blefuscu.atom"
+    atom_url = Plek.new.website_root + "/world/blefuscu.atom"
     expected_url = Plek.new.website_root +
       URI.encode("/government/email-signup/new?email_signup[feed]=#{atom_url}")
 


### PR DESCRIPTION
Whitehall bound email subscriptions links for World Locations should be
sending a subscription link of the form `/world/<location>.atom` instead
of `/government/world/<location>.atom`.