### PR TITLE
Upgrade to latest govuk_app_config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,17 +4,15 @@ ruby File.read(".ruby-version").strip
 
 gem 'gds-api-adapters', '~> 51.2'
 gem 'govuk_ab_testing', '~> 2.4.1'
-gem 'govuk_app_config', '~> 0.3'
+gem 'govuk_app_config', '~> 1.3.0'
 gem 'govuk_frontend_toolkit', '~> 7.2.0'
 gem 'govuk_navigation_helpers', '9.0.0'
 gem 'govuk_publishing_components', '~> 5.0.0'
-gem 'logstasher', '0.6.2' # 0.6.5+ changes the JSON schema used for events
 gem 'plek', '~> 2.1.1'
 gem 'rails', '5.1.4'
 gem 'sass-rails', '~> 5.0.3'
 gem 'slimmer', '~> 11.1.0'
 gem 'uglifier', '~> 4.1.5'
-gem 'unicorn', '~> 5.4.0'
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
-    faraday (0.13.1)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     gds-api-adapters (51.2.0)
@@ -124,9 +124,11 @@ GEM
       rubocop-rspec (~> 1.19.0)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (0.3.0)
-      sentry-raven (~> 2.6.3)
+    govuk_app_config (1.3.0)
+      logstasher (~> 1.2.2)
+      sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
+      unicorn (~> 5.4.0)
     govuk_frontend_toolkit (7.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
@@ -160,12 +162,13 @@ GEM
     json (2.1.0)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
-    kgio (2.11.1)
+    kgio (2.11.2)
     kramdown (1.15.0)
     link_header (0.0.8)
-    logstash-event (1.1.5)
-    logstasher (0.6.2)
-      logstash-event (~> 1.1.0)
+    logstash-event (1.2.02)
+    logstasher (1.2.2)
+      activesupport (>= 4.0)
+      logstash-event (~> 1.2.0)
       request_store
     loofah (2.1.1)
       crass (~> 1.0.2)
@@ -248,7 +251,8 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    request_store (1.3.2)
+    request_store (1.4.0)
+      rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -281,7 +285,7 @@ GEM
     scss_lint (0.56.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.3)
-    sentry-raven (2.6.3)
+    sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -341,13 +345,12 @@ DEPENDENCIES
   gds-api-adapters (~> 51.2)
   govuk-lint
   govuk_ab_testing (~> 2.4.1)
-  govuk_app_config (~> 0.3)
+  govuk_app_config (~> 1.3.0)
   govuk_frontend_toolkit (~> 7.2.0)
   govuk_navigation_helpers (= 9.0.0)
   govuk_publishing_components (~> 5.0.0)
   govuk_schemas (~> 2.3.0)
   jasmine-rails
-  logstasher (= 0.6.2)
   minitest-spec-rails
   mocha
   plek (~> 2.1.1)
@@ -359,7 +362,6 @@ DEPENDENCIES
   simplecov-rcov
   slimmer (~> 11.1.0)
   uglifier (~> 4.1.5)
-  unicorn (~> 5.4.0)
   webmock
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,12 +62,4 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Enable JSON-style logging
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
-  config.logstasher.supress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,9 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass the request id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:varnish_id] = request.headers['X-Varnish']
-  end
-end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config"
+GovukUnicorn.configure(self)


### PR DESCRIPTION
Removes config and gems that are now taken care of by `govuk_app_config`.

https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md