### PR TITLE
Use title components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read(".ruby-version").strip
+
 gem 'gds-api-adapters', '~> 47.9'
 gem 'govuk_ab_testing', '~> 2.4'
 gem 'govuk_app_config', '~> 0.3'

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,8 @@
 @import "design-patterns/buttons";
 
 @import "helpers/layouts";
-@import 'components/*';
+@import "helpers/margins";
+@import "components/*";
 
 @import "views/browse";
 @import "views/latest-changes";

--- a/app/assets/stylesheets/helpers/_margins.scss
+++ b/app/assets/stylesheets/helpers/_margins.scss
@@ -1,0 +1,24 @@
+@mixin responsive-bottom-margin {
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 1.5;
+  }
+}
+
+@mixin responsive-top-margin {
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter * 1.5;
+  }
+}
+
+@mixin responsive-vertical-margins {
+  @include responsive-bottom-margin;
+  @include responsive-top-margin;
+}
+
+.add-title-margin {
+  @include responsive-top-margin;
+}

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,35 +1,6 @@
 .taxon-page {
-
-  .taxon-title {
-    margin-top: $gutter-half;
-    margin-bottom: $gutter-half;
-
-    @include media(tablet) {
-      margin-top: $gutter * 1.5;
-      margin-bottom: $gutter * 1.5;
-    }
-
-    .context {
-      @include core-24;
-      color: $secondary-text-colour;
-    }
-
-    h1 {
-      @include bold-48;
-    }
-
-    &.length-long h1 {
-      @include bold-36;
-    }
-  }
-
-  h1 {
-    box-sizing: border-box;
-    display: block;
-
-    +p {
-      @include core-24;
-    }
+  .taxon-description {
+    @include core-24;
   }
 
   h2 {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -29,14 +29,6 @@
     display: block;
   }
 
-  .page-header {
-    margin-top: $gutter * 3;
-
-    h1 {
-      padding-top: 0;
-    }
-  }
-
   .child-topics-list {
     ol {
       list-style-type: none;

--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -1,32 +1,6 @@
 .topics-page {
 
   .page-header {
-    padding: $gutter-half 0;
-    margin: 0;
-
-    h1 {
-      @include bold-48;
-      padding: 20px 0;
-
-      @include media(mobile) {
-        width: auto;
-        padding: 0 0 $gutter-half;
-      }
-
-      a {
-        @include core-27($line-height: 1);
-        display: block;
-        margin-bottom: 0.25em;
-        text-shadow: none;
-        color: $secondary-text-colour;
-        text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-    }
-
     h2 {
       @include core-24;
       color: inherit;

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -1,6 +1,9 @@
 <% content_for :title, "#{subtopic.title}: latest documents" %>
 <% content_for :page_title do %>
-  <span><%= subtopic.title %></span>: latest documents
+  <%= render "govuk_component/title", {
+        title: "Latest documents",
+        context: { text: subtopic.title, href: subtopic.base_path }
+      } %>
 <% end %>
 
 <% content_for :meta_section do %>

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -7,14 +7,10 @@
 <% end %>
 
 <header class="page-header group">
-  <div class="full-width">
-    <div class="heading">
-      <h1>
-        <%= link_to organisation["title"], organisation["base_path"] %>
-        Services and information
-      </h1>
-    </div>
-  </div>
+  <%= render "govuk_component/title", {
+        title: "Services and information",
+        context: { text: organisation["title"], href: organisation["base_path"] }
+      } %>
 </header>
 
 <div class="browse-container full-width" data-module="track-click">

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -3,13 +3,10 @@
 <header class="page-header group">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <div class="heading">
-        <h1><%= yield :page_title %></h1>
-
-        <% if organisations.any? %>
-          <%= render "govuk_component/metadata", from: organisations.array_of_links %>
-        <% end %>
-      </div>
+      <%= yield :page_title %>
+      <% if organisations.any? %>
+        <%= render "govuk_component/metadata", from: organisations.array_of_links %>
+      <% end %>
     </div>
 
     <div class="column-one-third">

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
 
-    <div class="column-one-third">
+    <div class="column-one-third add-title-margin">
       <div class="latest-subscribe">
         <ul>
           <li class="email primary">

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -8,10 +8,16 @@
   <meta name='govuk:navigation-page-type' content='Second Level Topic'>
 <% end %>
 <% content_for :page_title do %>
-  <%- if subtopic.parent -%>
-    <%= link_to subtopic.parent.title, subtopic.parent.base_path %>
-  <%- end -%>
-  <%= subtopic.title %>
+  <%
+    title_params = { title: subtopic.title }
+    if subtopic.parent
+      title_params[:context] = {
+        text: subtopic.parent.title,
+        href: subtopic.parent.base_path
+      }
+    end
+  %>
+  <%= render "govuk_component/title", title_params %>
 <% end %>
 
 <% content_for :meta_section do %>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,11 +1,12 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <div class="taxon-title length-long">
-      <h1>
-        <%= presented_taxon.title %>
-      </h1>
-      <p><%= presented_taxon.description %></p>
-      <%= render partial: 'email_alerts', locals: { presented_taxon: presented_taxon } %>
-    </div>
+    <%= render "govuk_component/title", {
+      title: presented_taxon.title,
+      average_title_length: 'long',
+      margin_bottom: 0
+    } %>
+
+    <p class="taxon-description"><%= presented_taxon.description %></p>
+    <%= render partial: 'email_alerts', locals: { presented_taxon: presented_taxon } %>
   </div>
 </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -10,9 +10,7 @@
 <% content_for :page_class, "topics-page" %>
 
 <header class="page-header group">
-  <div class="full-width">
-    <h1><%= topic.title %></h1>
-  </div>
+  <%= render "govuk_component/title", title: topic.title %>
 </header>
 
 <div class="browse-container full-width topics-page" data-module="track-click">

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -65,9 +65,10 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
     # Then I should see the subtopic metadata
     within '.page-header' do
-      within 'h1' do
-        assert page.has_content?("Oil and Gas")
-        assert page.has_content?("Offshore")
+      within_static_component 'title' do |component_args|
+        assert_equal component_args[:title], "Offshore"
+        assert_equal component_args[:context][:text], "Oil and Gas"
+        assert_equal component_args[:context][:href], "/topic/oil-and-gas"
       end
 
       within_static_component('metadata') do
@@ -97,9 +98,10 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
     # Then I should see the subtopic metadata
     within '.page-header' do
-      within 'h1' do
-        assert page.has_content?("Oil and Gas")
-        assert page.has_content?("Offshore")
+      within_static_component 'title' do |component_args|
+        assert_equal component_args[:title], "Offshore"
+        assert_equal component_args[:context][:text], "Oil and Gas"
+        assert_equal component_args[:context][:href], "/topic/oil-and-gas"
       end
 
       within_static_component('metadata') do
@@ -138,8 +140,10 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
       # Then I should see the subtopic metadata
       within '.page-header' do
-        within 'h1' do
-          assert page.has_content?("Offshore: latest documents")
+        within_static_component 'title' do |component_args|
+          assert_equal component_args[:title], "Latest documents"
+          assert_equal component_args[:context][:text], "Offshore"
+          assert_equal component_args[:context][:href], "/topic/oil-and-gas/offshore"
         end
 
         within_static_component('metadata') do

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -389,9 +389,7 @@ private
   end
 
   def and_i_can_see_an_email_signup_link
-    taxon_title = page.find('.taxon-title')
-
-    assert taxon_title.has_link?(
+    assert page.has_link?(
       'Get email alerts for this topic',
       href: "/email-signup/?topic=#{current_path}"
     )


### PR DESCRIPTION
Depends on https://github.com/alphagov/static/pull/1160 being merged and deployed

* Switch from bespoke title rendering to the static component
* Keep titles consistent with the rest of GOV.UK

Part of https://trello.com/c/ec0YjgQ4/

Paths to check:
```
/education
/topic/business-tax/vat
/topic/business-tax/vat/latest
/government/organisations/environment-agency/services-information
```