### PR TITLE
Ignore GdsApi::TimedOutException

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'gds-api-adapters', '~> 47.9'
 gem 'govuk_ab_testing', '~> 2.4'
-gem 'govuk_app_config', '~> 0.2'
+gem 'govuk_app_config', '~> 0.3'
 gem 'govuk_frontend_toolkit', '~> 4.3.0'
 gem 'govuk_navigation_helpers', '6.3.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       rubocop (~> 0.49.0)
       scss_lint
     govuk_ab_testing (2.4.0)
-    govuk_app_config (0.2.0)
+    govuk_app_config (0.3.0)
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
     govuk_frontend_toolkit (4.3.0)
@@ -295,7 +295,7 @@ DEPENDENCIES
   gds-api-adapters (~> 47.9)
   govuk-lint
   govuk_ab_testing (~> 2.4)
-  govuk_app_config (~> 0.2)
+  govuk_app_config (~> 0.3)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (= 6.3.0)
   govuk_schemas

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,8 @@
+GovukError.configure do |config|
+  # A couple of hundred timeouts occur each day. This can be caused by
+  # rummager or content-store being busy, or network issues. They generally
+  # aren't a big deal, since Fastly will show the mirror. We can safely
+  # ignore the errors because we have other monitoring in place that alerts
+  # us if the error rate reaches certain thresholds. 
+  config.excluded_exceptions << "GdsApi::TimedOutException"
+end


### PR DESCRIPTION
See comment for details. If this solves most un-actionable errors in Sentry it should be replicated to other frontend applications as well.

Update `govuk_config` to use `GovukError.configure`.

https://trello.com/c/lqHmGMEB