### PR TITLE
Track clicks on everything to do with topics

### DIFF
--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -34,6 +34,6 @@
   </div>
 </header>
 
-<div class="browse-container full-width">
+<div class="browse-container full-width" data-module="track-click">
   <%= yield %>
 </div>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -21,13 +21,27 @@
     organisations: organisations(subtopic.content_id),
     link_to_latest_feed: true,
   }) do %>
-  <% subtopic.lists.each do |list| -%>
+  <% subtopic.lists.each_with_index do |list, list_index| -%>
     <nav class="index-list with-title" aria-labelledby="<%= list.title.parameterize %>">
       <h1 id="<%= list.title.parameterize %>"><%= list.title %></h1>
       <ul>
-      <% list.contents.each do |list_item| -%>
+      <% list.contents.each_with_index do |list_item, list_item_index| -%>
         <li>
-          <a href="<%= list_item.base_path %>"><%= list_item.title %></a>
+          <%=
+            link_to(
+              list_item.title,
+              list_item.base_path,
+              data: {
+                track_category: 'subtopicContentItemLinkClicked',
+                track_action: "#{list_index + 1}.#{list_item_index + 1}",
+                track_label: list_item.base_path,
+                track_options: {
+                  dimension28: list.contents.count.to_s,
+                  dimension29: list_item.title,
+                },
+              }
+            )
+          %>
         </li>
       <% end -%>
       </ul>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -32,7 +32,7 @@
               list_item.title,
               list_item.base_path,
               data: {
-                track_category: 'subtopicContentItemLinkClicked',
+                track_category: 'navSubtopicContentItemLinkClicked',
                 track_action: "#{list_index + 1}.#{list_item_index + 1}",
                 track_label: list_item.base_path,
                 track_options: {

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -11,12 +11,26 @@
   </div>
 </header>
 
-<div class="browse-container full-width topics-page">
+<div class="browse-container full-width topics-page" data-module="track-click">
   <nav class="topics">
     <ul>
-      <% topic.children.each do |subtopic|%>
+      <% topic.children.each_with_index do |subtopic, index|%>
         <li>
-          <a href="<%= subtopic.base_path %>"><%= subtopic.title %></a>
+          <%=
+            link_to(
+              subtopic.title,
+              subtopic.base_path,
+              data: {
+                track_category: 'topicLinkClicked',
+                track_action: "#{index + 1}",
+                track_label: subtopic.base_path,
+                track_options: {
+                  dimension28: topic.children.count.to_s,
+                  dimension29: subtopic.title,
+                },
+              }
+            )
+          %>
         </li>
       <% end %>
     </ul>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -21,7 +21,7 @@
               subtopic.title,
               subtopic.base_path,
               data: {
-                track_category: topic.base_path == '/topic' ? 'topicLinkClicked' : 'subtopicLinkClicked',
+                track_category: topic.base_path == '/topic' ? 'navTopicLinkClicked' : 'navSubtopicLinkClicked',
                 track_action: "#{index + 1}",
                 track_label: subtopic.base_path,
                 track_options: {

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -21,7 +21,7 @@
               subtopic.title,
               subtopic.base_path,
               data: {
-                track_category: 'topicLinkClicked',
+                track_category: topic.base_path == '/topic' ? 'topicLinkClicked' : 'subtopicLinkClicked',
                 track_action: "#{index + 1}",
                 track_label: subtopic.base_path,
                 track_options: {

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -201,4 +201,109 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  it "adds tracking attributes to links within sections" do
+    # Given a curated subtopic exists
+    content_store_has_item(
+      "/topic/oil-and-gas/offshore",
+      oil_and_gas_subtopic_item("offshore", details: {
+        groups: [
+          {
+            name: "Oil rigs",
+            contents: [
+              "/oil-rig-safety-requirements",
+            ],
+          },
+          {
+            name: "Piping",
+            contents: [
+              "/undersea-piping-restrictions",
+            ],
+          },
+        ]
+      })
+    )
+
+    stub_topic_organisations('oil-and-gas/offshore', 'content-id-for-offshore')
+
+    visit "/topic/oil-and-gas/offshore"
+
+    assert page.has_selector?('.browse-container[data-module="track-click"]')
+
+    oil_rig_safety_requirements = page.find(
+      'a',
+      text: 'Oil rig safety requirements',
+    )
+
+    assert_equal(
+      'subtopicContentItemLinkClicked',
+      oil_rig_safety_requirements['data-track-category'],
+      'Expected a tracking category to be set in the data attributes'
+    )
+
+    assert_equal(
+      '1.1',
+      oil_rig_safety_requirements['data-track-action'],
+      'Expected the link position to be set in the data attributes'
+    )
+
+    assert_equal(
+      '/oil-rig-safety-requirements',
+      oil_rig_safety_requirements['data-track-label'],
+      'Expected the content item base path to be set in the data attributes'
+    )
+
+    assert oil_rig_safety_requirements['data-track-options'].present?
+
+    data_options = JSON.parse(oil_rig_safety_requirements['data-track-options'])
+    assert_equal(
+      '1',
+      data_options['dimension28'],
+      'Expected the total number of content items within the section to be present in the tracking options'
+    )
+
+    assert_equal(
+      'Oil rig safety requirements',
+      data_options['dimension29'],
+      'Expected the subtopic title to be present in the tracking options'
+    )
+
+    undersea_piping_restrictions = page.find(
+      'a',
+      text: 'Undersea piping restrictions',
+    )
+
+    assert_equal(
+      'subtopicContentItemLinkClicked',
+      undersea_piping_restrictions['data-track-category'],
+      'Expected a tracking category to be set in the data attributes'
+    )
+
+    assert_equal(
+      '2.1',
+      undersea_piping_restrictions['data-track-action'],
+      'Expected the link position to be set in the data attributes'
+    )
+
+    assert_equal(
+      '/undersea-piping-restrictions',
+      undersea_piping_restrictions['data-track-label'],
+      'Expected the content item base path to be set in the data attributes'
+    )
+
+    assert undersea_piping_restrictions['data-track-options'].present?
+
+    data_options = JSON.parse(undersea_piping_restrictions['data-track-options'])
+    assert_equal(
+      '1',
+      data_options['dimension28'],
+      'Expected the total number of content items within the section to be present in the tracking options'
+    )
+
+    assert_equal(
+      'Undersea piping restrictions',
+      data_options['dimension29'],
+      'Expected the subtopic title to be present in the tracking options'
+    )
+  end
 end

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -236,7 +236,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     )
 
     assert_equal(
-      'subtopicContentItemLinkClicked',
+      'navSubtopicContentItemLinkClicked',
       oil_rig_safety_requirements['data-track-category'],
       'Expected a tracking category to be set in the data attributes'
     )
@@ -274,7 +274,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     )
 
     assert_equal(
-      'subtopicContentItemLinkClicked',
+      'navSubtopicContentItemLinkClicked',
       undersea_piping_restrictions['data-track-category'],
       'Expected a tracking category to be set in the data attributes'
     )

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -132,4 +132,58 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
       'Expected the topic title to be present in the tracking options'
     )
   end
+
+  it "tracks clicks events on subtopic pages" do
+    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
+        "children" => [
+          {
+            "title" => "Wells",
+            "base_path" => "/topic/oil-and-gas/wells",
+          },
+        ],
+      }))
+
+    visit "/topic/oil-and-gas"
+
+    assert page.has_selector?('.topics-page[data-module="track-click"]')
+
+    within ".topics ul" do
+      within "li:nth-child(1)" do
+        subtopic_link = page.find('a', text: 'Wells')
+
+        assert_equal(
+          'subtopicLinkClicked',
+          subtopic_link['data-track-category'],
+          'Expected a tracking category to be set in the data attributes'
+        )
+
+        assert_equal(
+          '1',
+          subtopic_link['data-track-action'],
+          'Expected the link position to be set in the data attributes'
+        )
+
+        assert_equal(
+          '/topic/oil-and-gas/wells',
+          subtopic_link['data-track-label'],
+          'Expected the subtopic base path to be set in the data attributes'
+        )
+
+        assert subtopic_link['data-track-options'].present?
+
+        data_options = JSON.parse(subtopic_link['data-track-options'])
+        assert_equal(
+          '1',
+          data_options['dimension28'],
+          'Expected the total number of subtopics to be present in the tracking options'
+        )
+
+        assert_equal(
+          'Wells',
+          data_options['dimension29'],
+          'Expected the subtopic title to be present in the tracking options'
+        )
+      end
+    end
+  end
 end

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -100,7 +100,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     topic_link = page.find('a', text: 'Oil and Gas')
 
     assert_equal(
-      'topicLinkClicked',
+      'navTopicLinkClicked',
       topic_link['data-track-category'],
       'Expected a tracking category to be set in the data attributes'
     )
@@ -152,7 +152,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
         subtopic_link = page.find('a', text: 'Wells')
 
         assert_equal(
-          'subtopicLinkClicked',
+          'navSubtopicLinkClicked',
           subtopic_link['data-track-category'],
           'Expected a tracking category to be set in the data attributes'
         )

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -76,4 +76,60 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  it 'tracks click events on topic pages' do
+    content_store_has_item("/topic",
+      base_path: "/topic",
+      title: "Topics",
+      format: "topic",
+      public_updated_at: 10.days.ago.iso8601,
+      details: {},
+      links: {
+        children: [
+          {
+            title: "Oil and Gas",
+            base_path: "/topic/oil-and-gas",
+          },
+        ],
+      })
+
+    visit "/topic"
+
+    assert page.has_selector?('.topics-page[data-module="track-click"]')
+
+    topic_link = page.find('a', text: 'Oil and Gas')
+
+    assert_equal(
+      'topicLinkClicked',
+      topic_link['data-track-category'],
+      'Expected a tracking category to be set in the data attributes'
+    )
+
+    assert_equal(
+      '1',
+      topic_link['data-track-action'],
+      'Expected the link position to be set in the data attributes'
+    )
+
+    assert_equal(
+      '/topic/oil-and-gas',
+      topic_link['data-track-label'],
+      'Expected the topic base path to be set in the data attributes'
+    )
+
+    assert topic_link['data-track-options'].present?
+
+    data_options = JSON.parse(topic_link['data-track-options'])
+    assert_equal(
+      '1',
+      data_options['dimension28'],
+      'Expected the total number of topics to be present in the tracking options'
+    )
+
+    assert_equal(
+      'Oil and Gas',
+      data_options['dimension29'],
+      'Expected the topic title to be present in the tracking options'
+    )
+  end
 end


### PR DESCRIPTION
In this PR, we add tracking events to clicks on topics, subtopics and content items under subtopics. Here are examples of the events being sent to GA:

### Topics

When visiting `/topic` and clicking on a topic link (e.g. Business Tax), we fire the following event to GA:

```
Running command: ga("send", {hitType: "event", eventCategory: "navTopicLinkClicked", eventAction: "4", eventLabel: "/topic/business-tax", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension2: "topic", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension17: "topic", dimension20: "collections", dimension32: "none", dimension33: "finding", dimension34: "other", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", transport: "beacon", dimension28: "50", dimension29: "Business tax"})
```

The most important attributes here are:
- `eventCategory: "navTopicLinkClicked"`;
- `eventAction: "4"` - meaning it's the 4th link from the top;
- `eventLabel: "/topic/business-tax"` - the href of the link we clicked;
- `dimension28: "50"` - there were 50 links on the page;
- `dimension29: "Business tax"` - and we clicked on "Business tax".

### Subtopics

When visiting the topic page `/topic/business-tax` and clicking on a subtopic (e.g. Corporation Tax), we fire the following event to GA:

```
ga("send", {hitType: "event", eventCategory: "navSubtopicLinkClicked", eventAction: "7", eventLabel: "/topic/business-tax/corporation-tax", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension2: "topic", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension17: "topic", dimension20: "collections", dimension32: "none", dimension33: "finding", dimension34: "other", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", transport: "beacon", dimension28: "26", dimension29: "Corporation Tax"})
```

The most important attributes here are:
- `eventCategory: "navSubtopicLinkClicked"`;
- `eventAction: "7"` - meaning it's the 7th link from the top;
- `eventLabel: "/topic/business-tax/corporation-tax"` - the href of the link we clicked;
- `dimension28: "26"` - there were 26 links on the page;
- `dimension29: "Corporation Tax"` - and we clicked on "Corporation Tax".

### Content items within subtopics

When visiting the subtopic page `/topic/business-tax/corporation-tax` and clicking on "Director's loans" under "Working out your Corporation Tax", we send the following event to GA:

```
ga("send", {hitType: "event", eventCategory: "navSubtopicContentItemLinkClicked", eventAction: "3.4", eventLabel: "/directors-loans", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension1: "business tax", dimension2: "topic", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension17: "topic", dimension20: "collections", dimension32: "none", dimension33: "finding", dimension34: "other", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", transport: "beacon", dimension28: "5", dimension29: "Director's loans"})
```

The most important attributes here are:
- `eventCategory: "navSubtopicContentItemLinkClicked"`;
- `eventAction: "3.4"` - meaning it's the 4th link from the 3rd section;
- `eventLabel: "/directors-loans"` - the href of the link we clicked;
- `dimension28: "5"` - there were 5 links on the subsection where the link was;
- `dimension29: "Director's loans"` - and we clicked on "Director's loans".

Example pages currently on integration:
- https://www-origin.integration.publishing.service.gov.uk/topic
- https://www-origin.integration.publishing.service.gov.uk/topic/business-tax
- https://www-origin.integration.publishing.service.gov.uk/topic/business-tax/corporation-tax

https://trello.com/c/1zi6Nr3B/31-add-link-position-tracking-to-whitehall-navigation