### PR TITLE
Expose all child content that lives underneath a parent on the topic and list pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.16.1

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -25,7 +25,7 @@ private
       start: 0,
       count: number_of_links,
       fields: RummagerFields::TAXON_SEARCH_FIELDS,
-      filter_taxons: Array(content_id),
+      filter_part_of_taxonomy_tree: Array(content_id),
       order: '-popularity',
     }
     params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -24,7 +24,7 @@ private
       start: 0,
       count: number_of_links,
       fields: RummagerFields::TAXON_SEARCH_FIELDS,
-      filter_taxons: [content_id],
+      filter_part_of_taxonomy_tree: [content_id],
       order: '-public_timestamp',
     }
     params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -57,7 +57,7 @@ describe MostPopularContent do
     end
 
     it 'scopes the results to the current taxon' do
-      assert_includes_params(filter_taxons: Array(taxon_content_id)) do
+      assert_includes_params(filter_part_of_taxonomy_tree: Array(taxon_content_id)) do
         most_popular_content.fetch
       end
     end

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -60,7 +60,7 @@ describe MostRecentContent do
   end
 
   it "scopes the results to the current taxon" do
-    assert_includes_params(filter_taxons: [taxon_content_id]) do
+    assert_includes_params(filter_part_of_taxonomy_tree: [taxon_content_id]) do
       most_recent_content.fetch
     end
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -26,7 +26,7 @@ module RummagerHelpers
       start: 0,
       count: 5,
       fields: fields,
-      filter_taxons: Array(content_id),
+      filter_part_of_taxonomy_tree: Array(content_id),
       order: '-popularity',
     }
     params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
@@ -47,7 +47,7 @@ module RummagerHelpers
       start: 0,
       count: 5,
       fields: fields,
-      filter_taxons: [content_id],
+      filter_part_of_taxonomy_tree: [content_id],
       order: '-public_timestamp',
     }
     params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ ENV["RAILS_ENV"] ||= "test"
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'webmock/minitest'
 WebMock.disable_net_connect!


### PR DESCRIPTION
# details

Earlier in the quarter, we decided to show only content tagged to a specific taxon. 

As the product has developed and has since gone live, a number of reasons have emerged that points more towards each taxon page exposing all content underneath it rather than that specific level. (A taxon exposing all its child content) 

# scope

Changes on the topic pages and the finders to expose all content underneath a parent taxon. 

# reasons
- Some taxons show content which is a few years old giving the impression nothing has been done. 

- Descriptions are tree specific so confusing for users when they cannot find what they are looking for at that level. 

- In order to get to content at a more specific level, users have to traverse the tree. This results in more clicks in one's navigation journey. 

The trello card is [Expose all child content that lives underneath a parent on the topic and list pages](https://trello.com/c/GOGErTW6/11-expose-all-child-content-that-lives-underneath-a-parent-on-the-topic-and-list-pages)