### PR TITLE
Enable the end-to-end tests for collections publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,4 +11,6 @@ node {
       govuk.runRakeTask("spec:javascript")
     }
   })
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
+  govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
This will allow us to run the tests defined in the [E2E project](https://github.com/alphagov/publishing-e2e-tests) for collections publishing to ensure that publishing between applications still works when changes are made to this repo