### PR TITLE
Remove special config for errors

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,8 +1,0 @@
-GovukError.configure do |config|
-  # A couple of hundred timeouts occur each day. This can be caused by
-  # rummager or content-store being busy, or network issues. They generally
-  # aren't a big deal, since Fastly will show the mirror. We can safely
-  # ignore the errors because we have other monitoring in place that alerts
-  # us if the error rate reaches certain thresholds.
-  config.excluded_exceptions << "GdsApi::TimedOutException"
-end


### PR DESCRIPTION
This might be interfering with the default error handling, which excludes `GdsApi::TimedOutException` errors raised by the application.