### PR TITLE
Add learn to drive link to https://www.gov.uk/browse/driving/driving-licences

### DIFF
--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -27,17 +27,12 @@ private
       meta_section: meta_section,
       task_list_ab_test: task_list_ab_test,
       task_list_ab_variant: task_list_ab_variant,
-      page_is_under_task_list_ab_test: page_is_under_task_list_ab_test?
+      page_is_under_task_list_ab_test: task_list_ab_test.page_is_under_test?
     }
   end
 
   def meta_section
     page.active_top_level_browse_page.title.downcase
-  end
-
-  def page_is_under_task_list_ab_test?
-    params[:top_level_slug] == 'driving' &&
-      params[:second_level_slug] == 'learning-to-drive'
   end
 
   def page

--- a/app/models/task_list_ab_test_request.rb
+++ b/app/models/task_list_ab_test_request.rb
@@ -12,11 +12,13 @@ class TaskListAbTestRequest
     @requested_variant = @ab_test.requested_variant(request.headers)
   end
 
-  def show_tasklist_link?(list_title, params)
+  def show_tasklist_link?(list_title)
     requested_variant.variant?('B') &&
-      list_title == 'Popular services' &&
-      (@request.path == '/browse/driving/learning-to-drive' ||
-        params[:second_level_slug] == 'learning-to-drive')
+      list_title == 'Popular services' && page_is_under_test?
+  end
+
+  def page_is_under_test?
+    ["/browse/driving/learning-to-drive", "/browse/driving/driving-licences"].include? @request.path
   end
 
   def set_response_vary_header(response)

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -9,7 +9,7 @@
     <% end %>
 
     <ul>
-      <% if task_list_ab_test.show_tasklist_link?(list.title, params) %>
+      <% if task_list_ab_test.show_tasklist_link?(list.title) %>
         <li>
           <%= link_to(
             "Learn to drive a car: step by step",

--- a/test/controllers/task_list_second_level_browse_page_controller_test.rb
+++ b/test/controllers/task_list_second_level_browse_page_controller_test.rb
@@ -8,6 +8,7 @@ describe SecondLevelBrowsePageController do
     before do
       setup_content_for('learning-to-drive')
       setup_content_for('driving-licences')
+      setup_content_for('vegetable-sales')
     end
 
     describe "when in A variant" do
@@ -43,6 +44,25 @@ describe SecondLevelBrowsePageController do
 
             assert_response 200
             assert_includes @response.body, 'Learn to drive a car: step by step'
+          end
+        end
+      end
+    end
+
+    describe "with irrelevant pages" do
+      %w(A B).each do |variant|
+        it "should not display a link to learning to drive in variant #{variant}" do
+          with_variant TaskListBrowse: variant, assert_meta_tag: false do
+            get(
+              :show,
+              params: {
+                top_level_slug: "driving",
+                second_level_slug: "vegetable-sales"
+              }
+            )
+
+            assert_response 200
+            refute_includes @response.body, 'Learn to drive a car: step by step'
           end
         end
       end

--- a/test/controllers/task_list_second_level_browse_page_controller_test.rb
+++ b/test/controllers/task_list_second_level_browse_page_controller_test.rb
@@ -6,6 +6,49 @@ describe SecondLevelBrowsePageController do
 
   describe "TaskListSidebar A/B test content" do
     before do
+      setup_content_for('learning-to-drive')
+      setup_content_for('driving-licences')
+    end
+
+    describe "when in A variant" do
+      %w(driving-licences learning-to-drive).each do |slug|
+        it "should not display a link to the 'learn to drive' tasklist link in #{slug}" do
+          with_variant TaskListBrowse: 'A' do
+            get(
+              :show,
+              params: {
+                top_level_slug: "driving",
+                second_level_slug: slug
+              }
+            )
+
+            assert_response 200
+            refute_includes @response.body, 'Learn to drive a car: step by step'
+          end
+        end
+      end
+    end
+
+    describe "when in B variant" do
+      %w(driving-licences learning-to-drive).each do |slug|
+        it "should display a link to the 'learn to drive' tasklist link in #{slug}" do
+          with_variant TaskListBrowse: 'B' do
+            get(
+              :show,
+              params: {
+                top_level_slug: "driving",
+                second_level_slug: slug
+              }
+            )
+
+            assert_response 200
+            assert_includes @response.body, 'Learn to drive a car: step by step'
+          end
+        end
+      end
+    end
+
+    def setup_content_for(slug)
       contents = [
         "/apply-first-provisional-driving-licence",
         "/book-theory-test",
@@ -15,11 +58,11 @@ describe SecondLevelBrowsePageController do
       ]
 
       content_store_has_item(
-        "/browse/driving/learning-to-drive",
-        content_id: 'learning-to-drive-id',
+        "/browse/driving/#{slug}",
+        content_id: "#{slug}-id",
         links: {
           active_top_level_browse_page: [{
-            title: 'Learning to drive',
+            title: slug,
           }],
           second_level_browse_pages: [
             {
@@ -41,44 +84,10 @@ describe SecondLevelBrowsePageController do
       )
 
       rummager_has_documents_for_browse_page(
-        "learning-to-drive-id",
-        ["learning-to-drive"] + contents.map { |path| path [1..-1] },
+        "#{slug}-id",
+        [slug] + contents.map { |path| path [1..-1] },
         page_size: 1000
       )
-    end
-
-    describe "when in A variant" do
-      it "should not display a link to the 'learn to drive' tasklist link" do
-        with_variant TaskListBrowse: 'A' do
-          get(
-            :show,
-            params: {
-              top_level_slug: "driving",
-              second_level_slug: "learning-to-drive"
-            }
-          )
-
-          assert_response 200
-          refute_includes @response.body, 'Learn to drive a car: step by step'
-        end
-      end
-    end
-
-    describe "when in B variant" do
-      it "should display a link to the 'learn to drive' tasklist link" do
-        with_variant TaskListBrowse: 'B' do
-          get(
-            :show,
-            params: {
-              top_level_slug: "driving",
-              second_level_slug: "learning-to-drive"
-            }
-          )
-
-          assert_response 200
-          assert_includes @response.body, 'Learn to drive a car: step by step'
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
We've already added it to https://www.gov.uk/browse/driving/learning-to-drive but need to add it to 
the driving licences page too.