### PR TITLE
Identify legacy navigation in Analytics

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,10 @@ class ApplicationController < ActionController::Base
     ab_test.requested_variant(request.headers)
   end
 
+  def configure_ab_response
+    ab_variant.configure_response(response)
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def ab_variant
+    dimension = Rails.application.config.navigation_ab_test_dimension
+    ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
+    ab_test.requested_variant(request.headers)
+  end
+
 private
 
   def restrict_request_formats

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -34,11 +34,11 @@ private
   def show_html(page)
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
-      is_page_in_ab_test: lambda { top_level_redirect.present? },
+      page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: lambda { top_level_redirect }
     )
 
-    if taxon_resolver.page_ab_tested?
+    if page_in_ab_test?
       ab_variant.configure_response(response)
     end
 
@@ -52,10 +52,14 @@ private
     else
       render :show, locals: {
         page: page,
-        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        is_page_under_ab_test: page_in_ab_test?,
         ab_variant: ab_variant,
       }
     end
+  end
+
+  def page_in_ab_test?
+    top_level_redirect.present?
   end
 
   def top_level_redirect

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -33,13 +33,13 @@ private
 
   def show_html(page)
     taxon_resolver = TaxonRedirectResolver.new(
-      request,
+      ab_variant,
       is_page_in_ab_test: lambda { top_level_redirect.present? },
       map_to_taxon: lambda { top_level_redirect }
     )
 
     if taxon_resolver.page_ab_tested?
-      taxon_resolver.ab_variant.configure_response(response)
+      ab_variant.configure_response(response)
     end
 
     if taxon_resolver.taxon_base_path
@@ -53,7 +53,7 @@ private
       render :show, locals: {
         page: page,
         is_page_under_ab_test: taxon_resolver.page_ab_tested?,
-        ab_variant: taxon_resolver.ab_variant,
+        ab_variant: ab_variant,
       }
     end
   end

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -35,7 +35,7 @@ private
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
-      map_to_taxon: lambda { top_level_redirect }
+      map_to_taxon: top_level_redirect
     )
 
     if page_in_ab_test?

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -52,8 +52,13 @@ private
         page: page,
         is_page_under_ab_test: page_in_ab_test?,
         ab_variant: ab_variant,
+        legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier
       }
     end
+  end
+
+  def legacy_navigation_analytics_identifier
+    params[:top_level_slug] if top_level_redirect.present?
   end
 
   def page_in_ab_test?

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -38,9 +38,7 @@ private
       map_to_taxon: top_level_redirect
     )
 
-    if page_in_ab_test?
-      ab_variant.configure_response(response)
-    end
+    configure_ab_response if page_in_ab_test?
 
     if taxon_resolver.taxon_base_path
       redirect_to(

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -40,7 +40,7 @@ private
 
     configure_ab_response if page_in_ab_test?
 
-    if taxon_resolver.taxon_base_path
+    if taxon_resolver.redirect?
       redirect_to(
         controller: "taxons",
         action: "show",

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -32,13 +32,13 @@ class BrowseController < ApplicationController
 private
 
   def show_html(page)
+    configure_ab_response if page_in_ab_test?
+
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: top_level_redirect
     )
-
-    configure_ab_response if page_in_ab_test?
 
     if taxon_resolver.redirect?
       redirect_to(

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -28,7 +28,7 @@ private
 
     configure_ab_response if page_in_ab_test?
 
-    if taxon_resolver.taxon_base_path
+    if taxon_resolver.redirect?
       redirect_to(
         controller: "taxons",
         action: "show",

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -20,13 +20,13 @@ class SecondLevelBrowsePageController < ApplicationController
 private
 
   def show_html
+    configure_ab_response if page_in_ab_test?
+
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: second_level_redirect
     )
-
-    configure_ab_response if page_in_ab_test?
 
     if taxon_resolver.redirect?
       redirect_to(

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -23,7 +23,7 @@ private
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
-      map_to_taxon: lambda { second_level_redirect }
+      map_to_taxon: second_level_redirect
     )
 
     if page_in_ab_test?

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -41,8 +41,13 @@ private
         meta_section: meta_section,
         is_page_under_ab_test: page_in_ab_test?,
         ab_variant: ab_variant,
+        legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier
       }
     end
+  end
+
+  def legacy_navigation_analytics_identifier
+    params[:top_level_slug] if top_level_redirect.present?
   end
 
   def page_in_ab_test?

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -22,13 +22,11 @@ private
   def show_html
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
-      is_page_in_ab_test: lambda {
-        top_level_redirect.present? && second_level_redirect.present?
-      },
+      page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: lambda { second_level_redirect }
     )
 
-    if taxon_resolver.page_ab_tested?
+    if page_in_ab_test?
       ab_variant.configure_response(response)
     end
 
@@ -43,10 +41,14 @@ private
       render :show, locals: {
         page: page,
         meta_section: meta_section,
-        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        is_page_under_ab_test: page_in_ab_test?,
         ab_variant: ab_variant,
       }
     end
+  end
+
+  def page_in_ab_test?
+    top_level_redirect.present? && second_level_redirect.present?
   end
 
   def top_level_redirect

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -21,7 +21,7 @@ private
 
   def show_html
     taxon_resolver = TaxonRedirectResolver.new(
-      request,
+      ab_variant,
       is_page_in_ab_test: lambda {
         top_level_redirect.present? && second_level_redirect.present?
       },
@@ -29,7 +29,7 @@ private
     )
 
     if taxon_resolver.page_ab_tested?
-      taxon_resolver.ab_variant.configure_response(response)
+      ab_variant.configure_response(response)
     end
 
     if taxon_resolver.taxon_base_path
@@ -44,7 +44,7 @@ private
         page: page,
         meta_section: meta_section,
         is_page_under_ab_test: taxon_resolver.page_ab_tested?,
-        ab_variant: taxon_resolver.ab_variant,
+        ab_variant: ab_variant,
       }
     end
   end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -26,9 +26,7 @@ private
       map_to_taxon: second_level_redirect
     )
 
-    if page_in_ab_test?
-      ab_variant.configure_response(response)
-    end
+    configure_ab_response if page_in_ab_test?
 
     if taxon_resolver.taxon_base_path
       redirect_to(

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -1,4 +1,6 @@
 class ServicesAndInformationController < ApplicationController
+  before_action :configure_ab_response, if: :page_in_ab_test?
+
   def index
     setup_content_item_and_navigation_helpers(service_and_information)
 
@@ -7,10 +9,6 @@ class ServicesAndInformationController < ApplicationController
       page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: "education"
     )
-
-    if page_in_ab_test?
-      ab_variant.configure_response(response)
-    end
 
     if taxon_resolver.taxon_base_path
       redirect_to(

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -5,7 +5,7 @@ class ServicesAndInformationController < ApplicationController
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
-      map_to_taxon: lambda { "education" }
+      map_to_taxon: "education"
     )
 
     if page_in_ab_test?

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -4,11 +4,11 @@ class ServicesAndInformationController < ApplicationController
 
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
-      is_page_in_ab_test: lambda { params[:organisation_id] == "department-for-education" },
+      page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: lambda { "education" }
     )
 
-    if taxon_resolver.page_ab_tested?
+    if page_in_ab_test?
       ab_variant.configure_response(response)
     end
 
@@ -24,13 +24,17 @@ class ServicesAndInformationController < ApplicationController
         service_and_information: service_and_information,
         organisation: service_and_information.organisation,
         grouped_links: grouped_links,
-        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        is_page_under_ab_test: page_in_ab_test?,
         ab_variant: ab_variant,
       }
     end
   end
 
 private
+
+  def page_in_ab_test?
+    params[:organisation_id] == "department-for-education"
+  end
 
   def base_path
     "/government/organisations/#{params[:organisation_id]}/services-information"

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -10,7 +10,7 @@ class ServicesAndInformationController < ApplicationController
       map_to_taxon: "education"
     )
 
-    if taxon_resolver.taxon_base_path
+    if taxon_resolver.redirect?
       redirect_to(
         controller: "taxons",
         action: "show",

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -3,13 +3,13 @@ class ServicesAndInformationController < ApplicationController
     setup_content_item_and_navigation_helpers(service_and_information)
 
     taxon_resolver = TaxonRedirectResolver.new(
-      request,
+      ab_variant,
       is_page_in_ab_test: lambda { params[:organisation_id] == "department-for-education" },
       map_to_taxon: lambda { "education" }
     )
 
     if taxon_resolver.page_ab_tested?
-      taxon_resolver.ab_variant.configure_response(response)
+      ab_variant.configure_response(response)
     end
 
     if taxon_resolver.taxon_base_path
@@ -25,7 +25,7 @@ class ServicesAndInformationController < ApplicationController
         organisation: service_and_information.organisation,
         grouped_links: grouped_links,
         is_page_under_ab_test: taxon_resolver.page_ab_tested?,
-        ab_variant: taxon_resolver.ab_variant,
+        ab_variant: ab_variant,
       }
     end
   end

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -8,7 +8,7 @@ class SubtopicsController < ApplicationController
       map_to_taxon: second_level_redirect
     )
 
-    if taxon_resolver.taxon_base_path
+    if taxon_resolver.redirect?
       redirect_to(
         controller: "taxons",
         action: "show",

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -3,7 +3,7 @@ class SubtopicsController < ApplicationController
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
-      map_to_taxon: lambda { redirects[params[:topic_slug]][params[:subtopic_slug]] }
+      map_to_taxon: second_level_redirect
     )
 
     if page_in_ab_test?
@@ -41,7 +41,7 @@ private
   end
 
   def second_level_redirect
-    redirects[params[:topic_slug]][params[:subtopic_slug]]
+    redirects.dig(params[:topic_slug], params[:subtopic_slug])
   end
 
   def organisations(subtopic_content_id)

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,7 +1,7 @@
 class SubtopicsController < ApplicationController
   def show
     taxon_resolver = TaxonRedirectResolver.new(
-      request,
+      ab_variant,
       is_page_in_ab_test: lambda {
         !redirects[params[:topic_slug]].nil? &&
           !redirects[params[:topic_slug]][params[:subtopic_slug]].nil?
@@ -10,7 +10,7 @@ class SubtopicsController < ApplicationController
     )
 
     if taxon_resolver.page_ab_tested?
-      taxon_resolver.ab_variant.configure_response(response)
+      ab_variant.configure_response(response)
     end
 
     if taxon_resolver.taxon_base_path
@@ -27,7 +27,7 @@ class SubtopicsController < ApplicationController
       render :show, locals: {
         subtopic: subtopic,
         meta_section: subtopic.parent.title.downcase,
-        ab_variant: taxon_resolver.ab_variant,
+        ab_variant: ab_variant,
         is_page_under_ab_test: taxon_resolver.page_ab_tested?,
       }
     end

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,14 +1,12 @@
 class SubtopicsController < ApplicationController
+  before_action :configure_ab_response, if: :page_in_ab_test?
+
   def show
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: second_level_redirect
     )
-
-    if page_in_ab_test?
-      ab_variant.configure_response(response)
-    end
 
     if taxon_resolver.taxon_base_path
       redirect_to(

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -8,13 +8,13 @@ class TopicsController < ApplicationController
 
   def show
     taxon_resolver = TaxonRedirectResolver.new(
-      request,
+      ab_variant,
       is_page_in_ab_test: lambda { !redirects[params[:topic_slug]].nil? },
       map_to_taxon: lambda { redirects[params[:topic_slug]] }
     )
 
     if taxon_resolver.page_ab_tested?
-      taxon_resolver.ab_variant.configure_response(response)
+      ab_variant.configure_response(response)
     end
 
     if taxon_resolver.taxon_base_path
@@ -30,7 +30,7 @@ class TopicsController < ApplicationController
 
       render :index, locals: {
         topic: topic,
-        ab_variant: taxon_resolver.ab_variant,
+        ab_variant: ab_variant,
         is_page_under_ab_test: taxon_resolver.page_ab_tested?,
       }
     end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -10,7 +10,7 @@ class TopicsController < ApplicationController
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
       page_is_in_ab_test: page_in_ab_test?,
-      map_to_taxon: lambda { redirects[params[:topic_slug]] }
+      map_to_taxon: top_level_redirect
     )
 
     if page_in_ab_test?

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,6 @@
 class TopicsController < ApplicationController
+  before_action :configure_ab_response, if: :page_in_ab_test?, only: [:show]
+
   def index
     topic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(topic)
@@ -12,10 +14,6 @@ class TopicsController < ApplicationController
       page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: top_level_redirect
     )
-
-    if page_in_ab_test?
-      ab_variant.configure_response(response)
-    end
 
     if taxon_resolver.taxon_base_path
       redirect_to(

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -9,11 +9,11 @@ class TopicsController < ApplicationController
   def show
     taxon_resolver = TaxonRedirectResolver.new(
       ab_variant,
-      is_page_in_ab_test: lambda { !redirects[params[:topic_slug]].nil? },
+      page_is_in_ab_test: page_in_ab_test?,
       map_to_taxon: lambda { redirects[params[:topic_slug]] }
     )
 
-    if taxon_resolver.page_ab_tested?
+    if page_in_ab_test?
       ab_variant.configure_response(response)
     end
 
@@ -31,9 +31,19 @@ class TopicsController < ApplicationController
       render :index, locals: {
         topic: topic,
         ab_variant: ab_variant,
-        is_page_under_ab_test: taxon_resolver.page_ab_tested?,
+        is_page_under_ab_test: page_in_ab_test?,
       }
     end
+  end
+
+private
+
+  def page_in_ab_test?
+    top_level_redirect.present?
+  end
+
+  def top_level_redirect
+    redirects[params[:topic_slug]]
   end
 
   def redirects

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -15,7 +15,7 @@ class TopicsController < ApplicationController
       map_to_taxon: top_level_redirect
     )
 
-    if taxon_resolver.taxon_base_path
+    if taxon_resolver.redirect?
       redirect_to(
         controller: "taxons",
         action: "show",

--- a/app/helpers/navigation_ab_helper.rb
+++ b/app/helpers/navigation_ab_helper.rb
@@ -1,0 +1,9 @@
+module NavigationAbHelper
+  def legacy_navigation_meta_tag(analytics_identifier)
+    if analytics_identifier
+      "<meta name='govuk:navigation-legacy' content='#{analytics_identifier}'>"
+    else
+      ''
+    end
+  end
+end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -2,10 +2,8 @@ class TaxonRedirectResolver
   attr_reader :taxon_base_path, :fragment
 
   def initialize(ab_variant, page_is_in_ab_test:, map_to_taxon:)
-    @map_to_taxon = map_to_taxon
-
     if page_is_in_ab_test && ab_variant.variant?('B')
-      @taxon_base_path, @fragment = @map_to_taxon.call.split('#')
+      @taxon_base_path, @fragment = map_to_taxon.split('#')
     end
   end
 end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -1,11 +1,7 @@
 class TaxonRedirectResolver
-  attr_reader :ab_variant, :taxon_base_path, :fragment
+  attr_reader :taxon_base_path, :fragment
 
-  def initialize(request, is_page_in_ab_test:, map_to_taxon:)
-    dimension = Rails.application.config.navigation_ab_test_dimension
-    ab_test = GovukAbTesting::AbTest.new("EducationNavigation", dimension: dimension)
-    @ab_variant = ab_test.requested_variant(request.headers)
-
+  def initialize(ab_variant, is_page_in_ab_test:, map_to_taxon:)
     @is_page_in_ab_test = is_page_in_ab_test
     @map_to_taxon = map_to_taxon
 

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -6,4 +6,8 @@ class TaxonRedirectResolver
       @taxon_base_path, @fragment = map_to_taxon.split('#')
     end
   end
+
+  def redirect?
+    taxon_base_path.present?
+  end
 end

--- a/app/lib/taxon_redirect_resolver.rb
+++ b/app/lib/taxon_redirect_resolver.rb
@@ -1,16 +1,11 @@
 class TaxonRedirectResolver
   attr_reader :taxon_base_path, :fragment
 
-  def initialize(ab_variant, is_page_in_ab_test:, map_to_taxon:)
-    @is_page_in_ab_test = is_page_in_ab_test
+  def initialize(ab_variant, page_is_in_ab_test:, map_to_taxon:)
     @map_to_taxon = map_to_taxon
 
-    if page_ab_tested? && ab_variant.variant?('B')
+    if page_is_in_ab_test && ab_variant.variant?('B')
       @taxon_base_path, @fragment = @map_to_taxon.call.split('#')
     end
-  end
-
-  def page_ab_tested?
-    @is_page_in_ab_test.call
   end
 end

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -3,6 +3,7 @@
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>
     <%= ab_variant.analytics_meta_tag.html_safe %>
+    <%= legacy_navigation_meta_tag(legacy_navigation_analytics_identifier).html_safe %>
   <% end %>
 <% end %>
 <% content_for :page_class, "browse" %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -3,6 +3,7 @@
 <% content_for :meta_tags do %>
   <% if is_page_under_ab_test %>
     <%= ab_variant.analytics_meta_tag.html_safe %>
+    <%= legacy_navigation_meta_tag(legacy_navigation_analytics_identifier).html_safe %>
   <% end %>
 <% end %>
 <% content_for :page_class, "browse" %>

--- a/test/unit/navigation_ab_helper_test.rb
+++ b/test/unit/navigation_ab_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class NavigationAbHelperTest < ActionView::TestCase
+  tests NavigationAbHelper
+
+  describe "#legacy_navigation_meta_tag" do
+    it "returns a 'govuk:navigation-legacy' meta tag if given an identifier" do
+      expected = "<meta name='govuk:navigation-legacy' content='foo'>"
+      result = legacy_navigation_meta_tag('foo')
+      assert_equal expected, result
+    end
+
+    it "returns empty string if called with nil" do
+      assert_equal '', legacy_navigation_meta_tag(nil)
+    end
+  end
+end


### PR DESCRIPTION
Refactoring the AB test controller code, before implementing the new dimension to identify legacy navigation pages.

[Trello](https://trello.com/c/IPAyElBg/248-send-identifying-value-for-legacy-education-childcare-navigation-pages)