### PR TITLE
Switch tasklist link test name/dimension

### DIFF
--- a/app/models/task_list_ab_test_request.rb
+++ b/app/models/task_list_ab_test_request.rb
@@ -8,7 +8,7 @@ class TaskListAbTestRequest
     @request = request
     dimension = Rails.application.config.task_list_ab_test_dimension
 
-    @ab_test = GovukAbTesting::AbTest.new("TaskListSidebar", dimension: dimension)
+    @ab_test = GovukAbTesting::AbTest.new("TaskListBrowse", dimension: dimension)
     @requested_variant = @ab_test.requested_variant(request.headers)
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,6 @@ module Collections
     config.autoload_paths += %W(#{config.root}/lib)
 
     # Google Analytics dimension assigned to the Tasklist A/B test
-    config.task_list_ab_test_dimension = 66
+    config.task_list_ab_test_dimension = 43
   end
 end

--- a/test/controllers/task_list_second_level_browse_page_controller_test.rb
+++ b/test/controllers/task_list_second_level_browse_page_controller_test.rb
@@ -49,7 +49,7 @@ describe SecondLevelBrowsePageController do
 
     describe "when in A variant" do
       it "should not display a link to the 'learn to drive' tasklist link" do
-        with_variant TaskListSidebar: 'A' do
+        with_variant TaskListBrowse: 'A' do
           get(
             :show,
             params: {
@@ -66,7 +66,7 @@ describe SecondLevelBrowsePageController do
 
     describe "when in B variant" do
       it "should display a link to the 'learn to drive' tasklist link" do
-        with_variant TaskListSidebar: 'B' do
+        with_variant TaskListBrowse: 'B' do
           get(
             :show,
             params: {

--- a/test/models/task_list_ab_test_request_test.rb
+++ b/test/models/task_list_ab_test_request_test.rb
@@ -9,11 +9,11 @@ describe TaskListAbTestRequest do
 
   describe "setup A/B testing" do
     it "should setup the test name" do
-      assert_equal @ab_test.ab_test_name, "TaskListSidebar"
+      assert_equal @ab_test.ab_test_name, "TaskListBrowse"
     end
 
     it 'should setup the dimension' do
-      assert_equal @ab_test.dimension, 66
+      assert_equal @ab_test.dimension, 43
     end
 
     it 'should setup allowed_variants' do


### PR DESCRIPTION
We want to control this under its own test so that we can manage the sidebar
test independently of the link in browse.

The new test dimension was assigned in https://trello.com/c/ergjXLKU/272-assign-custom-dimensions-for-tasklistbrowse-and-tasklistheader-ab-tests

This work is tracked under https://trello.com/c/AAE3VmdV/262-add-fastly-tests-%F0%9F%9A%97

The new cookie is listed on https://www.gov.uk/help/cookies?20171102