### PR TITLE
Style services with blue highlight boxes

### DIFF
--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -1,6 +1,7 @@
 .app-c-highlight-boxes {
   display: flex;
   flex-wrap: wrap;
+  margin-top: $gutter-half;
 }
 
 .app-c-highlight-boxes__item-wrapper {
@@ -13,7 +14,7 @@
   box-sizing: border-box;
 
   @include media(mobile) {
-    width: 50%;
+    width: 100%;
   }
 }
 

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -28,6 +28,10 @@ module Supergroups
       tagged_content(taxon_id).any?
     end
 
+    def partial_template
+      "taxons/sections/#{name}"
+    end
+
     def tagged_content(_taxon_id)
       raise NotImplementedError.new
     end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -27,6 +27,7 @@ module SupergroupSections
         {
           title: supergroup.title,
           documents: supergroup.document_list(taxon_id),
+          partial_template: supergroup.partial_template,
           see_more_link: supergroup.finder_link(base_path),
           show_section: supergroup.show_section?(taxon_id)
         }

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/document_list',
+  items: section[:documents],
+  margin_top: true,
+  margin_bottom: true
+%>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,5 +1,9 @@
-<%= render 'govuk_publishing_components/components/document_list',
-  items: section[:documents],
-  margin_top: true,
-  margin_bottom: true
-%>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/document_list',
+  items: section[:documents],
+  margin_top: true,
+  margin_bottom: true
+%>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,5 +1,9 @@
-<%= render 'govuk_publishing_components/components/document_list',
-  items: section[:documents],
-  margin_top: true,
-  margin_bottom: true
-%>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/document_list',
+  items: section[:documents],
+  margin_top: true,
+  margin_bottom: true
+%>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,5 +1,9 @@
-<%= render 'govuk_publishing_components/components/document_list',
-  items: section[:documents],
-  margin_top: true,
-  margin_bottom: true
-%>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -3,3 +3,13 @@
   margin_top: true,
   margin_bottom: true
 %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/document_list',
+  items: section[:documents],
+  margin_top: true,
+  margin_bottom: true
+%>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,7 +1,6 @@
-<%= render 'govuk_publishing_components/components/document_list',
-  items: section[:documents],
-  margin_top: true,
-  margin_bottom: true
+<%= render 'components/highlight-boxes',
+  items: section[:documents].shift(3),
+  inverse: true
 %>
 
 <div class="grid-row">

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,0 +1,5 @@
+<%= render 'govuk_publishing_components/components/document_list',
+  items: section[:documents],
+  margin_top: true,
+  margin_bottom: true
+%>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,5 +1,9 @@
-<%= render 'govuk_publishing_components/components/document_list',
-  items: section[:documents],
-  margin_top: true,
-  margin_bottom: true
-%>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,10 +16,10 @@
       <div class="grid-row">
         <div class="column-two-thirds">
           <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
-          <%= render 'govuk_publishing_components/components/document_list',
-            items: section[:documents],
-            margin_top: true,
-            margin_bottom: true
+          <%= render(
+            partial: section[:partial_template],
+            locals: { section: section }
+          )
          %>
          <%= link_to(
            section[:see_more_link][:text],

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -16,17 +16,17 @@
       <div class="grid-row">
         <div class="column-two-thirds">
           <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
-          <%= render(
-            partial: section[:partial_template],
-            locals: { section: section }
-          )
-         %>
-         <%= link_to(
-           section[:see_more_link][:text],
-           section[:see_more_link][:url]
-         )%>
         </div>
       </div>
+      <%= render(
+        partial: section[:partial_template],
+        locals: { section: section }
+      )
+     %>
+     <%= link_to(
+       section[:see_more_link][:text],
+       section[:see_more_link][:url]
+     )%>
     </div>
     <% end %>
   <% end %>

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -25,4 +25,10 @@ describe Supergroups::Supergroup do
       assert expected_details, supergroup.finder_link(base_path)
     end
   end
+
+  describe '#partial_template' do
+    it 'returns the path to the section view' do
+      assert 'taxons/sections/supergroup_name', supergroup.partial_template
+    end
+  end
 end

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -24,7 +24,7 @@ describe SupergroupSections::Sections do
 
     it 'returns a list of supergroup details' do
       @sections.each do |section|
-        assert_equal(%i(title documents see_more_link show_section), section.keys)
+        assert_equal(%i(title documents partial_template see_more_link show_section), section.keys)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/mYqcJWRx

Style the first three services on a taxon page in a blue box

### Examples

5 services: https://govuk-collections-pr-616.herokuapp.com/education
Less than 5 services: https://govuk-collections-pr-616.herokuapp.com/childcare-parenting/intercountry-adoption

### Before

![screen shot 2018-04-11 at 12 40 38](https://user-images.githubusercontent.com/5793815/38614599-953f2d88-3d85-11e8-84ed-82141c912010.png)

### After

![screen shot 2018-04-11 at 12 39 16](https://user-images.githubusercontent.com/5793815/38614614-9cd8c3a6-3d85-11e8-8e33-7dfcb88c74ef.png)
