### PR TITLE
Fix test includes

### DIFF
--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-include RummagerHelpers
-
 describe Supergroups::GuidanceAndRegulation do
+  include RummagerHelpers
+
   let(:taxon_id) { '12345' }
   let(:guidance_and_regulation_supergroup) { Supergroups::GuidanceAndRegulation.new }
 

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
-include RummagerHelpers, SupergroupHelpers
-
 describe Supergroups::NewsAndCommunications do
+  include RummagerHelpers
+  include SupergroupHelpers
+
   DEFAULT_WHITEHALL_IMAGE_URL = "/government/assets/placeholder.jpg".freeze
   let(:taxon_id) { '12345' }
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
-include RummagerHelpers, SupergroupHelpers
-
 describe Supergroups::PolicyAndEngagement do
+  include RummagerHelpers
+  include SupergroupHelpers
+
   let(:taxon_id) { '12345' }
   let(:policy_and_engagement_supergroup) { Supergroups::PolicyAndEngagement.new }
 

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-include RummagerHelpers
-
 describe Supergroups::Services do
+  include RummagerHelpers
+
   let(:taxon_id) { '12345' }
   let(:service_supergroup) { Supergroups::Services.new }
 

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-include RummagerHelpers
-
 describe Supergroups::Supergroup do
+  include RummagerHelpers
+
   let(:taxon_id) { '12345' }
   let(:supergroup_name) { 'supergroup_name' }
   let(:supergroup) { Supergroups::Supergroup.new(supergroup_name) }

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-include RummagerHelpers
-
 describe Supergroups::Transparency do
+  include RummagerHelpers
+
   let(:taxon_id) { '12345' }
   let(:transparency_supergroup) { Supergroups::Transparency.new }
 


### PR DESCRIPTION
This commit moves the `include` declarations for supergroup tests into the test description blocks to fix a linter error.