### PR TITLE
Create a new tracking event navGridContentClicked

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -65,6 +65,43 @@ class TaxonPresenter
     accordion_items
   end
 
+  def options_for_leaf_content(index:)
+    {
+      module: 'track-click',
+      track_category: 'navLeafLinkClicked',
+      track_action: (index + 1).to_s,
+      track_label: tagged_content[index].base_path,
+      track_options: { dimension28: tagged_content.size.to_s,
+                       dimension29: tagged_content[index].title }
+    }
+  end
+
+  def options_for_child_taxon(index:)
+    {
+      module: 'track-click',
+      track_category: 'navGridContentClicked',
+      track_action: (index + 1).to_s,
+      track_label: child_taxons[index].base_path,
+      track_options: { dimension26: tagged_content.any? ? '2' : '1',
+                       dimension27: (child_taxons.length + tagged_content.length).to_s,
+                       dimension28: child_taxons.size.to_s,
+                       dimension29: child_taxons[index].title }
+    }
+  end
+
+  def options_for_tagged_content(index:)
+    {
+      module: 'track-click',
+      track_category: 'navGridContentClicked',
+      track_action: "L#{index + 1}",
+      track_label: tagged_content[index].base_path,
+      track_options: { dimension26: '2',
+                       dimension27: (child_taxons.length + tagged_content.length).to_s,
+                       dimension28: tagged_content.size.to_s,
+                       dimension29: tagged_content[index].title }
+    }
+  end
+
 private
 
   def ordered_child_taxons

--- a/app/views/taxons/_tagged_content_list.html.erb
+++ b/app/views/taxons/_tagged_content_list.html.erb
@@ -17,17 +17,9 @@
                   <%= link_to(
                     content_item.title,
                     Plek.new.website_root + content_item.base_path,
-                    data: {
-                      track_category: is_grid ? 'navGridLeafLinkClicked' : 'navLeafLinkClicked',
-                      track_action: index + 1,
-                      track_label: content_item.base_path,
-                      track_options: {
-                          dimension28: presented_taxon.tagged_content.size.to_s,
-                          dimension29: content_item.title,
-                      },
-                      module: 'track-click',
-                    }
-                    ) %>
+                    data: is_grid ? presented_taxon.options_for_tagged_content(index: index) :
+                              presented_taxon.options_for_leaf_content(index: index)
+                  ) %>
                 </h2>
                 <p><%= content_item.description %></p>
               </li>

--- a/app/views/taxons/grid.html.erb
+++ b/app/views/taxons/grid.html.erb
@@ -16,16 +16,7 @@
           <%= link_to(
             child_taxon.title,
             child_taxon.base_path,
-            data: {
-              track_category: 'navGridLinkClicked',
-              track_action: index + 1,
-              track_label: child_taxon.base_path,
-              track_options: {
-                dimension28: presented_taxon.child_taxons.size.to_s,
-                dimension29: child_taxon.title,
-              },
-              module: 'track-click',
-            }
+            data: presented_taxon.options_for_child_taxon(index: index)
           )%>
         </h2>
         <p><%= child_taxon.description %></p>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -33,7 +33,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_links_to_the_child_taxons_in_a_grid
     and_the_grid_has_tracking_attributes
     and_i_can_see_content_tagged_to_the_taxon
-    and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
     and_the_page_is_tracked_as_a_grid
     and_i_can_see_an_email_signup_link
   end
@@ -281,27 +280,15 @@ private
   end
 
   def and_the_grid_has_tracking_attributes
-    tracked_links = page.all(:css, "a[data-track-category='navGridLinkClicked']")
-    tracked_links.size.must_equal @child_taxons.size
-
-    tracked_links.each_with_index do |link, index|
-      expected_tracking_options = {
-        dimension28: @child_taxons.size.to_s,
-        dimension29: @child_taxons[index]['title']
-      }
-
-      link[:'data-track-action'].must_equal "#{index + 1}"
-      link[:'data-track-label'].must_equal @child_taxons[index]['base_path']
-      link[:'data-track-options'].must_equal expected_tracking_options.to_json
-      link[:'data-module'].must_equal 'track-click'
-    end
+    tracked_links = page.all(:css, "a[data-track-category='navGridContentClicked']")
+    tracked_links.size.must_equal(@child_taxons.size + @taxon.tagged_content.size)
 
     # Test an example free from logic
     assert page.has_css?(
-      "a[data-track-category='navGridLinkClicked']" +
+      "a[data-track-category='navGridContentClicked']" +
       "[data-track-action='1']" +
       "[data-track-label='/education-training-and-skills/student-finance']" +
-      "[data-track-options='{\"dimension28\":\"1\",\"dimension29\":\"Student finance\"}']" +
+      "[data-track-options='{\"dimension26\":\"2\",\"dimension27\":\"16\",\"dimension28\":\"1\",\"dimension29\":\"Student finance\"}']" +
       "[data-module='track-click']"
     )
   end
@@ -374,13 +361,6 @@ private
 
   alias_method :and_i_can_see_content_tagged_to_the_taxon_and_the_associate,
     :and_i_can_see_content_tagged_to_the_taxon
-
-  def and_the_content_tagged_to_the_grandfather_taxon_has_tracking_attributes
-    assert_leaf_tracking_attributes_present(
-      'navGridLeafLinkClicked',
-      search_results
-    )
-  end
 
   def and_the_blue_box_links_have_tracking_attributes
     assert_leaf_tracking_attributes_present(

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -1,5 +1,8 @@
 require 'test_helper'
 
+include RummagerHelpers
+include TaxonHelpers
+
 describe TaxonPresenter do
   describe '#rendering_type' do
     it 'returns GRID when the taxon has grandchildren' do
@@ -47,6 +50,182 @@ describe TaxonPresenter do
 
       WorldTaxonomySorter.expects(:call).returns(%w(c b a))
       TaxonPresenter.new(taxon).accordion_content
+    end
+  end
+
+  describe 'options' do
+    let(:content_hash) { funding_and_finance_for_students_taxon }
+    let(:content_item) { ContentItem.new(content_hash) }
+    let(:taxon) { Taxon.new(ContentItem.new(content_hash)) }
+    let(:child_taxon) { taxon.child_taxons.first }
+    let(:taxon_presenter) { TaxonPresenter.new(taxon) }
+
+    describe '#options_for_leaf_content' do
+      before :each do
+        @search_results = generate_search_results(15)
+        stub_content_for_taxon([taxon.content_id], @search_results)
+      end
+
+      describe 'root options' do
+        subject { taxon_presenter.options_for_leaf_content(index: 10) }
+
+        it 'contains the track-click module' do
+          assert_equal('track-click', subject[:module])
+        end
+
+        it 'contains the navLeafLinkClicked track_category' do
+          assert_equal('navLeafLinkClicked', subject[:track_category])
+        end
+
+        it 'contains track-action equal to the index + 1' do
+          assert_equal('11', subject[:track_action])
+        end
+
+        it 'contains track_label equal to the base path of the content' do
+          assert_equal(@search_results[10]['link'], subject[:track_label])
+        end
+      end
+
+      describe 'dimensions' do
+        subject { taxon_presenter.options_for_leaf_content(index: 10)[:track_options] }
+
+        describe 'dimension 28 - number of tagged content items' do
+          it 'contains the number of tagged content items' do
+            assert_equal('15', subject[:dimension28])
+          end
+        end
+
+        describe 'dimension 29 - title of the tagged content item' do
+          it 'contains the title of tagged content item' do
+            assert_equal(@search_results[10]['title'], subject[:dimension29])
+          end
+        end
+      end
+    end
+
+    describe '#options_for_tagged_content' do
+      describe 'root options' do
+        before :each do
+          @search_results = generate_search_results(15)
+          stub_content_for_taxon([taxon.content_id], @search_results)
+        end
+
+        subject { taxon_presenter.options_for_tagged_content(index: 10) }
+
+        it 'contains the track-click module' do
+          assert_equal('track-click', subject[:module])
+        end
+
+        it 'contains the navGridContentClicked track_category' do
+          assert_equal('navGridContentClicked', subject[:track_category])
+        end
+
+        it 'contains track-action equal to the index + 1 prefixed with an L' do
+          assert_equal('L11', subject[:track_action])
+        end
+
+        it 'contains track_label equal to the base path of the content' do
+          assert_equal(@search_results[10]['link'], subject[:track_label])
+        end
+      end
+
+      describe 'dimensions' do
+        before :each do
+          @search_results = generate_search_results(15)
+          stub_content_for_taxon([taxon.content_id], @search_results)
+        end
+
+        subject { taxon_presenter.options_for_tagged_content(index: 10)[:track_options] }
+
+        describe 'dimension 26 - "2" (these options by definition have tagged content items)' do
+          context 'there is a leaf grid section' do
+            it 'is 2' do
+              assert_equal('2', subject[:dimension26])
+            end
+          end
+        end
+
+        describe 'dimension 27 - total number of links on page (incl main and leaf section)' do
+          it 'contains the title of tagged content item' do
+            assert_equal('16', subject[:dimension27])
+          end
+        end
+
+        describe 'dimension 28 - number of tagged content items' do
+          it 'contains the number of tagged content items' do
+            assert_equal('15', subject[:dimension28])
+          end
+        end
+
+        describe 'dimension 29 - title of the tagged content item' do
+          it 'contains the title of tagged content item' do
+            assert_equal(@search_results[10]['title'], subject[:dimension29])
+          end
+        end
+      end
+    end
+
+    describe '#options_for_child_taxon' do
+      describe 'root options' do
+        before :each do
+          stub_content_for_taxon([taxon.content_id], generate_search_results(15))
+        end
+
+        subject { taxon_presenter.options_for_child_taxon(index: 0) }
+
+        it 'contains the track-click module' do
+          assert_equal('track-click', subject[:module])
+        end
+
+        it 'contains the navGridContentClicked track_category' do
+          assert_equal('navGridContentClicked', subject[:track_category])
+        end
+
+        it 'contains track-action equal to the index + 1' do
+          assert_equal('1', subject[:track_action])
+        end
+
+        it 'contains track_label equal to the base path of the child taxon' do
+          assert_equal(child_taxon.base_path, subject[:track_label])
+        end
+      end
+
+      describe 'dimensions' do
+        subject { taxon_presenter.options_for_child_taxon(index: 0)[:track_options] }
+
+        describe 'dimension 26 - 1 or 2 (depend if there is leaf grid section or not)' do
+          it 'is 2 because there is a leaf grid section' do
+            stub_content_for_taxon([taxon.content_id], generate_search_results(15))
+            assert_equal('2', subject[:dimension26])
+          end
+
+          it 'is 1 because there is no leaf grid section' do
+            stub_content_for_taxon([taxon.content_id], generate_search_results(0))
+            assert_equal('1', subject[:dimension26])
+          end
+        end
+
+        describe 'dimension 27 - total number of links on page (incl main and leaf section)' do
+          it 'contains the title of tagged content item' do
+            stub_content_for_taxon([taxon.content_id], generate_search_results(15))
+            assert_equal('16', subject[:dimension27])
+          end
+        end
+
+        describe 'dimension 28 - number of child taxons' do
+          it 'contains the number of child taxons' do
+            stub_content_for_taxon([taxon.content_id], generate_search_results(15))
+            assert_equal('1', subject[:dimension28])
+          end
+        end
+
+        describe 'dimension 29 - title of the child taxon' do
+          it 'contains the title of tagged content item' do
+            stub_content_for_taxon([taxon.content_id], generate_search_results(15))
+            assert_equal(child_taxon.title, subject[:dimension29])
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/FABDiyBp/150-create-new-event-tracking-navgridcontentclicked

A new event is added called 'navGridContentClicked' is added to the grid page with the following attributes:

- Event label: url of the content link clicked
- Event action: position of the content link clicked this should begin 1-12 and then return a L1, L2, L3 to signify leaf link
- Navigation section (dimension26): 1 or 2 (depend if there is leaf grid section or not)
- Navigation links (dimension27: total number of links on page (incl main and leaf section)
- Number of links(dimension28): number of links in section of link that was clicked (either main or leaf grid section)
- Link text (dimension29): displayed text of content link
