### PR TITLE
Refactor sections

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -20,12 +20,13 @@ class Taxon
     @tagged_content ||= fetch_tagged_content
   end
 
-  def services_content
-    @services_content ||= fetch_most_popular_content('services')
-  end
-
-  def guidance_and_regulation_content
-    @guidance_and_regulation_content ||= fetch_most_popular_content('guidance_and_regulation')
+  def section_content(supergroup)
+    case supergroup
+    when "guidance_and_regulation"
+      guidance_and_regulation_content
+    when "services"
+      services_content
+    end
   end
 
   def self.find(base_path)
@@ -72,5 +73,13 @@ private
 
   def fetch_most_popular_content(content_purpose_supergroup = 'guidance_and_regulation')
     MostPopularContent.fetch(content_id: content_id, filter_content_purpose_supergroup: content_purpose_supergroup)
+  end
+
+  def services_content
+    @services_content ||= fetch_most_popular_content('services')
+  end
+
+  def guidance_and_regulation_content
+    @guidance_and_regulation_content ||= fetch_most_popular_content('guidance_and_regulation')
   end
 end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -8,8 +8,7 @@ class TaxonPresenter
     :tagged_content,
     :child_taxons,
     :live_taxon?,
-    :guidance_and_regulation_content,
-    :services_content,
+    :section_content,
     to: :taxon
   )
 
@@ -17,27 +16,39 @@ class TaxonPresenter
     @taxon = taxon
   end
 
-  def guidance_and_regulation_list
-    guidance_and_regulation_content.each.map do |link|
+  def sections
+    supergroups = %w(guidance_and_regulation)
+
+    supergroups.map do |supergroup|
+      {
+        show_section: show_section?(supergroup),
+        title: section_title(supergroup),
+        documents: section_document_list(supergroup)
+      }
+    end
+  end
+
+  def section_title(supergroup)
+    supergroup.humanize
+  end
+
+  def section_document_list(supergroup)
+    section_content(supergroup).each.map do |document|
       {
         link: {
-          text: link.title,
-          path: link.base_path
+          text: document.title,
+          path: document.base_path
         },
         metadata: {
-          public_updated_at: link.public_updated_at,
-          document_type: link.content_store_document_type.humanize
+          public_updated_at: document.public_updated_at,
+          document_type: document.content_store_document_type.humanize
         },
       }
     end
   end
 
-  def guidance_and_regulation_section_title
-    'guidance_and_regulation'.humanize
-  end
-
-  def show_guidance_section?
-    guidance_and_regulation_content.count.positive?
+  def show_section?(supergroup)
+    section_content(supergroup).any?
   end
 
   def show_subtopic_grid?

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -10,18 +10,20 @@
 %>
 
 <div class="full-page-width-wrapper">
-  <% if presented_taxon.show_guidance_section? %>
-  <div class="taxon-page__section-group">
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <h2 class="taxon-page__section-heading"><%= presented_taxon.guidance_and_regulation_section_title %></h2>
-        <%= render 'govuk_publishing_components/components/document_list',
-              items: presented_taxon.guidance_and_regulation_list,
-              margin_top: true
+  <% presented_taxon.sections.each do |section| %>
+    <% if section[:show_section] %>
+    <div class="taxon-page__section-group">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
+          <%= render 'govuk_publishing_components/components/document_list',
+            items: section[:documents],
+            margin_top: true
          %>
+        </div>
       </div>
     </div>
-  </div>
+    <% end %>
   <% end %>
 </div>
 

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -59,7 +59,7 @@ describe Taxon do
         .with(content_id: @taxon.content_id, filter_content_purpose_supergroup: 'guidance_and_regulation')
         .returns(results)
 
-      assert_equal(results, @taxon.guidance_and_regulation_content)
+      assert_equal(results, @taxon.section_content("guidance_and_regulation"))
     end
 
     it "requests services content" do
@@ -69,7 +69,7 @@ describe Taxon do
         .with(content_id: @taxon.content_id, filter_content_purpose_supergroup: 'services')
         .returns(results)
 
-      assert_equal(results, @taxon.services_content)
+      assert_equal(results, @taxon.section_content("services"))
     end
 
     it 'requests for guidance document supertype by default' do

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -75,13 +75,25 @@ describe TaxonPresenter do
     end
   end
 
+  describe 'supergroup_sections' do
+    it 'returns a list of supergroup details' do
+      taxon = mock
+      taxon.stubs(:section_content).returns([])
+      taxon_presenter = TaxonPresenter.new(taxon)
+
+      taxon_presenter.sections.each do |section|
+        assert_equal(section.keys.sort, %i(documents show_section title))
+      end
+    end
+  end
+
   describe 'guidance_and_regulation_section' do
     it 'checks whether guidance section should be shown' do
       taxon = mock
-      taxon.stubs(:guidance_and_regulation_content).returns([])
+      taxon.stubs(:section_content).returns([])
       taxon_presenter = TaxonPresenter.new(taxon)
 
-      refute taxon_presenter.show_guidance_section?
+      refute taxon_presenter.show_section?("guidance_and_regulation")
     end
 
     it 'formats guidance and regulation content for document list' do
@@ -109,10 +121,10 @@ describe TaxonPresenter do
       ]
 
       taxon = mock
-      taxon.stubs(:guidance_and_regulation_content).returns(guidance_content)
+      taxon.stubs(:section_content).returns(guidance_content)
       taxon_presenter = TaxonPresenter.new(taxon)
 
-      assert_equal expected, taxon_presenter.guidance_and_regulation_list
+      assert_equal expected, taxon_presenter.section_document_list("guidance_and_regulation")
     end
   end
 


### PR DESCRIPTION
Refactor the section methods in taxon_presenter to no longer be specific to each supergroup.

We still require the content retrieval methods to be specific, e.g: guidance_and_regulation_content