### PR TITLE
Add print styles to collections for task list

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,0 +1,3 @@
+@import "typography";
+
+@import "components/task-list-print";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 
   <%= render partial: 'govuk_component/analytics_meta_tags',
     locals: { content_item: @content_item } %>
+  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
 </head>
 
 <body>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -2,6 +2,7 @@ Rails.application.config.assets.precompile += %w(
   application-ie6.css
   application-ie7.css
   application-ie8.css
+  print.css
 )
 
 Rails.application.config.assets.prefix = "/collections"

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,6 +1,7 @@
 if defined?(GovukPublishingComponents)
   GovukPublishingComponents.configure do |c|
     c.component_guide_title = "Collections Component Guide"
+    c.application_print_stylesheet = "print"
   end
 
   if Rails.env.development?


### PR DESCRIPTION
- add mechanism for displaying print styles
- add print css, includes only print styles for task list

Work motivated by the addition of the new task list component design, noticed that collections has no print styles and the task list needs some. Not merging until we've sorted out the components gem.

Wait for [this PR to be merged](https://github.com/alphagov/collections/pull/449) before merging.

Trello card: https://trello.com/c/ELorPDMS/393-do-all-the-task-list-gem-component-things
