### PR TITLE
Add organisation section to taxon page

### DIFF
--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -66,6 +66,10 @@ class Taxon
     phase == "live"
   end
 
+  def organisations
+    @organisations ||= TaggedOrganisations.fetch(content_id)
+  end
+
 private
 
   def fetch_tagged_content

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -9,6 +9,7 @@ class TaxonPresenter
     :child_taxons,
     :live_taxon?,
     :section_content,
+    :organisations,
     to: :taxon
   )
 
@@ -87,5 +88,20 @@ class TaxonPresenter
                        dimension28: child_taxons.size.to_s,
                        dimension29: child_taxons[index].title }
     }
+  end
+
+  def taxon_organisations
+    organisations.map do |organisation|
+      {
+        link: {
+          text: organisation.title,
+          path: organisation.link
+        }
+      }
+    end
+  end
+
+  def show_organisations?
+    organisations.any?
   end
 end

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -1,0 +1,14 @@
+<% if presented_taxon.show_organisations? %>
+  <div class="taxon-page__section-group">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <h2 class="taxon-page__section-heading">Organisations</h2>
+        <%= render 'govuk_publishing_components/components/document_list',
+          items: presented_taxon.taxon_organisations,
+          margin_top: true,
+          margin_bottom: false
+      %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -30,6 +30,8 @@
     </div>
     <% end %>
   <% end %>
+
+  <%= render(partial: 'organisations', locals: { presented_taxon: presented_taxon }) %>
 </div>
 
 <% if content_for(:is_taxon_with_subtopics) %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -15,6 +15,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_news_and_communications_section
     and_i_can_see_the_policy_and_engagement_section
     and_i_can_see_the_transparency_section
+    and_i_can_see_the_organisations_list
     and_i_can_see_the_sub_topics_grid
   end
 
@@ -75,6 +76,7 @@ private
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'news_and_communications')
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'policy_and_engagement')
     stub_most_recent_content_for_taxon(content_id, tagged_content, filter_content_purpose_supergroup: 'transparency')
+    stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
   def when_i_visit_that_taxon
@@ -175,6 +177,14 @@ private
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
+  def and_i_can_see_the_organisations_list
+    assert page.has_content?('Organisations')
+
+    tagged_organisations.each do |item|
+      assert page.has_link?(item['value']['title'], href: item['value']['link'])
+    end
+  end
+
   def and_i_can_see_the_sub_topics_grid
     assert page.has_selector?('nav.taxon-page__grid')
 
@@ -217,6 +227,25 @@ private
 
   def tagged_content
     generate_search_results(5)
+  end
+
+  def tagged_organisations
+    [
+      {
+        'value' => {
+          'title' => 'Department for Education',
+          'link' => '/government/organisations/department-for-education',
+          'organisation_state' => 'live'
+        }
+      },
+      {
+        'value' => {
+          'title' => 'Ofsted',
+          'link' => '/government/organisations/ofsted',
+          'organisation_state' => 'live'
+        }
+      }
+    ]
   end
 
   def finder_query_string(supergroup)

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -69,6 +69,26 @@ module RummagerHelpers
     )
   end
 
+  def stub_organisations_for_taxon(content_id, organisations)
+    params = {
+      count: 0,
+      aggregate_organisations: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      filter_taxons: [content_id]
+    }
+
+    Services.rummager
+    .stubs(:search)
+    .with(params)
+    .returns(
+      'results' => [],
+      'aggregates' => {
+        'organisations' => {
+          'options' => organisations
+        }
+      }
+    )
+  end
+
   def generate_search_results(count)
     (1..count).map do |number|
       rummager_document_for_slug("content-item-#{number}")


### PR DESCRIPTION
This is the work that I did to add a organisation section to the taxon 
page. If the taxon has any tagged organisations, they are listed using
the document list component.

As this is V1, we just want to show a list of all the tagged organisations
Showing logos and branding may come later.

https://trello.com/c/7c6dGWkJ/144-add-an-organisations-section-to-the-topic-page