### PR TITLE
Remove beta banners from task list pages

### DIFF
--- a/app/views/tasklist/show.html.erb
+++ b/app/views/tasklist/show.html.erb
@@ -5,7 +5,6 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_component/beta_label' %>
   <%= render 'govuk_component/breadcrumbs', tasklist[:links] %>
 <% end %>
 


### PR DESCRIPTION
Task lists are not in beta, so removing the beta banner from these pages.

Trello card: https://trello.com/c/rh00pGyA/406-remove-the-beta-banner-from-our-3-task-lists-pages