### PR TITLE
Add featured item for News & Communication on topic pages

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -36,19 +36,40 @@
 }
 
 .taxon-page__featured-item {
+  @extend %contain-floats;
+  margin-top: $gutter-two-thirds;
+
   .taxon-page__featured-image {
-    margin-top: 20px;
-    width: 100%;
+    @include box-sizing(border-box);
+    width: (1 / 3) * 100%;
+    float: left;
+    margin-bottom: $gutter-one-third;
+    padding-right: $gutter-half;
+
+    @include media(tablet) {
+      float: none;
+      margin-bottom: $gutter-one-third;
+      padding-right: 0;
+      width: 100%;
+    }
+  }
+
+  .taxon-page__featured-text {
+    display: inline-block;
+    width: (2 / 3) * 100%;
+
+    @include media(tablet) {
+      width: 100%;
+    }
   }
 
   .taxon-page__featured-link {
-    @include bold-27;
-    display: block;
-    margin: $gutter-half 0 $gutter-one-third 0;
+    @include bold-19;
   }
 
   .taxon-page__featured-metadata-wrapper {
     @include core-16;
+    margin-top: $gutter-one-third / 2;
 
     .taxon-page__featured-metadata {
       display: inline-block;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -36,6 +36,11 @@
 }
 
 .taxon-page__featured-item {
+  .taxon-page__featured-image {
+    margin-top: 20px;
+    width: 100%;
+  }
+
   .taxon-page__featured-link {
     @include bold-27;
     display: block;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -39,6 +39,10 @@
   @extend %contain-floats;
   margin-top: $gutter-two-thirds;
 
+  &--single {
+    min-width: 330px;
+  }
+
   .taxon-page__featured-image {
     @include box-sizing(border-box);
     width: (1 / 3) * 100%;
@@ -76,6 +80,13 @@
       margin-right: $gutter-two-thirds;
     }
   }
+}
+
+.taxon-page__featured-see-more {
+  display: block;
+  padding-top: $gutter-two-thirds;
+  padding-left: $gutter-half;
+  clear: both;
 }
 
 .taxon-page__grid {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -35,6 +35,23 @@
   margin-top: 0;
 }
 
+.taxon-page__featured-item {
+  .taxon-page__featured-link {
+    @include bold-27;
+    display: block;
+    margin: $gutter-half 0 $gutter-one-third 0;
+  }
+
+  .taxon-page__featured-metadata-wrapper {
+    @include core-16;
+
+    .taxon-page__featured-metadata {
+      display: inline-block;
+      margin-right: $gutter-two-thirds;
+    }
+  }
+}
+
 .taxon-page__grid {
   background-color: $grey-4;
   padding-top: $gutter;

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -9,5 +9,10 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
+
+
+    def promoted_content_count(*)
+      1
+    end
   end
 end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -36,9 +36,14 @@ module Supergroups
     end
 
     def news_item_photo(base_path)
+      default_news_image = {
+        "url": "/government/assets/placeholder.jpg",
+        "alt_text": ""
+      }.with_indifferent_access
+
       news_item = ::Services.content_store.content_item(base_path)
 
-      news_item["details"]["image"]
+      news_item["details"]["image"] || default_news_image
     end
 
     def promoted_content_count(*)

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -10,6 +10,36 @@ module Supergroups
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
 
+    def document_list(taxon_id)
+      tagged_content(taxon_id).each_with_index.map do |document, index|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path
+          },
+          metadata: {
+            public_updated_at: document.public_updated_at,
+            organisations: document.organisations,
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        if index < promoted_content_count
+          document_image = news_item_photo(document.base_path)
+          data[:image] = {}
+          data[:image][:url] = document_image["url"]
+          data[:image][:alt] = document_image["alt_text"]
+        end
+
+        data
+      end
+    end
+
+    def news_item_photo(base_path)
+      news_item = ::Services.content_store.content_item(base_path)
+
+      news_item["details"]["image"]
+    end
 
     def promoted_content_count(*)
       1

--- a/app/views/taxons/_document_list_with_grid.html.erb
+++ b/app/views/taxons/_document_list_with_grid.html.erb
@@ -5,5 +5,10 @@
       margin_top: true,
       margin_bottom: true
     %>
+
+    <%= link_to(
+       see_more_link[:text],
+       see_more_link[:url]
+     )%>
   </div>
 </div>

--- a/app/views/taxons/_document_list_with_grid.html.erb
+++ b/app/views/taxons/_document_list_with_grid.html.erb
@@ -1,14 +1,16 @@
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: documents,
-      margin_top: true,
-      margin_bottom: true
-    %>
+<% if documents.any? %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render 'govuk_publishing_components/components/document_list',
+        items: documents,
+        margin_top: true,
+        margin_bottom: true
+      %>
 
-    <%= link_to(
-       see_more_link[:text],
-       see_more_link[:url]
-     )%>
+      <%= link_to(
+        see_more_link[:text],
+        see_more_link[:url]
+      )%>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -2,4 +2,4 @@
   items: section[:documents].shift(section[:promoted_content_count])
 %>
 
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -6,6 +6,7 @@
 
 <div class="grid-row">
   <div class="taxon-page__featured-item column-one-third ">
+    <img class="taxon-page__featured-image" src="<%= featured_item[:image][:url] %>" alt="<%= featured_item[:image][:alt] %>">
     <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
     <div class="taxon-page__featured-metadata-wrapper">
       <% featured_item[:metadata].each do |metadata_key, metadata_value| %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -7,17 +7,19 @@
 <div class="grid-row">
   <div class="taxon-page__featured-item column-one-third ">
     <img class="taxon-page__featured-image" src="<%= featured_item[:image][:url] %>" alt="<%= featured_item[:image][:alt] %>">
-    <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
-    <div class="taxon-page__featured-metadata-wrapper">
-      <% featured_item[:metadata].each do |metadata_key, metadata_value| %>
-        <% if metadata_key.to_s.eql?("public_updated_at") %>
-          <time class="taxon-page__featured-metadata" datetime="<%= metadata_value.iso8601 %>">
-            <%= l(metadata_value, format: '%e %B %Y') %>
-          </time>
-        <% else %>
-          <p class="taxon-page__featured-metadata"><%= metadata_value %></p>
+    <div class="taxon-page__featured-text">
+      <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
+      <div class="taxon-page__featured-metadata-wrapper">
+        <% featured_item[:metadata].each do |metadata_key, metadata_value| %>
+          <% if metadata_key.to_s.eql?("public_updated_at") %>
+            <time class="taxon-page__featured-metadata" datetime="<%= metadata_value.iso8601 %>">
+              <%= l(metadata_value, format: '%e %B %Y') %>
+            </time>
+          <% else %>
+            <p class="taxon-page__featured-metadata"><%= metadata_value %></p>
+          <% end %>
         <% end %>
-      <% end %>
+      </div>
     </div>
   </div>
 

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,1 +1,35 @@
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>
+<%
+  featured_item = section[:documents].shift(section[:promoted_content_count]).first
+  no_more_news_items = section[:documents].empty?
+  featured_item_layout_class = "taxon-page__featured-item--single" if no_more_news_items
+%>
+
+<div class="grid-row">
+  <div class="taxon-page__featured-item column-one-third ">
+    <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
+    <div class="taxon-page__featured-metadata-wrapper">
+      <% featured_item[:metadata].each do |metadata_key, metadata_value| %>
+        <% if metadata_key.to_s.eql?("public_updated_at") %>
+          <time class="taxon-page__featured-metadata" datetime="<%= metadata_value.iso8601 %>">
+            <%= l(metadata_value, format: '%e %B %Y') %>
+          </time>
+        <% else %>
+          <p class="taxon-page__featured-metadata"><%= metadata_value %></p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="column-two-thirds">
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents],
+      margin_top: true,
+      margin_bottom: true
+    %>
+
+    <%= link_to(
+       section[:see_more_link][:text],
+       section[:see_more_link][:url]
+     )%>
+  </div>
+</div>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,11 +1,11 @@
 <%
   featured_item = section[:documents].shift(section[:promoted_content_count]).first
-  no_more_news_items = section[:documents].empty?
-  featured_item_layout_class = "taxon-page__featured-item--single" if no_more_news_items
+  documents = section[:documents].any?
+  featured_item_layout_class = "taxon-page__featured-item--single" if !documents
 %>
 
 <div class="grid-row">
-  <div class="taxon-page__featured-item column-one-third ">
+  <div class="taxon-page__featured-item column-one-third <%= featured_item_layout_class %>">
     <img class="taxon-page__featured-image" src="<%= featured_item[:image][:url] %>" alt="<%= featured_item[:image][:alt] %>">
     <div class="taxon-page__featured-text">
       <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
@@ -23,16 +23,15 @@
     </div>
   </div>
 
-  <div class="column-two-thirds">
+  <div class="<%= documents ? "column-two-thirds" : "taxon-page__featured-see-more" %>">
     <%= render 'govuk_publishing_components/components/document_list',
       items: section[:documents],
       margin_top: true,
       margin_bottom: true
     %>
-
     <%= link_to(
-       section[:see_more_link][:text],
-       section[:see_more_link][:url]
-     )%>
+      section[:see_more_link][:text],
+      section[:see_more_link][:url]
+    )%>
   </div>
 </div>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -2,4 +2,4 @@
   items: section[:documents].shift(section[:promoted_content_count])
 %>
 
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -2,5 +2,4 @@
   items: section[:documents].shift(section[:promoted_content_count]),
   inverse: true
 %>
-
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents] } %>
+<%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -23,10 +23,6 @@
         locals: { section: section }
       )
      %>
-     <%= link_to(
-       section[:see_more_link][:text],
-       section[:see_more_link][:url]
-     )%>
     </div>
     <% end %>
   <% end %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -77,6 +77,8 @@ private
     content_store_has_item(child_one_base_path, child_one)
     content_store_has_item(child_two_base_path, child_two)
 
+    content_store_has_item('/content-item-1', content_item_for_base_path('/content-item-1'))
+
     @content_item = content_item_without_children(base_path, content_id)
 
     @content_item["links"]["child_taxons"] = [child_one, child_two]
@@ -163,6 +165,7 @@ private
 
   def and_i_can_see_the_news_and_communications_section
     assert page.has_content?("News and communications")
+    assert page.has_selector?('.taxon-page__featured-item')
 
     tagged_content_for_news_and_communications.each do |item|
       all_other_sections_list_item_test(item)

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -62,12 +62,12 @@ private
       {
         'title' => 'Content item 1',
         'description' => 'Description of content item 1',
-        'link' => 'content-item-1'
+        'link' => 'world-content-item-1'
       },
       {
         'title' => 'Content item 2',
         'description' => 'Description of content item 2',
-        'link' => 'content-item-2'
+        'link' => 'world-content-item-2'
       },
     ]
   end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 include RummagerHelpers, SupergroupHelpers
 
 describe Supergroups::NewsAndCommunications do
+  DEFAULT_WHITEHALL_IMAGE_URL = "/government/assets/placeholder.jpg".freeze
   let(:taxon_id) { '12345' }
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }
 
@@ -60,6 +61,37 @@ describe Supergroups::NewsAndCommunications do
           refute content_item.key?(:image)
         end
       end
+    end
+
+    it 'returns the default whitehall image if no image is present' do
+      content = content_item_for_base_path('/government/tagged/content').merge(
+        "details": {}
+      )
+
+      content_store_has_item('/government/tagged/content', content)
+
+      MostRecentContent.any_instance
+      .stubs(:fetch)
+      .returns(section_tagged_content_list('news_story'))
+
+      assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.document_list(taxon_id).first[:image][:url]
+    end
+
+    it 'uses empty alt text if using the default whitehall image' do
+      # The default whitehall image does not give more context/information to the user about the news item they are viewing.
+      # We therefore want to hide the image from screenreaders by setting alt_text to a blank value
+
+      content = content_item_for_base_path('/government/tagged/content').merge(
+        "details": {}
+      )
+
+      content_store_has_item('/government/tagged/content', content)
+
+      MostRecentContent.any_instance
+      .stubs(:fetch)
+      .returns(section_tagged_content_list('news_story'))
+
+      assert_equal "", news_and_communications_supergroup.document_list(taxon_id).first[:image][:alt]
     end
   end
 end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -1,12 +1,25 @@
 require 'test_helper'
 
-include RummagerHelpers
+include RummagerHelpers, SupergroupHelpers
 
 describe Supergroups::NewsAndCommunications do
   let(:taxon_id) { '12345' }
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }
 
   describe '#document_list' do
+    before do
+      content = content_item_for_base_path('/government/tagged/content').merge(
+        "details": {
+          "image": {
+            "url": "an/image/path",
+            "alt_text": "some alt text"
+          }
+        }
+      )
+
+      content_store_has_item('/government/tagged/content', content)
+    end
+
     it 'returns a document list for the news and communications supergroup' do
       MostRecentContent.any_instance
         .stubs(:fetch)
@@ -22,11 +35,31 @@ describe Supergroups::NewsAndCommunications do
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
             organisations: 'Tagged Content Organisation',
             document_type: 'News story'
+          },
+          image: {
+            url: 'an/image/path',
+            alt: 'some alt text'
           }
         }
       ]
 
       assert_equal expected, news_and_communications_supergroup.document_list(taxon_id)
+    end
+
+    it 'returns an image for the first news item only' do
+      tagged_document_list = %w(news_story correspondance press_release)
+
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(tagged_content(tagged_document_list))
+
+      news_and_communications_supergroup.document_list(taxon_id).each_with_index do |content_item, i|
+        if i.eql?(0)
+          assert content_item.key?(:image)
+        else
+          refute content_item.key?(:image)
+        end
+      end
     end
   end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-include RummagerHelpers
+include RummagerHelpers, SupergroupHelpers
 
 describe Supergroups::PolicyAndEngagement do
   let(:taxon_id) { '12345' }
@@ -140,47 +140,5 @@ describe Supergroups::PolicyAndEngagement do
         end
       end
     end
-  end
-
-  def tagged_content(document_types)
-    content_list = []
-    document_types.each do |document_type|
-      content_list.push(*section_tagged_content_list(document_type))
-    end
-    content_list
-  end
-
-  def expected_results(document_types)
-    results = []
-    document_types.each do |document_type|
-      results.push(*expected_result(document_type))
-    end
-    results
-  end
-
-  def expected_result(document_type)
-    result = {
-      link: {
-        text: 'Tagged Content Title',
-        path: '/government/tagged/content'
-      },
-      metadata: {
-        public_updated_at: '2018-02-28T08:01:00.000+00:00',
-        organisations: 'Tagged Content Organisation',
-        document_type: document_type.humanize,
-      }
-    }
-
-    if consultation?(document_type)
-      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
-    end
-
-    [result]
-  end
-
-  def consultation?(document_type)
-    document_type == 'open_consultation' ||
-      document_type == 'consultation_outcome' ||
-      document_type == 'closed_consultation'
   end
 end

--- a/test/support/supergroups_helpers.rb
+++ b/test/support/supergroups_helpers.rb
@@ -1,0 +1,45 @@
+module SupergroupHelpers
+  def tagged_content(document_types)
+    content_list = []
+    document_types.each do |document_type|
+      content_list.push(*section_tagged_content_list(document_type))
+    end
+    content_list
+  end
+
+  def expected_results(document_types)
+    results = []
+    document_types.each do |document_type|
+      results.push(*expected_result(document_type))
+    end
+    results
+  end
+
+  def expected_result(document_type)
+    result = {
+      link: {
+        text: 'Tagged Content Title',
+        path: '/government/tagged/content'
+      },
+      metadata: {
+        public_updated_at: '2018-02-28T08:01:00.000+00:00',
+        organisations: 'Tagged Content Organisation',
+        document_type: document_type.humanize,
+      }
+    }
+
+    if consultation?(document_type)
+      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
+    end
+
+    [result]
+  end
+
+private
+
+  def consultation?(document_type)
+    document_type == 'open_consultation' ||
+      document_type == 'consultation_outcome' ||
+      document_type == 'closed_consultation'
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/bpfOboeR/34-show-a-photo-above-the-first-news-and-communication-item

We want to highlight the most recent item in News and Communication so it stands out to users. If an item does not have an image, it will use the default whitehall road sign image - as far as I'm aware, "correspondence" document types do not have images so will always use the default.

**FYI: some images will appear as broken because they use a relative URL and the heroku app isn't on https://gov.uk. I'll double check these on integration before deploying**

**Before:**
<img width="984" alt="screen shot 2018-04-24 at 10 28 17" src="https://user-images.githubusercontent.com/29889908/39178665-392f2e38-47aa-11e8-8011-d5757f0a9eed.png">

**After:**
<img width="993" alt="screen shot 2018-04-24 at 10 26 35" src="https://user-images.githubusercontent.com/29889908/39178681-43e26cdc-47aa-11e8-8de0-d8c5c6f1b481.png">

**Example Links:**
Component Guide: https://govuk-collections-pr-631.herokuapp.com/component-guide
With Image: https://govuk-collections-pr-631.herokuapp.com/education/pupil-wellbeing-behaviour-and-attendance
Using default whitehall image (won't work in heroku without image URL hacking): https://govuk-collections-pr-631.herokuapp.com/education/further-and-higher-education-skills-and-vocational-training
Only one news item (won't work in heroku without image URL hacking): https://govuk-collections-pr-631.herokuapp.com/education/financial-management-for-further-education-providers


