### PR TITLE
Prioritise consultations in the policy and engagement section

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'jasmine-rails'
   gem 'pry-byebug'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.9)
@@ -365,6 +366,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   slimmer (~> 12.0.0)
+  timecop
   uglifier (~> 4.1.9)
   webmock
 

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -38,5 +38,9 @@ module Supergroups
       # we should treat them the same
       document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
     end
+
+    def special_format_count(*)
+      3
+    end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -21,6 +21,10 @@ module Supergroups
           }
         }
 
+        if consultation?(document.content_store_document_type)
+          data[:metadata][:closing_date] = consultation_closing_date(document.base_path)
+        end
+
         data
       end
     end
@@ -45,6 +49,12 @@ module Supergroups
       return 3 if consultation_count > 3
 
       consultation_count
+    end
+
+    def consultation_closing_date(base_path)
+      @consultation = ::Services.content_store.content_item(base_path)
+      date = Date.parse(@consultation["details"]["closing_date"])
+      date.strftime("%d %B %Y")
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -54,7 +54,12 @@ module Supergroups
     def consultation_closing_date(base_path)
       @consultation = ::Services.content_store.content_item(base_path)
       date = Date.parse(@consultation["details"]["closing_date"])
-      date.strftime("%d %B %Y")
+
+      if date < Time.zone.today
+        return date.strftime("Date closed %d %B %Y")
+      end
+
+      date.strftime("Closing date %d %B %Y")
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -8,6 +8,15 @@ module Supergroups
 
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content.select do |content_item|
+        consultation?(content_item.content_store_document_type)
+      end | @content
+    end
+
+    def consultation?(document_type)
+      document_type == 'open_consultation' ||
+      document_type == 'consultation_outcome' ||
+      document_type == 'closed_consultation'
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -8,15 +8,24 @@ module Supergroups
 
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
-      @content.select do |content_item|
-        consultation?(content_item.content_store_document_type)
-      end | @content
+
+      @content.select { |content_item| consultation?(content_item.content_store_document_type) } | @content
     end
 
     def consultation?(document_type)
       document_type == 'open_consultation' ||
-      document_type == 'consultation_outcome' ||
-      document_type == 'closed_consultation'
+        document_type == 'consultation_outcome' ||
+        document_type == 'closed_consultation'
+    end
+
+    def special_format_count(taxon_id)
+      consultation_count = tagged_content(taxon_id).count do |content_item|
+        consultation?(content_item.content_store_document_type)
+      end
+
+      return 3 if consultation_count > 3
+
+      consultation_count
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -6,6 +6,25 @@ module Supergroups
       super('policy_and_engagement')
     end
 
+    def document_list(taxon_id)
+      tagged_content(taxon_id).each.map do |document|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path,
+            featured: true
+          },
+          metadata: {
+            public_updated_at: document.public_updated_at,
+            organisations: document.organisations,
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        data
+      end
+    end
+
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
 

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -23,5 +23,9 @@ module Supergroups
         data
       end
     end
+
+    def special_format_count(*)
+      3
+    end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -53,5 +53,9 @@ module Supergroups
         data
       end
     end
+
+    def special_format_count(*)
+      0
+    end
   end
 end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -29,7 +29,8 @@ module SupergroupSections
           documents: supergroup.document_list(taxon_id),
           partial_template: supergroup.partial_template,
           see_more_link: supergroup.finder_link(base_path),
-          show_section: supergroup.show_section?(taxon_id)
+          show_section: supergroup.show_section?(taxon_id),
+          special_format_count: supergroup.special_format_count(taxon_id)
         }
       end
     end

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,5 +1,5 @@
 <%= render 'components/highlight-boxes',
-  items: section[:documents].shift(3)
+  items: section[:documents].shift(section[:special_format_count])
 %>
 
 <%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,1 +1,5 @@
+<%= render 'components/highlight-boxes',
+  items: section[:documents].shift(section[:special_format_count])
+%>
+
 <%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,5 +1,5 @@
 <%= render 'components/highlight-boxes',
-  items: section[:documents].shift(3),
+  items: section[:documents].shift(section[:special_format_count]),
   inverse: true
 %>
 

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -16,7 +16,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -45,7 +46,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -56,7 +58,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -67,7 +70,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -78,7 +82,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -89,7 +94,8 @@ describe Supergroups::PolicyAndEngagement do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            featured: true
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -101,5 +101,35 @@ describe Supergroups::PolicyAndEngagement do
 
       assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
     end
+
+    it 'only show applies special formatting to consultations' do
+      tagged_content = []
+      tagged_content.push(*section_tagged_content_list('case_study'))
+      tagged_content.push(*section_tagged_content_list('case_study'))
+      tagged_content.push(*section_tagged_content_list('case_study'))
+      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(tagged_content)
+
+      assert_equal 2, policy_and_engagement_supergroup.special_format_count(taxon_id)
+    end
+
+    it 'only show applies special formatting to the first three consultations' do
+      tagged_content = []
+      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+      tagged_content.push(*section_tagged_content_list('open_consultation'))
+      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(tagged_content)
+
+      assert_equal 3, policy_and_engagement_supergroup.special_format_count(taxon_id)
+    end
   end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -28,5 +28,78 @@ describe Supergroups::PolicyAndEngagement do
 
       assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
     end
+
+    it 'prioritises consultations over other content' do
+      tagged_content = []
+      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+      tagged_content.push(*section_tagged_content_list('case_study'))
+      tagged_content.push(*section_tagged_content_list('open_consultation'))
+      tagged_content.push(*section_tagged_content_list('case_study'))
+      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(tagged_content)
+
+      expected = [
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content'
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Consultation outcome'
+          }
+        },
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content'
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Open consultation'
+          }
+        },
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content'
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Closed consultation'
+          }
+        },
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content'
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Case study'
+          }
+        },
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content'
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Case study'
+          }
+        }
+      ]
+
+      assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+    end
   end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -30,112 +30,152 @@ describe Supergroups::PolicyAndEngagement do
       assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
     end
 
-    it 'prioritises consultations over other content' do
-      tagged_content = []
-      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-      tagged_content.push(*section_tagged_content_list('case_study'))
-      tagged_content.push(*section_tagged_content_list('open_consultation'))
-      tagged_content.push(*section_tagged_content_list('case_study'))
-      tagged_content.push(*section_tagged_content_list('closed_consultation'))
-
-      MostRecentContent.any_instance
-        .stubs(:fetch)
-        .returns(tagged_content)
-
-      expected = [
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
-          },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Consultation outcome'
+    describe 'consultations' do
+      before do
+        content = content_item_for_base_path('/government/tagged/content').merge(
+          "details": {
+            "body": "",
+            "closing_date": "2018-07-10T23:45:00.000+00:00"
           }
-        },
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
+        )
+
+        content_store_has_item('/government/tagged/content', content)
+      end
+
+      it 'prioritises consultations over other content' do
+        tagged_content = []
+        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+        tagged_content.push(*section_tagged_content_list('case_study'))
+        tagged_content.push(*section_tagged_content_list('open_consultation'))
+        tagged_content.push(*section_tagged_content_list('case_study'))
+        tagged_content.push(*section_tagged_content_list('closed_consultation'))
+
+        MostRecentContent.any_instance
+          .stubs(:fetch)
+          .returns(tagged_content)
+
+        expected = [
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Consultation outcome',
+              closing_date: '10 July 2018'
+            }
           },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Open consultation'
-          }
-        },
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Open consultation',
+              closing_date: '10 July 2018'
+            }
           },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Closed consultation'
-          }
-        },
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Closed consultation',
+              closing_date: '10 July 2018'
+            }
           },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Case study'
-          }
-        },
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Case study'
+            }
           },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Case study'
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Case study'
+            }
           }
-        }
-      ]
+        ]
 
-      assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
-    end
+        assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+      end
 
-    it 'only show applies special formatting to consultations' do
-      tagged_content = []
-      tagged_content.push(*section_tagged_content_list('case_study'))
-      tagged_content.push(*section_tagged_content_list('case_study'))
-      tagged_content.push(*section_tagged_content_list('case_study'))
-      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+      it 'only show applies special formatting to consultations' do
+        tagged_content = []
+        tagged_content.push(*section_tagged_content_list('case_study'))
+        tagged_content.push(*section_tagged_content_list('case_study'))
+        tagged_content.push(*section_tagged_content_list('case_study'))
+        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+        tagged_content.push(*section_tagged_content_list('closed_consultation'))
 
-      MostRecentContent.any_instance
-        .stubs(:fetch)
-        .returns(tagged_content)
+        MostRecentContent.any_instance
+          .stubs(:fetch)
+          .returns(tagged_content)
 
-      assert_equal 2, policy_and_engagement_supergroup.special_format_count(taxon_id)
-    end
+        assert_equal 2, policy_and_engagement_supergroup.special_format_count(taxon_id)
+      end
 
-    it 'only show applies special formatting to the first three consultations' do
-      tagged_content = []
-      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-      tagged_content.push(*section_tagged_content_list('closed_consultation'))
-      tagged_content.push(*section_tagged_content_list('open_consultation'))
-      tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-      tagged_content.push(*section_tagged_content_list('closed_consultation'))
+      it 'only show applies special formatting to the first three consultations' do
+        tagged_content = []
+        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+        tagged_content.push(*section_tagged_content_list('closed_consultation'))
+        tagged_content.push(*section_tagged_content_list('open_consultation'))
+        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
+        tagged_content.push(*section_tagged_content_list('closed_consultation'))
 
-      MostRecentContent.any_instance
-        .stubs(:fetch)
-        .returns(tagged_content)
+        MostRecentContent.any_instance
+          .stubs(:fetch)
+          .returns(tagged_content)
 
-      assert_equal 3, policy_and_engagement_supergroup.special_format_count(taxon_id)
+        assert_equal 3, policy_and_engagement_supergroup.special_format_count(taxon_id)
+      end
+
+      it 'gets the closing date of consultations' do
+        MostRecentContent.any_instance
+          .stubs(:fetch)
+          .returns(section_tagged_content_list('open_consultation'))
+
+        expected = [
+          {
+            link: {
+              text: 'Tagged Content Title',
+              path: '/government/tagged/content',
+              featured: true
+            },
+            metadata: {
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              organisations: 'Tagged Content Organisation',
+              document_type: 'Open consultation',
+              closing_date: '10 July 2018'
+            }
+          }
+        ]
+
+        assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+      end
     end
   end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -12,22 +12,7 @@ describe Supergroups::PolicyAndEngagement do
         .stubs(:fetch)
         .returns(section_tagged_content_list('case_study'))
 
-      expected = [
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            featured: true
-          },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Case study'
-          }
-        }
-      ]
-
-      assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+      assert_equal expected_result('case_study'), policy_and_engagement_supergroup.document_list(taxon_id)
     end
 
     describe 'consultations' do
@@ -43,139 +28,115 @@ describe Supergroups::PolicyAndEngagement do
       end
 
       it 'prioritises consultations over other content' do
-        tagged_content = []
-        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-        tagged_content.push(*section_tagged_content_list('case_study'))
-        tagged_content.push(*section_tagged_content_list('open_consultation'))
-        tagged_content.push(*section_tagged_content_list('case_study'))
-        tagged_content.push(*section_tagged_content_list('closed_consultation'))
+        tagged_document_list = %w(
+          consultation_outcome
+          case_study
+          open_consultation
+          case_study
+          closed_consultation
+        )
+
+        expected_order = %w(
+          consultation_outcome
+          open_consultation
+          closed_consultation
+          case_study
+          case_study
+        )
 
         MostRecentContent.any_instance
           .stubs(:fetch)
-          .returns(tagged_content)
+          .returns(tagged_content(tagged_document_list))
 
-        expected = [
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Consultation outcome',
-              closing_date: '10 July 2018'
-            }
-          },
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Open consultation',
-              closing_date: '10 July 2018'
-            }
-          },
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Closed consultation',
-              closing_date: '10 July 2018'
-            }
-          },
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Case study'
-            }
-          },
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Case study'
-            }
-          }
-        ]
-
-        assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+        assert_equal expected_results(expected_order), policy_and_engagement_supergroup.document_list(taxon_id)
       end
 
-      it 'only show applies special formatting to consultations' do
-        tagged_content = []
-        tagged_content.push(*section_tagged_content_list('case_study'))
-        tagged_content.push(*section_tagged_content_list('case_study'))
-        tagged_content.push(*section_tagged_content_list('case_study'))
-        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-        tagged_content.push(*section_tagged_content_list('closed_consultation'))
+      describe '#special_format_count' do
+        it 'only show applies special formatting to consultations' do
+          tagged_document_list = %w(
+            case_study
+            case_study
+            case_study
+            consultation_outcome
+            closed_consultation
+          )
 
-        MostRecentContent.any_instance
-          .stubs(:fetch)
-          .returns(tagged_content)
+          MostRecentContent.any_instance
+            .stubs(:fetch)
+            .returns(tagged_content(tagged_document_list))
 
-        assert_equal 2, policy_and_engagement_supergroup.special_format_count(taxon_id)
+          assert_equal 2, policy_and_engagement_supergroup.special_format_count(taxon_id)
+        end
+
+        it 'only show applies special formatting to the first three consultations' do
+          tagged_document_list = %w(
+            consultation_outcome
+            closed_consultation
+            open_consultation
+            consultation_outcome
+            closed_consultation
+          )
+
+          MostRecentContent.any_instance
+            .stubs(:fetch)
+            .returns(tagged_content(tagged_document_list))
+
+          assert_equal 3, policy_and_engagement_supergroup.special_format_count(taxon_id)
+        end
       end
 
-      it 'only show applies special formatting to the first three consultations' do
-        tagged_content = []
-        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-        tagged_content.push(*section_tagged_content_list('closed_consultation'))
-        tagged_content.push(*section_tagged_content_list('open_consultation'))
-        tagged_content.push(*section_tagged_content_list('consultation_outcome'))
-        tagged_content.push(*section_tagged_content_list('closed_consultation'))
+      describe '#consultation_closing_date' do
+        it 'gets the closing date of consultations' do
+          MostRecentContent.any_instance
+            .stubs(:fetch)
+            .returns(section_tagged_content_list('open_consultation'))
 
-        MostRecentContent.any_instance
-          .stubs(:fetch)
-          .returns(tagged_content)
-
-        assert_equal 3, policy_and_engagement_supergroup.special_format_count(taxon_id)
-      end
-
-      it 'gets the closing date of consultations' do
-        MostRecentContent.any_instance
-          .stubs(:fetch)
-          .returns(section_tagged_content_list('open_consultation'))
-
-        expected = [
-          {
-            link: {
-              text: 'Tagged Content Title',
-              path: '/government/tagged/content',
-              featured: true
-            },
-            metadata: {
-              public_updated_at: '2018-02-28T08:01:00.000+00:00',
-              organisations: 'Tagged Content Organisation',
-              document_type: 'Open consultation',
-              closing_date: '10 July 2018'
-            }
-          }
-        ]
-
-        assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+          assert_equal expected_result('open_consultation'), policy_and_engagement_supergroup.document_list(taxon_id)
+        end
       end
     end
+  end
+
+  def tagged_content(document_types)
+    content_list = []
+    document_types.each do |document_type|
+      content_list.push(*section_tagged_content_list(document_type))
+    end
+    content_list
+  end
+
+  def expected_results(document_types)
+    results = []
+    document_types.each do |document_type|
+      results.push(*expected_result(document_type))
+    end
+    results
+  end
+
+  def expected_result(document_type)
+    result = {
+      link: {
+        text: 'Tagged Content Title',
+        path: '/government/tagged/content',
+        featured: true
+      },
+      metadata: {
+        public_updated_at: '2018-02-28T08:01:00.000+00:00',
+        organisations: 'Tagged Content Organisation',
+        document_type: document_type.humanize,
+      }
+    }
+
+    if consultation?(document_type)
+      result[:metadata][:closing_date] = '10 July 2018'
+    end
+
+    [result]
+  end
+
+  def consultation?(document_type)
+    document_type == 'open_consultation' ||
+      document_type == 'consultation_outcome' ||
+      document_type == 'closed_consultation'
   end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -20,7 +20,7 @@ describe Supergroups::PolicyAndEngagement do
         content = content_item_for_base_path('/government/tagged/content').merge(
           "details": {
             "body": "",
-            "closing_date": "2018-07-10T23:45:00.000+00:00"
+            "closing_date": "2017-07-10T23:45:00.000+00:00"
           }
         )
 
@@ -86,12 +86,58 @@ describe Supergroups::PolicyAndEngagement do
       end
 
       describe '#consultation_closing_date' do
-        it 'gets the closing date of consultations' do
+        it 'gets the closing date of past consultations' do
           MostRecentContent.any_instance
             .stubs(:fetch)
             .returns(section_tagged_content_list('open_consultation'))
 
           assert_equal expected_result('open_consultation'), policy_and_engagement_supergroup.document_list(taxon_id)
+        end
+
+        it 'gets the closing date of future consultations' do
+          rummager_result = [
+            Document.new(
+              title: 'Tagged Content Title',
+              description: 'Description of tagged content',
+              public_updated_at: '2018-02-28T08:01:00.000+00:00',
+              base_path: '/government/tagged/content-1',
+              content_store_document_type: 'open_consultation',
+              organisations: 'Tagged Content Organisation'
+            )
+          ]
+
+          MostRecentContent.any_instance
+            .stubs(:fetch)
+            .returns(rummager_result)
+
+          content = content_item_for_base_path('/government/tagged/content-1').merge(
+            "details": {
+              "body": "",
+              "closing_date": "2018-07-10T23:45:00.000+00:00"
+            }
+          )
+
+          content_store_has_item('/government/tagged/content-1', content)
+
+          expected = [
+            {
+              link: {
+                text: 'Tagged Content Title',
+                path: '/government/tagged/content-1',
+                featured: true
+              },
+              metadata: {
+                public_updated_at: '2018-02-28T08:01:00.000+00:00',
+                organisations: 'Tagged Content Organisation',
+                document_type: 'Open consultation',
+                closing_date: 'Closing date 10 July 2018'
+              }
+            }
+          ]
+
+          Timecop.freeze("2018-04-18") do
+            assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+          end
         end
       end
     end
@@ -128,7 +174,7 @@ describe Supergroups::PolicyAndEngagement do
     }
 
     if consultation?(document_type)
-      result[:metadata][:closing_date] = '10 July 2018'
+      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
     end
 
     [result]

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -24,7 +24,7 @@ describe SupergroupSections::Sections do
 
     it 'returns a list of supergroup details' do
       @sections.each do |section|
-        assert_equal(%i(title documents partial_template see_more_link show_section), section.keys)
+        assert_equal(%i(title documents partial_template see_more_link show_section special_format_count), section.keys)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/lZhCKzi7

### What's changed
Promote consultation content in the Policy and engagement section, and render them in a highlight box.

Example topic page: https://govuk-collections-pr-625.herokuapp.com/education/funding-and-finance-for-students

### Before
![screen shot 2018-04-18 at 18 08 33](https://user-images.githubusercontent.com/5793815/38947143-8905b5ec-4333-11e8-9fbc-80fa386b58c8.png)

### After
![screen shot 2018-04-18 at 18 09 26](https://user-images.githubusercontent.com/5793815/38947176-a75f2a14-4333-11e8-9e63-cf1ac3086455.png)
