### PR TITLE
Show tasklists for "Get Divorce" and "End Civil Partnership"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,19 @@ module ApplicationHelper
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end
+
+  def tasklist_link_for(title, path, section_index)
+    link_to(
+      title,
+      path,
+      data: {
+        track_category: 'thirdLevelBrowseLinkClicked',
+        track_action: "#{section_index + 1}.0",
+        track_label: path,
+        track_options: {
+          dimension29: title
+        }
+      }
+    )
+  end
 end

--- a/app/models/task_list_ab_test_request.rb
+++ b/app/models/task_list_ab_test_request.rb
@@ -17,12 +17,26 @@ class TaskListAbTestRequest
       list_title == 'Popular services' && page_is_under_test?
   end
 
+  def show_divorce_related_tasklists?(list_title)
+    requested_variant.variant?('B') &&
+      list_title == 'Getting separated or divorced' && page_is_under_test?
+  end
+
+  def hide_list_item_link?(list_item)
+    base_path = '/separation-divorce'
+
+    list_item.base_path == base_path &&
+      requested_variant.variant?('B')
+  end
+
   def page_is_under_test?
     [
       "/browse/driving/learning-to-drive",
       "/browse/driving/learning-to-drive.json",
       "/browse/driving/driving-licences",
       "/browse/driving/driving-licences.json",
+      "/browse/births-deaths-marriages/marriage-divorce",
+      "/browse/births-deaths-marriages/marriage-divorce.json",
     ].include? @request.path
   end
 

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -11,21 +11,31 @@
     <ul>
       <% if task_list_ab_test.show_tasklist_link?(list.title) %>
         <li>
-          <%= link_to(
+          <%= tasklist_link_for(
             "Learn to drive a car: step by step",
             learn_to_drive_a_car_path,
-            data: {
-              track_category: 'thirdLevelBrowseLinkClicked',
-              track_action: "#{section_index + 1}.0",
-              track_label: learn_to_drive_a_car_path,
-              track_options: {
-                dimension29: "Learn to drive a car: step by step"
-              }
-            }
-          ) %>
+            section_index
+            ) %>
+        </li>
+      <% elsif task_list_ab_test.show_divorce_related_tasklists?(list.title) %>
+        <li>
+          <%= tasklist_link_for(
+            "Get a divorce: step by step",
+            get_a_divorce_path,
+            section_index
+            ) %>
+        </li>
+        <li>
+          <%= tasklist_link_for(
+            "End a civil partnership: step by step",
+            end_a_civil_partnership_path,
+            section_index
+            ) %>
         </li>
       <% end %>
+
       <% list.contents.each_with_index do |list_item, index| %>
+        <% next if task_list_ab_test.hide_list_item_link?(list_item) %>
         <li>
           <%= link_to(
             list_item.title,


### PR DESCRIPTION
This commit will show the links on the browse page for "Get Divorce" and
"End Civil Partnership" takslists. It also hides the link "/separation-divorce" when on variant "B".

Trello: https://trello.com/c/YZebW21D

## Looks
![screen shot 2017-12-19 at 15 17 55](https://user-images.githubusercontent.com/136777/34163864-dbadfc72-e4cf-11e7-99f9-4a358a17c367.png)


