### PR TITLE
Run the E2E tests with the new collections tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections")
   govuk.buildProject(
     overrideTestTask: {
       stage("Run tests") {


### PR DESCRIPTION
We've updated any tests that are related to the collections frontend to
now be tagged with collections, for example collections-publisher and
content-tagger both use the frontend. By changing the E2E Test command
collections will now run all of these tests.