### PR TITLE
Update placeholder image URL

### DIFF
--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -37,7 +37,7 @@ module Supergroups
 
     def news_item_photo(base_path)
       default_news_image = {
-        "url": "/government/assets/placeholder.jpg",
+        "url": "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg",
         "alt_text": ""
       }.with_indifferent_access
 

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -4,7 +4,7 @@ describe Supergroups::NewsAndCommunications do
   include RummagerHelpers
   include SupergroupHelpers
 
-  DEFAULT_WHITEHALL_IMAGE_URL = "/government/assets/placeholder.jpg".freeze
+  DEFAULT_WHITEHALL_IMAGE_URL = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg".freeze
   let(:taxon_id) { '12345' }
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }
 


### PR DESCRIPTION
Update the placeholder image URL for news and communications so that the image displays on integration and staging.

**Before:**
<img width="999" alt="screen shot 2018-04-26 at 12 04 16" src="https://user-images.githubusercontent.com/29889908/39302342-3589864c-494a-11e8-9a2a-8410f69383b5.png">

**After:**
<img width="985" alt="screen shot 2018-04-26 at 12 04 11" src="https://user-images.githubusercontent.com/29889908/39302391-5ec45eba-494a-11e8-91af-f6095767e1dd.png">
