### PR TITLE
Use the meta tags component from the gem

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,7 @@
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= yield :meta_section %>
-
-  <%= render partial: 'govuk_component/analytics_meta_tags',
-    locals: { content_item: @content_item } %>
+  <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
 </head>
 


### PR DESCRIPTION
This replaces the analytics meta tags component from Static with the new [meta tags component](https://github.com/alphagov/govuk_publishing_components/pull/278) in the gem. There should be no changes in behaviour.

https://trello.com/c/pU7YINt1