### PR TITLE
Add email-alert-api bearer token

### DIFF
--- a/lib/services.rb
+++ b/lib/services.rb
@@ -4,7 +4,10 @@ require 'gds_api/rummager'
 
 module Services
   def self.email_alert_api
-    @email_alert_api ||= GdsApi::EmailAlertApi.new(Plek.new.find('email-alert-api'))
+    @email_alert_api ||= GdsApi::EmailAlertApi.new(
+      Plek.new.find('email-alert-api'),
+      bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "bearer_token")
+    )
   end
 
   def self.content_store


### PR DESCRIPTION
Email-alert-api is getting authentication/authorisation. This commit adds a bearer token for it.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)