### PR TITLE
Only show email alert option if taxon is live

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -11,6 +11,10 @@ module EmailHelper
     whitehall_base_email_sign_up_url + whitehall_atom_url
   end
 
+  def taxon_is_live?(presented_taxon)
+    presented_taxon.live_taxon?
+  end
+
 private
 
   WHITEHALL_EMAIL_SIGNUP_PATH = "/government/email-signup/new?email_signup[feed]=".freeze

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -35,4 +35,8 @@ class ContentItem
   def merge(to_merge)
     ContentItem.new(content_item_data.merge(to_merge))
   end
+
+  def phase
+    @content_item_data["phase"]
+  end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -9,6 +9,7 @@ class Taxon
     :description,
     :linked_items,
     :to_hash,
+    :phase,
     to: :content_item
   )
 
@@ -76,6 +77,10 @@ class Taxon
 
   def world_related?
     base_path.starts_with?("/world")
+  end
+
+  def live_taxon?
+    phase == "live"
   end
 
 private

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -12,6 +12,7 @@ class TaxonPresenter
     :tagged_content,
     :grandchildren?,
     :child_taxons,
+    :live_taxon?,
     :most_popular_content,
     :can_subscribe?,
     :world_related?,

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,21 +1,23 @@
-<div class='subscriptions'>
-  <% if render_whitehall_email_links?(presented_taxon) %>
-    <div class="feeds">
-      <%= link_to(whitehall_email_url, class:'email-alerts') do %>
-        Get email alerts for this topic
-        <span class="visuallyhidden"><%= presented_taxon.title %></span>
-      <% end %>
+<% if taxon_is_live?(presented_taxon) %>
+  <div class='subscriptions'>
+    <% if render_whitehall_email_links?(presented_taxon) %>
+      <div class="feeds">
+        <%= link_to(whitehall_email_url, class:'email-alerts') do %>
+          Get email alerts for this topic
+          <span class="visuallyhidden"><%= presented_taxon.title %></span>
+        <% end %>
 
-      <%= link_to "Feed", whitehall_atom_url, class: "feed js-feed" %>
-      <div class="feed-panel js-feed-panel">
-        <h3>Copy and paste this URL in to your feed reader</h3>
-        <input value="<%= whitehall_atom_url %>">
+        <%= link_to "Feed", whitehall_atom_url, class: "feed js-feed" %>
+        <div class="feed-panel js-feed-panel">
+          <h3>Copy and paste this URL in to your feed reader</h3>
+          <input value="<%= whitehall_atom_url %>">
+        </div>
       </div>
-    </div>
-  <% else %>
-    <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
-      Get email alerts for this topic
-      <span class='visuallyhidden'><%= presented_taxon.title %></span>
-    </a>
-  <% end %>
-</div>
+    <% else %>
+      <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
+        Get email alerts for this topic
+        <span class='visuallyhidden'><%= presented_taxon.title %></span>
+      </a>
+    <% end %>
+  </div>
+<% end %>

--- a/test/fixtures/content_store/funding_and_finance_for_students.json
+++ b/test/fixtures/content_store/funding_and_finance_for_students.json
@@ -3,6 +3,7 @@
   "title": "Funding and finance for students",
   "description": "Description for funding and finance for students",
   "base_path": "\/education-training-and-skills\/funding-and-finance-for-students",
+  "phase": "live",
   "links": {
     "parent_taxons": [
       {

--- a/test/fixtures/content_store/running_education_institution.json
+++ b/test/fixtures/content_store/running_education_institution.json
@@ -3,6 +3,7 @@
   "content_id": "27c5c52b-3b36-4119-b461-976197d929bf",
   "title": "Running a further or higher education institution",
   "description": "Running a further or higher education institution - description",
+  "phase": "live",
   "links": {
     "parent_taxons": [
       {

--- a/test/fixtures/content_store/student_finance.json
+++ b/test/fixtures/content_store/student_finance.json
@@ -3,6 +3,7 @@
   "title": "Student finance",
   "description": "Student finance content",
   "base_path": "\/education-training-and-skills\/student-finance",
+  "phase": "live",
   "links": {
     "parent_taxons": [
       {
@@ -20,6 +21,7 @@
         "description": "Description of student sponsorship",
         "base_path": "\/education-training-and-skills\/student-sponsorship",
         "locale": "en",
+        "phase": "live",
         "links": {
           "parent_taxons": [
             {
@@ -38,6 +40,7 @@
         "description": "Description of student loans",
         "base_path": "\/education-training-and-skills\/student-loans",
         "locale": "en",
+        "phase": "live",
         "links": {
           "parent_taxons": [
             {

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -10,7 +10,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     @base_path = '/world/usa'
     @child_taxon_base_path = '/world/news-and-events-usa'
 
-    world_usa = world_usa_taxon(base_path: @base_path)
+    world_usa = world_usa_taxon(base_path: @base_path, phase: 'live')
     world_usa_news_events = world_usa_news_events_taxon(base_path: @child_taxon_base_path)
 
     content_store_has_item(@base_path, world_usa)

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -25,6 +25,14 @@ describe Taxon do
       assert_equal @taxon.base_path, student_finance_taxon['base_path']
     end
 
+    it 'has a phase' do
+      assert_equal @taxon.phase, student_finance_taxon['phase']
+    end
+
+    it 'checks if content is live' do
+      assert(@taxon.live_taxon?)
+    end
+
     it 'has two taxon children' do
       assert_equal @taxon.child_taxons.length, 2
 

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -3,7 +3,8 @@ class EmailHelperTest < ActionView::TestCase
   test "should return true if we are browsing a world location" do
     presented_taxon = stub(
       world_related?: true,
-      renders_as_accordion?: true
+      renders_as_accordion?: true,
+      live_taxon?: true
     )
 
     assert render_whitehall_email_links?(presented_taxon)
@@ -12,7 +13,8 @@ class EmailHelperTest < ActionView::TestCase
   test "should return false if we are browsing a world location leaf page" do
     presented_taxon = stub(
       world_related?: true,
-      renders_as_accordion?: false
+      renders_as_accordion?: false,
+      live_taxon?: true
     )
 
     refute render_whitehall_email_links?(presented_taxon)
@@ -21,10 +23,28 @@ class EmailHelperTest < ActionView::TestCase
   test "should return false if we are browsing any other taxon" do
     presented_taxon = stub(
       world_related?: false,
-      renders_as_accordion?: true
+      renders_as_accordion?: true,
+      live_taxon?: true
     )
 
     refute render_whitehall_email_links?(presented_taxon)
+  end
+
+
+  test "should return true if we are browsing a taxon that is live" do
+    presented_taxon = stub(
+      live_taxon?: true
+    )
+
+    assert taxon_is_live?(presented_taxon)
+  end
+
+  test "should return false if we are browsing a taxon that is not live" do
+    presented_taxon = stub(
+      live_taxon?: false
+    )
+
+    refute taxon_is_live?(presented_taxon)
   end
 
   test "should return a valid whitehall .atom url in the form /government/{url}.atom" do


### PR DESCRIPTION
Trello: https://trello.com/c/L6CEUHtK/74-only-show-email-notification-link-on-live-taxon-pages

We are planning on publishing the taxonomy so that all the taxonomy is live, but in different phases, e.g: 'alpha', 'beta' and 'live'. This will make it easier for teams who need to work and prototype with the draft taxonomy, e.g: Topic Pages team. However, we need to make sure that pages for alpha and beta don't allow users to subscribe to email alerts.