### PR TITLE
Remove extra filtering code for exceptions

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -5,13 +5,4 @@ GovukError.configure do |config|
   # ignore the errors because we have other monitoring in place that alerts
   # us if the error rate reaches certain thresholds.
   config.excluded_exceptions << "GdsApi::TimedOutException"
-
-  config.should_capture = Proc.new { |e|
-    # We're overriding the `should_capture` block here:
-    # https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/configure.rb#L9-L19
-    GovukStatsd.increment("errors_occurred")
-    GovukStatsd.increment("errbit.errors_occurred")
-
-    !e.cause.class.name.in?(config.excluded_exceptions)
-  }
 end


### PR DESCRIPTION
In https://github.com/alphagov/collections/pull/388 I fixed a bug and introduced another: the `e` argument to the proc isn't an exception, but a `Raven::Event`. To make sure we don't do this again, this commit reverts the changes so that error reporting will definitely work. In a follow up PR we'll try again, but this time with tests.

https://trello.com/c/h7Rt76jU