### PR TITLE
Don't report timeouts to Sentry (Part II)

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -3,6 +3,15 @@ GovukError.configure do |config|
   # rummager or content-store being busy, or network issues. They generally
   # aren't a big deal, since Fastly will show the mirror. We can safely
   # ignore the errors because we have other monitoring in place that alerts
-  # us if the error rate reaches certain thresholds. 
+  # us if the error rate reaches certain thresholds.
   config.excluded_exceptions << "GdsApi::TimedOutException"
+
+  config.should_capture = Proc.new {
+    # We're overriding the `should_capture` block here:
+    # https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/configure.rb#L9-L19
+    GovukStatsd.increment("errors_occurred")
+    GovukStatsd.increment("errbit.errors_occurred")
+
+    !e.cause.class.name.in?(config.excluded_exceptions)
+  }
 end


### PR DESCRIPTION
In https://github.com/alphagov/collections/pull/383 I tried filtering timeout exceptions, because they're mostly noise and distract from real errors.

That PR doesn't work because Rails rescues and re-raises errors. This means that the error we see is actually a `ActionView::Template::Error`:

<img width="1319" alt="screen shot 2017-09-27 at 17 53 24" src="https://user-images.githubusercontent.com/233676/30926367-c9e758bc-a3ac-11e7-8df3-3a98b2f0f536.png">

We can't filter out those errors because it's likely that any real problems would be masked by that.

A solution is to look at the `cause` of the exception. This is the exception that's the original cause, see:

```rb
begin
  begin
    raise ArgumentError
  rescue
    raise StandardError
  end
rescue => e
  puts e.class.name # "StandardError"
  puts e.cause.class.name # "ArgumentError"
end
```

I've proposed a solution on the Raven repo: https://github.com/getsentry/raven-ruby/issues/765, but it's a bit of a risky change to make in that gem.

This commit is a experiment to see if we can filter by looking at `cause`. If it works we can push it up to the gem, and eventually to the Sentry client.

https://trello.com/c/lqHmGMEB