### PR TITLE
Amend finder param names

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -62,8 +62,8 @@ class TaxonPresenter
     link_text = supergroup.humanize.downcase
 
     query_string = {
-      taxons: base_path,
-      content_purpose_supergroup: supergroup
+      topic: base_path,
+      group: supergroup
     }.to_query
 
     {

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -221,8 +221,8 @@ private
 
   def finder_query_string(supergroup)
     {
-      taxons: @content_item['base_path'],
-      content_purpose_supergroup: supergroup
+      topic: @content_item['base_path'],
+      group: supergroup
     }.to_query
   end
 end

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -136,7 +136,7 @@ describe TaxonPresenter do
 
       expected_link_details = {
         text: "See all guidance and regulation",
-        url: "/search/advanced?content_purpose_supergroup=guidance_and_regulation&taxons=%2Ffoo"
+        url: "/search/advanced?group=guidance_and_regulation&topic=%2Ffoo"
       }
 
       assert_equal expected_link_details, taxon_presenter.section_finder_link("guidance_and_regulation")


### PR DESCRIPTION
https://trello.com/c/a5f5TIhK/150-amend-finder-params & https://trello.com/c/VhXdAw1c

Counterpart to https://github.com/alphagov/finder-frontend/pull/443

`taxons` becomes `topic`
`content_purpose_supergroup` becomes `group`