### PR TITLE
Add policy and engagement section

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -17,6 +17,7 @@ class TaxonPresenter
   SUPERGROUPS = %w(services
                    guidance_and_regulation
                    news_and_communications
+                   policy_and_engagement
                    transparency).freeze
 
   def initialize(taxon)

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -13,6 +13,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_services_section
     and_i_can_see_the_guidance_and_regulation_section
     and_i_can_see_the_news_and_communications_section
+    and_i_can_see_the_policy_and_engagement_section
     and_i_can_see_the_transparency_section
     and_i_can_see_the_sub_topics_grid
   end
@@ -72,6 +73,7 @@ private
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'guidance_and_regulation')
     stub_most_popular_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'services')
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'news_and_communications')
+    stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'policy_and_engagement')
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'transparency')
   end
 
@@ -138,6 +140,21 @@ private
     expected_link = {
       text: "See all news and communications",
       url: "/search/advanced?" + finder_query_string("news_and_communications")
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_policy_and_engagement_section
+    assert page.has_content?("Policy and engagement")
+
+    tagged_content.each do |item|
+      assert page.has_link?(item["title"], href: item["link"])
+    end
+
+    expected_link = {
+      text: "See all policy and engagement",
+      url: "/search/advanced?" + finder_query_string("policy_and_engagement")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])


### PR DESCRIPTION
Trello: https://trello.com/c/Yc6CCX87

Add the Policy and engagement section to the topic page.

![screenshot-collections dev gov uk-2018 03 20-16-27-23](https://user-images.githubusercontent.com/5793815/37668140-a5ec0df8-2c5b-11e8-900e-64d658cdbbc1.png)


See: https://govuk-collections-pr-575.herokuapp.com/education