### PR TITLE
Redirect `/world/all` to `/world`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
     get ":subtopic_slug", on: :member, to: "subtopics#show"
   end
 
+  #TODO this redirect causes the request to be routed to Whitehall where
+  #the country A-Z currently lives. This needs to be removed when the world index
+  #page is rendered here
+  get '/world/all', to: redirect('/world')
+
   get "/topic/:topic_slug/:subtopic_slug/latest",
     to: "latest_changes#index", as: :latest_changes
 


### PR DESCRIPTION
As part of the worldwide taxonomy migration we currently need to leave the `/world` page rendered by Whitehall as there isn't an equivalent, or suitable format within Collections. We do need the `/world` taxon as part of the taxonomy but it won't be rendered.

The solution for this is to publish the taxon to `/world/all` and redirect `/world/all` to `/world` which will fall through the router to Whitehall.

This PR adds a redirect to routes to accomplish this.