### PR TITLE
Add current path to beta banner survey

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,8 @@ module ApplicationHelper
   def hairspace(string)
     string.gsub(/\s/, "\u200A") # \u200A = unicode hairspace
   end
+
+  def current_path_without_query_string
+    request.original_fullpath.split("?", 2).first
+  end
 end

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -17,7 +17,7 @@
         message: <<-MESSAGE
         This is a test version of the layout of this page.
         <a id=taxonomy-survey
-           href='https://www.smartsurvey.co.uk/s/betasurvey2017'
+           href='https://www.smartsurvey.co.uk/s/betasurvey2017?c=#{current_path_without_query_string}'
            target='_blank'
            rel='noopener noreferrer'>
           Take the survey to help us improve it

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  tests ApplicationHelper
+
+  describe "#current_path_without_query_string" do
+    it "returns the path of the current request" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+
+    it "returns the path of the current request stripping off any query string parameters" do
+      self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar', "QUERY_STRING" => 'ham=jam&spam=gram'))
+      assert_equal '/foo/bar', current_path_without_query_string
+    end
+  end
+end

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -28,9 +28,7 @@ class EmailHelperTest < ActionView::TestCase
   end
 
   test "should return a valid whitehall .atom url in the form /government/{url}.atom" do
-    define_singleton_method(:request) do
-      return OpenStruct.new(fullpath: "/world/blefuscu")
-    end
+    self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/world/blefuscu'))
 
     expected_atom_url = Plek.new.website_root + "/world/blefuscu.atom"
 
@@ -38,9 +36,7 @@ class EmailHelperTest < ActionView::TestCase
   end
 
   test "should return a valid whitehall email signup link" do
-    define_singleton_method(:request) do
-      return OpenStruct.new(fullpath: "/world/blefuscu")
-    end
+    self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/world/blefuscu'))
 
     atom_url = Plek.new.website_root + "/world/blefuscu.atom"
     expected_url = Plek.new.website_root +


### PR DESCRIPTION
For: https://trello.com/c/Bo5SQrIm/215-add-page-tracking-custom-dimension-into-education-beta-survey-banner

We need to add a `c` param containing the current path to the survey link to allow the user research team to filter responses from the part of the site they came from.