### PR TITLE
Implement email-link component for topic pages

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -2,6 +2,14 @@
   @include bold-27;
 }
 
+.taxon-page__email-link-wrapper {
+  background-color: $grey-4;
+  margin-top: -$gutter;
+  margin-bottom: $gutter;
+  border-bottom: 1px solid $border-colour;
+  padding: $gutter;
+}
+
 .taxon-page__section-description {
   @include core-19;
   margin-top: $gutter-one-third;

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -11,6 +11,14 @@
 
 <%= render partial: 'page_header', locals: { presented_taxon: presented_taxon } %>
 
-<div class="full-page-width-wrapper">
-  <%= render partial: 'email_alerts', locals: { presented_taxon: presented_taxon } %>
-</div>
+<% if taxon_is_live?(presented_taxon) %>
+  <div class="taxon-page__email-link-wrapper">
+    <div class="full-page-width-wrapper">
+        <%= render "components/email-link", {
+          text: "Sign up for updates to this topic page",
+          href: "/email-signup/?topic=#{presented_taxon.base_path}"
+        } %>
+    </div>
+  </div>
+<% end %>
+

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -80,14 +80,14 @@ private
 
   def and_i_can_see_the_email_signup_link
     assert page.has_link?(
-      'Get email alerts for this topic',
+      'Sign up for updates to this topic page',
       href: "/email-signup/?topic=#{current_path}"
     )
   end
 
   def and_i_cannot_see_an_email_signup_link
     refute page.has_link?(
-      'Get email alerts for this topic',
+      'Sign up for updates to this topic page',
       href: "/email-signup/?topic=#{current_path}"
     )
   end


### PR DESCRIPTION
Uses new component (bell icon) on topic pages, eg

Example pages:
Grid: https://govuk-collections-pr-555.herokuapp.com/education
Accordion: https://govuk-collections-pr-555.herokuapp.com/education/funding-and-finance-for-students
Leaf: https://govuk-collections-pr-555.herokuapp.com/education/education-of-disadvantaged-children

![screen shot 2018-03-16 at 10 45 14](https://user-images.githubusercontent.com/31649453/37516767-2cb9d70a-2907-11e8-89cf-cf6bf18f50a8.png)


The old style of email link (envelope icon) should continue to appear on other pages, eg:
https://govuk-collections-pr-555.herokuapp.com/world/afghanistan
