### PR TITLE
Ensure we're sending a legacySectionID when navigating /browse in JS

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -350,12 +350,15 @@
       var sectionTitle = this.$section.find('h1').text();
       sectionTitle = sectionTitle ? sectionTitle.toLowerCase() : 'browse';
 
+      var legacySectionIdentifier = state.sectionData['legacy_navigation_analytics_identifier'];
+
       if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
         GOVUK.analytics.trackPageview(
           state.path,
           null,
           {
-            dimension1: sectionTitle
+            dimension1: sectionTitle,
+            dimension30: legacySectionIdentifier
           }
         );
       }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -23,7 +23,8 @@ class BrowseController < ApplicationController
       f.json do
         render json: {
           breadcrumbs: breadcrumb_content,
-          html: second_level_browse_pages_partial(page)
+          html: second_level_browse_pages_partial(page),
+          legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier || 'none'
         }
       end
     end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -11,7 +11,8 @@ class SecondLevelBrowsePageController < ApplicationController
       f.json do
         render json: {
           breadcrumbs: breadcrumb_content,
-          html: render_partial('_links', page: page)
+          html: render_partial('_links', page: page),
+          legacy_navigation_analytics_identifier: legacy_navigation_analytics_identifier || 'none'
         }
       end
     end

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -130,6 +130,29 @@ describe('browse-columns.js', function() {
     expect(context.$breadcrumbs.find('li').length).toEqual(2);
   });
 
+  it("should track a page view", function() {
+    GOVUK.analytics = jasmine.createSpyObj('analytics', ['trackPageview']);
+
+    var state = {
+      path: 'foo',
+      sectionData: {
+        legacy_navigation_analytics_identifier: 'legacy-section-identifier'
+      }
+    };
+
+    var bc = new GOVUK.BrowseColumns({ $el: $('<div>') });
+    bc.trackPageview(state);
+
+    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith(
+      'foo',
+      null,
+      {
+        dimension1: 'browse',
+        dimension30: 'legacy-section-identifier'
+      }
+    );
+  });
+
   // http://stackoverflow.com/questions/9821166/error-accessing-jquerywindow-height-in-jasmine-while-running-tests-in-maven
   function setWindowSize(size) {
     $.prototype.width = function() {


### PR DESCRIPTION
Previous attempts at tracking the performance of browse pages covered by
the Education AB test, failed when users followed AJAX'd links in the
mainstream browse navigation.

This change ensures that we're sending the correct override for the
'GOVUK:legacy-navigation' meta-tag when tracking page views in this
world.

[Trello](https://trello.com/c/IPAyElBg/248-send-identifying-value-for-legacy-education-childcare-navigation-pages)