### PR TITLE
Update to `/end-civil-partnership` tasklist

### DIFF
--- a/config/tasklists/end-a-civil-partnership.json
+++ b/config/tasklists/end-a-civil-partnership.json
@@ -202,7 +202,7 @@
                   "context": "£50"
                 },
                 {
-                  "href": "/divorce/if-your-husband-or-wife-lacks-mental-capacity",
+                  "href": "/end-civil-partnership/if-your-husband-or-wife-lacks-mental-capacity",
                   "text": "Get help if your civil partner can’t make decisions for themselves"
                 },
                 {


### PR DESCRIPTION
One of the links in the tasklist has `/divorce` in the slug rather than `/end-civil-partnership`. This has now been updated.