### PR TITLE
Revert "Bump uglifier from 2.7.2 to 4.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'plek', '~> 1.11.0'
 gem 'rails', '5.1.4'
 gem 'sass-rails', '~> 5.0.3'
 gem 'slimmer', '~> 11.1.0'
-gem 'uglifier', '~> 4.0.2'
+gem 'uglifier', '~> 2.7.1'
 gem 'unicorn', '~> 4.9.0'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,8 +309,9 @@ GEM
     tilt (2.0.8)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    uglifier (4.0.2)
-      execjs (>= 0.3.0, < 3)
+    uglifier (2.7.2)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -357,7 +358,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   slimmer (~> 11.1.0)
-  uglifier (~> 4.0.2)
+  uglifier (~> 2.7.1)
   unicorn (~> 4.9.0)
   webmock
 


### PR DESCRIPTION
Reverts alphagov/collections#426

This has caused an error in integration, can be reproduced by running
`govuk_setenv collections rake assets:precompile --trace RAILS_ENV=production`



```
Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```