### PR TITLE
Add Navigation Legacy meta tag to topics pages

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -58,7 +58,7 @@ private
   end
 
   def legacy_navigation_analytics_identifier
-    params[:top_level_slug] if top_level_redirect.present?
+    top_level_redirect.split('/').first if page_in_ab_test?
   end
 
   def page_in_ab_test?

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -47,7 +47,7 @@ private
   end
 
   def legacy_navigation_analytics_identifier
-    params[:top_level_slug] if top_level_redirect.present?
+    second_level_redirect.split('/').first if page_in_ab_test?
   end
 
   def page_in_ab_test?

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -24,11 +24,16 @@ class SubtopicsController < ApplicationController
         meta_section: subtopic.parent.title.downcase,
         ab_variant: ab_variant,
         is_page_under_ab_test: page_in_ab_test?,
+        legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier
       }
     end
   end
 
 private
+
+  def legacy_navigation_analytics_identifier
+    second_level_redirect.split('/').first if page_in_ab_test?
+  end
 
   def page_in_ab_test?
     top_level_redirect.present? && second_level_redirect.present?

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -30,11 +30,16 @@ class TopicsController < ApplicationController
         topic: topic,
         ab_variant: ab_variant,
         is_page_under_ab_test: page_in_ab_test?,
+        legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier
       }
     end
   end
 
 private
+
+  def legacy_navigation_analytics_identifier
+    top_level_redirect.split('/').first if page_in_ab_test?
+  end
 
   def page_in_ab_test?
     top_level_redirect.present?

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,7 +1,10 @@
 <% content_for :title, subtopic.combined_title %>
 <%= render 'shared/tag_meta', tag: subtopic %>
-<% if is_page_under_ab_test %>
-  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
+    <%= legacy_navigation_meta_tag(legacy_navigation_analytics_identifier).html_safe %>
+  <% end %>
 <% end %>
 <% content_for :page_title do %>
   <%- if subtopic.parent -%>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,7 +1,10 @@
 <% content_for :title, topic.title %>
 <%= render 'shared/tag_meta', tag: topic %>
-<% if is_page_under_ab_test %>
-  <%= ab_variant.analytics_meta_tag.html_safe %>
+<% content_for :meta_tags do %>
+  <% if is_page_under_ab_test %>
+    <%= ab_variant.analytics_meta_tag.html_safe %>
+    <%= legacy_navigation_meta_tag(legacy_navigation_analytics_identifier).html_safe %>
+  <% end %>
 <% end %>
 <% content_for :page_class, "topics-page" %>
 

--- a/test/integration/legacy_navigation_analytics_test.rb
+++ b/test/integration/legacy_navigation_analytics_test.rb
@@ -1,0 +1,121 @@
+require 'integration_test_helper'
+
+class LegacyNavigationAnalyticsTest < ActionDispatch::IntegrationTest
+  include GovukAbTesting::MinitestHelpers
+  include AnalyticsHelpers
+  include GdsApi::TestHelpers::ContentItemHelpers
+  include RummagerHelpers
+
+  before do
+    @existing_framework = GovukAbTesting.configuration.acceptance_test_framework
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = :capybara
+    end
+  end
+
+  after do
+    Capybara.reset_sessions!
+
+    GovukAbTesting.configure do |config|
+      config.acceptance_test_framework = @existing_framework
+    end
+  end
+
+  def setup_content_item(basepath)
+    item = content_item_for_base_path(basepath).merge(
+      "content_id" => 'dummy-content-id',
+      "links" => {
+        "active_top_level_browse_page" => [{
+          "title" => 'Foo',
+          "base_path" => '/foo',
+          "description" => 'foo',
+          "content_id" => 'foo'
+        }],
+        "parent" => [{
+          "title" => 'Foo',
+          "base_path" => '/foo',
+          "description" => 'foo',
+          "content_id" => 'foo'
+        }]
+      }
+    )
+    content_store_has_item(basepath, item)
+  end
+
+  test "Legacy browse pages in AB scope have analytics meta tag" do
+    path = '/browse/education'
+    setup_content_item(path)
+    with_variant EducationNavigation: "A" do
+      visit path
+      assert page_has_meta_tag?('govuk:navigation-legacy', 'education')
+    end
+  end
+
+  test "Second level browse pages in AB scope have analytics meta tag" do
+    path = '/browse/education/find-course'
+    rummager_has_documents_for_second_level_browse_page('dummy-content-id', ['foo'])
+    setup_content_item(path)
+    with_variant EducationNavigation: "A" do
+      visit path
+      assert page_has_meta_tag?('govuk:navigation-legacy', 'education')
+    end
+  end
+
+  test "Legacy Topic pages in AB scope have analytics meta tag" do
+    path = '/topic/further-education-skills'
+    setup_content_item(path)
+    with_variant EducationNavigation: "A" do
+      visit path
+      assert page_has_meta_tag?('govuk:navigation-legacy', 'education')
+    end
+  end
+
+  test "Subtopic pages in AB scope have analytics meta tag" do
+    path = '/topic/further-education-skills/apprenticeships'
+    setup_subtopic_organisations('dummy-content-id')
+    rummager_has_documents_for_subtopic('dummy-content-id', ['foo'])
+    setup_content_item(path)
+    with_variant EducationNavigation: "A" do
+      visit path
+      assert page_has_meta_tag?('govuk:navigation-legacy', 'education')
+    end
+  end
+
+  def setup_subtopic_organisations(subtopic_content_id)
+    Services.rummager.stubs(:search).with(
+      count: "0",
+      filter_topic_content_ids: [subtopic_content_id],
+      facet_organisations: "1000"
+    ).returns(
+      "facets" => {
+        "organisations" => {
+          "options" => [
+            "value" => {
+              "title" => 'foo',
+              "link" => 'bar'
+            }
+          ]
+        }
+      }
+    )
+  end
+
+  def rummager_has_documents_for_subtopic(subtopic_content_id, document_slugs, format = "guide", page_size: 1000)
+    results = document_slugs.map.with_index do |slug, i|
+      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+    end
+
+    results.each_slice(page_size).with_index do |results_page, page|
+      start = page * page_size
+      Services.rummager.stubs(:search).with(
+        start: start,
+        count: page_size,
+        filter_topic_content_ids: [subtopic_content_id],
+        fields: %w(title link format),
+      ).returns("results" => results_page,
+        "start" => start,
+        "total" => results.size)
+    end
+  end
+end

--- a/test/support/analytics_helpers.rb
+++ b/test/support/analytics_helpers.rb
@@ -1,0 +1,5 @@
+module AnalyticsHelpers
+  def page_has_meta_tag?(name, content)
+    page.has_selector?(:xpath, "/html/head/meta[@name='#{name}'][@content='#{content}']", visible: false)
+  end
+end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -144,6 +144,24 @@ module RummagerHelpers
     end
   end
 
+  def rummager_has_documents_for_second_level_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 1000)
+    results = document_slugs.map.with_index do |slug, i|
+      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+    end
+
+    results.each_slice(page_size).with_index do |results_page, page|
+      start = page * page_size
+      Services.rummager.stubs(:search).with(
+        start: start,
+        count: page_size,
+        filter_mainstream_browse_page_content_ids: [browse_page_content_id],
+        fields: %w(title link format),
+      ).returns("results" => results_page,
+        "start" => start,
+        "total" => results.size)
+    end
+  end
+
   def expect_search_params(params)
     GdsApi::Rummager.any_instance.expects(:search)
       .with(has_entries(params))


### PR DESCRIPTION
Topic pages that are covered by the EducationAB test scope are also in need of this tracking code.

The `govuk:navigation-legacy` meta tag feeds into `dimension30` of our analytics implementation. It's acceptable values are `education`, `childcare-parenting`, or `none`.

[Trello](https://trello.com/c/IPAyElBg/248-send-identifying-value-for-legacy-education-childcare-navigation-pages)