### PR TITLE
Add content ID meta tag for tracking step navs

### DIFF
--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, content_item.title %>
 
 <% content_for :meta_tags do %>
+  <meta name="govuk:content-id" content="<%= content_item.content_id %>">
   <meta name="description" content="<%= content_item.description %>">
 <% end %>
 


### PR DESCRIPTION
Step nav pages (like https://www.gov.uk/learn-to-drive-a-car) are currently missing the content ID from Google Analytics, specifically the custom dimension 4 is prefilled with the default zeros.
This adds the corresponding meta tag to fix that.

I'm not sure why it wasn't implemented in collections in general, so I only implemented it for step by step navigation pages. Let me know if I should change that to be used for all collections pages.

[Trello card](https://trello.com/c/6guzTjNX)