### PR TITLE
Tweak highlight box styling

### DIFF
--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -2,19 +2,24 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-right: -25px;
+  }
 }
 
 .app-c-highlight-boxes__item-wrapper {
   @include core-19;
   list-style-type: none;
-  padding: 5px 25px $gutter-two-thirds 0;
-  width: 33%;
+  padding: 5px 10px 25px 0;
+  width: 100%;
   min-height: 150px;
-  min-width: 280px;
+  min-width: 250px;
   @include box-sizing(border-box);
 
-  @include media(mobile) {
-    width: 100%;
+  @include media(tablet) {
+    width: 33%;
+    padding: 5px 25px 25px 0;
   }
 }
 

--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -14,7 +14,6 @@
   list-style-type: none;
   padding: 5px 10px 25px 0;
   width: 100%;
-  min-height: 150px;
   min-width: 250px;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -10,12 +10,12 @@
 
 .app-c-highlight-boxes__item-wrapper {
   @include core-19;
+  @include box-sizing(border-box);
   list-style-type: none;
   padding: 5px 10px 25px 0;
   width: 100%;
   min-height: 150px;
   min-width: 250px;
-  @include box-sizing(border-box);
 
   @include media(tablet) {
     width: 33%;
@@ -24,11 +24,11 @@
 }
 
 .app-c-highlight-boxes__item {
+  @include box-sizing(border-box);
   border: 1px solid $grey-2;
   padding: $gutter-half * 1.5;
   height: 100%;
   box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;
-  @include box-sizing(border-box);
 }
 
 .app-c-highlight-boxes--inverse {

--- a/app/assets/stylesheets/components/_highlight-boxes.scss
+++ b/app/assets/stylesheets/components/_highlight-boxes.scss
@@ -26,7 +26,6 @@
 .app-c-highlight-boxes__item {
   border: 1px solid $grey-2;
   padding: $gutter-half * 1.5;
-  width: 100%;
   height: 100%;
   box-shadow: 7px 7px 0 $white, 8px 8px 0 $grey-2;
   @include box-sizing(border-box);


### PR DESCRIPTION
While adding the highlight boxes to the Guidance and Regulation section, [ @andysellick noticed a few minor changes](https://github.com/alphagov/collections/pull/618) that could be made to the highlight box code.

### Highlight boxes do not take full width ([link to comment](https://github.com/alphagov/collections/pull/618#discussion_r181061782))
Andy noticed that the highlight boxes don't take up the full width of the supergroup section they are placed in. On investigation, the actual component takes up the space, but the boxes themselves do not due to a `padding-right: 25px` on each box. 

I have added a negative `-25px` margin right on the parent container to counteract this. 

**Before:**
<img width="973" alt="screen shot 2018-04-12 at 16 27 07" src="https://user-images.githubusercontent.com/29889908/38687351-64b23892-3e6e-11e8-9ff6-53c966c3bb97.png">

**After:**
<img width="984" alt="screen shot 2018-04-12 at 16 26 46" src="https://user-images.githubusercontent.com/29889908/38687355-68ca8240-3e6e-11e8-8444-c5d87ef2184c.png">

I've chosen this over other options because of the following:

- `justify-content: space-between` - component breaks when passed less than 3 items (see screenshot below)
- Removing padding-right on last child - difficult to apply when using flex wrap, as the "last item" in each row will change on resizing.

<img width="920" alt="screen shot 2018-04-12 at 15 13 58" src="https://user-images.githubusercontent.com/29889908/38687280-38c9272c-3e6e-11e8-8923-33216f473f06.png">


### Other issues
The following issues have also been addressed in this PR:

- Unnecessary `width: 100%` on `.app-c-highlight-boxes__item`
- Consistency of `@include` location in component CSS

https://govuk-collections-pr-620.herokuapp.com/component-guide/highlight-boxes
https://govuk-collections-pr-620.herokuapp.com/education
