### PR TITLE
Add json paths

### DIFF
--- a/app/models/task_list_ab_test_request.rb
+++ b/app/models/task_list_ab_test_request.rb
@@ -18,7 +18,12 @@ class TaskListAbTestRequest
   end
 
   def page_is_under_test?
-    ["/browse/driving/learning-to-drive", "/browse/driving/driving-licences"].include? @request.path
+    [
+      "/browse/driving/learning-to-drive",
+      "/browse/driving/learning-to-drive.json",
+      "/browse/driving/driving-licences",
+      "/browse/driving/driving-licences.json",
+    ].include? @request.path
   end
 
   def set_response_vary_header(response)


### PR DESCRIPTION
When we're testing for paths we need to include all of them, especially
as browse calls the json end points when browsing between levels