### PR TITLE
Amend tests to remove GovDelivery references

### DIFF
--- a/features/step_definitions/email_alert_signup_steps.rb
+++ b/features/step_definitions/email_alert_signup_steps.rb
@@ -9,7 +9,7 @@ Given(/^a topic subscription is expected$/) do
         "topics" => ['content-id-for-fields-and-wells']
       }
     ).returns({"subscriber_list" =>
-       # This redirects to govdelivery in real life, but force redirection to a fake path to verify redirect success
+       # This redirects to email-alert-api in real life, but force redirection to a fake path to verify redirect success
        {"subscription_url" => "/email_success"}
     })
 end

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -42,7 +42,7 @@ describe EmailSignupsController do
   describe 'POST :create with a valid email signup' do
     setup do
       @email_signup.stubs(:save).returns(true)
-      @email_signup.expects(:subscription_url).returns('http://govdelivery_signup_url')
+      @email_signup.expects(:subscription_url).returns('http://email_alert_api_signup_url')
     end
 
     it 'registers the signup' do
@@ -51,11 +51,11 @@ describe EmailSignupsController do
       post :create, params: @valid_subtopic_params
     end
 
-    it 'redirects to the govdelivery URL' do
+    it 'redirects to the email-alert-api URL' do
       post :create, params: @valid_subtopic_params
 
       assert_response :redirect
-      assert_redirected_to 'http://govdelivery_signup_url'
+      assert_redirected_to 'http://email_alert_api_signup_url'
     end
   end
 

--- a/test/models/email_signup_test.rb
+++ b/test/models/email_signup_test.rb
@@ -11,7 +11,7 @@ describe EmailSignup do
       to_return(
         body: {
           subscriber_list: {
-            subscription_url: "http://govdelivery_signup_url"
+            subscription_url: "http://email_alert_api_signup_url"
           },
         }.to_json
       )
@@ -22,7 +22,7 @@ describe EmailSignup do
   end
 
   describe "#save" do
-    it "creates the topic in GovDelivery using the subtopic slug and combined title" do
+    it "creates the topic in email-alert-api using the subtopic slug and combined title" do
       email_signup = EmailSignup.new(@subtopic)
       assert email_signup.save
       assert_requested @request
@@ -40,7 +40,7 @@ describe EmailSignup do
       email_signup = EmailSignup.new(@subtopic)
       email_signup.save
 
-      assert_equal "http://govdelivery_signup_url", email_signup.subscription_url
+      assert_equal "http://email_alert_api_signup_url", email_signup.subscription_url
     end
   end
 end


### PR DESCRIPTION
They are no longer valid.

Trello: https://trello.com/c/VK18GrmW/736-clean-up-all-remaining-govdelivery-references-across-all-repos