### PR TITLE
Only show email alert for taxons and child taxons when phase is live

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -11,6 +11,10 @@ module EmailHelper
     whitehall_base_email_sign_up_url + whitehall_atom_url
   end
 
+  def taxon_is_live?(presented_taxon)
+    presented_taxon.live_taxon?
+  end
+
 private
 
   WHITEHALL_EMAIL_SIGNUP_PATH = "/government/email-signup/new?email_signup[feed]=".freeze

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -35,4 +35,8 @@ class ContentItem
   def merge(to_merge)
     ContentItem.new(content_item_data.merge(to_merge))
   end
+
+  def phase
+    @content_item_data["phase"]
+  end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -37,6 +37,8 @@ class ContentItem
   end
 
   def phase
-    @content_item_data["phase"]
+    @content_item_data.fetch("phase")
+  rescue KeyError => e
+    raise "Error searching content item: #{e}"
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -9,6 +9,7 @@ class Taxon
     :description,
     :linked_items,
     :to_hash,
+    :phase,
     to: :content_item
   )
 
@@ -76,6 +77,10 @@ class Taxon
 
   def world_related?
     base_path.starts_with?("/world")
+  end
+
+  def live_taxon?
+    phase == "live"
   end
 
 private

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -12,6 +12,7 @@ class TaxonPresenter
     :tagged_content,
     :grandchildren?,
     :child_taxons,
+    :live_taxon?,
     :most_popular_content,
     :can_subscribe?,
     :world_related?,

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, presented_taxon.title %>
 <% content_for :meta_tags do %>
+  <% if !presented_taxon.live_taxon? %>
+    <% # prevent search engines from indexing this page %>
+    <meta name="robots" content="noindex, nofollow">
+  <% end %>
   <meta name="description" content="<%= presented_taxon.description %>">
   <meta name="govuk:navigation-page-type" content="<%= presented_taxon.rendering_type %>" />
 <% end %>

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,21 +1,23 @@
-<div class='subscriptions'>
-  <% if render_whitehall_email_links?(presented_taxon) %>
-    <div class="feeds">
-      <%= link_to(whitehall_email_url, class:'email-alerts') do %>
-        Get email alerts for this topic
-        <span class="visuallyhidden"><%= presented_taxon.title %></span>
-      <% end %>
+<% if taxon_is_live?(presented_taxon) %>
+  <div class='subscriptions'>
+    <% if render_whitehall_email_links?(presented_taxon) %>
+      <div class="feeds">
+        <%= link_to(whitehall_email_url, class:'email-alerts') do %>
+          Get email alerts for this topic
+          <span class="visuallyhidden"><%= presented_taxon.title %></span>
+        <% end %>
 
-      <%= link_to "Feed", whitehall_atom_url, class: "feed js-feed" %>
-      <div class="feed-panel js-feed-panel">
-        <h3>Copy and paste this URL in to your feed reader</h3>
-        <input value="<%= whitehall_atom_url %>">
+        <%= link_to "Feed", whitehall_atom_url, class: "feed js-feed" %>
+        <div class="feed-panel js-feed-panel">
+          <h3>Copy and paste this URL in to your feed reader</h3>
+          <input value="<%= whitehall_atom_url %>">
+        </div>
       </div>
-    </div>
-  <% else %>
-    <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
-      Get email alerts for this topic
-      <span class='visuallyhidden'><%= presented_taxon.title %></span>
-    </a>
-  <% end %>
-</div>
+    <% else %>
+      <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
+        Get email alerts for this topic
+        <span class='visuallyhidden'><%= presented_taxon.title %></span>
+      </a>
+    <% end %>
+  </div>
+<% end %>

--- a/test/fixtures/content_store/funding_and_finance_for_students.json
+++ b/test/fixtures/content_store/funding_and_finance_for_students.json
@@ -3,6 +3,7 @@
   "title": "Funding and finance for students",
   "description": "Description for funding and finance for students",
   "base_path": "\/education-training-and-skills\/funding-and-finance-for-students",
+  "phase": "live",
   "links": {
     "parent_taxons": [
       {

--- a/test/fixtures/content_store/running_education_institution.json
+++ b/test/fixtures/content_store/running_education_institution.json
@@ -3,6 +3,7 @@
   "content_id": "27c5c52b-3b36-4119-b461-976197d929bf",
   "title": "Running a further or higher education institution",
   "description": "Running a further or higher education institution - description",
+  "phase": "live",
   "links": {
     "parent_taxons": [
       {

--- a/test/fixtures/content_store/student_finance_draft.json
+++ b/test/fixtures/content_store/student_finance_draft.json
@@ -3,7 +3,7 @@
   "title": "Student finance",
   "description": "Student finance content",
   "base_path": "\/education-training-and-skills\/student-finance",
-  "phase": "live",
+  "phase": "beta",
   "links": {
     "parent_taxons": [
       {
@@ -21,7 +21,7 @@
         "description": "Description of student sponsorship",
         "base_path": "\/education-training-and-skills\/student-sponsorship",
         "locale": "en",
-        "phase": "live",
+        "phase": "beta",
         "links": {
           "parent_taxons": [
             {
@@ -40,7 +40,7 @@
         "description": "Description of student loans",
         "base_path": "\/education-training-and-skills\/student-loans",
         "locale": "en",
-        "phase": "live",
+        "phase": "beta",
         "links": {
           "parent_taxons": [
             {

--- a/test/fixtures/content_store/travelling_to_the_usa.json
+++ b/test/fixtures/content_store/travelling_to_the_usa.json
@@ -3,6 +3,7 @@
   "title": "Travelling to the USA",
   "description": "Includes travel advice and how to get married abroad.",
   "base_path": "\/world\/usa\/travelling-to-the-usa",
+  "phase": "live",
   "locale": "en",
   "links": {
     "parent_taxons": [

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -83,6 +83,25 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     then_i_cannot_see_the_blue_box_section
   end
 
+  it 'sets up a non-live taxon page' do
+    given_there_is_a_taxon_with_grandchildren
+    and_the_taxon_is_not_live
+    when_i_visit_the_taxon_page
+    then_page_has_meta_robots
+    and_i_cannot_see_an_email_signup_link
+  end
+
+  it 'sets up a non-live taxon with no grandchildren' do
+    given_there_is_a_taxon_without_grandchildren
+    and_the_taxon_without_grandchildren_is_not_live
+    and_there_are_popular_items_for_the_taxon
+    when_i_visit_the_taxon_page
+    then_i_can_see_there_is_a_page_title
+    and_i_can_see_the_general_information_section_in_the_accordion
+    and_i_can_see_links_to_the_child_taxons_in_an_accordion
+    and_i_cannot_see_an_email_signup_link
+  end
+
 private
 
   def then_i_can_see_the_blue_box_with_its_details
@@ -154,6 +173,13 @@ private
     )
   end
 
+  def and_the_taxon_is_not_live
+    taxon_in_beta =
+      funding_and_finance_for_students_taxon(base_path: @base_path, phase: 'beta')
+
+    content_store_has_item(@base_path, taxon_in_beta)
+  end
+
   def given_there_is_a_taxon_without_grandchildren
     @base_path = '/education/student-finance'
     student_finance = student_finance_taxon(base_path: @base_path)
@@ -178,6 +204,12 @@ private
     stub_content_for_taxon(@taxon.content_id, search_results)
     stub_content_for_taxon(student_sponsorship_taxon['content_id'], search_results)
     stub_content_for_taxon(student_loans_taxon['content_id'], search_results)
+  end
+
+  def and_the_taxon_without_grandchildren_is_not_live
+    taxon_in_beta = student_finance_draft_taxon(base_path: @base_path, phase: 'beta')
+
+    content_store_has_item(@base_path, taxon_in_beta)
   end
 
   def and_the_taxon_has_no_tagged_content
@@ -230,6 +262,16 @@ private
       @taxon.description,
       content,
       "The content of the meta description should be the taxon description"
+    )
+  end
+
+  def then_page_has_meta_robots
+    content = page.find('meta[name="robots"]', visible: false)['content']
+
+    assert_equal(
+      "noindex, nofollow",
+      content,
+      "The content of the robots meta tag should be 'noindex, nofollow'"
     )
   end
 
@@ -367,6 +409,13 @@ private
 
   def and_i_can_see_an_email_signup_link
     assert page.has_link?(
+      'Get email alerts for this topic',
+      href: "/email-signup/?topic=#{current_path}"
+    )
+  end
+
+  def and_i_cannot_see_an_email_signup_link
+    assert page.has_no_link?(
       'Get email alerts for this topic',
       href: "/email-signup/?topic=#{current_path}"
     )

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -10,7 +10,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     @base_path = '/world/usa'
     @child_taxon_base_path = '/world/news-and-events-usa'
 
-    world_usa = world_usa_taxon(base_path: @base_path)
+    world_usa = world_usa_taxon(base_path: @base_path, phase: 'live')
     world_usa_news_events = world_usa_news_events_taxon(base_path: @child_taxon_base_path)
 
     content_store_has_item(@base_path, world_usa)

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -25,6 +25,14 @@ describe Taxon do
       assert_equal @taxon.base_path, student_finance_taxon['base_path']
     end
 
+    it 'has a phase' do
+      assert_equal @taxon.phase, student_finance_taxon['phase']
+    end
+
+    it 'checks if content is live' do
+      assert(@taxon.live_taxon?)
+    end
+
     it 'has two taxon children' do
       assert_equal @taxon.child_taxons.length, 2
 

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -29,6 +29,16 @@ describe Taxon do
       assert_equal @taxon.phase, student_finance_taxon['phase']
     end
 
+    it 'errors if phase is not found' do
+      student_finance_taxon_without_phase = student_finance_taxon
+      student_finance_taxon_without_phase.delete('phase')
+
+      content_item = ContentItem.new(student_finance_taxon_without_phase)
+      @taxon_without_phase = Taxon.new(content_item)
+
+      assert_raises(RuntimeError) { @taxon_without_phase.phase }
+    end
+
     it 'checks if content is live' do
       assert(@taxon.live_taxon?)
     end

--- a/test/support/taxon_helpers.rb
+++ b/test/support/taxon_helpers.rb
@@ -14,6 +14,11 @@ module TaxonHelpers
     fetch_and_validate_taxon(:running_education_institution, params)
   end
 
+  # This taxon is in beta phase and does not have grandchildren
+  def student_finance_draft_taxon(params = {})
+    fetch_and_validate_taxon(:student_finance_draft, params)
+  end
+
   def student_sponsorship_taxon(params = {})
     fetch_and_validate_taxon(:student_sponsorship, params)
   end

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -3,7 +3,8 @@ class EmailHelperTest < ActionView::TestCase
   test "should return true if we are browsing a world location" do
     presented_taxon = stub(
       world_related?: true,
-      renders_as_accordion?: true
+      renders_as_accordion?: true,
+      live_taxon?: true
     )
 
     assert render_whitehall_email_links?(presented_taxon)
@@ -12,7 +13,8 @@ class EmailHelperTest < ActionView::TestCase
   test "should return false if we are browsing a world location leaf page" do
     presented_taxon = stub(
       world_related?: true,
-      renders_as_accordion?: false
+      renders_as_accordion?: false,
+      live_taxon?: true
     )
 
     refute render_whitehall_email_links?(presented_taxon)
@@ -21,10 +23,28 @@ class EmailHelperTest < ActionView::TestCase
   test "should return false if we are browsing any other taxon" do
     presented_taxon = stub(
       world_related?: false,
-      renders_as_accordion?: true
+      renders_as_accordion?: true,
+      live_taxon?: true
     )
 
     refute render_whitehall_email_links?(presented_taxon)
+  end
+
+
+  test "should return true if we are browsing a taxon that is live" do
+    presented_taxon = stub(
+      live_taxon?: true
+    )
+
+    assert taxon_is_live?(presented_taxon)
+  end
+
+  test "should return false if we are browsing a taxon that is not live" do
+    presented_taxon = stub(
+      live_taxon?: false
+    )
+
+    refute taxon_is_live?(presented_taxon)
   end
 
   test "should return a valid whitehall .atom url in the form /government/{url}.atom" do


### PR DESCRIPTION
This commit reverts #516, which in turn reverted #505, #507 and #508.

In preparation for publishing the taxonomy in phases of alpha, beta or live, we want to make sure that we only show email alert buttons for taxons that are live.

We had to revert the original commit as child taxons in a content item did not have a 'phase'. This has now been added so we can add this logic back in.

**Note: [last commit](https://github.com/alphagov/collections/pull/522/commits/493220f1f0f5bf40421dce1f0f8d9b4359019db5) introduces use of `fetch` to better handle if taxons have no phase. We have chosen to raise an error in this case, but this is up for debate and worth reviewing more closely to make sure it's been implemented in the right way.**