### PR TITLE
Get 5 most recent news and communications

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -26,6 +26,8 @@ class Taxon
       guidance_and_regulation_content
     when "services"
       services_content
+    when "news_and_communications"
+      news_and_communications_content
     end
   end
 
@@ -81,5 +83,13 @@ private
 
   def guidance_and_regulation_content
     @guidance_and_regulation_content ||= fetch_most_popular_content('guidance_and_regulation')
+  end
+
+  def fetch_most_recent_content(content_purpose_supergroup = 'news_and_communications')
+    MostRecentContent.fetch(content_id: content_id, filter_content_purpose_supergroup: content_purpose_supergroup)
+  end
+
+  def news_and_communications_content
+    @news_and_communications_content ||= fetch_most_recent_content('news_and_communications')
   end
 end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,0 +1,33 @@
+class MostRecentContent
+  attr_reader :content_id, :filter_content_purpose_supergroup, :number_of_links
+
+  def initialize(content_id:, filter_content_purpose_supergroup:, number_of_links: 5)
+    @content_id = content_id
+    @filter_content_purpose_supergroup = filter_content_purpose_supergroup
+    @number_of_links = number_of_links
+  end
+
+  def fetch
+    search_response.documents
+  end
+
+private
+
+  def search_response
+    search_fields = %w(title
+                       link
+                       content_store_document_type
+                       public_timestamp
+                       organisations)
+    params = {
+      start: 0,
+      count: number_of_links,
+      fields: search_fields,
+      filter_taxons: [content_id],
+      order: '-public_timestamp',
+    }
+    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
+
+    RummagerSearch.new(params)
+  end
+end

--- a/test/models/taxon_test.rb
+++ b/test/models/taxon_test.rb
@@ -79,5 +79,18 @@ describe Taxon do
 
       assert_equal ["guidance_content"], @taxon.tagged_content
     end
+
+    it "requests news_and_communications content" do
+      results = %i(result_1 result_2 result_3 result_4 result_5)
+
+      MostRecentContent.stubs(:fetch)
+        .with(
+          content_id: @taxon.content_id,
+          filter_content_purpose_supergroup: "news_and_communications",
+        )
+        .returns(results)
+
+      assert_equal(results, @taxon.section_content("news_and_communications"))
+    end
   end
 end

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+describe MostRecentContent do
+  def most_recent_content
+    @most_recent_content ||= MostRecentContent.new(
+      content_id: taxon_content_id,
+      filter_content_purpose_supergroup: "news_and_communications",
+    )
+  end
+
+  def taxon_content_id
+    "a18d16c4-29ff-41c2-a667-022f7615ba49"
+  end
+
+  describe "#fetch" do
+    it "returns the results from search" do
+      search_results = {
+        "results" => [
+          { "title" => "First news story" },
+          { "title" => "Second news story" },
+          { "title" => "Third news story" },
+          { "title" => "Fourth news story" },
+          { "title" => "Fifth news story" }
+        ]
+      }
+
+      Services.rummager.stubs(:search).returns(search_results)
+
+      results = most_recent_content.fetch
+      assert_equal(results.count, 5)
+    end
+  end
+
+  it "starts from the first page" do
+    assert_includes_params(start: 0) do
+      most_recent_content.fetch
+    end
+  end
+
+  it "requests five results by default" do
+    assert_includes_params(count: 5) do
+      most_recent_content.fetch
+    end
+  end
+
+  it "requests a limited number of fields" do
+    fields = %w(title
+                link
+                content_store_document_type
+                public_timestamp
+                organisations)
+
+    assert_includes_params(fields: fields) do
+      most_recent_content.fetch
+    end
+  end
+
+  it "orders the results by public_timestamp in descending order" do
+    assert_includes_params(order: '-public_timestamp') do
+      most_recent_content.fetch
+    end
+  end
+
+  it "scopes the results to the current taxon" do
+    assert_includes_params(filter_taxons: [taxon_content_id]) do
+      most_recent_content.fetch
+    end
+  end
+
+  it "filters content by the requested filter_content_purpose_supergroup only" do
+    assert_includes_params(filter_content_purpose_supergroup: "news_and_communications") do
+      most_recent_content.fetch
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/XgaAp2Iw/136-get-the-5-most-recent-news-and-communications

This implements a service to fetch the 5 most recent items from search, and enables this feature for the `news_and_communications` content purpose supergroup.