### PR TITLE
Add transparency section

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -16,7 +16,8 @@ class TaxonPresenter
   # page is important.
   SUPERGROUPS = %w(services
                    guidance_and_regulation
-                   news_and_communications).freeze
+                   news_and_communications
+                   transparency).freeze
 
   def initialize(taxon)
     @taxon = taxon

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -13,6 +13,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_services_section
     and_i_can_see_the_guidance_and_regulation_section
     and_i_can_see_the_news_and_communications_section
+    and_i_can_see_the_transparency_section
     and_i_can_see_the_sub_topics_grid
   end
 
@@ -71,6 +72,7 @@ private
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'guidance_and_regulation')
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'services')
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'news_and_communications')
+    stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'transparency')
   end
 
   def when_i_visit_that_taxon
@@ -136,6 +138,21 @@ private
     expected_link = {
       text: "See all news and communications",
       url: "/search/advanced?" + finder_query_string("news_and_communications")
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_transparency_section
+    assert page.has_content?("Transparency")
+
+    tagged_content.each do |item|
+      assert page.has_link?(item["title"], href: item["link"])
+    end
+
+    expected_link = {
+      text: "See all transparency",
+      url: "/search/advanced?" + finder_query_string("transparency")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])


### PR DESCRIPTION
Trello: https://trello.com/c/Hy74qZ8s/142-add-a-transparency-section-to-the-topic-page

<img width="709" alt="screen shot 2018-03-20 at 15 11 44" src="https://user-images.githubusercontent.com/29889908/37663393-074635ac-2c51-11e8-861e-a25e1aab235b.png">

https://govuk-collections-pr-574.herokuapp.com/education
https://govuk-collections-pr-574.herokuapp.com/education/funding-and-finance-for-students
