### PR TITLE
Fix error reporting

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -6,7 +6,7 @@ GovukError.configure do |config|
   # us if the error rate reaches certain thresholds.
   config.excluded_exceptions << "GdsApi::TimedOutException"
 
-  config.should_capture = Proc.new {
+  config.should_capture = Proc.new { |e|
     # We're overriding the `should_capture` block here:
     # https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/configure.rb#L9-L19
     GovukStatsd.increment("errors_occurred")


### PR DESCRIPTION
https://github.com/alphagov/collections/pull/386 introduced a bug when adding filtering for errors. That's unfortunate because it prevents errors from being reported, so I've only just noticed this. We'll have to come up with a way to prevent this in the future.

https://trello.com/c/lqHmGMEB