### PR TITLE
Add learn-to-drive-a-car task list page

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,5 @@
 
 require File.expand_path('../config/application', __FILE__)
 
+task default: [:lint]
 Collections::Application.load_tasks

--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -1,0 +1,5 @@
+class TasklistController < ApplicationController
+  def show
+    render :show, locals: { tasklist: TasklistContent.learn_to_drive_config }
+  end
+end

--- a/app/services/tasklist_content.rb
+++ b/app/services/tasklist_content.rb
@@ -1,0 +1,9 @@
+class TasklistContent
+  def self.learn_to_drive_config
+    @learn_to_drive_config ||= JSON.parse(
+      File.read(
+        Rails.root.join("config", "tasklists", "learn-to-drive-a-car.json")
+        )
+      ).deep_symbolize_keys
+  end
+end

--- a/app/views/tasklist/show.html.erb
+++ b/app/views/tasklist/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Learn to drive a car: step by step" %>
+
+<% content_for :breadcrumbs do %>
+  <%= render 'govuk_component/beta_label' %>
+  <%= render 'govuk_component/breadcrumbs', tasklist[:links] %>
+<% end %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_component/title',
+        title: tasklist[:title],
+        average_title_length: 'long' %>
+
+    <%= render 'govuk_component/lead_paragraph',
+        text: tasklist[:description] %>
+  </div>
+</div>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "govuk_component/task_list", tasklist[:tasklist] %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
 
+  get "/learn-to-drive-a-car", to: 'tasklist#show'
+
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: [:index, :show], param: :top_level_slug do
@@ -33,8 +35,6 @@ Rails.application.routes.draw do
   get "/government/organisations/:organisation_id/services-information",
     to: "services_and_information#index",
     as: :services_and_information
-
-  get '/learn-to-drive-a-car', to: 'tasklist#show'
 
   get '*taxon_base_path', to: 'taxons#show'
 end

--- a/config/tasklists/learn-to-drive-a-car.json
+++ b/config/tasklists/learn-to-drive-a-car.json
@@ -1,0 +1,156 @@
+{
+  "title": "Learn to drive a car: step by step",
+  "base_path": "/learn-to-drive-a-car",
+  "description": "Check what you need to do to learn to drive.",
+  "links": {
+    "breadcrumbs": [
+      { "title": "Home", "url": "/" },
+      { "title": "Driving and transport", "url": "/browse/driving"},
+      { "title": "Learning to drive", "url": "/browse/driving/learning-to-drive"}
+    ]
+  },
+  "tasklist": {
+    "steps": [
+      [
+        {
+          "title": "Check you're allowed to drive",
+          "panel_descriptions": ["Most people can start learning to drive when they’re 17."],
+          "panel_links": [
+            {
+              "href": "/vehicles-can-drive",
+              "text": "Check what age you can drive"
+            },
+            {
+              "href": "/legal-obligations-drivers-riders",
+              "text": "Requirements for driving legally"
+            },
+            {
+              "href": "/driving-eyesight-rules",
+              "text": "Driving eyesight rules"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Get a provisional driving licence",
+          "panel_links": [
+            {
+              "href": "/apply-first-provisional-driving-licence",
+              "text": "Apply for your first provisional driving licence"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Driving lessons and practice",
+          "panel_descriptions": ["You need a provisional driving licence to take lessons or practice."],
+          "panel_links": [
+            {
+              "href": "/guidance/the-highway-code",
+              "text": "The Highway Code"
+            },
+            {
+              "href": "/driving-lessons-learning-to-drive",
+              "text": "Taking driving lessons"
+            },
+            {
+              "href": "/find-driving-schools-and-lessons",
+              "text": "Find driving schools, lessons and instructors"
+            },
+            {
+              "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+              "text": "Practise vehicle safety questions"
+            }
+          ]
+        },
+        {
+          "title": "Prepare for your theory test",
+          "panel_links": [
+            {
+              "href": "/theory-test/revision-and-practice",
+              "text": "Theory test revision and practice"
+            },
+            {
+              "href": "/take-practice-theory-test",
+              "text": "Take a practice theory test"
+            },
+            {
+              "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+              "text": "Theory and hazard perception test app"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your theory test",
+          "panel_descriptions": ["You need a provisional driving licence to book your theory test."],
+          "panel_links": [
+            {
+              "href": "/book-theory-test",
+              "text": "Book your theory test"
+            },
+            {
+              "href": "/theory-test/what-to-take",
+              "text": "What to take to your test"
+            },
+            {
+              "href": "/change-theory-test",
+              "text": "Change your theory test appointment"
+            },
+            {
+              "href": "/check-theory-test",
+              "text": "Check your theory test appointment details"
+            },
+            {
+              "href": "/cancel-theory-test",
+              "text": "Cancel your theory test"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Book and manage your driving test",
+          "panel_descriptions": ["You must pass your theory test before you can book your driving test."],
+          "panel_links": [
+            {
+              "href": "/book-driving-test",
+              "text": "Book your driving test"
+            },
+            {
+              "href": "/driving-test/what-to-take",
+              "text": "What to take to your test"
+            },
+            {
+              "href": "/change-driving-test",
+              "text": "Change your driving test appointment"
+            },
+            {
+              "href": "/check-driving-test",
+              "text": "Check your driving test appointment details"
+            },
+            {
+              "href": "/cancel-driving-test",
+              "text": "Cancel your driving test"
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "When you pass",
+          "panel_descriptions": ["You can start driving as soon as you pass your driving test."],
+          "panel_links": [
+            {
+              "href": "/pass-plus",
+              "text": "Find out about Pass Plus training courses"
+            }
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --rails --diff --format clang app test lib config"
+end

--- a/test/integration/tasklist_page_test.rb
+++ b/test/integration/tasklist_page_test.rb
@@ -1,0 +1,47 @@
+require 'integration_test_helper'
+
+class TasklistPageTest < ActionDispatch::IntegrationTest
+  it "renders the learn to drive page" do
+    visit "/learn-to-drive-a-car"
+
+    assert page.has_css?(shared_component_selector('breadcrumbs'))
+
+    within_static_component 'breadcrumbs' do |breadcrumb_arg|
+      assert_equal [
+        { "title" => "Home", "url" => "/" },
+        { "title" => "Driving and transport", "url" => "/browse/driving" },
+        { "title" => "Learning to drive", "url" => "/browse/driving/learning-to-drive" }
+      ], breadcrumb_arg[:breadcrumbs]
+    end
+
+    assert page.has_css?(shared_component_selector('title'))
+
+    within_static_component 'title' do |component_args|
+      assert_equal "Learn to drive a car: step by step", component_args[:title]
+    end
+
+    assert page.has_css?(shared_component_selector('lead_paragraph'))
+
+    within_static_component 'lead_paragraph' do |paragraph_args|
+      assert_equal "Check what you need to do to learn to drive.", paragraph_args[:text]
+    end
+
+    assert page.has_css?(shared_component_selector('task_list'))
+
+    within_static_component('task_list') do |tasklist_args|
+      assert_equal 6, tasklist_args[:steps].count
+
+      assert_equal [], tasklist_step_keys(tasklist_args) - %w(title panel panel_descriptions panel_links)
+
+      assert_equal [], tasklist_panel_links_keys(tasklist_args) - %w(href text), []
+    end
+  end
+
+  def tasklist_step_keys(tasklist_args)
+    tasklist_args[:steps].flatten.flat_map(&:keys).uniq
+  end
+
+  def tasklist_panel_links_keys(tasklist_args)
+    tasklist_args[:steps].flatten.flat_map { |step| step["panel_links"] }.flat_map(&:keys).uniq
+  end
+end


### PR DESCRIPTION
This is reliant on the tasklist component in https://github.com/alphagov/static/pull/1173, so to test this you will need to have a local static running on the `create-tasklist-component` branch until that is merged and deployed.

We will add Smokey tests to cover this behaviour [similar to the tests for the accordion]( https://github.com/alphagov/smokey/blob/400f14728e2a2cfb5887d0b4fc42373b617ee1c0/features/collections.feature#L21-L31)

This page is the first item in the public beta of task list pages run by the modelling-services team.

The content item for this page is [manually published from collections-publisher](https://github.com/alphagov/collections-publisher/pull/250)

The json file recording the content is deep symbolized after parsing to facilitate working with components which use symbolized keys.

This page is expected to mostly replicate [the prototype](https://govuk-services-prototype.herokuapp.com/services/learn-to-drive-a-car) although some small differences are likely after design review of the tasklist component.

Somewhat to do with: https://trello.com/c/M8ZYKOF1/231-create-hardcoded-json-for-learning-to-drive-beta
but mostly: https://trello.com/c/nByQmGoZ/201-implement-tasklist-page-in-preparation-for-public-beta-rollout

## Screenshots

### Desktop
![screen shot 2017-10-27 at 08 50 36](https://user-images.githubusercontent.com/773037/32093568-a4712fae-baf4-11e7-82bb-f5a81702b827.png)

![screen shot 2017-10-27 at 08 51 02](https://user-images.githubusercontent.com/773037/32093567-a456eb26-baf4-11e7-95c8-95f1914c0f63.png)

### Mobile
![collections dev gov uk_learn-to-drive-a-car iphone 6 1](https://user-images.githubusercontent.com/773037/32093554-920d4e74-baf4-11e7-983c-478ea4b9e0a5.png)

![collections dev gov uk_learn-to-drive-a-car iphone 6 2](https://user-images.githubusercontent.com/773037/32093553-91e27bf4-baf4-11e7-8045-ea7108fd6825.png)
