### PR TITLE
Refactor tasklist_controller

### DIFF
--- a/app/controllers/tasklist_controller.rb
+++ b/app/controllers/tasklist_controller.rb
@@ -1,28 +1,20 @@
 class TasklistController < ApplicationController
   def show
-    content_item = ContentItem.find!("/learn-to-drive-a-car")
+    content_item = ContentItem.find!(base_path)
 
     render :show, locals: {
       content_item: content_item,
-      tasklist: TasklistContent.learn_to_drive_config
+      tasklist: TasklistContent.find_file(slug)
     }
   end
 
-  def show_end_a_civil_partnership
-    content_item = ContentItem.find!("/end-a-civil-partnership")
+private
 
-    render :show, locals: {
-      content_item: content_item,
-      tasklist: TasklistContent.end_a_civil_partnership_config
-    }
+  def base_path
+    request.path
   end
 
-  def show_get_a_divorce
-    content_item = ContentItem.find!("/get-a-divorce")
-
-    render :show, locals: {
-      content_item: content_item,
-      tasklist: TasklistContent.get_a_divorce_config
-    }
+  def slug
+    base_path[1..-1]
   end
 end

--- a/app/services/tasklist_content.rb
+++ b/app/services/tasklist_content.rb
@@ -1,16 +1,4 @@
 class TasklistContent
-  def self.learn_to_drive_config
-    @learn_to_drive_config ||= find_file("learn-to-drive-a-car")
-  end
-
-  def self.end_a_civil_partnership_config
-    @end_a_civil_partnership_config ||= find_file("end-a-civil-partnership")
-  end
-
-  def self.get_a_divorce_config
-    @get_a_divorce_config ||= find_file("get-a-divorce")
-  end
-
   def self.find_file(filename)
     JSON.parse(
       File.read(

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,5 @@ module Collections
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W(#{config.root}/lib)
-
-    # Google Analytics dimension assigned to the Tasklist A/B test
-    config.task_list_ab_test_dimension = 43
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,6 @@ module Collections
     }
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,8 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide" if defined?(GovukPublishingComponents)
 
   get "/learn-to-drive-a-car", to: 'tasklist#show'
-  get "/get-a-divorce", to: 'tasklist#show_get_a_divorce'
-
-  get "/end-a-civil-partnership", to: 'tasklist#show_end_a_civil_partnership'
+  get "/get-a-divorce", to: 'tasklist#show'
+  get "/end-a-civil-partnership", to: 'tasklist#show'
 
   get "/browse.json" => redirect("/api/content/browse")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,11 @@ Rails.application.routes.draw do
 
   get "/browse.json" => redirect("/api/content/browse")
 
-  resources :browse, only: [:index, :show], param: :top_level_slug do
+  resources :browse, only: %i(index show), param: :top_level_slug do
     get ':second_level_slug', on: :member, to: "second_level_browse_page#show"
   end
 
-  resources :topics, only: [:index, :show], path: :topic, param: :topic_slug do
+  resources :topics, only: %i(index show), path: :topic, param: :topic_slug do
     get ":subtopic_slug", on: :member, to: "subtopics#show"
   end
 


### PR DESCRIPTION
Change the show action to cater for all hard coded step by step navigation
pages rather than having an action per page.

This gives us a head start on rendering pages from the content store and is
the first part of https://trello.com/c/3pQPJDmj/440-allow-collections-to-render-task-lists-from-the-publishing-api