### PR TITLE
Group exceptions in Sentry by type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 46.0'
+  gem 'gds-api-adapters', github: 'alphagov/gds-api-adapters', branch: 'group-sentry-errors'
 end
 
 gem 'plek', '~> 1.11.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: git://github.com/alphagov/gds-api-adapters.git
+  revision: 340e7e3395d4154a40a14e337431079f27e630d6
+  branch: group-sentry-errors
+  specs:
+    gds-api-adapters (47.8.0)
+      link_header
+      lrucache (~> 0.1.1)
+      null_logger
+      plek (>= 1.9.0)
+      rack-cache
+      rest-client (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -82,19 +95,12 @@ GEM
     debug_inspector (0.0.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (46.0.0)
-      link_header
-      lrucache (~> 0.1.1)
-      null_logger
-      plek (>= 1.9.0)
-      rack-cache
-      rest-client (~> 2.0)
     gherkin (4.0.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -205,7 +211,7 @@ GEM
     raindrops (0.17.0)
     rake (11.3.0)
     request_store (1.3.1)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -263,7 +269,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicode-display_width (1.1.0)
     unicorn (4.9.0)
       kgio (~> 2.6)
@@ -286,7 +292,7 @@ DEPENDENCIES
   binding_of_caller
   capybara (~> 2.14.0)
   cucumber-rails (~> 1.4.2)
-  gds-api-adapters (~> 46.0)
+  gds-api-adapters!
   govuk-lint
   govuk_ab_testing (~> 2.4)
   govuk_app_config (~> 0.2)


### PR DESCRIPTION
This makes Sentry group exceptions by type instead of message, so all exceptions like `GdsApi::TimedOutException` will get grouped as one error and not an error per URL.

Using branch of gds-api-adapters to make sure this is a good thing to do.