### PR TITLE
Use WorldWideTaxon in world wide test

### DIFF
--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -18,11 +18,11 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
 
     @taxon = WorldWideTaxon.find(@base_path)
     stub_content_for_taxon(@taxon.content_id, search_results) # For the "general information" taxon
-    stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+    stub_content_for_taxon(@taxon.content_id, search_results)
     stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_content_purpose_supergroup: nil)
 
     @child_taxon = WorldWideTaxon.find(@child_taxon_base_path)
-    stub_content_for_taxon(@child_taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+    stub_content_for_taxon(@child_taxon.content_id, search_results)
 
     visit @base_path
     govuk_feeds = page.find('.feeds')
@@ -48,7 +48,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     content_store_has_item(@base_path, world_usa)
 
     @taxon = WorldWideTaxon.find(@base_path)
-    stub_content_for_taxon(@taxon.content_id, search_results, filter_navigation_document_supertype: nil)
+    stub_content_for_taxon(@taxon.content_id, search_results)
 
     visit @base_path
 

--- a/test/presenters/world_wide_taxon_presenter_test.rb
+++ b/test/presenters/world_wide_taxon_presenter_test.rb
@@ -31,7 +31,7 @@ describe WorldWideTaxonPresenter do
   describe 'options' do
     let(:content_hash) { funding_and_finance_for_students_taxon }
     let(:content_item) { ContentItem.new(content_hash) }
-    let(:taxon) { Taxon.new(ContentItem.new(content_hash)) }
+    let(:taxon) { WorldWideTaxon.new(ContentItem.new(content_hash)) }
     let(:child_taxon) { taxon.child_taxons.first }
     let(:world_wide_taxon_presenter) { WorldWideTaxonPresenter.new(taxon) }
 

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,7 +1,7 @@
 module RummagerHelpers
   include RummagerFields
 
-  def stub_content_for_taxon(content_ids, results, filter_navigation_document_supertype: 'guidance')
+  def stub_content_for_taxon(content_ids, results)
     params = {
       start: 0,
       count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
@@ -9,7 +9,24 @@ module RummagerHelpers
       filter_taxons: Array(content_ids),
       order: 'title',
     }
-    params[:filter_navigation_document_supertype] = filter_navigation_document_supertype if filter_navigation_document_supertype.present?
+
+    Services.rummager.stubs(:search)
+      .with(params)
+      .returns(
+        "results" => results,
+        "start" => 0,
+        "total" => results.size,
+      )
+
+    # TODO: remove me once Taxon is no longer using TaggedContent in tests
+    params = {
+      start: 0,
+      count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      fields: %w(title description link document_collections content_store_document_type),
+      filter_taxons: Array(content_ids),
+      order: 'title',
+      filter_navigation_document_supertype: 'guidance',
+    }
 
     Services.rummager.stubs(:search)
       .with(params)


### PR DESCRIPTION
In the context of world wide taxonomy, we're always dealing with WorldWideTaxons, never Taxons.

We forgot to change this in https://github.com/alphagov/collections/pull/533.

We have to temporarily keep stubbing the rummager results with `filter_navigation_document_supertype`, because the Taxon tests still test TaggedContent.

More PRs to follow.