### PR TITLE
[REVIEW ONLY] Add end civil partnership tasklist page

### DIFF
--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -9,6 +9,11 @@ class TasklistController < ApplicationController
   end
 
   def show_end_a_civil_partnership
-    render :show, locals: { tasklist: TasklistContent.end_a_civil_partnership_config }
+    content_item = ContentItem.find!("/end-a-civil-partnership")
+
+    render :show, locals: {
+      content_item: content_item,
+      tasklist: TasklistContent.end_a_civil_partnership_config
+    }
   end
 end

--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -7,4 +7,8 @@ class TasklistController < ApplicationController
       tasklist: TasklistContent.learn_to_drive_config
     }
   end
+
+  def show_end_a_civil_partnership
+    render :show, locals: { tasklist: TasklistContent.end_a_civil_partnership_config }
+  end
 end

--- a/app/services/tasklist_content.rb
+++ b/app/services/tasklist_content.rb
@@ -1,9 +1,17 @@
 class TasklistContent
   def self.learn_to_drive_config
-    @learn_to_drive_config ||= JSON.parse(
+    @learn_to_drive_config ||= find_file("learn-to-drive-a-car")
+  end
+
+  def self.end_a_civil_partnership_config
+    @end_a_civil_partnership_config ||= find_file("end-a-civil-partnership")
+  end
+
+  def self.find_file(filename)
+    JSON.parse(
       File.read(
-        Rails.root.join("config", "tasklists", "learn-to-drive-a-car.json")
-        )
-      ).deep_symbolize_keys
+        Rails.root.join("config", "tasklists", "#{filename}.json")
+      )
+    ).deep_symbolize_keys
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
 
   get "/learn-to-drive-a-car", to: 'tasklist#show'
 
+  get "/end-a-civil-partnership", to: 'tasklist#show_end_a_civil_partnership'
+
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: [:index, :show], param: :top_level_slug do

--- a/config/tasklists/end-a-civil-partnership.json
+++ b/config/tasklists/end-a-civil-partnership.json
@@ -31,7 +31,7 @@
             },
             {
               "type": "list",
-              "links": [
+              "contents": [
                 {
                   "href": "https://www.relate.org.uk/relationship-help/help-separation-and-divorce",
                   "text": "Get advice from Relate"
@@ -43,7 +43,7 @@
                 {
                   "href": "http://www.counselling-directory.org.uk/adv-search.html",
                   "text": "Find a counsellor",
-                  "cost": "£35 to £60 per session"
+                  "context": "£35 to £60 per session"
                 },
                 {
                   "href": "https://www.samaritans.org/how-we-can-help-you/contact-us",
@@ -65,7 +65,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/end-civil-partnership",
                   "text": "Check your civil partnership meets the criteria"
@@ -87,7 +87,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/looking-after-children-divorce",
                   "text": "Make arrangements for your children"
@@ -105,7 +105,7 @@
             {
               "type": "list",
               "style": "choice",
-              "links": [
+              "contents": [
                 {
                   "href": "/benefits-calculators",
                   "text": "benefits you're eligible for"
@@ -142,7 +142,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/end-civil-partnership/file-application",
                   "text": "How to start the process to end your civil partnership"
@@ -158,7 +158,7 @@
                 {
                   "href": "/end-civil-partnership/file-application",
                   "text": "Pay the court fee",
-                  "cost": "£550"
+                  "context": "£550"
                 },
                 {
                   "href": "/get-help-with-court-fees",
@@ -181,7 +181,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/find-a-legal-adviser",
                   "text": "Get legal advice"
@@ -194,16 +194,16 @@
             },
             {
               "type": "list",
-              "links": [
+              "contents": [
                 {
                   "href": "/divorce-missing-husband-wife",
                   "text": "Find your civil partner's address",
-                  "cost": "£0 to £100"
+                  "context": "£0 to £100"
                 },
                 {
                   "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1112",
                   "text": "Apply to skip the dissolution order if you can’t find their address",
-                  "cost": "£50"
+                  "context": "£50"
                 },
                 {
                   "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
@@ -212,7 +212,7 @@
                 {
                   "href": "/divorce-missing-husband-wife",
                   "text": "End the civil partnership because you think your partner is dead",
-                  "cost": "£365"
+                  "context": "£365"
                 }
               ]
             }
@@ -230,7 +230,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/end-civil-partnership/apply-for-a-conditional-order",
                   "text": "Why you need a conditional order"
@@ -248,7 +248,7 @@
             {
               "type": "list",
               "style": "choice",
-              "links": [
+              "contents": [
                 {
                   "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=144",
                   "text": "unreasonable behaviour"
@@ -293,7 +293,7 @@
             {
               "type": "list",
               "style": "required",
-              "links": [
+              "contents": [
                 {
                   "href": "/end-civil-partnership/apply-for-a-final-order",
                   "text": "Why you need a final order"

--- a/config/tasklists/end-a-civil-partnership.json
+++ b/config/tasklists/end-a-civil-partnership.json
@@ -1,0 +1,322 @@
+{
+  "title": "End a civil partnership: step by step",
+  "base_path": "/end-a-civil-partnership",
+  "description": "<p>Find out how to legally end your civil partnership in England and Wales.</p><p>There is a different process if you're in <a href=\"https://www.scotcourts.gov.uk/taking-action/divorce-and-dissolution-of-civil-partnership\">Scotland</a> or <a href=\"https://www.nidirect.gov.uk/articles/getting-divorcedissolution-civil-partnership\">Northern Ireland</a>.</p>",
+  "links": {
+    "breadcrumbs": [
+      {
+        "title": "Home",
+        "url": "/"
+      },
+      {
+        "title": "Births, deaths, marriages and care",
+        "url": "/browse/births-deaths-marriages"
+      },
+      {
+        "title": "Marriage, civil partnership and divorce",
+        "url": "/browse/births-deaths-marriages/marriage-divorce"
+      }
+    ]
+  },
+  "tasklist": {
+    "groups": [
+      [
+        {
+          "title": "Get support and advice",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You can get support and advice to help you deal with disputes and emotional stress."
+            },
+            {
+              "type": "list",
+              "links": [
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/help-separation-and-divorce",
+                  "text": "Get advice from Relate"
+                },
+                {
+                  "href": "https://www.relate.org.uk/relationship-help/talk-someone",
+                  "text": "Get counselling from Relate (in person, by phone or online)"
+                },
+                {
+                  "href": "http://www.counselling-directory.org.uk/adv-search.html",
+                  "text": "Find a counsellor",
+                  "cost": "£35 to £60 per session"
+                },
+                {
+                  "href": "https://www.samaritans.org/how-we-can-help-you/contact-us",
+                  "text": "Contact the Samaritans if you need to speak to someone urgently"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Check you can end a civil partnership",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You must meet certain legal requirements for you to end your civil partnership."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/end-civil-partnership",
+                  "text": "Check your civil partnership meets the criteria"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Make arrangements for your children, money and property",
+          "optional": true,
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You should try to agree how you'll deal with your children, money and property before you apply to end your civil partnership."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/looking-after-children-divorce",
+                  "text": "Make arrangements for your children"
+                },
+                {
+                  "href": "/money-property-when-relationship-ends",
+                  "text": "Divide your money and property"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You should also check if ending your civil partnership will affect:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "links": [
+                {
+                  "href": "/benefits-calculators",
+                  "text": "benefits you're eligible for"
+                },
+                {
+                  "href": "/report-benefits-change-circumstances",
+                  "text": "benefits you already receive"
+                },
+                {
+                  "href": "/contact-pension-service",
+                  "text": "your State Pension"
+                },
+                {
+                  "href": "/visas-when-you-separate-or-divorce",
+                  "text": "your UK visa status"
+                },
+                {
+                  "href": "/stay-in-home-during-separation-or-divorce",
+                  "text": "whether you can live in your current home"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "File an application",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "You need to fill in a dissolution application."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/end-civil-partnership/file-application",
+                  "text": "How to start the process to end your civil partnership"
+                },
+                {
+                  "href": "/end-civil-partnership/grounds-for-ending-a-civil-partnership",
+                  "text": "Check the list of reasons why you can end a civil partnership"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1115",
+                  "text": "Fill in a dissolution application form"
+                },
+                {
+                  "href": "/end-civil-partnership/file-application",
+                  "text": "Pay the court fee",
+                  "cost": "£550"
+                },
+                {
+                  "href": "/get-help-with-court-fees",
+                  "text": "Get help with court fees"
+                },
+                {
+                  "href": "https://courttribunalfinder.service.gov.uk/search/",
+                  "text": "Send copies of the form to your nearest divorce centre"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Your civil partner will receive a copy of the dissolution application. You'll be told when they respond and what you'll need to do next."
+            },
+            {
+              "type": "paragraph",
+              "text": "You might need to get legal advice if your civil partner disagrees with your application."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/find-a-legal-adviser",
+                  "text": "Get legal advice"
+                }
+              ]
+            },
+            {
+              "type": "substep",
+              "optional": true
+            },
+            {
+              "type": "list",
+              "links": [
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "Find your civil partner's address",
+                  "cost": "£0 to £100"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1112",
+                  "text": "Apply to skip the dissolution order if you can’t find their address",
+                  "cost": "£50"
+                },
+                {
+                  "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
+                  "text": "Get help if your civil partner can’t make decisions for themselves"
+                },
+                {
+                  "href": "/divorce-missing-husband-wife",
+                  "text": "End the civil partnership because you think your partner is dead",
+                  "cost": "£365"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Send the court more details about ending your civil partnership",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "If the court agrees with your dissolution application, you can apply for a document called a 'conditional order'. You can give more information about why the civil partnership has broken down."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/end-civil-partnership/apply-for-a-conditional-order",
+                  "text": "Why you need a conditional order"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=154",
+                  "text": "Fill in the application form"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "You need to say why you're ending the civil partnership. Choose the form that matches what you put in the dissolution application:"
+            },
+            {
+              "type": "list",
+              "style": "choice",
+              "links": [
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=144",
+                  "text": "unreasonable behaviour"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=142",
+                  "text": "adultery"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=146",
+                  "text": "desertion"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=149",
+                  "text": "2 years' separation"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=150",
+                  "text": "5 years' separation"
+                }
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court. "
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "title": "Finalise your divorce",
+          "contents": [
+            {
+              "type": "paragraph",
+              "text": "Once you, your civil partner and the court all agree, you can apply for a document called a 'final order' to end your civil partnership. You can do this 6 weeks to 12 months after you receive the conditional order."
+            },
+            {
+              "type": "paragraph",
+              "text": "If you want a legally-binding arrangement for dividing money and property you must apply to the court for this before you apply for a final order."
+            },
+            {
+              "type": "list",
+              "style": "required",
+              "links": [
+                {
+                  "href": "/end-civil-partnership/apply-for-a-final-order",
+                  "text": "Why you need a final order"
+                },
+                {
+                  "href": "http://hmctsformfinder.justice.gov.uk/HMCTS/GetForm.do?court_forms_id=1114",
+                  "text": "Fill in the final order application form"
+                }
+
+              ]
+            },
+            {
+              "type": "paragraph",
+              "text": "Send the forms to the court."
+            },
+            {
+              "type": "paragraph",
+              "text": "Once it's approved, they'll send you both a copy of the final order to say your civil partnership has legally ended."
+            }
+
+          ]
+        }
+      ]
+    ]
+  }
+}

--- a/test/integration/end_civil_partnership_tasklist_page_test.rb
+++ b/test/integration/end_civil_partnership_tasklist_page_test.rb
@@ -1,0 +1,55 @@
+require 'integration_test_helper'
+
+class EndCivilPartnershipTasklistPageTest < ActionDispatch::IntegrationTest
+  before do
+    path = "/end-a-civil-partnership"
+    content_store_has_item(path, schema: 'generic')
+
+    visit path
+  end
+
+  it "renders the breadcrumbs in the end a civil partnership page" do
+    assert page.has_css?(shared_component_selector('breadcrumbs'))
+
+    within_static_component 'breadcrumbs' do |breadcrumb_arg|
+      assert_equal [
+        { "title" => "Home", "url" => "/" },
+        { "title" => "Births, deaths, marriages and care", "url" => "/browse/births-deaths-marriages" },
+        { "title" => "Marriage, civil partnership and divorce", "url" => "/browse/births-deaths-marriages/marriage-divorce" }
+      ], breadcrumb_arg[:breadcrumbs]
+    end
+  end
+
+  it "renders the title in the end a civil partnership page" do
+    assert page.has_css?(shared_component_selector('title'))
+
+    within_static_component 'title' do |component_args|
+      assert_equal "End a civil partnership: step by step", component_args[:title]
+    end
+  end
+
+  it "renders the tasklist in the end a civil partnership page" do
+    assert page.has_css?(tasklist_component)
+
+    within(tasklist_component) do
+      group_titles = [
+        "Get support and advice",
+        "Check you can end a civil partnership",
+        "Make arrangements for your children, money and property",
+        "File an application",
+        "Send the court more details about ending your civil partnership",
+        "Finalise your divorce"
+      ]
+
+      group_titles.each_with_index do |group_title, index|
+        step = index + 1
+
+        assert_match("Step #{step} #{group_title}", page.text)
+      end
+    end
+  end
+
+  def tasklist_component
+    "[data-module='gemtasklist']"
+  end
+end


### PR DESCRIPTION
The Modelling Services team are implementing a new tasklist "End a civil partnership: step by step".

It uses the new tasklist component that is being updated in `static` (alphagov/static#1201).

We will merge this once the component is ready.

Trello card: [Add end-a-civil-partnership task list page](https://trello.com/c/NewvyNH7/)

![end-civil-partnership-tasklist](https://user-images.githubusercontent.com/19667619/33713879-d4ea097e-db44-11e7-93a9-8904dce82922.png)
