### PR TITLE
Guidance regulation boxes

### DIFF
--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -8,13 +8,13 @@
   @include core-19;
   list-style-type: none;
   padding: 5px 25px $gutter-two-thirds 0;
-  width: 33%;
+  width: 100%;
   min-height: 150px;
-  min-width: 280px;
+  min-width: 250px;
   @include box-sizing(border-box);
 
-  @include media(mobile) {
-    width: 100%;
+  @include media(tablet) {
+    width: 33%;
   }
 }
 

--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -11,7 +11,7 @@
   width: 33%;
   min-height: 150px;
   min-width: 280px;
-  box-sizing: border-box;
+  @include box-sizing(border-box);
 
   @include media(mobile) {
     width: 100%;
@@ -23,8 +23,8 @@
   padding: $gutter-half $gutter-half $gutter;
   width: 100%;
   height: 100%;
-  box-sizing: border-box;
   box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;
+  @include box-sizing(border-box);
 }
 
 .app-c-highlight-boxes--inverse {

--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -8,19 +8,19 @@
   @include core-19;
   list-style-type: none;
   padding: 5px 25px $gutter-two-thirds 0;
-  width: 100%;
+  width: 33%;
   min-height: 150px;
-  min-width: 250px;
+  min-width: 280px;
   @include box-sizing(border-box);
 
-  @include media(tablet) {
-    width: 33%;
+  @include media(mobile) {
+    width: 100%;
   }
 }
 
 .app-c-highlight-boxes__item {
   border: 1px solid $grey-2;
-  padding: $gutter-half $gutter-half $gutter;
+  padding: $gutter-half * 1.5;
   width: 100%;
   height: 100%;
   box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -34,7 +34,9 @@ module Supergroups
     end
 
     def guide?(document)
-      document.content_store_document_type == 'guide'
+      # Although answers and guides are 2 different document types, they are conceptually the same so
+      # we should treat them the same
+      document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
     end
   end
 end

--- a/app/views/taxons/_document_list_with_grid.html.erb
+++ b/app/views/taxons/_document_list_with_grid.html.erb
@@ -1,0 +1,9 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: documents,
+      margin_top: true,
+      margin_bottom: true
+    %>
+  </div>
+</div>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -2,12 +2,4 @@
   items: section[:documents].shift(3)
 %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
-  </div>
-</div>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,3 +1,7 @@
+<%= render 'components/highlight-boxes',
+  items: section[:documents].shift(3)
+%>
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <%= render 'govuk_publishing_components/components/document_list',

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,9 +1,1 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
-  </div>
-</div>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,9 +1,1 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
-  </div>
-</div>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -3,12 +3,4 @@
   inverse: true
 %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
-  </div>
-</div>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,9 +1,1 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
-  </div>
-</div>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>


### PR DESCRIPTION
Trello: https://trello.com/c/3iq7F2VK/16-add-white-boxes-to-guidance-and-regulation-section

We want to show the most popular guidance and regulation content in highlight boxes so they are more prominent to users.

<img width="1004" alt="screen shot 2018-04-12 at 10 23 52" src="https://user-images.githubusercontent.com/29889908/38668258-a0ec794a-3e3b-11e8-9be3-507f5b169aab.png">

Example Pages with varying numbers of tagged guidance and regulation content

- https://govuk-collections-pr-618.herokuapp.com/education
- https://govuk-collections-pr-618.herokuapp.com/education/help-with-school-costs
- https://govuk-collections-pr-618.herokuapp.com/education/home-schooling
