### PR TITLE
Add dummy content store to startup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Collections Frontend
 
-Collections serves the GOV.UK navigation pages, 
+Collections serves the GOV.UK navigation pages,
 
 ![Browse page](docs/browse-page.jpg)
 ![Topic page](docs/topic-page.jpg)
@@ -48,7 +48,7 @@ Collections serves the GOV.UK navigation pages,
   `associated_taxons` links. In this case the tagged content of the taxon will
   include content that is directly tagged to it and also content that has been
   tagged to any of the associated taxons.
-  
+
 
 ## Technical documentation
 
@@ -90,7 +90,25 @@ Content for taxon pages is returned by a search in Rummager based on content_ids
 
 ### Running the application
 
-`bundle exec rails server`
+```
+./startup.sh
+```
+
+The app should start on http://localhost:3070 or
+http://collections.dev.gov.uk on GOV.UK development machines.
+
+```
+./startup.sh --live
+```
+
+This will run the app and point it at the production GOV.UK `content-store` and `static` instances.
+
+```
+./startup.sh --dummy
+```
+
+This will run the app and point it at the [dummy content store](https://govuk-content-store-examples.herokuapp.com/), which serves the content schema examples and random content.
+
 
 ### Running the test suite
 
@@ -98,7 +116,7 @@ Use `bundle exec rake` to run the test suite, excluding JavaScript
 
 #### Javascript tests
 
-Use `bundle exec rake spec:javascript` to run Jasmine tests  
+Use `bundle exec rake spec:javascript` to run Jasmine tests
 Alternatively, visit [`collections.dev.gov.uk/specs`](http://collections.dev.gov.uk/specs)
 for a live debugger in your browser
 

--- a/startup.sh
+++ b/startup.sh
@@ -9,6 +9,13 @@ if [[ $1 == "--live" ]] ; then
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3070
+elif [[ $1 == "--dummy" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://govuk-content-store-examples.herokuapp.com/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
+  bundle exec rails s -p 3070
 else
   bundle exec rails s -p 3070
 fi


### PR DESCRIPTION
We're going to be putting step by step navigation into the content store, and it would be easier to work with converting collections to read from there if we can use the dummy content store.

https://trello.com/c/3pQPJDmj/440-allow-collections-to-render-task-lists-from-the-publishing-api