### PR TITLE
Get most popular content for guidance and services

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -80,18 +80,16 @@ class Taxon
 
 private
 
-  GUIDANCE = 'guidance'.freeze
-
   def fetch_tagged_content
     taxon_content_ids = [content_id] + associated_taxons.map(&:content_id)
     TaggedContent.fetch(
       taxon_content_ids,
-      filter_by_document_supertype: GUIDANCE,
+      filter_by_document_supertype: 'guidance',
       validate: true
     )
   end
 
   def fetch_most_popular_content
-    MostPopularContent.fetch(content_id: content_id, filter_by_document_supertype: GUIDANCE)
+    MostPopularContent.fetch(content_id: content_id, filter_content_purpose_supergroup: 'guidance_and_regulation')
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -21,6 +21,11 @@ class Taxon
     @tagged_content ||= fetch_tagged_content
   end
 
+
+  def guidance_and_regulation_content
+    @guidance_and_regulation_content ||= fetch_most_popular_content('guidance_and_regulation')
+  end
+
   def most_popular_content
     @most_popular_content ||= fetch_most_popular_content
   end
@@ -89,7 +94,7 @@ private
     )
   end
 
-  def fetch_most_popular_content
-    MostPopularContent.fetch(content_id: content_id, filter_content_purpose_supergroup: 'guidance_and_regulation')
+  def fetch_most_popular_content(content_purpose_supergroup = 'guidance_and_regulation')
+    MostPopularContent.fetch(content_id: content_id, filter_content_purpose_supergroup: content_purpose_supergroup)
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -21,6 +21,9 @@ class Taxon
     @tagged_content ||= fetch_tagged_content
   end
 
+  def services_content
+    @services_content ||= fetch_most_popular_content('services')
+  end
 
   def guidance_and_regulation_content
     @guidance_and_regulation_content ||= fetch_most_popular_content('guidance_and_regulation')

--- a/app/models/world_wide_taxon.rb
+++ b/app/models/world_wide_taxon.rb
@@ -80,7 +80,7 @@ private
   def fetch_most_popular_content
     MostPopularContent.fetch(
       content_id: content_id,
-      filter_by_document_supertype: nil,
+      filter_content_purpose_supergroup: nil,
     )
   end
 end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -13,6 +13,7 @@ class TaxonPresenter
     :grandchildren?,
     :child_taxons,
     :live_taxon?,
+    :guidance_and_regulation_content,
     :most_popular_content,
     :can_subscribe?,
     to: :taxon

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -14,6 +14,7 @@ class TaxonPresenter
     :child_taxons,
     :live_taxon?,
     :guidance_and_regulation_content,
+    :services_content,
     :most_popular_content,
     :can_subscribe?,
     to: :taxon

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,14 +1,14 @@
 class MostPopularContent
-  attr_reader :content_id, :filter_by_document_supertype, :number_of_links
+  attr_reader :content_id, :filter_content_purpose_supergroup, :number_of_links
 
-  def initialize(content_id:, filter_by_document_supertype:, number_of_links: 5)
+  def initialize(content_id:, filter_content_purpose_supergroup:, number_of_links: 5)
     @content_id = content_id
-    @filter_by_document_supertype = filter_by_document_supertype
+    @filter_content_purpose_supergroup = filter_content_purpose_supergroup
     @number_of_links = number_of_links
   end
 
-  def self.fetch(content_id:, filter_by_document_supertype:)
-    new(content_id: content_id, filter_by_document_supertype: filter_by_document_supertype).fetch
+  def self.fetch(content_id:, filter_content_purpose_supergroup:)
+    new(content_id: content_id, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
   end
 
   def fetch
@@ -27,7 +27,7 @@ private
       filter_part_of_taxonomy_tree: content_id,
       order: '-popularity',
     }
-    params[:filter_navigation_document_supertype] = filter_by_document_supertype if filter_by_document_supertype.present?
+    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     RummagerSearch.new(params)
   end

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -19,7 +19,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     @taxon = WorldWideTaxon.find(@base_path)
     stub_content_for_taxon(@taxon.content_id, search_results) # For the "general information" taxon
     stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
-    stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+    stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_content_purpose_supergroup: nil)
 
     @child_taxon = WorldWideTaxon.find(@child_taxon_base_path)
     stub_content_for_taxon(@child_taxon.content_id, search_results, filter_navigation_document_supertype: nil)

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -82,6 +82,15 @@ describe Taxon do
 
       assert_equal(results, @taxon.guidance_and_regulation_content)
     end
+
+    it "requests services content" do
+      results = [:result_1, :result_2]
+
+      MostPopularContent.stubs(:fetch)
+        .with(content_id: @taxon.content_id, filter_content_purpose_supergroup: 'services')
+        .returns(results)
+
+      assert_equal(results, @taxon.services_content)
     end
 
     it 'requests for guidance document supertype by default' do

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -73,17 +73,10 @@ describe Taxon do
       assert_equal(results, @taxon.most_popular_content)
     end
 
-    it 'knows about its most popular content items' do
-      results = [:result_1, :result_2]
-      MostPopularContent.stubs(:fetch).returns(results)
-
-      assert_equal(results, @taxon.most_popular_content)
-    end
-
     it "requests popular content of document supertype 'guidance' by default" do
       results = [:result_1, :result_2]
       MostPopularContent.stubs(:fetch)
-        .with(content_id: @taxon.content_id, filter_by_document_supertype: 'guidance')
+        .with(content_id: @taxon.content_id, filter_content_purpose_supergroup: 'guidance_and_regulation')
         .returns(results)
 
       assert_equal(results, @taxon.most_popular_content)

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -73,13 +73,15 @@ describe Taxon do
       assert_equal(results, @taxon.most_popular_content)
     end
 
-    it "requests popular content of document supertype 'guidance' by default" do
+    it "requests guidance_and_regulation content" do
       results = [:result_1, :result_2]
+
       MostPopularContent.stubs(:fetch)
         .with(content_id: @taxon.content_id, filter_content_purpose_supergroup: 'guidance_and_regulation')
         .returns(results)
 
-      assert_equal(results, @taxon.most_popular_content)
+      assert_equal(results, @taxon.guidance_and_regulation_content)
+    end
     end
 
     it 'requests for guidance document supertype by default' do

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -5,7 +5,7 @@ describe MostPopularContent do
   def most_popular_content
     @most_popular_content ||= MostPopularContent.new(
       content_id: taxon_content_id,
-      filter_by_document_supertype: 'guidance'
+      filter_content_purpose_supergroup: 'guidance_and_regulation'
     )
   end
 
@@ -60,8 +60,8 @@ describe MostPopularContent do
       end
     end
 
-    it 'filters content by the requested filter_by_document_supertype only' do
-      assert_includes_params(filter_navigation_document_supertype: 'guidance') do
+    it 'filters content by the requested filter_content_purpose_supergroup only' do
+      assert_includes_params(filter_content_purpose_supergroup: 'guidance_and_regulation') do
         most_popular_content.fetch
       end
     end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -18,7 +18,7 @@ module RummagerHelpers
       )
   end
 
-  def stub_most_popular_content_for_taxon(content_id, results, filter_navigation_document_supertype: 'guidance')
+  def stub_most_popular_content_for_taxon(content_id, results, filter_content_purpose_supergroup: 'guidance_and_regulation')
     params = {
       start: 0,
       count: 5,
@@ -26,7 +26,7 @@ module RummagerHelpers
       filter_part_of_taxonomy_tree: content_id,
       order: '-popularity',
     }
-    params[:filter_navigation_document_supertype] = filter_navigation_document_supertype if filter_navigation_document_supertype.present?
+    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     Services.rummager.stubs(:search)
     .with(params)


### PR DESCRIPTION
Trello cards: 
* https://trello.com/c/gfFoXi88
* https://trello.com/c/5lT4LyVS

## Motivation

In the new design for the taxon pages, we want to be able to group content by the [content_purpose_supergroup](https://github.com/alphagov/govuk_document_types/blob/master/data/supertypes.yml#L485).

For `guidance_and_regulation` and `services`, we want to get the top 5 most popular pieces of content.

## Changes

This PR only contains changes to the search filters used to get the data. `MostPopularContent` filters on content_purpose_supergroup rather than document_type. 

The most popular content displayed on World pages is unaffected because those pages were never filtered by content type.

New functions have been added to the `TaxonPresenter` to allow us to get `services` and `guidance_and_regulation` content but these aren't being used yet. The taxon template that uses this methods will be added in a later PR.

## Note

The existing code to get the most popular content traverses all of the child taxons to get the most popular content and sorts them in title order.