### PR TITLE
Add tracking to highlight boxes within supergroup sections

### DIFF
--- a/app/helpers/highlight_boxes_helper.rb
+++ b/app/helpers/highlight_boxes_helper.rb
@@ -1,0 +1,9 @@
+module HighlightBoxesHelper
+  def data_tracking?(items)
+    items.each do |item|
+      return true if item[:link][:data_attributes]
+    end
+
+    false
+  end
+end

--- a/app/views/components/_highlight-boxes.html.erb
+++ b/app/views/components/_highlight-boxes.html.erb
@@ -4,16 +4,17 @@
   inverse_class = "app-c-highlight-boxes--inverse" if inverse
 %>
 <% if items.any? %>
-  <ol class="app-c-highlight-boxes">
+  <ol class="app-c-highlight-boxes" <%= "data-module=track-click" if data_tracking?(local_assigns[:items]) %>>
     <% items.each do |content_item| %>
       <li class="app-c-highlight-boxes__item-wrapper">
         <div class="app-c-highlight-boxes__item <%= inverse_class %>">
-          <a
-            class="app-c-highlight-boxes__title <%= "app-c-highlight-boxes__title--featured" if content_item[:link][:featured] %>"
-            href="<%= content_item[:link].fetch(:path) %>"
-          >
-            <%= content_item[:link].fetch(:text)  %>
-          </a>
+          <%= link_to(
+            content_item[:link].fetch(:text),
+            content_item[:link].fetch(:path),
+            class: "app-c-highlight-boxes__title #{"app-c-highlight-boxes__title--featured" if content_item[:link][:featured]}",
+            data: content_item[:link][:data_attributes]
+            )
+          %>
 
           <% if content_item[:link][:description] %>
             <p class="app-c-highlight-boxes__description"><%= content_item[:link][:description] %></p>

--- a/app/views/components/docs/highlight-boxes.yml
+++ b/app/views/components/docs/highlight-boxes.yml
@@ -107,3 +107,36 @@ examples:
           document_type: Speech
           organisation: DfE and Ofqual
           public_updated_at: 2016-06-27 10:29:44
+  with_data_tracking_attributes:
+    data:
+      items:
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          data_attributes: {
+            track_category: "servicesHighlightBoxClicked",
+            track_action: 1,
+            track_label: "/becoming-an-apprentice"
+          }
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44
+      - link:
+          text: Becoming an apprentice
+          path: /becoming-an-apprentice
+          description: Becoming an apprentice - what to expect, apprenticeship levels, pay and training, making an application, complaining about an apprenticeship
+          data_attributes: {
+            track_category: "servicesHighlightBoxClicked",
+            track_action: 2,
+            track_label: "/becoming-an-apprentice",
+            track_options: {
+              dimension28: 2,
+              dimension29: "Becoming an apprentice"
+            }
+          }
+        metadata:
+          document_type: Speech
+          organisation: DfE and Ofqual
+          public_updated_at: 2016-06-27 10:29:44

--- a/test/components/highlight_boxes_test.rb
+++ b/test/components/highlight_boxes_test.rb
@@ -171,4 +171,57 @@ class HighlightBoxesTest < ComponentTestCase
 
     assert_select ".app-c-highlight-boxes__title.app-c-highlight-boxes__title--featured"
   end
+
+  test "adds data tracking attributes when data_attributes provided" do
+    render_component(
+      items: [
+        {
+          link: {
+            text: 'Become an apprentice',
+            path: '/become-an-apprentice',
+            description: "How to become an apprentice",
+            data_attributes: {
+              track_category: "servicesHighlightBoxClicked",
+              track_action: 1,
+              track_label: "/becoming-an-apprentice"
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2016-06-27 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Guide'
+          }
+        },
+        {
+          link: {
+            text: 'Student finance',
+            path: '/student-finance',
+            description: "Student finance",
+            data_attributes: {
+              track_category: "servicesHighlightBoxClicked",
+              track_action: 2,
+              track_label: "/student-finance",
+              track_options: {
+                dimension28: 2,
+                dimension29: "Student Finance"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("1994-11-21 14:50:33 +0000"),
+            organisations: 'Department of Education',
+            document_type: 'Detailed Guide'
+          }
+        }
+      ]
+    )
+
+    assert_select ".app-c-highlight-boxes__title[data-track-category='servicesHighlightBoxClicked']"
+    assert_select ".app-c-highlight-boxes__title[data-track-action='1']"
+    assert_select ".app-c-highlight-boxes__title[data-track-label='/becoming-an-apprentice']"
+
+    assert_select ".app-c-highlight-boxes__title[data-track-action='2']"
+    assert_select ".app-c-highlight-boxes__title[data-track-label='/student-finance']"
+    assert_select ".app-c-highlight-boxes__title[data-track-options='{\"dimension28\":2,\"dimension29\":\"Student Finance\"}']"
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/ezNswqdS/73-add-tracking-to-highlight-boxes-on-topic-pages

This PR covers expanding the highlight box component to include data tracking. It *does not* cover using these tracking abilities on topic pages. This will now be addressed in a separate PR.

Component Guide: https://govuk-collections-pr-652.herokuapp.com/component-guide/highlight-boxes