### PR TITLE
Use a document type routing constraint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => '/specs' if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
-  get "/learn-to-drive-a-car", to: 'step_nav#show'
-
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: %i(index show), param: :top_level_slug do
@@ -35,6 +33,10 @@ Rails.application.routes.draw do
   get "/government/organisations/:organisation_id/services-information",
     to: "services_and_information#index",
     as: :services_and_information
+
+  constraints DocumentTypeRoutingConstraint.new('step_by_step_nav') do
+    get "/:slug", to: 'step_nav#show'
+  end
 
   get '*taxon_base_path', to: 'taxons#show'
 end

--- a/lib/document_type_inspector.rb
+++ b/lib/document_type_inspector.rb
@@ -1,0 +1,40 @@
+class DocumentTypeInspector
+  include ActiveSupport::Rescuable
+
+  attr_reader :error
+
+  def initialize(slug)
+    @slug = slug
+  end
+
+  def document_type
+    content_item['document_type']
+  end
+
+private
+
+  attr_reader :slug
+
+  def handle_api_errors
+    yield
+  rescue GdsApi::HTTPErrorResponse,
+         GdsApi::InvalidUrl => e
+    @error = e
+    {}
+  end
+
+  def content_item
+    return {} if error?
+    @_content_item ||= handle_api_errors do
+      content_store.content_item("/#{slug}")
+    end
+  end
+
+  def error?
+    @error.present?
+  end
+
+  def content_store
+    @_content_store ||= Services.content_store
+  end
+end

--- a/lib/document_type_routing_constraint.rb
+++ b/lib/document_type_routing_constraint.rb
@@ -1,0 +1,32 @@
+class DocumentTypeRoutingConstraint
+  def initialize(document_type, document_type_inspector: DocumentTypeInspector)
+    @document_type = document_type
+    @document_type_inspector = document_type_inspector
+  end
+
+  def matches?(request)
+    @request = request
+    document_type == @document_type
+  end
+
+private
+
+  def document_type
+    @request.env[:__document_type] ||= begin
+      document_type_inspector.document_type || set_error(document_type_inspector.error) || :no_match
+    end
+  end
+
+  def set_error(err)
+    @request.env[:__api_error] = err
+    false
+  end
+
+  def document_type_inspector
+    @request.env[:__inspector] ||= @document_type_inspector.new(slug)
+  end
+
+  def slug
+    @request.params.fetch(:slug)
+  end
+end

--- a/test/lib/document_type_inspector_test.rb
+++ b/test/lib/document_type_inspector_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class DocumentTypeInspectorTest < ActiveSupport::TestCase
+  def subject
+    @_s ||= DocumentTypeInspector.new(:slug)
+  end
+
+  context "content-store lookup throws an error" do
+    setup do
+      @error = GdsApi::HTTPNotFound.new("asd")
+      stub_content_store_raises(@error)
+    end
+
+    context "#document_type" do
+      should "return nil" do
+        assert_nil subject.document_type
+      end
+    end
+
+    context "#error" do
+      should "return the error" do
+        subject.document_type
+        assert subject.error == @error
+      end
+    end
+  end
+
+  def stub_content_store_raises(error)
+    Services.expects(:content_store).raises(error)
+  end
+
+  def set_content_item_document_type(document_type)
+    @content_item = { 'schema_name' => document_type }
+    stub_content_store
+  end
+
+  def stub_content_store
+    content_store = stub
+    content_store.expects(:content_item).returns(@content_item || {})
+    Services.expects(:content_store).returns(content_store)
+  end
+end

--- a/test/lib/document_type_routing_constraint_test.rb
+++ b/test/lib/document_type_routing_constraint_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class DocumentTypeRoutingConstraintTest < ActiveSupport::TestCase
+  context "#matches?" do
+    context "when the content_store returns a document" do
+      setup do
+        @document_type = "foo"
+        @inspector = stub(new: stub(document_type: @document_type, error: nil))
+      end
+
+      should "return true if document_type matches" do
+        assert subject(@document_type, @inspector).matches?(request)
+      end
+
+      should "return false if document_type doesn't match" do
+        assert_not subject("not_the_document_type", @inspector).matches?(request)
+      end
+    end
+
+    context "when the content_store API call throws an error" do
+      setup do
+        @error = GdsApi::HTTPNotFound.new(404)
+        @inspector = stub(new: stub(document_type: nil, error: @error))
+        @request = request
+      end
+
+      should "return false" do
+        assert_not subject("foo", @inspector).matches?(@request)
+      end
+
+      should "set an error on the request object" do
+        subject("foo", @inspector).matches?(@request)
+        assert @request.env[:__api_error] == @error
+      end
+    end
+  end
+
+  context "instances are memoized and used across multiple requests" do
+    setup do
+      @api_proxy = stub
+      @document_type = "static across requests"
+      @document_type_inspector_instance = stub(document_type: @document_type, error: nil)
+      @subject = subject("foo", @api_proxy)
+    end
+
+    should "make new API calls each time" do
+      @api_proxy.expects(:new).twice.returns(@document_type_inspector_instance)
+      @subject.matches?(request)
+      @subject.matches?(request)
+    end
+  end
+
+  context "a request will be passed to multiple instances" do
+    setup do
+      @api_proxy = stub
+      @inspector_instance = stub(document_type: "baz", error: nil)
+      @request = request
+    end
+
+    should "not make additional API calls" do
+      @api_proxy.expects(:new).once.returns(@inspector_instance)
+      subject("foo", @api_proxy).matches?(@request)
+      subject("bar", @api_proxy).matches?(@request)
+    end
+  end
+
+  def request
+    env = {}
+    stub(params: { slug: 'test_slug' }, env: env)
+  end
+
+  def subject(document_type, document_type_inspector)
+    DocumentTypeRoutingConstraint.new(document_type, document_type_inspector: document_type_inspector)
+  end
+end


### PR DESCRIPTION
We can't determine the type of the document from the path, so we need to inspect the content item to see where it should be routed.

I've taken this from Frontend where it works very well, although across many more document types.