### PR TITLE
Hide 2 non-guidance document collections

### DIFF
--- a/config/guidance_document_collections.json
+++ b/config/guidance_document_collections.json
@@ -1173,5 +1173,15 @@
     "base_path": "/government/collections/pe-and-sport-survey",
     "surface_collection": false,
     "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/better-communication-research-programme",
+    "surface_collection": false,
+    "surface_content": true
+  },
+  {
+    "base_path": "/government/collections/maladministration-reports",
+    "surface_collection": false,
+    "surface_content": true
   }
 ]


### PR DESCRIPTION
As requested by Graeme, we shouldn't display document collections with
only non-guidance content on them. This commit removes 2 of those
collections from taxonomy pages.

Trello: https://trello.com/c/qJG7mzSR/246-hide-2-collections-featuring-non-guidance-content-only