### PR TITLE
Track clicks on services and info pages

### DIFF
--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -45,7 +45,7 @@ private
       ServicesAndInformationLinksGrouper.new(params[:organisation_id])
 
     links_grouper.parsed_grouped_links.reject do |group|
-      group["title"].nil?
+      group.title.nil?
     end
   end
 end

--- a/app/lib/services_and_information_links_grouper.rb
+++ b/app/lib/services_and_information_links_grouper.rb
@@ -5,13 +5,7 @@ class ServicesAndInformationLinksGrouper
 
   def parsed_grouped_links
     grouped_links_from_rummager.map do |group|
-      {
-        "title" => group["value"]["title"],
-        "examples" => group["value"]["example_info"]["examples"],
-        "document_count" => group["value"]["example_info"]["total"],
-        "subsector_link" => group["value"]["link"],
-        "more_documents" => more_documents?(group),
-      }
+      ServicesAndInformationGroup.new(group)
     end
   end
 
@@ -23,10 +17,5 @@ private
       filter_organisations: @organisation_id,
       facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
     ).to_hash["facets"]["specialist_sectors"]["options"]
-  end
-
-  def more_documents?(group)
-    # Check if there are more documents than are being shown
-    group["value"]["example_info"]["total"] > group["value"]["example_info"]["examples"].count
   end
 end

--- a/app/models/example_link.rb
+++ b/app/models/example_link.rb
@@ -1,0 +1,11 @@
+require 'active_model'
+
+class ExampleLink
+  include ActiveModel::Model
+
+  attr_accessor(
+    :title,
+    :link,
+    :class
+  )
+end

--- a/app/models/services_and_information_group.rb
+++ b/app/models/services_and_information_group.rb
@@ -1,0 +1,42 @@
+class ServicesAndInformationGroup
+  attr_reader :group
+
+  def initialize(group)
+    @group = group
+  end
+
+  def title
+    group.dig("value", "title")
+  end
+
+  def examples
+    @examples ||= begin
+      example_list = group.dig("value", "example_info", "examples") || []
+
+      if more_documents?
+        example_list << {
+          'link' => subsector_link,
+          'title' => 'See more',
+          'class' => 'other'
+        }
+      end
+
+      example_list.map { |example| ExampleLink.new(example) }
+    end
+  end
+
+private
+
+  def document_count
+    group.dig("value", "example_info", "total")
+  end
+
+  def subsector_link
+    group.dig("value", "link")
+  end
+
+  # Check if there are more documents than are being shown
+  def more_documents?
+    document_count > group.dig("value", "example_info", "examples").count
+  end
+end

--- a/app/views/services_and_information/_grouped_links.html.erb
+++ b/app/views/services_and_information/_grouped_links.html.erb
@@ -1,10 +1,25 @@
-<% grouped_links.each do |group| -%>
+<% grouped_links.each_with_index do |group, group_index| -%>
   <nav class="index-list with-title" aria-labelledby="<%= group.title.parameterize %>">
     <h1 id="<%= group.title.parameterize %>"><%= group.title %></h1>
     <ul>
-    <% group.examples.each do |group_link| -%>
+    <% group.examples.each_with_index do |group_link, group_link_index| -%>
       <li>
-        <a href="<%= group_link.link %>" class="<%= group_link.class %>"><%= group_link.title %></a>
+        <%=
+            link_to(
+              group_link.title,
+              group_link.link,
+              data: {
+                track_category: 'navServicesInformationLinkClicked',
+                track_action: "#{group_index + 1}.#{group_link_index + 1}",
+                track_label: group_link.link,
+                track_options: {
+                  dimension28: group.examples.count.to_s,
+                  dimension29: group_link.title,
+                },
+              },
+              class: group_link.class
+            )
+          %>
       </li>
     <% end -%>
     </ul>

--- a/app/views/services_and_information/_grouped_links.html.erb
+++ b/app/views/services_and_information/_grouped_links.html.erb
@@ -1,17 +1,12 @@
 <% grouped_links.each do |group| -%>
-  <nav class="index-list with-title" aria-labelledby="<%= group["title"].parameterize %>">
-    <h1 id="<%= group["title"].parameterize %>"><%= group["title"] %></h1>
+  <nav class="index-list with-title" aria-labelledby="<%= group.title.parameterize %>">
+    <h1 id="<%= group.title.parameterize %>"><%= group.title %></h1>
     <ul>
-    <% group["examples"].each do |group_link| -%>
+    <% group.examples.each do |group_link| -%>
       <li>
-        <a href="<%= group_link["link"] %>"><%= group_link["title"] %></a>
+        <a href="<%= group_link.link %>" class="<%= group_link.class %>"><%= group_link.title %></a>
       </li>
     <% end -%>
-    <% if group["more_documents"] %>
-      <li>
-        <a href="<%= group["subsector_link"] %>" class="other">See more</a>
-      </li>
-    <% end %>
     </ul>
   </nav>
 <% end -%>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -17,6 +17,6 @@
   </div>
 </header>
 
-<div class="browse-container full-width">
+<div class="browse-container full-width" data-module="track-click">
   <%= render partial: 'grouped_links', locals: { grouped_links: grouped_links } %>
 </div>

--- a/test/integration/services_and_information_browsing_test.rb
+++ b/test/integration/services_and_information_browsing_test.rb
@@ -28,4 +28,84 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
 
     assert page.has_selector?(shared_component_selector('breadcrumbs'))
   end
+
+  it 'includes tracking attributes on all links' do
+    visit "/government/organisations/hm-revenue-customs/services-information"
+
+    assert page.has_selector?('.browse-container[data-module="track-click"]')
+
+    within "nav.index-list:nth-child(1) ul" do
+      content_item_link = page.first('li a')
+
+      assert_equal(
+        'navServicesInformationLinkClicked',
+        content_item_link['data-track-category'],
+        'Expected a tracking category to be set in the data attributes'
+      )
+
+      assert_equal(
+        '1.1',
+        content_item_link['data-track-action'],
+        'Expected the link position to be set in the data attributes'
+      )
+
+      assert_equal(
+        content_item_link[:href],
+        content_item_link['data-track-label'],
+        'Expected the content item base path to be set in the data attributes'
+      )
+
+      assert content_item_link['data-track-options'].present?
+
+      data_options = JSON.parse(content_item_link['data-track-options'])
+      assert_equal(
+        page.all('li a').count.to_s,
+        data_options['dimension28'],
+        'Expected the total number of content items within the section to be present in the tracking options'
+      )
+
+      assert_equal(
+        content_item_link.text,
+        data_options['dimension29'],
+        'Expected the content item title to be present in the tracking options'
+      )
+    end
+
+    within "nav.index-list:nth-child(2) ul" do
+      content_item_link = page.first('li a')
+
+      assert_equal(
+        'navServicesInformationLinkClicked',
+        content_item_link['data-track-category'],
+        'Expected a tracking category to be set in the data attributes'
+      )
+
+      assert_equal(
+        '2.1',
+        content_item_link['data-track-action'],
+        'Expected the link position to be set in the data attributes'
+      )
+
+      assert_equal(
+        content_item_link[:href],
+        content_item_link['data-track-label'],
+        'Expected the content item base path to be set in the data attributes'
+      )
+
+      assert content_item_link['data-track-options'].present?
+
+      data_options = JSON.parse(content_item_link['data-track-options'])
+      assert_equal(
+        page.all('li a').count.to_s,
+        data_options['dimension28'],
+        'Expected the total number of content items within the section to be present in the tracking options'
+      )
+
+      assert_equal(
+        content_item_link.text,
+        data_options['dimension29'],
+        'Expected the content item title to be present in the tracking options'
+      )
+    end
+  end
 end


### PR DESCRIPTION
In this PR I've:
- refactored services and information code to use objects instead of hashes;
- added tracking to all links present in services and information pages.

Please check the individual commit messages for more details.

Here is an example tracking event:

```
ga("send", {hitType: "event", eventCategory: "navServicesInformationLinkClicked", eventAction: "1.4", eventLabel: "/government/publications/adoption-statutory-guidance-2013", dimension15: "200", dimension16: "unknown", dimension11: "2", dimension2: "services_and_information", dimension3: "other", dimension4: "00000000-0000-0000-0000-000000000000", dimension9: "<D6>", dimension17: "generic", dimension20: "collections", dimension32: "none", dimension33: "finding", dimension34: "other", dimension56: "other", dimension57: "other", dimension58: "other", dimension59: "other", dimension39: "false", dimension26: "0", dimension27: "0", dimension41: "EducationNavigation:A", transport: "beacon", dimension28: "5", dimension29: "Adoption: statutory guidance"})
```

The most important attributes here are:
- `eventCategory: "navServicesInformationLinkClicked"`;
- `eventAction: "1.4"` - meaning it's the 4th link from the 1st section;
- `eventLabel: "/government/publications/adoption-statutory-guidance-2013"` - the href of the link we clicked;
- `dimension28: "5"` - there were 5 links on the page;
- `dimension29: "Adoption: statutory guidance"` - and we clicked on "Adoption: statutory guidance".

Trello: https://trello.com/c/1zi6Nr3B/31-add-link-position-tracking-to-whitehall-navigation