### PR TITLE
the pageElementInteraction event sends number of content links

### DIFF
--- a/app/assets/javascripts/modules/accordion-with-descriptions.js
+++ b/app/assets/javascripts/modules/accordion-with-descriptions.js
@@ -283,7 +283,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.track = trackClick;
 
       function trackClick() {
-        accordionTracker.track('pageElementInteraction', trackingAction(), {label: trackingLabel()});
+        var tracking_options = {label: trackingLabel(), dimension28: subsectionView.numberOfContentItems().toString()}
+        accordionTracker.track('pageElementInteraction', trackingAction(), tracking_options);
 
         if (!subsectionView.isClosed()) {
           accordionTracker.track(
@@ -317,7 +318,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.track = function(category, action, options) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           options = options || {};
-          options["dimension28"] = totalSubsections.toString();
+          options["dimension28"] = options["dimension28"] || totalSubsections.toString();
           GOVUK.analytics.trackEvent(category, action, options);
         }
       }

--- a/spec/javascripts/modules/accordion-with-descriptions_spec.js
+++ b/spec/javascripts/modules/accordion-with-descriptions_spec.js
@@ -35,6 +35,7 @@ describe('An accordion with descriptions module', function () {
       </div>\
     </div>';
   var expectedAccordionSectionCount = 2;
+  var expectedAccordionContentCount = 1;
 
   beforeEach(function () {
     accordion = new GOVUK.Modules.AccordionWithDescriptions();
@@ -168,7 +169,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
 
@@ -184,7 +185,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
 
@@ -200,7 +201,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
   });
@@ -239,7 +240,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
 
@@ -256,7 +257,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
 
@@ -274,7 +275,7 @@ describe('An accordion with descriptions module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
-        dimension28: expectedAccordionSectionCount.toString()
+        dimension28: expectedAccordionContentCount.toString()
       });
     });
   });


### PR DESCRIPTION
trello: https://trello.com/c/WgrJdXZN/148-amend-dimension28-number-of-links-tracking-on-pageelementinteraction-event-on-accordion-pages

When dimension28 is applied to pageElementInteraction event, it now returns the number of content 
links within an opened accordion.