### PR TITLE
Fix css scoping for collections title

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -28,6 +28,8 @@
 
 .taxon-page--grid {
   .child-topics-list {
+    @include taxon-element-styles;
+
     ol {
       list-style-type: none;
       padding-bottom: $gutter-half;
@@ -60,9 +62,9 @@
 
 .taxon-page--leaf,
 .taxon-page--grid {
-  @include taxon-element-styles;
-
   .parent-topic-contents {
+    @include taxon-element-styles;
+
     .topic-content {
       padding-bottom: $gutter;
 


### PR DESCRIPTION
We have added the lead paragraph component to titles in Collections. However, on some pages the component css is being overridden by taxon-page styling, e.g: on https://www.gov.uk/education.

**Before:**
<img width="656" alt="screen shot 2017-10-18 at 16 03 32" src="https://user-images.githubusercontent.com/29889908/31726090-e9a19dbc-b41d-11e7-8b2b-2dfcdaa40594.png">

**After:**
<img width="649" alt="screen shot 2017-10-18 at 16 10 29" src="https://user-images.githubusercontent.com/29889908/31726438-e2bd1b10-b41e-11e7-8817-2b51f991b2e2.png">



