### PR TITLE
Add link to the finder list page from each section

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -23,7 +23,8 @@ class TaxonPresenter
       {
         show_section: show_section?(supergroup),
         title: section_title(supergroup),
-        documents: section_document_list(supergroup)
+        documents: section_document_list(supergroup),
+        see_more_link: section_finder_link(supergroup)
       }
     end
   end
@@ -49,6 +50,20 @@ class TaxonPresenter
 
   def show_section?(supergroup)
     section_content(supergroup).any?
+  end
+
+  def section_finder_link(supergroup)
+    link_text = supergroup.humanize.downcase
+
+    query_string = {
+      taxons: base_path,
+      content_purpose_supergroup: supergroup
+    }.to_query
+
+    {
+      text: "See all #{link_text}",
+      url: "/search/advanced?#{query_string}"
+    }
   end
 
   def show_subtopic_grid?

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -21,6 +21,10 @@
             margin_top: true,
             margin_bottom: true
          %>
+         <%= link_to(
+           section[:see_more_link][:text],
+           section[:see_more_link][:url]
+         )%>
         </div>
       </div>
     </div>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -100,6 +100,13 @@ private
     tagged_content.each do |item|
       assert page.has_link?(item["title"], href: item["link"])
     end
+
+    expected_link = {
+      text: "See all guidance and regulation",
+      url: "/search/advanced?" + finder_query_string("guidance_and_regulation")
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
   def and_i_can_see_the_services_section
@@ -108,6 +115,13 @@ private
     tagged_content.each do |item|
       assert page.has_link?(item["title"], href: item["link"])
     end
+
+    expected_link = {
+      text: "See all services",
+      url: "/search/advanced?" + finder_query_string('services')
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
   def and_i_can_see_the_sub_topics_grid
@@ -152,5 +166,12 @@ private
 
   def tagged_content
     generate_search_results(5)
+  end
+
+  def finder_query_string(supergroup)
+    {
+      taxons: @content_item['base_path'],
+      content_purpose_supergroup: supergroup
+    }.to_query
   end
 end

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -79,10 +79,11 @@ describe TaxonPresenter do
     it 'returns a list of supergroup details' do
       taxon = mock
       taxon.stubs(:section_content).returns([])
+      taxon.stubs(:base_path)
       taxon_presenter = TaxonPresenter.new(taxon)
 
       taxon_presenter.sections.each do |section|
-        assert_equal(section.keys.sort, %i(documents show_section title))
+        assert_equal(%i(show_section title documents see_more_link), section.keys)
       end
     end
   end
@@ -125,6 +126,20 @@ describe TaxonPresenter do
       taxon_presenter = TaxonPresenter.new(taxon)
 
       assert_equal expected, taxon_presenter.section_document_list("guidance_and_regulation")
+    end
+
+    it 'formats the link to the guidance and regulation finder page' do
+      taxon = mock
+      taxon.stubs(:guidance_and_regulation_content).returns([])
+      taxon.stubs(:base_path).returns("/foo")
+      taxon_presenter = TaxonPresenter.new(taxon)
+
+      expected_link_details = {
+        text: "See all guidance and regulation",
+        url: "/search/advanced?content_purpose_supergroup=guidance_and_regulation&taxons=%2Ffoo"
+      }
+
+      assert_equal expected_link_details, taxon_presenter.section_finder_link("guidance_and_regulation")
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/b9mzRtCa

Add a link from each supergroup section on the topic page to list page in finder-frontend.

Example page: https://govuk-collections-pr-566.herokuapp.com/education/funding-and-finance-for-students

The links to the finders on this page will try to route you to a page within the preview app. In a "normal" environment, you'll be routed to the finder page. 

E.g.

Example link to "Services" finder: https://www-origin.integration.publishing.service.gov.uk/search/advanced?content_purpose_supergroup=services&taxons=%2Feducation%2Ffunding-and-finance-for-students

Example link to "Guidance and regulation" finder: https://www-origin.integration.publishing.service.gov.uk/search/advanced?content_purpose_supergroup=guidance_and_regulation&taxons=%2Feducation%2Ffunding-and-finance-for-students