### PR TITLE
[WIP] Add left to right option for accordion component

### DIFF
--- a/app/assets/javascripts/components/accordion.js
+++ b/app/assets/javascripts/components/accordion.js
@@ -28,28 +28,28 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // Prevent FOUC, remove class hiding content
       $element.removeClass('js-hidden');
 
-      var $subsections = $element.find('.js-section');
-      var $subsectionHeaders = $element.find('.js-toggle-panel');
-      var totalSubsections = $element.find('.js-panel').length;
+      var $sections = $element.find('.js-section');
+      var $sectionHeaders = $element.find('.js-toggle-panel');
+      var totalSections = $element.find('.js-panel').length;
 
       var $openOrCloseAllButton;
 
-      var accordionTracker = new AccordionTracker(totalSubsections);
+      var accordionTracker = new AccordionTracker(totalSections);
 
       addButtonstoSections();
       addOpenCloseAllButton();
-      addIconsToSubsections();
+      addIconsToSections();
       addAriaControlsAttrForOpenCloseAllButton();
 
       closeAllSections();
       openLinkedSection();
 
-      bindToggleForSubsections(accordionTracker);
+      bindToggleForSections(accordionTracker);
       bindToggleOpenCloseAllButton(accordionTracker);
 
       // When navigating back in browser history to the accordion, the browser will try to be "clever" and return
       // the user to their previous scroll position. However, since we collapse all but the currently-anchored
-      // subsection, the content length changes and the user is returned to the wrong position (often the footer).
+      // section, the content length changes and the user is returned to the wrong position (often the footer).
       // In order to correct this behaviour, as the user leaves the page, we anticipate the correct height we wish the
       // user to return to by forcibly scrolling them to that height, which becomes the height the browser will return
       // them to.
@@ -58,10 +58,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       // still could have scrolled a long way down the page.
       function storeScrollPosition() {
         closeAllSections();
-        var $subsection = getSubsectionForAnchor();
+        var $section = getSectionForAnchor();
 
-        document.body.scrollTop = $subsection && $subsection.length
-          ? $subsection.offset().top
+        document.body.scrollTop = $section && $section.length
+          ? $section.offset().top
           : 0;
       }
 
@@ -69,15 +69,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $element.prepend('<div class="app-c-accordion__controls"><button aria-expanded="false" class="app-c-accordion__button app-c-accordion__button--controls js-section-controls-button">' + bulkActions.openAll.buttonText + '</button></div>');
       }
 
-      function addIconsToSubsections() {
-        $subsectionHeaders.append('<span class="app-c-accordion__icon"></span>');
+      function addIconsToSections() {
+        $sectionHeaders.append('<span class="app-c-accordion__icon"></span>');
       }
 
       function addAriaControlsAttrForOpenCloseAllButton() {
         var ariaControlsValue = "";
-        var $subsectionPanels = $element.find('.js-panel')
-        for (var i = 0; i < totalSubsections; i++) {
-          ariaControlsValue += $subsectionPanels[i].id + " "
+        var $sectionPanels = $element.find('.js-panel')
+        for (var i = 0; i < totalSections; i++) {
+          ariaControlsValue += $sectionPanels[i].id + " "
         }
 
         $openOrCloseAllButton = $element.find('.js-section-controls-button');
@@ -89,23 +89,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function setAllSectionsOpenState(isOpen) {
-        $.each($subsections, function () {
-          var subsectionView = new SubsectionView($(this));
-          subsectionView.preventHashUpdate();
-          subsectionView.setIsOpen(isOpen);
+        $.each($sections, function () {
+          var sectionView = new SectionView($(this));
+          sectionView.preventHashUpdate();
+          sectionView.setIsOpen(isOpen);
         });
       }
 
       function openLinkedSection() {
-        var $subsection = getSubsectionForAnchor();
+        var $section = getSectionForAnchor();
 
-        if ($subsection && $subsection.length) {
-          var subsectionView = new SubsectionView($subsection);
-          subsectionView.open();
+        if ($section && $section.length) {
+          var sectionView = new SectionView($section);
+          sectionView.open();
         }
       }
 
-      function getSubsectionForAnchor() {
+      function getSectionForAnchor() {
         var anchor = getActiveAnchor();
 
         return anchor.length
@@ -118,7 +118,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function addButtonstoSections() {
-        $.each($subsections, function () {
+        $.each($sections, function () {
           var $section = $(this);
           var $title = $section.find('.js-section-title');
           var contentId = $section.find('.js-panel').first().attr('id');
@@ -131,14 +131,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         });
       }
 
-      function bindToggleForSubsections(accordionTracker) {
+      function bindToggleForSections(accordionTracker) {
         $element.find('.js-toggle-panel').click(function (event) {
           preventLinkFollowingForCurrentTab(event);
 
-          var subsectionView = new SubsectionView($(this).closest('.js-section'));
-          subsectionView.toggle();
+          var sectionView = new SectionView($(this).closest('.js-section'));
+          sectionView.toggle();
 
-          var toggleClick = new SubsectionToggleClick(subsectionView, $subsections, accordionTracker);
+          var toggleClick = new SectionToggleClick(sectionView, $sections, accordionTracker);
           toggleClick.track();
 
           setOpenCloseAllText();
@@ -186,9 +186,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function setOpenCloseAllText() {
-        var openSubsections = $element.find('.section-is-open').length;
+        var openSections = $element.find('.section-is-open').length;
         // Find out if the number of is-opens == total number of sections
-        if (openSubsections === totalSubsections) {
+        if (openSections === totalSections) {
           $openOrCloseAllButton.text(bulkActions.closeAll.buttonText);
         } else {
           $openOrCloseAllButton.text(bulkActions.openAll.buttonText);
@@ -203,14 +203,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     };
 
-    function SubsectionView($subsectionElement) {
-      var $titleLink = $subsectionElement.find('.js-section-title-button');
-      var $subsectionContent = $subsectionElement.find('.js-panel');
+    function SectionView($sectionElement) {
+      var $titleLink = $sectionElement.find('.js-section-title-button');
+      var $sectionContent = $sectionElement.find('.js-panel');
       var shouldUpdateHash = true;
 
-      this.title = $subsectionElement.find('.js-section-title').text();
+      this.title = $sectionElement.find('.js-section-title').text();
       this.href = $titleLink.attr('href');
-      this.element = $subsectionElement;
+      this.element = $sectionElement;
 
       this.open = open;
       this.close = close;
@@ -234,17 +234,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function setIsOpen(isOpen) {
-        $subsectionElement.toggleClass('section-is-open', isOpen);
-        $subsectionContent.toggleClass('js-hidden', !isOpen);
+        $sectionElement.toggleClass('section-is-open', isOpen);
+        $sectionContent.toggleClass('js-hidden', !isOpen);
         $titleLink.attr("aria-expanded", isOpen);
 
         if (shouldUpdateHash) {
-          updateHash($subsectionElement);
+          updateHash($sectionElement);
         }
       }
 
       function isOpen() {
-        return $subsectionElement.hasClass('section-is-open');
+        return $sectionElement.hasClass('section-is-open');
       }
 
       function isClosed() {
@@ -256,13 +256,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
 
       function numberOfContentItems() {
-        return $subsectionContent.find('li').length;
+        return $sectionContent.find('li').length;
       }
     }
 
-    function updateHash($subsectionElement) {
-      var subsectionView = new SubsectionView($subsectionElement);
-      var hash = subsectionView.isOpen() && '#' + $subsectionElement.attr('id');
+    function updateHash($sectionElement) {
+      var sectionView = new SectionView($sectionElement);
+      var hash = sectionView.isOpen() && '#' + $sectionElement.attr('id');
       setHash(hash)
     }
 
@@ -276,46 +276,46 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       history.replaceState({}, '', newLocation);
     }
 
-    function SubsectionToggleClick(subsectionView, $subsections, accordionTracker) {
+    function SectionToggleClick(sectionView, $sections, accordionTracker) {
       this.track = trackClick;
 
       function trackClick() {
-        var tracking_options = {label: trackingLabel(), dimension28: subsectionView.numberOfContentItems().toString()}
+        var tracking_options = {label: trackingLabel(), dimension28: sectionView.numberOfContentItems().toString()}
         accordionTracker.track('pageElementInteraction', trackingAction(), tracking_options);
 
-        if (!subsectionView.isClosed()) {
+        if (!sectionView.isClosed()) {
           accordionTracker.track(
             'navAccordionLinkClicked',
-            String(subsectionIndex()),
+            String(sectionIndex()),
             {
-              label: subsectionView.href,
-              dimension28: String(subsectionView.numberOfContentItems()),
-              dimension29: subsectionView.title
+              label: sectionView.href,
+              dimension28: String(sectionView.numberOfContentItems()),
+              dimension29: sectionView.title
             }
           )
         }
       }
 
       function trackingLabel() {
-        return subsectionIndex() + '. ' + subsectionView.title;
+        return sectionIndex() + '. ' + sectionView.title;
       }
 
-      function subsectionIndex() {
-        return $subsections.index(subsectionView.element) + 1;
+      function sectionIndex() {
+        return $sections.index(sectionView.element) + 1;
       }
 
       function trackingAction() {
-        return (subsectionView.isClosed() ? 'accordionClosed' : 'accordionOpened');
+        return (sectionView.isClosed() ? 'accordionClosed' : 'accordionOpened');
       }
     }
 
     // A helper that sends a custom event request to Google Analytics if
     // the GOVUK module is setup
-    function AccordionTracker(totalSubsections) {
+    function AccordionTracker(totalSections) {
       this.track = function(category, action, options) {
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           options = options || {};
-          options["dimension28"] = options["dimension28"] || totalSubsections.toString();
+          options["dimension28"] = options["dimension28"] || totalSections.toString();
           GOVUK.analytics.trackEvent(category, action, options);
         }
       }

--- a/app/assets/javascripts/modules/current-location.js
+++ b/app/assets/javascripts/modules/current-location.js
@@ -1,3 +1,4 @@
+// used by accordion component
 (function(root) {
   "use strict";
   root.GOVUK = root.GOVUK || {};

--- a/app/assets/javascripts/support.js
+++ b/app/assets/javascripts/support.js
@@ -1,3 +1,4 @@
+// used by accordion component
 if(typeof window.GOVUK === 'undefined'){ window.GOVUK = {}; }
 if(typeof window.GOVUK.support === 'undefined'){ window.GOVUK.support = {}; }
 

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -28,7 +28,7 @@
   width: 16px;
   margin-top: -8px;
   background-image: image-url('icons-plus-minus.png'); // PNG fallback for SVG
-  background: image-url("icons-plus-minus.svg"), linear-gradient(transparent, transparent); // SVG sprite
+  background: image-url("icons-plus-minus.svg"), linear-gradient(transparent, transparent); // http://pauginer.com/post/36614680636/invisible-gradient-technique
   background-repeat: no-repeat;
   background-position: 0 -16px;
 
@@ -102,4 +102,34 @@
 
 .app-c-accordion__controls {
   @extend %contain-floats;
+}
+
+.app-c-accordion--controls-on-left {
+  &.app-c-accordion--active {
+    .app-c-accordion__icon {
+      left: $gutter-half;
+      right: auto;
+    }
+
+    .app-c-accordion__title,
+    .app-c-accordion__description {
+      padding-left: $gutter + $gutter-half;
+    }
+
+    .app-c-accordion__description {
+      padding-right: 0;
+    }
+
+    .app-c-accordion__panel {
+      padding-left: $gutter + $gutter-half;
+    }
+
+    .app-c-accordion__button--title {
+      margin-right: 0;
+    }
+
+    .app-c-accordion__button--controls {
+      float: left;
+    }
+  }
 }

--- a/app/views/components/_accordion.html.erb
+++ b/app/views/components/_accordion.html.erb
@@ -1,8 +1,9 @@
 <%
   sections ||= false
+  controls_on_left ||= false
 %>
 <% if sections %>
-  <div data-module="accordion" class="app-c-accordion js-hidden">
+  <div data-module="accordion" class="app-c-accordion js-hidden <%= "app-c-accordion--controls-on-left" if controls_on_left %>">
     <% sections.each_with_index do |section, index| %>
       <%
         id = section[:id] || section[:title].downcase.tr(" ","-")

--- a/app/views/components/docs/accordion.yml
+++ b/app/views/components/docs/accordion.yml
@@ -131,3 +131,22 @@ examples:
           panel: 'Second accordion panel'
         }
       ]
+  accordion_controls_on_the_left:
+    description: Put the plus/minus icon on the left of the accordion. More accessible for users using zoom.
+    data:
+      controls_on_left: true
+      sections: [
+        {
+          title: 'Buy a house',
+          panel: 'First accordion panel and the content that goes inside it to show what that content looks like when it is long enough to wrap to a second line.'
+        },
+        {
+          title: 'Build a house and the complicated building regulations relating to such a huge task',
+          description: 'Make sure that you are fully aware of the legislation involved in building a house and how you must comply with it',
+          panel: 'Second accordion panel and the content that goes inside it to show what that content looks like when it is long enough to wrap to a second line.'
+        },
+        {
+          title: 'Buy to let',
+          panel: 'Third accordion panel and the content that goes inside it to show what that content looks like when it is long enough to wrap to a second line.'
+        }
+      ]

--- a/spec/javascripts/components/accordion_spec.js
+++ b/spec/javascripts/components/accordion_spec.js
@@ -8,7 +8,7 @@ describe('An accordion module', function () {
       <div class="app-c-accordion__section js-section" id="topic-section-one">\
         <div class="app-c-accordion__header js-toggle-panel">\
           <h2 class="app-c-accordion__title js-section-title">Topic Section One</h2>\
-          <p class="app-c-accordion__description">Subsection description in here</p>\
+          <p class="app-c-accordion__description">Section description in here</p>\
         </div>\
         <div class="app-c-accordion__panel js-panel" id="section_panel_10_0">\
           <ul>\
@@ -21,7 +21,7 @@ describe('An accordion module', function () {
       <div class="app-c-accordion__section js-section" id="topic-section-two">\
         <div class="app-c-accordion__header js-toggle-panel">\
           <h2 class="app-c-accordion__title js-section-title">Topic Section Two</h2>\
-          <p class="app-c-accordion__description">Subsection description in here</p>\
+          <p class="app-c-accordion__description">Section description in here</p>\
         </div>\
         <div class="app-c-accordion__panel js-panel" id="section_panel_11_1">\
           <ul>\
@@ -59,15 +59,15 @@ describe('An accordion module', function () {
 
     expect($openCloseAllButton).toExist();
     expect($openCloseAllButton).toHaveText("Open all");
-    // It has an aria-expanded false attribute as all subsections are closed
+    // It has an aria-expanded false attribute as all sections are closed
     expect($openCloseAllButton).toHaveAttr("aria-expanded", "false");
-    // It has an aria-controls attribute that includes all the subsection_content IDs
+    // It has an aria-controls attribute that includes all the section_content IDs
     expect($openCloseAllButton).toHaveAttr('aria-controls', 'section_panel_10_0 section_panel_11_1 ');
   });
 
   it("has no sections which have an open state", function () {
-    var openSubsections = $element.find('.section-is-open').length;
-    expect(openSubsections).toEqual(0);
+    var openSections = $element.find('.section-is-open').length;
+    expect(openSections).toEqual(0);
   });
 
   it("inserts a button into each section to show/hide content", function () {
@@ -79,15 +79,15 @@ describe('An accordion module', function () {
     expect($titleButton[1]).toHaveAttr('aria-controls', 'section_panel_11_1');
   });
 
-  it("ensures all subsection content is hidden", function () {
-    $element.find('.app-c-accordion__section').each(function (index, $subsection) {
-      expect($subsection).not.toHaveClass('section-is-open');
+  it("ensures all section content is hidden", function () {
+    $element.find('.app-c-accordion__section').each(function (index, $section) {
+      expect($section).not.toHaveClass('section-is-open');
     });
   });
 
-  it("adds an open/close icon to each subsection", function () {
-    var $subsectionHeader = $element.find('.app-c-accordion__header');
-    expect($subsectionHeader).toContainElement('.app-c-accordion__icon');
+  it("adds an open/close icon to each section", function () {
+    var $sectionHeader = $element.find('.app-c-accordion__header');
+    expect($sectionHeader).toContainElement('.app-c-accordion__icon');
   });
 
   describe('Clicking the "Expand all" button', function () {
@@ -100,7 +100,7 @@ describe('An accordion module', function () {
       clickOpenCloseAll();
     });
 
-    it('adds a .subsection-is-open class to each subsection to hide the icon', function () {
+    it('adds a .section-is-open class to each section to hide the icon', function () {
       expect($element.find('.section-is-open').length).toEqual(2);
     });
 
@@ -142,17 +142,17 @@ describe('An accordion module', function () {
 
     // When a section is open (testing: toggleSection, openSection)
     it("has a class of section-is-open", function () {
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      var $subsection = $element.find('.app-c-accordion__section');
-      $subsectionLink.click();
-      expect($subsection).toHaveClass("section-is-open");
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      var $section = $element.find('.app-c-accordion__section');
+      $sectionLink.click();
+      expect($section).toHaveClass("section-is-open");
     });
 
     // When a section is open (testing: toggleState, setExpandedState)
     it("has a an aria-expanded attribute and the value is true", function () {
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      $subsectionLink.click();
-      expect($subsectionLink).toHaveAttr('aria-expanded', 'true');
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      $sectionLink.click();
+      expect($sectionLink).toHaveAttr('aria-expanded', 'true');
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {
@@ -162,8 +162,8 @@ describe('An accordion module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      $subsectionLink.click();
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      $sectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
@@ -178,8 +178,8 @@ describe('An accordion module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      var $subsectionIcon = $element.find('.app-c-accordion__icon');
-      $subsectionIcon.click();
+      var $sectionIcon = $element.find('.app-c-accordion__icon');
+      $sectionIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
@@ -194,8 +194,8 @@ describe('An accordion module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      var $subsectionHeader = $element.find('.app-c-accordion__header');
-      $subsectionHeader.click();
+      var $sectionHeader = $element.find('.app-c-accordion__header');
+      $sectionHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionOpened', {
         label: '1. Topic Section One',
@@ -208,21 +208,21 @@ describe('An accordion module', function () {
 
     // When a section is closed (testing: toggleSection, closeSection)
     it("removes the section-is-open class", function () {
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      var $subsection = $element.find('.app-c-accordion__section');
-      $subsectionLink.click();
-      expect($subsection).toHaveClass("section-is-open");
-      $subsectionLink.click();
-      expect($subsection).not.toHaveClass("section-is-open");
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      var $section = $element.find('.app-c-accordion__section');
+      $sectionLink.click();
+      expect($section).toHaveClass("section-is-open");
+      $sectionLink.click();
+      expect($section).not.toHaveClass("section-is-open");
     });
 
     // When a section is closed (testing: toggleState, setExpandedState)
     it("has a an aria-expanded attribute and the value is false", function () {
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      $subsectionLink.click();
-      expect($subsectionLink).toHaveAttr('aria-expanded', 'true');
-      $subsectionLink.click();
-      expect($subsectionLink).toHaveAttr('aria-expanded', 'false');
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      $sectionLink.click();
+      expect($sectionLink).toHaveAttr('aria-expanded', 'true');
+      $sectionLink.click();
+      expect($sectionLink).toHaveAttr('aria-expanded', 'false');
     });
 
     it("triggers a google analytics custom event when clicking on the title", function () {
@@ -232,9 +232,9 @@ describe('An accordion module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      var $subsectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
-      $subsectionLink.click();
-      $subsectionLink.click();
+      var $sectionLink = $element.find('.app-c-accordion__header .app-c-accordion__button--title');
+      $sectionLink.click();
+      $sectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
@@ -249,9 +249,9 @@ describe('An accordion module', function () {
       };
       spyOn(GOVUK.analytics, 'trackEvent');
 
-      var $subsectionIcon = $element.find('.app-c-accordion__icon');
-      $subsectionIcon.click();
-      $subsectionIcon.click();
+      var $sectionIcon = $element.find('.app-c-accordion__icon');
+      $sectionIcon.click();
+      $sectionIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
@@ -267,9 +267,9 @@ describe('An accordion module', function () {
       spyOn(GOVUK.analytics, 'trackEvent');
 
       accordion.start($element);
-      var $subsectionHeader = $element.find('.app-c-accordion__header');
-      $subsectionHeader.click();
-      $subsectionHeader.click();
+      var $sectionHeader = $element.find('.app-c-accordion__header');
+      $sectionHeader.click();
+      $sectionHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'accordionClosed', {
         label: '1. Topic Section One',
@@ -289,13 +289,13 @@ describe('An accordion module', function () {
     });
 
     it("opens the linked to topic section", function () {
-      var $subsection = $element.find('#topic-section-one');
-      expect($subsection).toHaveClass('section-is-open');
+      var $section = $element.find('#topic-section-one');
+      expect($section).toHaveClass('section-is-open');
     });
 
     it("leaves other sections closed", function () {
-      var $subsection = $element.find('#topic-section-two');
-      expect($subsection).not.toHaveClass('section-is-open');
+      var $section = $element.find('#topic-section-two');
+      expect($section).not.toHaveClass('section-is-open');
     });
   });
 

--- a/test/components/accordion_test.rb
+++ b/test/components/accordion_test.rb
@@ -29,11 +29,11 @@ class AccordionTest < ComponentTestCase
     render_component(sections: simple_accordion)
     assert_select ".app-c-accordion"
 
-    assert_select section1, id: "general-information-and-guidance"
+    assert_select section1 + "#general-information-and-guidance"
     assert_select section1 + " .app-c-accordion__title", text: "General information and guidance"
     assert_select section1 + " .app-c-accordion__panel", text: "1st panel contents"
 
-    assert_select section2, id: "alternative-provision-censuses"
+    assert_select section2 + "#alternative-provision-censuses"
     assert_select section2 + " .app-c-accordion__title", text: "Alternative provision censuses"
     assert_select section2 + " .app-c-accordion__panel", text: "2nd panel contents"
   end
@@ -54,7 +54,13 @@ class AccordionTest < ComponentTestCase
 
     render_component(sections: ids_accordion)
 
-    assert_select section1, id: "first-section-id"
-    assert_select section2, id: "alternative-provision-censuses"
+    assert_select section1 + "#first-section-id"
+    assert_select section2 + "#alternative-provision-censuses"
+  end
+
+  test "renders an accordion with plus minus icons on the left" do
+    render_component(sections: simple_accordion, controls_on_left: true)
+
+    assert_select ".app-c-accordion.app-c-accordion--controls-on-left"
   end
 end


### PR DESCRIPTION
Move the plus/minus icons on accordions to the left of the element, rather than the right. This is an accessibility fix for those using Zoomtext or similar screen magnification tools - it makes it so that the accordion functionality is much more obvious.

- rename all subsection variables to section
- add left to right option for accordion component

![screen shot 2017-11-07 at 09 08 38](https://user-images.githubusercontent.com/861310/32485423-4904e340-c39b-11e7-9957-1d9979d3587a.png)

PR: https://govuk-collections-pr-402.herokuapp.com/component-guide/accordion

Ideally would use https://github.com/alphagov/collections/compare/accordion-yield?expand=1 as a technique for calling the component, but the current documentation model doesn't support it.