### PR TITLE
Add get a divorce tasklist page

### DIFF
--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -16,4 +16,13 @@ class TasklistController < ApplicationController
       tasklist: TasklistContent.end_a_civil_partnership_config
     }
   end
+
+  def show_get_a_divorce
+    content_item = ContentItem.find!("/get-a-divorce")
+
+    render :show, locals: {
+      content_item: content_item,
+      tasklist: TasklistContent.get_a_divorce_config
+    }
+  end
 end

--- a/app/services/tasklist_content.rb
+++ b/app/services/tasklist_content.rb
@@ -7,6 +7,10 @@ class TasklistContent
     @end_a_civil_partnership_config ||= find_file("end-a-civil-partnership")
   end
 
+  def self.get_a_divorce_config
+    @get_a_divorce_config ||= find_file("get-a-divorce")
+  end
+
   def self.find_file(filename)
     JSON.parse(
       File.read(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
 
   get "/learn-to-drive-a-car", to: 'tasklist#show'
+  get "/get-a-divorce", to: 'tasklist#show_get_a_divorce'
 
   get "/end-a-civil-partnership", to: 'tasklist#show_end_a_civil_partnership'
 

--- a/config/tasklists/get-a-divorce.json
+++ b/config/tasklists/get-a-divorce.json
@@ -1,0 +1,318 @@
+{
+  "title": "Get a divorce: step by step",
+  "base_path": "/get-a-divorce",
+  "description": "<p>How to file for divorce if you’re in England or Wales.</p><p>There is a different process if you’re <a href=\"/divorce/respond-to-a-divorce-petition\">responding to a divorce petition</a>, or if you’re in <a href=\"https://www.scotcourts.gov.uk/taking-action/divorce-and-dissolution-of-civil-partnership\">Scotland</a> or <a href=\"https://www.nidirect.gov.uk/articles/getting-divorcedissolution-civil-partnership\">Northern Ireland</a>.</p>",
+  "links": {
+    "breadcrumbs": [
+      {
+        "title": "Home",
+        "url": "/"
+      },
+      {
+        "title": "Births, deaths, marriages and care",
+        "url": "/browse/births-deaths-marriages"
+      },
+      {
+        "title": "Marriage, civil partnership and divorce",
+        "url": "/browse/births-deaths-marriages/marriage-divorce"
+      }
+    ]
+  },
+  "tasklist": {
+    "groups": [
+      [
+        {
+          "title": "Get support and advice",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can get support and advice to help you deal with disputes and emotional stress."
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/help-separation-and-divorce",
+                  "text": "Get advice from Relate"
+                },
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/talk-someone",
+                  "text": "Get counselling from Relate (in person, by phone or online)"
+                },
+                {
+                  "href": "http://www.counselling-directory.org.uk/adv-search.html",
+                  "text": "Find a counsellor",
+                  "context": "£35 to £60 per session"
+                },
+                {
+                  "href": "https://www.samaritans.org/how-we-can-help-you/contact-us",
+                  "text": "Contact the Samaritans if you need to speak to someone urgently"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Check you can get a divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Your marriage must meet certain legal requirements for you to be able to get a divorce."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce",
+                  "text": "Check you can get a divorce"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Make arrangements for your children, money and property",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You should try to agree how you'll deal with your children, money and property before you start your divorce."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/looking-after-children-divorce",
+                  "text": "Make arrangements for your children"
+                },
+                {
+                  "href": "/money-property-when-relationship-ends",
+                  "text": "Divide your money and property"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You should also check if your divorce will affect:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "/benefits-calculators",
+                  "text": "benefits you're eligible for"
+                },
+                {
+                  "href": "/report-benefits-change-circumstances",
+                  "text": "benefits you already receive"
+                },
+                {
+                  "href": "/contact-pension-service",
+                  "text": "your State Pension"
+                },
+                {
+                  "href": "/visas-when-you-separate-or-divorce",
+                  "text": "your UK visa status"
+                },
+                {
+                  "href": "/stay-in-home-during-separation-or-divorce",
+                  "text": "whether you can live in your current home"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "File for divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need to fill in a divorce petition form."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/file-for-divorce",
+                  "text": "How to start the divorce process"
+                },
+                {
+                  "href": "/divorce/grounds-for-divorce",
+                  "text": "Check the list of reasons why you can get a divorce"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1115",
+                  "text": "Fill in the divorce petition form"
+                },
+                {
+                  "href": "/divorce/file-for-divorce",
+                  "text": "Pay the court fee",
+                  "context": "£550"
+                },
+                {
+                  "href": "/get-help-with-court-fees",
+                  "text": "Get help with court fees"
+                },
+                {
+                  "href": "https://courttribunalfinder.service.gov.uk/search/postcode?aol=Divorce&amp;spoe=start",
+                  "text": "Send copies of the form to your nearest divorce centre"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Your husband or wife will receive a copy of the divorce petition. You'll be told when they respond and what you'll need to do next."
+            },
+            {
+              "type": "paragraph",
+              "text": "You might need to get legal advice if your husband or wife disagrees with your divorce petition."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/find-a-legal-adviser",
+                  "text": "Get legal advice"
+                }
+              ]
+            },
+            {
+              "type": "substep",
+              "optional": true
+            },
+            {
+              "type": "list",
+              "contents": [
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "Find your husband or wife’s address",
+                  "context": "£0 to £100"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1112",
+                  "text": "Apply to skip the divorce petition if you can’t find their address",
+                  "context": "£50"
+                },
+                {
+                  "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
+                  "text": "Get help if your husband or wife can’t make decisions for themselves"
+                },
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "End the marriage because you think your husband or wife is dead",
+                  "context": "£365"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Send the court more details about your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "If the court agrees with your divorce petition, you can apply for a document called a 'decree nisi'. You can give more information about why the marriage has broken down."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/apply-for-decree-nisi",
+                  "text": "Why you need a decree nisi"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=154",
+                  "text": "Fill in the application form"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You need to say why you're getting a divorce. Choose the form that matches what you put in the divorce petition:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=144",
+                  "text": "unreasonable behaviour"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=142",
+                  "text": "adultery"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=146",
+                  "text": "desertion"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=149",
+                  "text": "2 years' separation"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=150",
+                  "text": "5 years' separation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. "
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Finalise your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Once you, your husband or wife, and the court all agree, you can apply for the final document to end your marriage. This is called a 'decree absolute'. You can do this 6 weeks to 12 months after you receive the decree nisi."
+            },
+            {
+              "type": "paragraph",
+              "text": "If you want a legally-binding arrangement for dividing money and property you must apply to the court for this before you apply for a decree absolute."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "contents": [
+                {
+                  "href": "/divorce/apply-for-a-decree-absolute",
+                  "text": "Why you need a decree absolute"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1114",
+                  "text": "Fill in the decree absolute application form"
+                }
+
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. Once it's approved, they'll send you both a copy of the decree absolute and your divorce will be complete."
+            }
+
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/test/integration/get_a_divorce_tasklist_page_test.rb
+++ b/test/integration/get_a_divorce_tasklist_page_test.rb
@@ -1,0 +1,54 @@
+require 'integration_test_helper'
+
+class GetADivorceTasklistPageTest < ActionDispatch::IntegrationTest
+  before do
+    path = "/get-a-divorce"
+    content_store_has_item(path, schema: 'generic')
+
+    visit path
+  end
+
+  it "renders the breadcrumbs in the divorce page" do
+    assert page.has_css?(shared_component_selector('breadcrumbs'))
+
+    within_static_component 'breadcrumbs' do |breadcrumb_arg|
+      assert_equal [
+        { "title" => "Home", "url" => "/" },
+        { "title" => "Births, deaths, marriages and care", "url" => "/browse/births-deaths-marriages" },
+        { "title" => "Marriage, civil partnership and divorce", "url" => "/browse/births-deaths-marriages/marriage-divorce" }
+      ], breadcrumb_arg[:breadcrumbs]
+    end
+  end
+
+  it "renders the title in the get a divorce page" do
+    assert page.has_css?(shared_component_selector('title'))
+
+    within_static_component 'title' do |component_args|
+      assert_equal "Get a divorce: step by step", component_args[:title]
+    end
+  end
+
+  it "renders tasklist in the the get a divorce page" do
+    assert page.has_css?(tasklist_component)
+
+    within(tasklist_component) do
+      group_titles = [
+        "Get support and advice",
+        "Check you can get a divorce",
+        "Make arrangements for your children, money and property",
+        "File for divorce",
+        "Send the court more details about your divorce",
+        "Finalise your divorce"
+      ]
+
+      group_titles.each_with_index do |group_title, index|
+        step = index + 1
+        assert_match("Step #{step} #{group_title}", page.text)
+      end
+    end
+  end
+
+  def tasklist_component
+    "[data-module='gemtasklist']"
+  end
+end

--- a/test/integration/tasklist_page_test.rb
+++ b/test/integration/tasklist_page_test.rb
@@ -1,7 +1,6 @@
 require 'integration_test_helper'
 
 class TasklistPageTest < ActionDispatch::IntegrationTest
-
   before do
     path = '/learn-to-drive-a-car'
     content_store_has_item(path, schema: 'generic')


### PR DESCRIPTION
The Modelling Services team are implementing a new tasklist "Get a divorce: step by step".

It uses the new tasklist component that is being updated in `static` (alphagov/static#1201).

We will merge this once the component is ready.

Trello card: [Add get-a-divorce task list page](https://trello.com/c/HRSF68rC)

![get-a-divorce-tasklist-1](https://user-images.githubusercontent.com/19667619/33602726-2464a868-d9a8-11e7-9708-100c7c65a8fd.png)
![get-a-divorce-tasklist-2](https://user-images.githubusercontent.com/19667619/33602727-2478db8a-d9a8-11e7-9f95-c4919d6ea58b.png)
![get-a-divorce-tasklist-3](https://user-images.githubusercontent.com/19667619/33602728-249717a8-d9a8-11e7-9c79-3b14c2a13115.png)
