### PR TITLE
Add services section

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -17,7 +17,7 @@ class TaxonPresenter
   end
 
   def sections
-    supergroups = %w(guidance_and_regulation)
+    supergroups = %w(services guidance_and_regulation)
 
     supergroups.map do |supergroup|
       {

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -18,7 +18,8 @@
           <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
           <%= render 'govuk_publishing_components/components/document_list',
             items: section[:documents],
-            margin_top: true
+            margin_top: true,
+            margin_bottom: true
          %>
         </div>
       </div>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -67,6 +67,7 @@ private
     # We still need to stub tagged content because it is used by the sub-topic grid
     stub_content_for_taxon(content_id, tagged_content)
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'guidance_and_regulation')
+    stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'services')
   end
 
   def when_i_visit_that_taxon
@@ -94,6 +95,14 @@ private
 
   def and_i_can_see_the_guidance_and_regulation_section
     assert page.has_content?('Guidance and regulation')
+
+    tagged_content.each do |item|
+      assert page.has_link?(item["title"], href: item["link"])
+    end
+  end
+
+  def and_i_can_see_the_services_section
+    assert page.has_content?('Services')
 
     tagged_content.each do |item|
       assert page.has_link?(item["title"], href: item["link"])


### PR DESCRIPTION
This adds the services section to topic pages. 

<img width="767" alt="screen shot 2018-03-16 at 16 27 53" src="https://user-images.githubusercontent.com/29889908/37532463-00f89ef0-2937-11e8-907b-d1ae24ea7aa0.png">

**Examples**
https://govuk-collections-pr-565.herokuapp.com/education/data-collection-and-censuses-for-schools
https://govuk-collections-pr-565.herokuapp.com/education/funding-and-finance-for-students