### PR TITLE
Add news and communication section to topic page

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -12,14 +12,18 @@ class TaxonPresenter
     to: :taxon
   )
 
+  # These should remain in order as the sequence of sections displayed on the
+  # page is important.
+  SUPERGROUPS = %w(services
+                   guidance_and_regulation
+                   news_and_communications).freeze
+
   def initialize(taxon)
     @taxon = taxon
   end
 
   def sections
-    supergroups = %w(services guidance_and_regulation)
-
-    supergroups.map do |supergroup|
+    SUPERGROUPS.map do |supergroup|
       {
         show_section: show_section?(supergroup),
         title: section_title(supergroup),

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -12,6 +12,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_email_signup_link
     and_i_can_see_the_services_section
     and_i_can_see_the_guidance_and_regulation_section
+    and_i_can_see_the_news_and_communications_section
     and_i_can_see_the_sub_topics_grid
   end
 
@@ -69,6 +70,7 @@ private
     stub_content_for_taxon(content_id, tagged_content)
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'guidance_and_regulation')
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'services')
+    stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'news_and_communications')
   end
 
   def when_i_visit_that_taxon
@@ -119,6 +121,21 @@ private
     expected_link = {
       text: "See all services",
       url: "/search/advanced?" + finder_query_string('services')
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_news_and_communications_section
+    assert page.has_content?("News and communications")
+
+    tagged_content.each do |item|
+      assert page.has_link?(item["title"], href: item["link"])
+    end
+
+    expected_link = {
+      text: "See all news and communications",
+      url: "/search/advanced?" + finder_query_string("news_and_communications")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -44,6 +44,31 @@ module RummagerHelpers
     )
   end
 
+  def stub_most_recent_content_for_taxon(content_id, results, filter_content_purpose_supergroup: 'news_and_communication')
+    fields = %w(title
+                link
+                content_store_document_type
+                public_timestamp
+                organisations)
+
+    params = {
+      start: 0,
+      count: 5,
+      fields: fields,
+      filter_taxons: [content_id],
+      order: '-public_timestamp',
+    }
+    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
+
+    Services.rummager.stubs(:search)
+    .with(params)
+    .returns(
+      "results" => results,
+      "start" => 0,
+      "total" => results.size,
+    )
+  end
+
   def generate_search_results(count)
     (1..count).map do |number|
       rummager_document_for_slug("content-item-#{number}")


### PR DESCRIPTION
For https://trello.com/c/NccsBG5H/137-add-a-news-and-communication-section-to-the-topic-page

This adds a "News and communication" section to topic pages.

**Examples**
https://govuk-collections-pr-573.herokuapp.com/education/education-of-disadvantaged-children
https://govuk-collections-pr-573.herokuapp.com/education/funding-and-finance-for-students

<img width="984" alt="news_and_communications" src="https://user-images.githubusercontent.com/13434452/37659840-e331fd70-2c48-11e8-8586-833512675b99.png">
