### PR TITLE
Remove govuk-title dependency

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,5 +1,28 @@
 .taxon-page {
 
+  .taxon-title {
+    margin-top: $gutter-half;
+    margin-bottom: $gutter-half;
+
+    @include media(tablet) {
+      margin-top: $gutter * 1.5;
+      margin-bottom: $gutter * 1.5;
+    }
+
+    .context {
+      @include core-24;
+      color: $secondary-text-colour;
+    }
+
+    h1 {
+      @include bold-48;
+    }
+
+    &.length-long h1 {
+      @include bold-36;
+    }
+  }
+
   h1 {
     box-sizing: border-box;
     display: block;

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <div class="govuk-title length-long">
+    <div class="taxon-title length-long">
       <h1>
         <%= presented_taxon.title %>
       </h1>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -409,9 +409,9 @@ private
   end
 
   def and_i_can_see_an_email_signup_link
-    govuk_title = page.find('.govuk-title')
+    taxon_title = page.find('.taxon-title')
 
-    assert govuk_title.has_link?(
+    assert taxon_title.has_link?(
       'Get email alerts for this topic',
       href: "/email-signup/?topic=#{current_path}"
     )


### PR DESCRIPTION
Removing the govuk-title class and moving the relevant styling over to collections.

This has been done as part of https://github.com/alphagov/static/pull/1117. This does now mean that styling is duplicated in static and collections. However, [there is a plan ](https://trello.com/c/ec0YjgQ4/220-update-titles-in-collections-to-use-title-and-lead-paragraph-components-in-static)to remove this in the future and instead use the static component.

Title should not look any different:
<img width="465" alt="screen shot 2017-08-24 at 11 30 44" src="https://user-images.githubusercontent.com/29889908/29662569-b247d4f0-88bf-11e7-89f9-efc0cf206308.png">
