### PR TITLE
Highlight boxes component

### DIFF
--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -1,0 +1,58 @@
+.app-c-highlight-boxes {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.app-c-highlight-boxes__item-wrapper {
+  @include core-19;
+  list-style-type: none;
+  padding: 5px 25px $gutter-two-thirds 0;
+  width: 33%;
+  min-height: 150px;
+  min-width: 280px;
+  box-sizing: border-box;
+
+  @include media(mobile) {
+    width: 50%;
+  }
+}
+
+.app-c-highlight-boxes__item {
+  border: 1px solid $grey-2;
+  padding: $gutter-half $gutter-half $gutter;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;
+}
+
+.app-c-highlight-boxes--inverse {
+  background-color: $govuk-blue;
+  border: 0;
+  color: $white;
+}
+
+.app-c-highlight-boxes--inverse .app-c-highlight-boxes__title {
+  color: $white;
+}
+
+.app-c-highlight-boxes__title {
+  @include bold-19;
+  display: block;
+  text-decoration: underline;
+  margin-bottom: 5px;
+}
+
+.app-c-highlight-boxes__title--featured {
+  @include bold-24;
+}
+
+.app-c-highlight-boxes__description {
+  margin-bottom: $gutter-one-third;
+}
+
+.app-c-highlight-boxes__metadata {
+  @include core-16;
+  display: inline-block;
+  margin-right: $gutter-half;
+}

--- a/app/views/components/_highlight-boxes.html.erb
+++ b/app/views/components/_highlight-boxes.html.erb
@@ -1,0 +1,37 @@
+<%
+  items ||= []
+  inverse ||= false
+  inverse_class = "app-c-highlight-boxes--inverse" if inverse
+%>
+<% if items.any? %>
+  <ol class="app-c-highlight-boxes">
+    <% items.each do |content_item| %>
+      <li class="app-c-highlight-boxes__item-wrapper">
+        <div class="app-c-highlight-boxes__item <%= inverse_class %>">
+          <a
+            class="app-c-highlight-boxes__title <%= "app-c-highlight-boxes__title--featured" if content_item[:link][:featured] %>"
+            href="<%= content_item[:link].fetch(:path) %>"
+          >
+            <%= content_item[:link].fetch(:text)  %>
+          </a>
+
+          <% if content_item[:link][:description] %>
+            <p class="app-c-highlight-boxes__description"><%= content_item[:link][:description] %></p>
+          <% end %>
+
+          <% if content_item[:metadata] %>
+            <% content_item[:metadata].each do |metadata_key, metadata_value| %>
+              <% if metadata_key.to_s.eql?("public_updated_at") %>
+                <time class="app-c-highlight-boxes__metadata" datetime="<%= metadata_value.iso8601 %>">
+                  <%= l(metadata_value, format: '%e %B %Y') %>
+                </time>
+              <% else %>
+                <p class="app-c-highlight-boxes__metadata"><%= metadata_value %></p>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/components/docs/highlight-boxes.yml
+++ b/app/views/components/docs/highlight-boxes.yml
@@ -1,0 +1,109 @@
+name: Highlight boxes
+description: Displays content item details in a grid of highlight boxes, with a max of 3 items per row.
+body: |
+  The highlight boxes have several optional flags which can be set:
+
+  - Inverse - renders the highlight boxes as white text on a blue background
+  - Featured - renders a specific highlight box with larger font size
+accessibility_criteria: |
+  The highlight boxes must:
+
+  - be visually distinct from other content on the page
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      items:
+      - link:
+          text: If your child is taken into care
+          path: /child-into-care
+        metadata:
+          document_type: Detailed guide
+      - link:
+          text: High needs funding
+          path: /high-needs-funding
+        metadata:
+          document_type: Guide
+      - link:
+          text: Joint Statement of the 4th meeting of the UK-China High-Level People to People Dialogue
+          path: /government/publications/joint-statement-of-the-4th-meeting-of-the-uk-china-high-level-people-to-people-dialogue
+        metadata:
+          document_type: Policy paper
+  with_descriptions_and_metadata:
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+  inverse:
+    data:
+      inverse: true
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+  featured_card:
+    description: "Used to highlight a specific content item within the highlight boxes, e.g: the most popular."
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          featured: true
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44

--- a/test/components/highlight_boxes_test.rb
+++ b/test/components/highlight_boxes_test.rb
@@ -1,0 +1,174 @@
+require 'component_test_helper'
+
+class HighlightBoxesTest < ComponentTestCase
+  def component_name
+    "highlight-boxes"
+  end
+
+  test "renders nothing if no items are provided" do
+    assert_empty render_component(
+      items: []
+    )
+  end
+
+  test "fails to render highlight boxes when no link text is provided" do
+    assert_raise do
+      render_component(
+        items: [
+          link: {
+            path: '/education'
+          },
+          metadata: {
+            organisation: "Department of Education"
+          }
+        ]
+      )
+    end
+  end
+
+  test "fails to render highlight boxes when no link path is provided" do
+    assert_raise do
+      render_component(
+        items: [
+          link: {
+            text: 'Department of Education'
+          },
+          metadata: {
+            organisation: "Department of Education"
+          }
+        ]
+      )
+    end
+  end
+
+  test "renders correct link text and path" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice'
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__title[href=\"/become-an-apprentice\"]", text: 'Become an apprentice'
+  end
+
+  test "renders a description if provided" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__description", text: 'How to become an apprentice'
+  end
+
+  test "renders metadata if provided" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Guide'
+    assert_select "time[datetime='2017-01-05T14:50:33Z']"
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Department of Education'
+  end
+
+  test "renders multiple content items" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: 'Become an apprentice',
+            path: '/become-an-apprentice',
+            description: "How to become an apprentice"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2016-06-27 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Guide'
+          }
+        },
+        {
+          link: {
+            text: 'Student finance',
+            path: '/student-finance',
+            description: "Student finance"
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("1994-11-21 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Detailed Guide'
+          }
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__item .app-c-highlight-boxes__title[href=\"/become-an-apprentice\"]", text: 'Become an apprentice'
+    assert_select ".app-c-highlight-boxes__item .app-c-highlight-boxes__description", text: 'How to become an apprentice'
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Guide'
+    assert_select "time[datetime='2016-06-27T14:50:33Z']"
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Department of Education'
+
+    assert_select ".app-c-highlight-boxes__item .app-c-highlight-boxes__title[href=\"/student-finance\"]", text: 'Student finance'
+    assert_select ".app-c-highlight-boxes__item .app-c-highlight-boxes__description", text: 'Student finance'
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Detailed Guide'
+    assert_select "time[datetime='1994-11-21T14:50:33Z']"
+    assert_select ".app-c-highlight-boxes__metadata", text: 'Department of Education'
+  end
+
+  test "adds inverse class when inverse flag passed" do
+    render_component(
+      inverse: true,
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice"
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__item.app-c-highlight-boxes--inverse"
+  end
+
+  test "adds featured class when featured flag passed" do
+    render_component(
+      items: [
+        link: {
+          text: 'Become an apprentice',
+          path: '/become-an-apprentice',
+          description: "How to become an apprentice",
+          featured: true
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse("2017-01-05 14:50:33 +0000"),
+          organisations: 'Department of Education',
+          document_type: 'Guide'
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__title.app-c-highlight-boxes__title--featured"
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/VJQ8f57p/100-highlight-boxes

<img width="988" alt="screen shot 2018-03-27 at 13 28 17" src="https://user-images.githubusercontent.com/29889908/37967260-bc22346e-31c2-11e8-91a2-f3cbddcc8a7c.png">

**Desktop**
<img width="905" alt="screen shot 2018-03-27 at 16 04 34" src="https://user-images.githubusercontent.com/29889908/37976092-95e0b918-31d8-11e8-94b9-75138dbe470c.png">


**Tablet**
<img width="813" alt="screen shot 2018-03-27 at 16 08 27" src="https://user-images.githubusercontent.com/29889908/37976299-1aeebd3a-31d9-11e8-86a9-ff6a59521b00.png">


**Mobile**
<img width="250" alt="screen shot 2018-03-27 at 16 06 25" src="https://user-images.githubusercontent.com/29889908/37976192-d7d1ccfe-31d8-11e8-84fd-5542a238d33f.png">

As this uses flexbox, in browsers with limited flex support the boxes are simply shown underneath each other. From what I've found, this is only likely to happen on older IE versions (IE8 - IE10) which we are only required to have 'functional' support for.

https://govuk-collections-pr-591.herokuapp.com/component-guide/highlight-boxes