### PR TITLE
Update learn-to-drive-a-car tasklist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gem 'gds-api-adapters', '~> 50.5'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 0.3'
 gem 'govuk_frontend_toolkit', '~> 7.2.0'
-gem 'govuk_navigation_helpers', '6.3.0'
-gem 'govuk_publishing_components', '~> 2.0.0', require: false
+gem 'govuk_navigation_helpers', '7.4.0'
+gem 'govuk_publishing_components', '~> 3.0.0'
 gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'plek', '~> 1.11.0'
 gem 'rails', '5.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (50.5.0)
+    gds-api-adapters (50.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -129,9 +129,11 @@ GEM
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_navigation_helpers (6.3.0)
+    govuk_navigation_helpers (7.4.0)
+      activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
-    govuk_publishing_components (2.0.0)
+      govuk_ab_testing (~> 2.4)
+    govuk_publishing_components (3.0.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -340,8 +342,8 @@ DEPENDENCIES
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 0.3)
   govuk_frontend_toolkit (~> 7.2.0)
-  govuk_navigation_helpers (= 6.3.0)
-  govuk_publishing_components (~> 2.0.0)
+  govuk_navigation_helpers (= 7.4.0)
+  govuk_publishing_components (~> 3.0.0)
   govuk_schemas (~> 2.3.0)
   jasmine-rails
   logstasher (= 0.6.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,3 +5,4 @@
 //= require modules/current-location
 //= require modules/feeds.js
 //= require components/accordion
+//= require components/task-list

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,6 @@
 @import "views/topics";
 @import "views/taxons";
 @import "views/email-signups";
+
+// gem components
+@import 'components/task-list';

--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -1,5 +1,10 @@
 class TasklistController < ApplicationController
   def show
-    render :show, locals: { tasklist: TasklistContent.learn_to_drive_config }
+    content_item = ContentItem.find!("/learn-to-drive-a-car")
+
+    render :show, locals: {
+      content_item: content_item,
+      tasklist: TasklistContent.learn_to_drive_config
+    }
   end
 end

--- a/app/views/tasklist/show.html.erb
+++ b/app/views/tasklist/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Learn to drive a car: step by step" %>
+<% content_for :title, content_item.title %>
 
 <% content_for :meta_tags do %>
-  <meta name="description" content="Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.">
+  <meta name="description" content="<%= content_item.description %>">
 <% end %>
 
 <% content_for :breadcrumbs do %>
@@ -16,12 +16,11 @@
         average_title_length: 'long',
         margin_bottom: 0 %>
 
-    <%= render 'govuk_component/lead_paragraph',
-        text: tasklist[:description] %>
+    <div class="govuk-govspeak"><%= raw(tasklist[:description]) %></div>
   </div>
 </div>
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render "govuk_component/task_list", tasklist[:tasklist] %>
+    <%= render "components/task_list", tasklist[:tasklist] %>
   </div>
 </div>

--- a/config/tasklists/learn-to-drive-a-car.json
+++ b/config/tasklists/learn-to-drive-a-car.json
@@ -1,7 +1,7 @@
 {
   "title": "Learn to drive a car: step by step",
   "base_path": "/learn-to-drive-a-car",
-  "description": "Check what you need to do to learn to drive.",
+  "description": "<p>Check what you need to do to learn to drive.</p>",
   "links": {
     "breadcrumbs": [
       { "title": "Home", "url": "/" },
@@ -14,19 +14,28 @@
       [
         {
           "title": "Check you're allowed to drive",
-          "panel_descriptions": ["Most people can start learning to drive when they’re 17."],
-          "panel_links": [
+          "contents": [
             {
-              "href": "/vehicles-can-drive",
-              "text": "Check what age you can drive"
+              "type": "paragraph",
+              "text": "Most people can start learning to drive when they’re 17."
             },
             {
-              "href": "/legal-obligations-drivers-riders",
-              "text": "Requirements for driving legally"
-            },
-            {
-              "href": "/driving-eyesight-rules",
-              "text": "Driving eyesight rules"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/vehicles-can-drive",
+                  "text": "Check what age you can drive"
+                },
+                {
+                  "href": "/legal-obligations-drivers-riders",
+                  "text": "Requirements for driving legally"
+                },
+                {
+                  "href": "/driving-eyesight-rules",
+                  "text": "Driving eyesight rules"
+                }
+              ]
             }
           ]
         }
@@ -34,10 +43,16 @@
       [
         {
           "title": "Get a provisional driving licence",
-          "panel_links": [
+          "contents": [
             {
-              "href": "/apply-first-provisional-driving-licence",
-              "text": "Apply for your first provisional driving licence"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/apply-first-provisional-driving-licence",
+                  "text": "Apply for your first provisional driving licence"
+                }
+              ]
             }
           ]
         }
@@ -45,40 +60,55 @@
       [
         {
           "title": "Driving lessons and practice",
-          "panel_descriptions": ["You need a provisional driving licence to take lessons or practice."],
-          "panel_links": [
+          "contents": [
             {
-              "href": "/guidance/the-highway-code",
-              "text": "The Highway Code"
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to take lessons or practice."
             },
             {
-              "href": "/driving-lessons-learning-to-drive",
-              "text": "Taking driving lessons"
-            },
-            {
-              "href": "/find-driving-schools-and-lessons",
-              "text": "Find driving schools, lessons and instructors"
-            },
-            {
-              "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
-              "text": "Practise vehicle safety questions"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/guidance/the-highway-code",
+                  "text": "The Highway Code"
+                },
+                {
+                  "href": "/driving-lessons-learning-to-drive",
+                  "text": "Taking driving lessons"
+                },
+                {
+                  "href": "/find-driving-schools-and-lessons",
+                  "text": "Find driving schools, lessons and instructors"
+                },
+                {
+                  "href": "/government/publications/car-show-me-tell-me-vehicle-safety-questions",
+                  "text": "Practise vehicle safety questions"
+                }
+              ]
             }
           ]
         },
         {
           "title": "Prepare for your theory test",
-          "panel_links": [
+          "contents": [
             {
-              "href": "/theory-test/revision-and-practice",
-              "text": "Theory test revision and practice"
-            },
-            {
-              "href": "/take-practice-theory-test",
-              "text": "Take a practice theory test"
-            },
-            {
-              "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
-              "text": "Theory and hazard perception test app"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/theory-test/revision-and-practice",
+                  "text": "Theory test revision and practice"
+                },
+                {
+                  "href": "/take-practice-theory-test",
+                  "text": "Take a practice theory test"
+                },
+                {
+                  "href": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
+                  "text": "Theory and hazard perception test app"
+                }
+              ]
             }
           ]
         }
@@ -86,27 +116,36 @@
       [
         {
           "title": "Book and manage your theory test",
-          "panel_descriptions": ["You need a provisional driving licence to book your theory test."],
-          "panel_links": [
+          "contents": [
             {
-              "href": "/book-theory-test",
-              "text": "Book your theory test"
+              "type": "paragraph",
+              "text": "You need a provisional driving licence to book your theory test."
             },
             {
-              "href": "/theory-test/what-to-take",
-              "text": "What to take to your test"
-            },
-            {
-              "href": "/change-theory-test",
-              "text": "Change your theory test appointment"
-            },
-            {
-              "href": "/check-theory-test",
-              "text": "Check your theory test appointment details"
-            },
-            {
-              "href": "/cancel-theory-test",
-              "text": "Cancel your theory test"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/book-theory-test",
+                  "text": "Book your theory test"
+                },
+                {
+                  "href": "/theory-test/what-to-take",
+                  "text": "What to take to your test"
+                },
+                {
+                  "href": "/change-theory-test",
+                  "text": "Change your theory test appointment"
+                },
+                {
+                  "href": "/check-theory-test",
+                  "text": "Check your theory test appointment details"
+                },
+                {
+                  "href": "/cancel-theory-test",
+                  "text": "Cancel your theory test"
+                }
+              ]
             }
           ]
         }
@@ -114,27 +153,36 @@
       [
         {
           "title": "Book and manage your driving test",
-          "panel_descriptions": ["You must pass your theory test before you can book your driving test."],
-          "panel_links": [
+          "contents": [
             {
-              "href": "/book-driving-test",
-              "text": "Book your driving test"
+              "type": "paragraph",
+              "text": "You must pass your theory test before you can book your driving test."
             },
             {
-              "href": "/driving-test/what-to-take",
-              "text": "What to take to your test"
-            },
-            {
-              "href": "/change-driving-test",
-              "text": "Change your driving test appointment"
-            },
-            {
-              "href": "/check-driving-test",
-              "text": "Check your driving test appointment details"
-            },
-            {
-              "href": "/cancel-driving-test",
-              "text": "Cancel your driving test"
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/book-driving-test",
+                  "text": "Book your driving test"
+                },
+                {
+                  "href": "/driving-test/what-to-take",
+                  "text": "What to take to your test"
+                },
+                {
+                  "href": "/change-driving-test",
+                  "text": "Change your driving test appointment"
+                },
+                {
+                  "href": "/check-driving-test",
+                  "text": "Check your driving test appointment details"
+                },
+                {
+                  "href": "/cancel-driving-test",
+                  "text": "Cancel your driving test"
+                }
+              ]
             }
           ]
         }
@@ -142,11 +190,25 @@
       [
         {
           "title": "When you pass",
-          "panel_descriptions": ["You can start driving as soon as you pass your driving test.","You must have an insurance policy that allows you to drive without supervision."],
-          "panel_links": [
+          "contents": [
             {
-              "href": "/pass-plus",
-              "text": "Find out about Pass Plus training courses"
+              "type": "paragraph",
+              "text": "You can start driving as soon as you pass your driving test."
+            },
+            {
+              "type": "paragraph",
+              "text": "You must have an insurance policy that allows you to drive without supervision."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/pass-plus",
+                  "text": "Find out about Pass Plus training courses"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
The new tasklist component in `static` is being updated with the lastest design and features (https://github.com/alphagov/static/pull/1201).

The data structure for this tasklist needs to change to work with the update.

We will merge this once the component is ready.

Trello card: [Update /learning-to-drive-a-car tasklist with new tasklist component](https://trello.com/c/lKnhdCXh/)

![updated-learn-to-drive-a-car-tasklist](https://user-images.githubusercontent.com/19667619/33552082-89edbafc-d8eb-11e7-8116-3a7553857d7f.png)
