### PR TITLE
[WIP] Add link to finder from each section

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -1,3 +1,5 @@
+require 'cgi/util'
+
 class TaxonPresenter
   attr_reader :taxon
   delegate(
@@ -24,7 +26,8 @@ class TaxonPresenter
       {
         show_section: show_section?(supergroup),
         title: section_title(supergroup),
-        documents: section_document_list(supergroup)
+        documents: section_document_list(supergroup),
+        link: section_finder_link(supergroup)
       }
     end
   end
@@ -54,6 +57,20 @@ class TaxonPresenter
 
   def section_content(supergroup)
     method(supergroup + "_content").call
+  end
+
+  def section_finder_link(supergroup)
+    text = supergroup.humanize.downcase
+    query_string = section_query_string(supergroup)
+
+    {
+      text: "See all #{text}",
+      url: "/search/advanced#{query_string}"
+    }
+  end
+
+  def section_query_string(supergroup)
+    CGI::escape("?taxons=#{base_path}&content_purpose_supergroup=#{supergroup}")
   end
 
   def show_subtopic_grid?

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -17,27 +17,43 @@ class TaxonPresenter
     @taxon = taxon
   end
 
-  def guidance_and_regulation_list
-    guidance_and_regulation_content.each.map do |link|
+  def sections
+    supergroups = %w(guidance_and_regulation)
+
+    supergroups.map do |supergroup|
+      {
+        show_section: show_section?(supergroup),
+        title: section_title(supergroup),
+        documents: section_document_list(supergroup)
+      }
+    end
+  end
+
+  def section_title(supergroup)
+    supergroup.humanize
+  end
+
+  def section_document_list(supergroup)
+    section_content(supergroup).each.map do |document|
       {
         link: {
-          text: link.title,
-          path: link.base_path
+          text: document.title,
+          path: document.base_path
         },
         metadata: {
-          public_updated_at: link.public_updated_at,
-          document_type: link.content_store_document_type.humanize
+          public_updated_at: document.public_updated_at,
+          document_type: document.content_store_document_type.humanize
         },
       }
     end
   end
 
-  def guidance_and_regulation_section_title
-    'guidance_and_regulation'.humanize
+  def show_section?(supergroup)
+    section_content(supergroup).any?
   end
 
-  def show_guidance_section?
-    guidance_and_regulation_content.count.positive?
+  def section_content(supergroup)
+    method(supergroup + "_content").call
   end
 
   def show_subtopic_grid?

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -20,6 +20,10 @@
             items: section[:documents],
             margin_top: true
          %>
+         <%= link_to(
+           section[:link][:text],
+           section[:link][:url]
+         )%>
         </div>
       </div>
     </div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -10,18 +10,20 @@
 %>
 
 <div class="full-page-width-wrapper">
-  <% if presented_taxon.show_guidance_section? %>
-  <div class="taxon-page__section-group">
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <h2 class="taxon-page__section-heading"><%= presented_taxon.guidance_and_regulation_section_title %></h2>
-        <%= render 'govuk_publishing_components/components/document_list',
-              items: presented_taxon.guidance_and_regulation_list,
-              margin_top: true
+  <% presented_taxon.sections.each do |section| %>
+    <% if section[:show_section] %>
+    <div class="taxon-page__section-group">
+      <div class="grid-row">
+        <div class="column-two-thirds">
+          <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
+          <%= render 'govuk_publishing_components/components/document_list',
+            items: section[:documents],
+            margin_top: true
          %>
+        </div>
       </div>
     </div>
-  </div>
+    <% end %>
   <% end %>
 </div>
 

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -1,4 +1,5 @@
 require 'integration_test_helper'
+require 'cgi/util'
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
@@ -98,6 +99,17 @@ private
     tagged_content.each do |item|
       assert page.has_link?(item["title"], href: item["link"])
     end
+
+    query_string = CGI::escape(
+      "?taxons=#{@content_item['base_path']}&content_purpose_supergroup=guidance_and_regulation"
+    )
+
+    expected_link = {
+      text: "See all guidance and regulation",
+      url: "/search/advanced#{query_string}"
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
   def and_i_can_see_the_sub_topics_grid

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -75,13 +75,27 @@ describe TaxonPresenter do
     end
   end
 
+  describe 'supergroup_sections' do
+    it 'returns a list of supergroup details' do
+      section_keys = %i(show_section title documents)
+
+      taxon = mock
+      taxon.stubs(:guidance_and_regulation_content).returns([])
+      taxon_presenter = TaxonPresenter.new(taxon)
+
+      taxon_presenter.sections.each do |section|
+        assert_equal(section.keys.sort, section_keys.sort)
+      end
+    end
+  end
+
   describe 'guidance_and_regulation_section' do
     it 'checks whether guidance section should be shown' do
       taxon = mock
       taxon.stubs(:guidance_and_regulation_content).returns([])
       taxon_presenter = TaxonPresenter.new(taxon)
 
-      refute taxon_presenter.show_guidance_section?
+      refute taxon_presenter.show_section?("guidance_and_regulation")
     end
 
     it 'formats guidance and regulation content for document list' do
@@ -112,7 +126,7 @@ describe TaxonPresenter do
       taxon.stubs(:guidance_and_regulation_content).returns(guidance_content)
       taxon_presenter = TaxonPresenter.new(taxon)
 
-      assert_equal expected, taxon_presenter.guidance_and_regulation_list
+      assert_equal expected, taxon_presenter.section_document_list("guidance_and_regulation")
     end
   end
 

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'cgi/util'
 
 include RummagerHelpers
 include TaxonHelpers
@@ -77,10 +78,11 @@ describe TaxonPresenter do
 
   describe 'supergroup_sections' do
     it 'returns a list of supergroup details' do
-      section_keys = %i(show_section title documents)
+      section_keys = %i(show_section title documents link)
 
       taxon = mock
       taxon.stubs(:guidance_and_regulation_content).returns([])
+      taxon.stubs(:base_path)
       taxon_presenter = TaxonPresenter.new(taxon)
 
       taxon_presenter.sections.each do |section|
@@ -127,6 +129,22 @@ describe TaxonPresenter do
       taxon_presenter = TaxonPresenter.new(taxon)
 
       assert_equal expected, taxon_presenter.section_document_list("guidance_and_regulation")
+    end
+
+    it 'formats the link to the guidance and regulation finder page' do
+      taxon = mock
+      taxon.stubs(:guidance_and_regulation_content).returns([])
+      taxon.stubs(:base_path).returns("/foo")
+      taxon_presenter = TaxonPresenter.new(taxon)
+
+      expected_query_string = CGI::escape("?taxons=#{taxon.base_path}&content_purpose_supergroup=guidance_and_regulation")
+
+      expected_link_details = {
+        text: "See all guidance and regulation",
+        url: "/search/advanced#{expected_query_string}"
+      }
+
+      assert_equal expected_link_details, taxon_presenter.section_finder_link("guidance_and_regulation")
     end
   end
 


### PR DESCRIPTION
Needs to be rebased against #558 

Trello: https://trello.com/c/b9mzRtCa

Add a link to filterable list page from each supergroup section.

Escapes the query string in case passing `/` as part of the taxon `base_path` causes any issues.