### PR TITLE
Make how the policy and engagement section is ordered easy to read

### DIFF
--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -31,7 +31,7 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
 
-      @content.select { |content_item| consultation?(content_item.content_store_document_type) } | @content
+      reorder_tagged_documents_to_prioritise_consultations
     end
 
     def consultation?(document_type)
@@ -59,6 +59,18 @@ module Supergroups
       end
 
       date.strftime("Closing date %d %B %Y")
+    end
+
+  private
+
+    def reorder_tagged_documents_to_prioritise_consultations
+      consultations = @content.select do |content_item|
+        consultation?(content_item.content_store_document_type)
+      end
+
+      other_document_types = @content - consultations
+
+      consultations + other_document_types
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lZhCKzi7

Follows on from PR #626 

The original code to prioritise consultations in the policy and engagement section was concise but difficult to read. 

This is an attempt to make it clear exactly how the content in the section is being ordered.

Example pages: 

* https://govuk-collections-pr-628.herokuapp.com/education
* https://govuk-collections-pr-628.herokuapp.com/education/funding-and-finance-for-students