### PR TITLE
Fix broken email links for /world content

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,8 +1,6 @@
 module EmailHelper
-  WHITEHALL_BOUND_BASE_PATH = "/world".freeze
-
-  def render_whitehall_email_links?(base_path)
-    base_path.starts_with?(WHITEHALL_BOUND_BASE_PATH) if base_path
+  def render_whitehall_email_links?(presented_taxon)
+    presented_taxon.world_related? && presented_taxon.renders_as_accordion?
   end
 
   def whitehall_atom_url

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -69,6 +69,7 @@ class Taxon
 
   def can_subscribe?
     return @can_subscribe if defined?(@can_subscribe)
+    return false if world_related?
 
     true
   end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -14,6 +14,7 @@ class TaxonPresenter
     :child_taxons,
     :most_popular_content,
     :can_subscribe?,
+    :world_related?,
     to: :taxon
   )
 

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,5 +1,5 @@
 <div class='subscriptions'>
-  <% if render_whitehall_email_links?(presented_taxon.base_path) %>
+  <% if render_whitehall_email_links?(presented_taxon) %>
     <div class="feeds">
       <%= link_to(whitehall_email_url, class:'email-alerts') do %>
         Get email alerts for this topic

--- a/test/fixtures/content_store/world_usa.json
+++ b/test/fixtures/content_store/world_usa.json
@@ -3,5 +3,29 @@
   "title": "USA",
   "description": "United States of America",
   "base_path": "\/world\/usa",
-  "links": { }
+  "links": {
+    "child_taxons": [
+      {
+        "content_id": "92d9d12e-1548-4587-8f13-6d5e102e5c1f",
+        "title": "News and events",
+        "description": "Find out about the UK government's diplomatic, security and development work in USA.",
+        "base_path": "\/world\/news-and-events-usa",
+        "locale": "en",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "5e9f2825-7706-11e4-a3cb-005056011aef",
+              "locale": "en",
+              "title": "USA",
+              "description": "United States of America",
+              "base_path": "\/world\/usa"
+            }
+          ],
+          "child_taxons": [
+            // child taxons are not expanded in the content store
+          ]
+        }
+      }
+    ]
+  }
 }

--- a/test/fixtures/content_store/world_usa_news_events.json
+++ b/test/fixtures/content_store/world_usa_news_events.json
@@ -1,0 +1,21 @@
+{
+  "content_id": "92d9d12e-1548-4587-8f13-6d5e102e5c1f",
+  "title": "News and events",
+  "description": "Find out about the UK government's diplomatic, security and development work in USA.",
+  "base_path": "\/world\/news-and-events-usa",
+  "locale": "en",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "5e9f2825-7706-11e4-a3cb-005056011aef",
+        "locale": "en",
+        "title": "USA",
+        "description": "United States of America",
+        "base_path": "\/world\/usa"
+      }
+    ],
+    "child_taxons": [
+      // child taxons are not expanded in the content store
+    ]
+  }
+}

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -8,13 +8,21 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
 
   it 'contains both the atom and email signup url if we are browsing a world location' do
     @base_path = '/world/usa'
+    @child_taxon_base_path = '/world/news-and-events-usa'
 
     world_usa = world_usa_taxon(base_path: @base_path)
+    world_usa_news_events = world_usa_news_events_taxon(base_path: @child_taxon_base_path)
 
     content_store_has_item(@base_path, world_usa)
+    content_store_has_item(@child_taxon_base_path, world_usa_news_events)
 
     @taxon = Taxon.find(@base_path)
+    stub_content_for_taxon(@taxon.content_id, search_results) # For the "general information" taxon
     stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+    stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+
+    @child_taxon = Taxon.find(@child_taxon_base_path)
+    stub_content_for_taxon(@child_taxon.content_id, search_results, filter_navigation_document_supertype: nil)
 
     visit @base_path
     govuk_feeds = page.find('.feeds')
@@ -29,6 +37,22 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     assert govuk_feeds.has_link?(
       href: expected_atom_url
     )
+  end
+
+  it 'does not contain the feed selector if we are browsing a world location leaf page' do
+    @base_path = '/world/usa'
+
+    world_usa = world_usa_taxon(base_path: @base_path)
+    world_usa.delete("links")
+
+    content_store_has_item(@base_path, world_usa)
+
+    @taxon = Taxon.find(@base_path)
+    stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+
+    visit @base_path
+
+    assert page.has_no_selector?('.feeds')
   end
 
   it 'does not contain the feed selector if we are not browsing a world location' do

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -18,15 +18,19 @@ module RummagerHelpers
       )
   end
 
-  def stub_most_popular_content_for_taxon(content_id, results)
-    Services.rummager.stubs(:search).with(
+  def stub_most_popular_content_for_taxon(content_id, results, filter_navigation_document_supertype: 'guidance')
+    params = {
       start: 0,
       count: 5,
       fields: %w(title link),
-      filter_navigation_document_supertype: 'guidance',
       filter_part_of_taxonomy_tree: content_id,
       order: '-popularity',
-    ).returns(
+    }
+    params[:filter_navigation_document_supertype] = filter_navigation_document_supertype if filter_navigation_document_supertype.present?
+
+    Services.rummager.stubs(:search)
+    .with(params)
+    .returns(
       "results" => results,
       "start" => 0,
       "total" => results.size,

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -26,6 +26,10 @@ module TaxonHelpers
     fetch_and_validate_taxon(:world_usa, params)
   end
 
+  def world_usa_news_events_taxon(params = {})
+    fetch_and_validate_taxon(:world_usa_news_events, params)
+  end
+
   # This taxon has an associated_taxon
   def travelling_to_the_usa_taxon(params = {})
     fetch_and_validate_taxon(:travelling_to_the_usa, params)

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -1,15 +1,30 @@
 require 'test_helper'
 class EmailHelperTest < ActionView::TestCase
   test "should return true if we are browsing a world location" do
-    world_location_base_path = "/world/blefuscu"
+    presented_taxon = stub(
+      world_related?: true,
+      renders_as_accordion?: true
+    )
 
-    assert render_whitehall_email_links?(world_location_base_path)
+    assert render_whitehall_email_links?(presented_taxon)
+  end
+
+  test "should return false if we are browsing a world location leaf page" do
+    presented_taxon = stub(
+      world_related?: true,
+      renders_as_accordion?: false
+    )
+
+    refute render_whitehall_email_links?(presented_taxon)
   end
 
   test "should return false if we are browsing any other taxon" do
-    base_path = "/education/student-finance"
+    presented_taxon = stub(
+      world_related?: false,
+      renders_as_accordion?: true
+    )
 
-    refute render_whitehall_email_links?(base_path)
+    refute render_whitehall_email_links?(presented_taxon)
   end
 
   test "should return a valid whitehall .atom url in the form /government/{url}.atom" do


### PR DESCRIPTION
This commit fixes broken email subscription links for `/world` content:

* Links to email subscriptions and feeds inside accordions are not displayed for pages under `/world` since these links simply replicate what is shown at the top of the page

* Links to email subscriptions and feeds at the top of “leaf” pages under `/world` are replaced by the default email subscription links to allow for taxonomy-based email subscriptions - these previously linked to broken whitehall pages

Trello: https://trello.com/c/AcE14fLU/40-remove-non-subscription-email-subscriptions-link-from-world-navigation

Before:

![screen shot 2017-07-20 at 09 54 52](https://user-images.githubusercontent.com/444232/28409137-9bcc6ca8-6d31-11e7-9397-3ff059c3c065.png)

![screen shot 2017-07-20 at 09 55 02](https://user-images.githubusercontent.com/444232/28409123-941e2aaa-6d31-11e7-8251-a46e8041d879.png)

After:

![screen shot 2017-07-20 at 09 54 39](https://user-images.githubusercontent.com/444232/28409116-8e5928b8-6d31-11e7-9788-e49ae41eb066.png)

![screen shot 2017-07-20 at 09 55 10](https://user-images.githubusercontent.com/444232/28409148-a065fa90-6d31-11e7-85b6-e26635262a32.png)
