### PR TITLE
Add link for "Learn to drive a car: step by step" page into /browse

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'gds-api-adapters', '~> 47.9'
+gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 0.3'
 gem 'govuk_frontend_toolkit', '~> 4.3.0'
 gem 'govuk_navigation_helpers', '6.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       rubocop (~> 0.49.0)
       rubocop-rspec (~> 1.16.0)
       scss_lint
+    govuk_ab_testing (2.4.1)
     govuk_app_config (0.3.0)
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
@@ -323,6 +324,7 @@ DEPENDENCIES
   cucumber-rails
   gds-api-adapters (~> 47.9)
   govuk-lint
+  govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 0.3)
   govuk_frontend_toolkit (~> 4.3.0)
   govuk_navigation_helpers (= 6.3.0)

--- a/app/controllers/concerns/task_list_ab_testing_concern.rb
+++ b/app/controllers/concerns/task_list_ab_testing_concern.rb
@@ -1,0 +1,17 @@
+module TaskListAbTestingConcern
+  def task_list_ab_test
+    @task_list_ab_test ||= begin
+      ab_test_request = TaskListAbTestRequest.new(request)
+      ab_test_request.set_response_vary_header(response)
+      ab_test_request
+    end
+  end
+
+  def task_list_ab_variant
+    task_list_ab_test.ab_test.requested_variant(request.headers)
+  end
+
+  def task_list_ab_response
+    task_list_ab_variant.configure_response(response)
+  end
+end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,4 +1,6 @@
 class SecondLevelBrowsePageController < ApplicationController
+  include TaskListAbTestingConcern
+
   enable_request_formats show: [:json]
 
   def show
@@ -11,7 +13,7 @@ class SecondLevelBrowsePageController < ApplicationController
       f.json do
         render json: {
           breadcrumbs: breadcrumb_content,
-          html: render_partial('_links', page: page)
+          html: render_partial('_links', page: page, task_list_ab_test: task_list_ab_test)
         }
       end
     end
@@ -22,12 +24,20 @@ private
   def show_html
     render :show, locals: {
       page: page,
-      meta_section: meta_section
+      meta_section: meta_section,
+      task_list_ab_test: task_list_ab_test,
+      task_list_ab_variant: task_list_ab_variant,
+      page_is_under_task_list_ab_test: page_is_under_task_list_ab_test?
     }
   end
 
   def meta_section
     page.active_top_level_browse_page.title.downcase
+  end
+
+  def page_is_under_task_list_ab_test?
+    params[:top_level_slug] == 'driving' &&
+      params[:second_level_slug] == 'learning-to-drive'
   end
 
   def page

--- a/app/models/task_list_ab_test_request.rb
+++ b/app/models/task_list_ab_test_request.rb
@@ -1,0 +1,25 @@
+class TaskListAbTestRequest
+  attr_accessor :requested_variant
+  attr_reader :ab_test
+
+  delegate :analytics_meta_tag, to: :requested_variant
+
+  def initialize(request)
+    @request = request
+    dimension = Rails.application.config.task_list_ab_test_dimension
+
+    @ab_test = GovukAbTesting::AbTest.new("TaskListSidebar", dimension: dimension)
+    @requested_variant = @ab_test.requested_variant(request.headers)
+  end
+
+  def show_tasklist_link?(list_title, params)
+    requested_variant.variant?('B') &&
+      list_title == 'Popular services' &&
+      (@request.path == '/browse/driving/learning-to-drive' ||
+        params[:second_level_slug] == 'learning-to-drive')
+  end
+
+  def set_response_vary_header(response)
+    requested_variant.configure_response(response)
+  end
+end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -9,6 +9,22 @@
     <% end %>
 
     <ul>
+      <% if task_list_ab_test.show_tasklist_link?(list.title, params) %>
+        <li>
+          <%= link_to(
+            "Learn to drive a car: step by step",
+            learn_to_drive_a_car_path,
+            data: {
+              track_category: 'thirdLevelBrowseLinkClicked',
+              track_action: "#{section_index + 1}.0",
+              track_label: learn_to_drive_a_car_path,
+              track_options: {
+                dimension29: "Learn to drive a car: step by step"
+              }
+            }
+          ) %>
+        </li>
+      <% end %>
       <% list.contents.each_with_index do |list_item, index| %>
         <li>
           <%= link_to(

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,6 +1,10 @@
 <% content_for :title, page.title %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
+  <% if page_is_under_task_list_ab_test %>
+    <%= task_list_ab_variant.analytics_meta_tag.html_safe %>
+  <% end %>
+
   <meta name='govuk:navigation-page-type' content='Second Level Browse'>
 <% end %>
 <% content_for :page_class, "browse" %>
@@ -11,9 +15,8 @@
 
 <div class="browse-panes subsection" data-state="subsection" data-module="track-click">
   <div id="subsection" class="subsection-pane pane with-sort">
-    <%= render 'links', page: page %>
+    <%= render 'links', page: page, task_list_ab_test: task_list_ab_test %>
   </div>
-
 
   <div id="section" class="section-pane pane">
     <%= render 'second_level_browse_pages',

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,8 @@ module Collections
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)
+
+    # Google Analytics dimension assigned to the Tasklist A/B test
+    config.task_list_ab_test_dimension = 66
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,7 @@ Rails.application.routes.draw do
     to: "services_and_information#index",
     as: :services_and_information
 
+  get '/learn-to-drive-a-car', to: 'tasklist#show'
+
   get '*taxon_base_path', to: 'taxons#show'
 end

--- a/test/controllers/task_list_second_level_browse_page_controller_test.rb
+++ b/test/controllers/task_list_second_level_browse_page_controller_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+describe SecondLevelBrowsePageController do
+  include RummagerHelpers
+  include GovukAbTesting::MinitestHelpers
+
+  describe "TaskListSidebar A/B test content" do
+    before do
+      contents = [
+        "/apply-first-provisional-driving-licence",
+        "/book-theory-test",
+        "/book-driving-test",
+        "/change-driving-test",
+        "/check-driving-test"
+      ]
+
+      content_store_has_item(
+        "/browse/driving/learning-to-drive",
+        content_id: 'learning-to-drive-id',
+        links: {
+          active_top_level_browse_page: [{
+            title: 'Learning to drive',
+          }],
+          second_level_browse_pages: [
+            {
+              "content-id": 'content-id',
+              "title": "title-content-id",
+              "base_path": '/browse/content-id'
+            }
+          ]
+        },
+        details: {
+          second_level_ordering: "curated",
+          groups: [
+            {
+              "name": "Popular services",
+              "contents": contents
+            },
+          ]
+        }
+      )
+
+      rummager_has_documents_for_browse_page(
+        "learning-to-drive-id",
+        ["learning-to-drive"] + contents.map { |path| path [1..-1] },
+        page_size: 1000
+      )
+    end
+
+    describe "when in A variant" do
+      it "should not display a link to the 'learn to drive' tasklist link" do
+        with_variant TaskListSidebar: 'A' do
+          get(
+            :show,
+            params: {
+              top_level_slug: "driving",
+              second_level_slug: "learning-to-drive"
+            }
+          )
+
+          assert_response 200
+          refute_includes @response.body, 'Learn to drive a car: step by step'
+        end
+      end
+    end
+
+    describe "when in B variant" do
+      it "should display a link to the 'learn to drive' tasklist link" do
+        with_variant TaskListSidebar: 'B' do
+          get(
+            :show,
+            params: {
+              top_level_slug: "driving",
+              second_level_slug: "learning-to-drive"
+            }
+          )
+
+          assert_response 200
+          assert_includes @response.body, 'Learn to drive a car: step by step'
+        end
+      end
+    end
+  end
+end

--- a/test/models/task_list_ab_test_request_test.rb
+++ b/test/models/task_list_ab_test_request_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+describe TaskListAbTestRequest do
+  setup do
+    mock_request = OpenStruct.new(headers: [])
+    task_list_request = TaskListAbTestRequest.new(mock_request)
+    @ab_test = task_list_request.ab_test
+  end
+
+  describe "setup A/B testing" do
+    it "should setup the test name" do
+      assert_equal @ab_test.ab_test_name, "TaskListSidebar"
+    end
+
+    it 'should setup the dimension' do
+      assert_equal @ab_test.dimension, 66
+    end
+
+    it 'should setup allowed_variants' do
+      assert_equal @ab_test.allowed_variants, %w(A B)
+    end
+
+    it 'should setup the control variant' do
+      assert_equal @ab_test.control_variant, "A"
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,12 @@ require 'gds_api/test_helpers/rummager'
 
 # Most tests use ActiveSupport TestCase behaviour, so we configure this here.
 
+# For integration tests that use capybara, we configure GovukAbTesting
+# accordingly before/after the tests.
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
   include Slimmer::TestHelpers::GovukComponents


### PR DESCRIPTION
We have added the `learn to drive a car: step by step` link into the 3rd level links of `Driving tests and learning to drive or ride` (2nd level).

This is behind the TaskListSidebar A/B test and only users of the B
variant should see this as we gradually increase the percentage.

This commit leaves a placeholder to create the HTML of the Tasklist page
itself, this is future work.

Paired with @deborahchua 
Trello: https://trello.com/c/xLxn5Ohy/214-add-a-b-test-functionality-into-collections-frontend-app