### PR TITLE
Move content id meta tag

### DIFF
--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, step_by_step.title %>
 
 <% content_for :meta_tags do %>
-  <meta name="govuk:content-id" content="<%= step_by_step.content_id %>">
   <meta name="description" content="<%= step_by_step.description %>">
 <% end %>
 


### PR DESCRIPTION
This is now part of the analytics component, which should be deployed at
the same time.

See https://github.com/alphagov/static/pull/1375