### PR TITLE
Add integration test for nonlive email alert logic

### DIFF
--- a/test/fixtures/content_store/student_finance_draft.json
+++ b/test/fixtures/content_store/student_finance_draft.json
@@ -1,0 +1,58 @@
+{
+  "content_id": "36dd87da-4973-5490-ab00-72025b1da500",
+  "title": "Student finance",
+  "description": "Student finance content",
+  "base_path": "\/education-training-and-skills\/student-finance",
+  "phase": "beta",
+  "links": {
+    "parent_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da505",
+        "locale": "en",
+        "title": "Funding and finance for students",
+        "description": "Description for funding and finance for students",
+        "base_path": "\/education-training-and-skills\/funding-and-finance-for-students"
+      }
+    ],
+    "child_taxons": [
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da501",
+        "title": "Student sponsorship",
+        "description": "Description of student sponsorship",
+        "base_path": "\/education-training-and-skills\/student-sponsorship",
+        "locale": "en",
+        "phase": "beta",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "36dd87da-4973-5490-ab00-72025b1da504",
+              "locale": "en",
+              "title": "Student finance",
+              "description": "Student finance content",
+              "base_path": "\/education-training-and-skills\/student-finance"
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "36dd87da-4973-5490-ab00-72025b1da502",
+        "title": "Student loans",
+        "description": "Description of student loans",
+        "base_path": "\/education-training-and-skills\/student-loans",
+        "locale": "en",
+        "phase": "beta",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "36dd87da-4973-5490-ab00-72025b1da503",
+              "locale": "en",
+              "title": "Student finance",
+              "description": "Student finance content",
+              "base_path": "\/education-training-and-skills\/student-finance"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -91,6 +91,17 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_cannot_see_an_email_signup_link
   end
 
+  it 'sets up a non-live taxon with no grandchildren' do
+    given_there_is_a_taxon_without_grandchildren
+    and_the_taxon_without_grandchildren_is_not_live
+    and_there_are_popular_items_for_the_taxon
+    when_i_visit_the_taxon_page
+    then_i_can_see_there_is_a_page_title
+    and_i_can_see_the_general_information_section_in_the_accordion
+    and_i_can_see_links_to_the_child_taxons_in_an_accordion
+    and_i_cannot_see_an_email_signup_link
+  end
+
 private
 
   def then_i_can_see_the_blue_box_with_its_details
@@ -177,7 +188,7 @@ private
     assert_not_nil @parent
 
     @child_taxons = student_finance['links']['child_taxons']
-    assert @child_taxons.length > 0
+    assert @child_taxons.length.positive?
 
     content_store_has_item(@base_path, student_finance)
     content_store_has_item(
@@ -193,6 +204,12 @@ private
     stub_content_for_taxon(@taxon.content_id, search_results)
     stub_content_for_taxon(student_sponsorship_taxon['content_id'], search_results)
     stub_content_for_taxon(student_loans_taxon['content_id'], search_results)
+  end
+
+  def and_the_taxon_without_grandchildren_is_not_live
+    taxon_in_beta = student_finance_draft_taxon(base_path: @base_path, phase: 'beta')
+
+    content_store_has_item(@base_path, taxon_in_beta)
   end
 
   def and_the_taxon_has_no_tagged_content
@@ -232,10 +249,10 @@ private
   end
 
   def when_i_visit_the_taxon_page
-      visit @base_path
-      if (400..599).cover?(page.status_code)
-        raise "Application error (#{page.status_code}): \n#{page.body}"
-      end
+    visit @base_path
+    if (400..599).cover?(page.status_code)
+      raise "Application error (#{page.status_code}): \n#{page.body}"
+    end
   end
 
   def then_i_can_see_the_meta_description

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -83,11 +83,12 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     then_i_cannot_see_the_blue_box_section
   end
 
-  it 'hides page from search engine when taxon is not live' do
+  it 'sets up a non-live taxon page' do
     given_there_is_a_taxon_with_grandchildren
     and_the_taxon_is_not_live
     when_i_visit_the_taxon_page
     then_page_has_meta_robots
+    and_i_cannot_see_an_email_signup_link
   end
 
 private
@@ -391,6 +392,13 @@ private
 
   def and_i_can_see_an_email_signup_link
     assert page.has_link?(
+      'Get email alerts for this topic',
+      href: "/email-signup/?topic=#{current_path}"
+    )
+  end
+
+  def and_i_cannot_see_an_email_signup_link
+    assert page.has_no_link?(
       'Get email alerts for this topic',
       href: "/email-signup/?topic=#{current_path}"
     )

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -14,6 +14,11 @@ module TaxonHelpers
     fetch_and_validate_taxon(:running_education_institution, params)
   end
 
+  # This taxon is in beta phase and does not have grandchildren
+  def student_finance_draft_taxon(params = {})
+    fetch_and_validate_taxon(:student_finance_draft, params)
+  end
+
   def student_sponsorship_taxon(params = {})
     fetch_and_validate_taxon(:student_sponsorship, params)
   end


### PR DESCRIPTION
Trello: https://trello.com/c/L6CEUHtK/74-only-show-email-notification-link-on-live-taxon-pages

This adds an integration test for the logic introduced in PR #505.

We need to make sure that an email signup link is not displayed on taxon pages that do not have a phase of 'live'.

**See the [original PR](https://github.com/alphagov/collections/pull/505) for more details on why this is being added**