### PR TITLE
Ensure leaf content has relative links

### DIFF
--- a/app/views/taxons/_tagged_content_list.html.erb
+++ b/app/views/taxons/_tagged_content_list.html.erb
@@ -16,7 +16,7 @@
                 <h2>
                   <%= link_to(
                     content_item.title,
-                    Plek.new.website_root + content_item.base_path,
+                    content_item.base_path,
                     data: is_grid ? presented_taxon.options_for_tagged_content(index: index) :
                               presented_taxon.options_for_leaf_content(index: index)
                   ) %>


### PR DESCRIPTION
Links with absolute addresses are considered external and trigger
an external-link-clicked event to Google Analytics.

Trello: https://trello.com/c/LqJozsgf/191-fix-external-link-event-bug-on-grid-leaf-links