### PR TITLE
Never show non-taxon things as taxon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,7 +369,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.4p296
 
 BUNDLED WITH
    1.16.1

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -10,7 +10,7 @@ class ContentItem
     @content_item_data = content_item_data
   end
 
-  %i[base_path title description content_id].each do |field|
+  %i[base_path title description content_id document_type].each do |field|
     define_method field do
       @content_item_data[field.to_s]
     end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -18,6 +18,11 @@ class Taxon
 
   def self.find(base_path)
     content_item = ContentItem.find!(base_path)
+
+    unless content_item.document_type == "taxon"
+      raise "Tried to render a taxon page for content item that is not a taxon"
+    end
+
     new(content_item)
   end
 

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -28,7 +28,31 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_cannot_see_an_email_signup_link
   end
 
+  it 'does not show anything but a taxon' do
+    given_there_is_a_thing_that_is_not_a_taxon
+    when_i_visit_that_thing
+    then_there_should_be_an_error
+  end
+
 private
+
+  def given_there_is_a_thing_that_is_not_a_taxon
+    thing = {
+      "base_path" => '/not-a-taxon',
+      "content_id" => "36dd87da-4973-5490-ab00-72025b1da602",
+      "document_type" => "not_a_taxon",
+    }
+
+    content_store_has_item('/not-a-taxon', thing)
+  end
+
+  def when_i_visit_that_thing
+    visit '/not-a-taxon'
+  end
+
+  def then_there_should_be_an_error
+    assert_equal 500, page.status_code
+  end
 
   def given_there_is_a_taxon_with_children
     child_one_base_path = "#{base_path}/child-1"


### PR DESCRIPTION
It seems like we have been showing the step by step pages with the taxon layout recently. I think this is caused by the `DocumentTypeRoutingConstraint` not finding the content item temporarily, and thinking it's a taxon (the fallback in the routes).

![screen shot 2018-04-10 at 14 04 37](https://user-images.githubusercontent.com/233676/38563008-c327ce9c-3cd3-11e8-92ab-b2a4526eb938.png)


By crashing we 1) get insight into the error, 2) Fastly will serve the previous (correct) page from the mirror, instead of a wrong page.