### PR TITLE
Add tracking to topic pages

### DIFF
--- a/app/helpers/data_tracking_helper.rb
+++ b/app/helpers/data_tracking_helper.rb
@@ -1,0 +1,9 @@
+module DataTrackingHelper
+  def track_click?(items)
+    items.each do |item|
+      return true if item[:link][:data_attributes]
+    end
+
+    false
+  end
+end

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -10,12 +10,6 @@ module Supergroups
       @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
 
-    def document_list(taxon_id)
-      items = tagged_content(taxon_id).drop(promoted_content_count)
-
-      format_document_data(items)
-    end
-
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
 

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -31,7 +31,7 @@ module Supergroups
     end
 
     def format_document_data(documents, data_category = "")
-      documents.each_with_index.map do |document, index|
+      documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -11,7 +11,9 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each_with_index.map do |document, index|
+      items = tagged_content(taxon_id).drop(promoted_content_count)
+
+      items.each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
@@ -29,6 +31,34 @@ module Supergroups
           data[:metadata][:public_updated_at] = document.public_updated_at
           data[:metadata][:organisations] = document.organisations
         end
+
+        data
+      end
+    end
+
+    def promoted_content(taxon_id)
+      items = tagged_content(taxon_id).shift(promoted_content_count)
+
+      items.each_with_index.map do |document, index|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
+          },
+          metadata: {
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        if guide?(document)
+          data[:link][:description] = document.description
+        else
+          data[:metadata][:public_updated_at] = document.public_updated_at
+          data[:metadata][:organisations] = document.organisations
+        end
+
+        data[:link][:data_attributes][:track_category] = data_module_label + "HighlightBoxClicked"
 
         data
       end

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -11,11 +11,12 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each.map do |document|
+      tagged_content(taxon_id).each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
-            path: document.base_path
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
           },
           metadata: {
             document_type: document.content_store_document_type.humanize
@@ -37,6 +38,16 @@ module Supergroups
       # Although answers and guides are 2 different document types, they are conceptually the same so
       # we should treat them the same
       document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
+    end
+
+  private
+
+    def data_attributes(base_path, index)
+      {
+        track_category: data_module_label + "DocumentListClicked",
+        track_action: index + 1,
+        track_label: base_path
+      }
     end
   end
 end

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -39,15 +39,5 @@ module Supergroups
       # we should treat them the same
       document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
     end
-
-  private
-
-    def data_attributes(base_path, index)
-      {
-        track_category: data_module_label + "DocumentListClicked",
-        track_action: index + 1,
-        track_label: base_path
-      }
-    end
   end
 end

--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -13,33 +13,25 @@ module Supergroups
     def document_list(taxon_id)
       items = tagged_content(taxon_id).drop(promoted_content_count)
 
-      items.each_with_index.map do |document, index|
-        data = {
-          link: {
-            text: document.title,
-            path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
-          },
-          metadata: {
-            document_type: document.content_store_document_type.humanize
-          }
-        }
-
-        if guide?(document)
-          data[:link][:description] = document.description
-        else
-          data[:metadata][:public_updated_at] = document.public_updated_at
-          data[:metadata][:organisations] = document.organisations
-        end
-
-        data
-      end
+      format_document_data(items)
     end
 
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
 
-      items.each_with_index.map do |document, index|
+      format_document_data(items, "HighlightBoxClicked")
+    end
+
+  private
+
+    def guide?(document)
+      # Although answers and guides are 2 different document types, they are conceptually the same so
+      # we should treat them the same
+      document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
+    end
+
+    def format_document_data(documents, data_category = "")
+      documents.each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
@@ -58,16 +50,12 @@ module Supergroups
           data[:metadata][:organisations] = document.organisations
         end
 
-        data[:link][:data_attributes][:track_category] = data_module_label + "HighlightBoxClicked"
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
 
         data
       end
-    end
-
-    def guide?(document)
-      # Although answers and guides are 2 different document types, they are conceptually the same so
-      # we should treat them the same
-      document.content_store_document_type == 'guide' || document.content_store_document_type == 'answer'
     end
   end
 end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -15,7 +15,8 @@ module Supergroups
         data = {
           link: {
             text: document.title,
-            path: document.base_path
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -50,7 +50,7 @@ module Supergroups
     end
 
     def format_document_data(documents, data_category = "")
-      documents.each_with_index.map do |document, index|
+      documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -11,29 +11,25 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each_with_index.map do |document, index|
-        data = {
-          link: {
-            text: document.title,
-            path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
-          },
-          metadata: {
-            public_updated_at: document.public_updated_at,
-            organisations: document.organisations,
-            document_type: document.content_store_document_type.humanize
-          }
+      items = tagged_content(taxon_id).drop(promoted_content_count)
+
+      format_document_data(items)
+    end
+
+    def promoted_content(taxon_id)
+      items = tagged_content(taxon_id).shift(promoted_content_count)
+
+      documents = format_document_data(items, "FeaturedLinkClicked")
+
+      documents.map do |document|
+        document_image = news_item_photo(document[:link][:path])
+        document[:image] = {
+          url: document_image["url"],
+          alt: document_image["alt_text"]
         }
-
-        if index < promoted_content_count
-          document_image = news_item_photo(document.base_path)
-          data[:image] = {}
-          data[:image][:url] = document_image["url"]
-          data[:image][:alt] = document_image["alt_text"]
-        end
-
-        data
       end
+
+      documents
     end
 
     def news_item_photo(base_path)
@@ -49,6 +45,31 @@ module Supergroups
 
     def promoted_content_count(*)
       1
+    end
+
+  private
+
+    def format_document_data(documents, data_category = "")
+      documents.each_with_index.map do |document, index|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
+          },
+          metadata: {
+            public_updated_at: document.public_updated_at,
+            organisations: document.organisations,
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
+
+        data
+      end
     end
   end
 end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -10,12 +10,6 @@ module Supergroups
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
 
-    def document_list(taxon_id)
-      items = tagged_content(taxon_id).drop(promoted_content_count)
-
-      format_document_data(items)
-    end
-
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
 
@@ -47,29 +41,6 @@ module Supergroups
 
     def promoted_content_count(*)
       1
-    end
-
-    def format_document_data(documents, data_category = "")
-      documents.each.with_index(1).map do |document, index|
-        data = {
-          link: {
-            text: document.title,
-            path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
-          },
-          metadata: {
-            public_updated_at: document.public_updated_at,
-            organisations: document.organisations,
-            document_type: document.content_store_document_type.humanize
-          }
-        }
-
-        if data_category.present?
-          data[:link][:data_attributes][:track_category] = data_module_label + data_category
-        end
-
-        data
-      end
     end
   end
 end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -43,11 +43,11 @@ module Supergroups
       news_item["details"]["image"] || default_news_image
     end
 
+  private
+
     def promoted_content_count(*)
       1
     end
-
-  private
 
     def format_document_data(documents, data_category = "")
       documents.each_with_index.map do |document, index|

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -7,26 +7,15 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each_with_index.map do |document, index|
-        data = {
-          link: {
-            text: document.title,
-            path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
-          },
-          metadata: {
-            public_updated_at: document.public_updated_at,
-            organisations: document.organisations,
-            document_type: document.content_store_document_type.humanize
-          }
-        }
+      items = tagged_content(taxon_id).drop(promoted_content_count(taxon_id))
 
-        if consultation?(document.content_store_document_type)
-          data[:metadata][:closing_date] = consultation_closing_date(document.base_path)
-        end
+      format_document_data(items)
+    end
 
-        data
-      end
+    def promoted_content(taxon_id)
+      items = tagged_content(taxon_id).shift(promoted_content_count(taxon_id))
+
+      format_document_data(items, "HighlightBoxClicked")
     end
 
     def tagged_content(taxon_id)
@@ -72,6 +61,33 @@ module Supergroups
       other_document_types = @content - consultations
 
       consultations + other_document_types
+    end
+
+    def format_document_data(documents, data_category = "")
+      documents.each_with_index.map do |document, index|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
+          },
+          metadata: {
+            public_updated_at: document.public_updated_at,
+            organisations: document.organisations,
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        if consultation?(document.content_store_document_type)
+          data[:metadata][:closing_date] = consultation_closing_date(document.base_path)
+        end
+
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
+
+        data
+      end
     end
   end
 end

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -7,11 +7,12 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each.map do |document|
+      tagged_content(taxon_id).each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
-            path: document.base_path
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -30,16 +30,6 @@ module Supergroups
         document_type == 'closed_consultation'
     end
 
-    def promoted_content_count(taxon_id)
-      consultation_count = tagged_content(taxon_id).count do |content_item|
-        consultation?(content_item.content_store_document_type)
-      end
-
-      return 3 if consultation_count > 3
-
-      consultation_count
-    end
-
     def consultation_closing_date(base_path)
       @consultation = ::Services.content_store.content_item(base_path)
       date = Date.parse(@consultation["details"]["closing_date"])
@@ -52,6 +42,16 @@ module Supergroups
     end
 
   private
+
+    def promoted_content_count(taxon_id)
+      consultation_count = tagged_content(taxon_id).count do |content_item|
+        consultation?(content_item.content_store_document_type)
+      end
+
+      return 3 if consultation_count > 3
+
+      consultation_count
+    end
 
     def reorder_tagged_documents_to_prioritise_consultations
       consultations = @content.select do |content_item|

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -64,7 +64,7 @@ module Supergroups
     end
 
     def format_document_data(documents, data_category = "")
-      documents.each_with_index.map do |document, index|
+      documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -10,12 +10,6 @@ module Supergroups
       @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
 
-    def document_list(taxon_id)
-      items = tagged_content(taxon_id).drop(promoted_content_count)
-
-      format_document_data(items)
-    end
-
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
 

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -24,14 +24,5 @@ module Supergroups
         data
       end
     end
-
-  private
-    def data_attributes(base_path, index)
-      {
-        track_category: data_module_label + "DocumentListClicked",
-        track_action: index + 1,
-        track_label: base_path
-      }
-    end
   end
 end

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -25,7 +25,7 @@ module Supergroups
   private
 
     def format_document_data(documents, data_category = "")
-      documents.each_with_index.map do |document, index|
+      documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -11,7 +11,21 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each_with_index.map do |document, index|
+      items = tagged_content(taxon_id).drop(promoted_content_count)
+
+      format_document_data(items)
+    end
+
+    def promoted_content(taxon_id)
+      items = tagged_content(taxon_id).shift(promoted_content_count)
+
+      format_document_data(items, "HighlightBoxClicked")
+    end
+
+  private
+
+    def format_document_data(documents, data_category = "")
+      documents.each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
@@ -20,6 +34,10 @@ module Supergroups
             data_attributes: data_attributes(document.base_path, index)
           }
         }
+
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
 
         data
       end

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -11,17 +11,27 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each.map do |document|
+      tagged_content(taxon_id).each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
             path: document.base_path,
-            description: document.description
+            description: document.description,
+            data_attributes: data_attributes(document.base_path, index)
           }
         }
 
         data
       end
+    end
+
+  private
+    def data_attributes(base_path, index)
+      {
+        track_category: data_module_label + "DocumentListClicked",
+        track_action: index + 1,
+        track_label: base_path
+      }
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -59,10 +59,6 @@ module Supergroups
       []
     end
 
-    def promoted_content_count(*)
-      3
-    end
-
     def data_module_label
       name.camelize(:lower)
     end
@@ -75,6 +71,10 @@ module Supergroups
         track_action: index + 1,
         track_label: base_path
       }
+    end
+
+    def promoted_content_count(*)
+      3
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -37,7 +37,9 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      format_document_data(tagged_content(taxon_id))
+      items = tagged_content(taxon_id).drop(promoted_content_count)
+
+      format_document_data(items)
     end
 
     def promoted_content(*)

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -37,11 +37,12 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each.map do |document|
+      tagged_content(taxon_id).each_with_index.map do |document, index|
         data = {
           link: {
             text: document.title,
-            path: document.base_path
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
           },
           metadata: {
             public_updated_at: document.public_updated_at,
@@ -60,6 +61,16 @@ module Supergroups
 
     def data_module_label
       name.camelize(:lower)
+    end
+
+  private
+
+    def data_attributes(base_path, index)
+      {
+        track_category: data_module_label + "DocumentListClicked",
+        track_action: index + 1,
+        track_label: base_path
+      }
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -37,7 +37,7 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each_with_index.map do |document, index|
+      tagged_content(taxon_id).each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,
@@ -68,7 +68,7 @@ module Supergroups
     def data_attributes(base_path, index)
       {
         track_category: data_module_label + "DocumentListClicked",
-        track_action: index + 1,
+        track_action: index,
         track_label: base_path
       }
     end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -37,22 +37,7 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      tagged_content(taxon_id).each.with_index(1).map do |document, index|
-        data = {
-          link: {
-            text: document.title,
-            path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
-          },
-          metadata: {
-            public_updated_at: document.public_updated_at,
-            organisations: document.organisations,
-            document_type: document.content_store_document_type.humanize
-          }
-        }
-
-        data
-      end
+      format_document_data(tagged_content(taxon_id))
     end
 
     def promoted_content(*)
@@ -75,6 +60,29 @@ module Supergroups
 
     def promoted_content_count(*)
       3
+    end
+
+    def format_document_data(documents, data_category = "")
+      documents.each.with_index(1).map do |document, index|
+        data = {
+          link: {
+            text: document.title,
+            path: document.base_path,
+            data_attributes: data_attributes(document.base_path, index)
+          },
+          metadata: {
+            public_updated_at: document.public_updated_at,
+            organisations: document.organisations,
+            document_type: document.content_store_document_type.humanize
+          }
+        }
+
+        if data_category.present?
+          data[:link][:data_attributes][:track_category] = data_module_label + data_category
+        end
+
+        data
+      end
     end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -57,5 +57,9 @@ module Supergroups
     def promoted_content_count(*)
       3
     end
+
+    def data_module_label
+      name.camelize(:lower)
+    end
   end
 end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -55,6 +55,10 @@ module Supergroups
       end
     end
 
+    def promoted_content(*)
+      []
+    end
+
     def promoted_content_count(*)
       3
     end

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -9,5 +9,9 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
     end
+
+    def promoted_content_count
+      0
+    end
   end
 end

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -39,13 +39,14 @@ private
   end
 
   def organisation_list_with_logos
-    organisations_with_logos.map do |org|
+    organisations_with_logos.map.with_index do |org, index|
       {
 
           name: org.logo_formatted_title,
           url: org.link,
           brand: org.brand,
           crest: org.crest,
+          data_attributes: data_attributes(org.link, index + 1)
       }
     end
   end

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -53,13 +53,24 @@ private
   def organisation_list_without_logos
     organisations_without_logos = organisations - organisations_with_logos
 
-    organisations_without_logos.map do |organisation|
+    tracking_number = organisations_with_logos.count
+
+    organisations_without_logos.map.with_index(1) do |organisation, index|
       {
         link: {
           text: organisation.title,
-          path: organisation.link
+          path: organisation.link,
+          data_attributes: data_attributes(organisation.link, tracking_number + index)
         }
       }
     end
+  end
+
+  def data_attributes(base_path, index)
+    {
+      track_category: "organisationsDocumentListClicked",
+      track_action: index,
+      track_label: base_path
+    }
   end
 end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -26,6 +26,7 @@ module SupergroupSections
       SupergroupSections::SUPERGROUPS.map do |supergroup|
         {
           title: supergroup.title,
+          promoted_content: supergroup.promoted_content(taxon_id),
           documents: supergroup.document_list(taxon_id),
           partial_template: supergroup.partial_template,
           promoted_content_count: supergroup.promoted_content_count(taxon_id),

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -29,7 +29,6 @@ module SupergroupSections
           promoted_content: supergroup.promoted_content(taxon_id),
           documents: supergroup.document_list(taxon_id),
           partial_template: supergroup.partial_template,
-          promoted_content_count: supergroup.promoted_content_count(taxon_id),
           see_more_link: supergroup.finder_link(base_path),
           show_section: supergroup.show_section?(taxon_id)
         }

--- a/app/views/taxons/_document_list_with_grid.html.erb
+++ b/app/views/taxons/_document_list_with_grid.html.erb
@@ -1,6 +1,6 @@
 <% if documents.any? %>
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(documents) %>>
       <%= render 'govuk_publishing_components/components/document_list',
         items: documents,
         margin_top: true,

--- a/app/views/taxons/_organisation_logos_and_list.html.erb
+++ b/app/views/taxons/_organisation_logos_and_list.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <% if organisations_without_logos.any? %>
-  <div>
+  <div <%= "data-module=track-click" if track_click?(organisations_without_logos) %>>
     <%= render 'govuk_publishing_components/components/document_list',
       items: organisations_without_logos,
       margin_bottom: true

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,5 +1,5 @@
 <%= render 'components/highlight-boxes',
-  items: section[:documents].shift(section[:promoted_content_count])
+  items: section[:promoted_content]
 %>
 
 <%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -23,7 +23,7 @@
     </div>
   </div>
 
-  <div class="<%= documents ? "column-two-thirds" : "taxon-page__featured-see-more" %>">
+  <div class="<%= documents ? "column-two-thirds" : "taxon-page__featured-see-more" %>" <%= "data-module=track-click" if track_click?(section[:documents]) %>>
     <%= render 'govuk_publishing_components/components/document_list',
       items: section[:documents],
       margin_top: true,

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,14 +1,19 @@
 <%
-  featured_item = section[:documents].shift(section[:promoted_content_count]).first
-  documents = section[:documents].any?
-  featured_item_layout_class = "taxon-page__featured-item--single" if !documents
+  featured_item = section[:promoted_content].first
+  featured_item_layout_class = "taxon-page__featured-item--single" if section[:documents].empty?
 %>
 
 <div class="grid-row">
-  <div class="taxon-page__featured-item column-one-third <%= featured_item_layout_class %>">
+  <div class="taxon-page__featured-item column-one-third <%= featured_item_layout_class %>" <%= "data-module=track-click" if track_click?(section[:promoted_content]) %>>
     <img class="taxon-page__featured-image" src="<%= featured_item[:image][:url] %>" alt="<%= featured_item[:image][:alt] %>">
     <div class="taxon-page__featured-text">
-      <a class="taxon-page__featured-link" href="<%= featured_item[:link][:path] %>"><%= featured_item[:link][:text] %></a>
+      <%= link_to(
+        featured_item[:link].fetch(:text),
+        featured_item[:link].fetch(:path),
+        class: "taxon-page__featured-link",
+        data: featured_item[:link][:data_attributes]
+        )
+      %>
       <div class="taxon-page__featured-metadata-wrapper">
         <% featured_item[:metadata].each do |metadata_key, metadata_value| %>
           <% if metadata_key.to_s.eql?("public_updated_at") %>
@@ -23,12 +28,16 @@
     </div>
   </div>
 
-  <div class="<%= documents ? "column-two-thirds" : "taxon-page__featured-see-more" %>" <%= "data-module=track-click" if track_click?(section[:documents]) %>>
+  <% if section[:documents].any? %>
+    <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(section[:documents]) %>>
     <%= render 'govuk_publishing_components/components/document_list',
       items: section[:documents],
       margin_top: true,
       margin_bottom: true
     %>
+  <% else %>
+    <div class="taxon-page__featured-see-more">
+  <% end %>
     <%= link_to(
       section[:see_more_link][:text],
       section[:see_more_link][:url]

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,5 +1,5 @@
 <%= render 'components/highlight-boxes',
-  items: section[:documents].shift(section[:promoted_content_count])
+  items: section[:promoted_content]
 %>
 
 <%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,5 +1,5 @@
 <%= render 'components/highlight-boxes',
-  items: section[:documents].shift(section[:promoted_content_count]),
+  items: section[:promoted_content],
   inverse: true
 %>
 <%= render partial: 'document_list_with_grid', locals: { documents: section[:documents], see_more_link: section[:see_more_link] } %>

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -16,7 +16,12 @@ describe Supergroups::GuidanceAndRegulation do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "guidanceAndRegulationDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -40,6 +45,11 @@ describe Supergroups::GuidanceAndRegulation do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             description: 'Description of tagged content',
+            data_attributes: {
+              track_category: "guidanceAndRegulationDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
           },
           metadata: {
             document_type: 'Guide'

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -10,7 +10,7 @@ describe Supergroups::GuidanceAndRegulation do
     it 'returns a document list for the guidance and regulation supergroup' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('guidance'))
+        .returns(section_tagged_content_list('guidance', 4))
 
       expected = [
         {
@@ -37,7 +37,7 @@ describe Supergroups::GuidanceAndRegulation do
     it 'return a document list for guides' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('guide'))
+        .returns(section_tagged_content_list('guide', 4))
 
       expected = [
         {
@@ -57,7 +57,39 @@ describe Supergroups::GuidanceAndRegulation do
         }
       ]
 
-      assert_equal expected, guidance_and_regulation_supergroup.document_list(taxon_id)
+      actual = guidance_and_regulation_supergroup.document_list(taxon_id)
+
+      assert_equal expected, actual
+      assert_equal 1, actual.count
+    end
+  end
+
+  describe '#promoted_content' do
+    it 'returns promoted content for the guidance and regulation supergroup' do
+      MostPopularContent.any_instance
+        .stubs(:fetch)
+        .returns(section_tagged_content_list('guidance'))
+
+      expected = [
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "guidanceAndRegulationHighlightBoxClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Guidance'
+          }
+        }
+      ]
+
+      assert_equal expected, guidance_and_regulation_supergroup.promoted_content(taxon_id)
     end
   end
 end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -9,23 +9,10 @@ describe Supergroups::NewsAndCommunications do
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }
 
   describe '#document_list' do
-    before do
-      content = content_item_for_base_path('/government/tagged/content').merge(
-        "details": {
-          "image": {
-            "url": "an/image/path",
-            "alt_text": "some alt text"
-          }
-        }
-      )
-
-      content_store_has_item('/government/tagged/content', content)
-    end
-
     it 'returns a document list for the news and communications supergroup' do
       MostRecentContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('news_story'))
+        .returns(section_tagged_content_list('news_story', 2))
 
       expected = [
         {
@@ -42,6 +29,60 @@ describe Supergroups::NewsAndCommunications do
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
             organisations: 'Tagged Content Organisation',
             document_type: 'News story'
+          }
+        }
+      ]
+
+      assert_equal expected, news_and_communications_supergroup.document_list(taxon_id)
+    end
+
+    it 'does not returns an image for news items' do
+      tagged_document_list = %w(news_story correspondance press_release)
+
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(tagged_content(tagged_document_list))
+
+      news_and_communications_supergroup.document_list(taxon_id).each do |content_item|
+        refute content_item.key?(:image)
+      end
+    end
+  end
+
+  describe '#promoted_content' do
+    before do
+      content = content_item_for_base_path('/government/tagged/content').merge(
+        "details": {
+          "image": {
+            "url": "an/image/path",
+            "alt_text": "some alt text"
+          }
+        }
+      )
+
+      content_store_has_item('/government/tagged/content', content)
+    end
+
+    it 'returns promoted content for the news and communications section' do
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(section_tagged_content_list('news_story'))
+
+      expected = [
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "newsAndCommunicationsFeaturedLinkClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'News story'
           },
           image: {
             url: 'an/image/path',
@@ -50,23 +91,20 @@ describe Supergroups::NewsAndCommunications do
         }
       ]
 
-      assert_equal expected, news_and_communications_supergroup.document_list(taxon_id)
+      assert_equal expected, news_and_communications_supergroup.promoted_content(taxon_id)
     end
 
-    it 'returns an image for the first news item only' do
+    it 'returns an image for the first news item' do
       tagged_document_list = %w(news_story correspondance press_release)
 
       MostRecentContent.any_instance
         .stubs(:fetch)
         .returns(tagged_content(tagged_document_list))
 
-      news_and_communications_supergroup.document_list(taxon_id).each_with_index do |content_item, i|
-        if i.eql?(0)
-          assert content_item.key?(:image)
-        else
-          refute content_item.key?(:image)
-        end
-      end
+      promoted_news = news_and_communications_supergroup.promoted_content(taxon_id)
+
+      assert_equal 1, promoted_news.size
+      assert promoted_news.first.key?(:image)
     end
 
     it 'returns the default whitehall image if no image is present' do
@@ -80,7 +118,7 @@ describe Supergroups::NewsAndCommunications do
       .stubs(:fetch)
       .returns(section_tagged_content_list('news_story'))
 
-      assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.document_list(taxon_id).first[:image][:url]
+      assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
     end
 
     it 'uses empty alt text if using the default whitehall image' do
@@ -97,7 +135,7 @@ describe Supergroups::NewsAndCommunications do
       .stubs(:fetch)
       .returns(section_tagged_content_list('news_story'))
 
-      assert_equal "", news_and_communications_supergroup.document_list(taxon_id).first[:image][:alt]
+      assert_equal "", news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:alt]
     end
   end
 end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -31,7 +31,12 @@ describe Supergroups::NewsAndCommunications do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "newsAndCommunicationsDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -50,7 +50,7 @@ describe Supergroups::PolicyAndEngagement do
       end
 
       describe '#special_format_count' do
-        it 'only include consultations in promoted_content_count' do
+        it 'only include consultations in promoted_content' do
           tagged_document_list = %w(
             case_study
             case_study
@@ -63,10 +63,10 @@ describe Supergroups::PolicyAndEngagement do
             .stubs(:fetch)
             .returns(tagged_content(tagged_document_list))
 
-          assert_equal 2, policy_and_engagement_supergroup.promoted_content_count(taxon_id)
+          assert_equal 2, policy_and_engagement_supergroup.promoted_content(taxon_id).count
         end
 
-        it 'only include first three consultations in promoted_content_count' do
+        it 'only include first three consultations in promoted_content' do
           tagged_document_list = %w(
             consultation_outcome
             closed_consultation
@@ -79,7 +79,7 @@ describe Supergroups::PolicyAndEngagement do
             .stubs(:fetch)
             .returns(tagged_content(tagged_document_list))
 
-          assert_equal 3, policy_and_engagement_supergroup.promoted_content_count(taxon_id)
+          assert_equal 3, policy_and_engagement_supergroup.promoted_content(taxon_id).count
         end
       end
 

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -124,7 +124,12 @@ describe Supergroups::PolicyAndEngagement do
             {
               link: {
                 text: 'Tagged Content Title',
-                path: '/government/tagged/content-1'
+                path: '/government/tagged/content-1',
+                data_attributes: {
+                  track_category: "policyAndEngagementDocumentListClicked",
+                  track_action: 1,
+                  track_label: '/government/tagged/content-1'
+                }
               },
               metadata: {
                 public_updated_at: '2018-02-28T08:01:00.000+00:00',
@@ -141,5 +146,46 @@ describe Supergroups::PolicyAndEngagement do
         end
       end
     end
+  end
+
+private
+
+  def expected_results(document_types)
+    results = []
+    document_types.each_with_index do |document_type, index|
+      results.push(*expected_result(document_type, index))
+    end
+    results
+  end
+
+  def expected_result(document_type, index = 0)
+    result = {
+      link: {
+        text: 'Tagged Content Title',
+        path: '/government/tagged/content',
+        data_attributes: {
+          track_category: "policyAndEngagementDocumentListClicked",
+          track_action: index + 1,
+          track_label: '/government/tagged/content'
+        }
+      },
+      metadata: {
+        public_updated_at: '2018-02-28T08:01:00.000+00:00',
+        organisations: 'Tagged Content Organisation',
+        document_type: document_type.humanize,
+      }
+    }
+
+    if consultation?(document_type)
+      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
+    end
+
+    [result]
+  end
+
+  def consultation?(document_type)
+    document_type == 'open_consultation' ||
+      document_type == 'consultation_outcome' ||
+      document_type == 'closed_consultation'
   end
 end

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -17,7 +17,12 @@ describe Supergroups::Services do
           link: {
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
-            description: 'Description of tagged content'
+            description: 'Description of tagged content',
+            data_attributes: {
+              track_category: "servicesDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
           }
         }
       ]

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -10,7 +10,7 @@ describe Supergroups::Services do
     it 'returns a document list for the services supergroup' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('form'))
+        .returns(section_tagged_content_list('form', 4))
 
       expected = [
         {
@@ -28,6 +28,29 @@ describe Supergroups::Services do
       ]
 
       assert_equal expected, service_supergroup.document_list(taxon_id)
+    end
+
+    it 'returns a promoted content list for the services supergroup' do
+      MostPopularContent.any_instance
+        .stubs(:fetch)
+        .returns(section_tagged_content_list('form'))
+
+      expected = [
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content',
+            description: 'Description of tagged content',
+            data_attributes: {
+              track_category: "servicesHighlightBoxClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
+          }
+        }
+      ]
+
+      assert_equal expected, service_supergroup.promoted_content(taxon_id)
     end
   end
 end

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -31,4 +31,10 @@ describe Supergroups::Supergroup do
       assert 'taxons/sections/supergroup_name', supergroup.partial_template
     end
   end
+
+  describe '#data_module_label' do
+    it 'returns the data tracking attribute name used by Google Analytics' do
+      assert 'supergroupName', supergroup.data_module_label
+    end
+  end
 end

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -16,7 +16,12 @@ describe Supergroups::Transparency do
         {
           link: {
             text: 'Tagged Content Title',
-            path: '/government/tagged/content'
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "transparencyDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content'
+            }
           },
           metadata: {
             public_updated_at: '2018-02-28T08:01:00.000+00:00',

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -63,7 +63,12 @@ describe TaxonOrganisationsPresenter do
           name: 'Department\nfor\nEducation',
           url: '/government/organisations/department-for-education',
           brand: 'department-for-education',
-          crest: 'single-identity'
+          crest: 'single-identity',
+          data_attributes: {
+            track_category: "organisationsDocumentListClicked",
+            track_action: 1,
+            track_label: '/government/organisations/department-for-education'
+          }
         }
       ]
 
@@ -109,12 +114,17 @@ describe TaxonOrganisationsPresenter do
 
       promoted_with_logos = []
 
-      5.times do
+      5.times do |index|
         promoted_with_logos.push(
           name: 'Department\nfor\nEducation',
           url: '/government/organisations/department-for-education',
           brand: 'department-for-education',
-          crest: 'single-identity'
+          crest: 'single-identity',
+          data_attributes: {
+            track_category: "organisationsDocumentListClicked",
+            track_action: index + 1,
+            track_label: '/government/organisations/department-for-education'
+          }
         )
       end
 
@@ -164,12 +174,17 @@ describe TaxonOrganisationsPresenter do
 
       promoted_with_logos = []
 
-      3.times do
+      3.times do |index|
         promoted_with_logos.push(
           name: 'Department\nfor\nEducation',
           url: '/government/organisations/department-for-education',
           brand: 'department-for-education',
-          crest: 'single-identity'
+          crest: 'single-identity',
+          data_attributes: {
+            track_category: "organisationsDocumentListClicked",
+            track_action: index + 1,
+            track_label: '/government/organisations/department-for-education'
+          }
         )
       end
 
@@ -209,7 +224,12 @@ describe TaxonOrganisationsPresenter do
           name: 'Department\nfor\nEducation',
           url: '/government/organisations/department-for-education',
           brand: 'department-for-education',
-          crest: 'single-identity'
+          crest: 'single-identity',
+          data_attributes: {
+            track_category: "organisationsDocumentListClicked",
+            track_action: 6,
+            track_label: '/government/organisations/department-for-education'
+          }
         }
       ]
 

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -35,7 +35,12 @@ describe TaxonOrganisationsPresenter do
         {
           link: {
             text: 'Department for Education',
-            path: '/government/organisations/department-for-education'
+            path: '/government/organisations/department-for-education',
+            data_attributes: {
+              track_category: "organisationsDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/organisations/department-for-education'
+            }
           }
         }
       ]
@@ -79,7 +84,12 @@ describe TaxonOrganisationsPresenter do
         {
           link: {
             text: "Department for Education",
-            path: "/government/organisations/department-for-education"
+            path: "/government/organisations/department-for-education",
+            data_attributes: {
+              track_category: "organisationsDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/organisations/department-for-education'
+            }
           }
         }
       ]
@@ -123,11 +133,16 @@ describe TaxonOrganisationsPresenter do
 
       promoted_without_logos = []
 
-      5.times do
+      5.times do |index|
         promoted_without_logos.push(
           link: {
             text: "Department for Education",
-            path: "/government/organisations/department-for-education"
+            path: "/government/organisations/department-for-education",
+            data_attributes: {
+              track_category: "organisationsDocumentListClicked",
+              track_action: index + 1,
+              track_label: '/government/organisations/department-for-education'
+            }
           }
         )
       end
@@ -162,7 +177,12 @@ describe TaxonOrganisationsPresenter do
         {
           link: {
             text: "Department for Education",
-            path: "/government/organisations/department-for-education"
+            path: "/government/organisations/department-for-education",
+            data_attributes: {
+              track_category: "organisationsDocumentListClicked",
+              track_action: 4,
+              track_label: '/government/organisations/department-for-education'
+            }
           }
         }
       ]
@@ -212,7 +232,12 @@ describe TaxonOrganisationsPresenter do
         {
           link: {
             text: 'Department for Education',
-            path: '/government/organisations/department-for-education'
+            path: '/government/organisations/department-for-education',
+            data_attributes: {
+              track_category: "organisationsDocumentListClicked",
+              track_action: 6,
+              track_label: '/government/organisations/department-for-education'
+            }
           }
         }
       ]

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -23,8 +23,18 @@ describe SupergroupSections::Sections do
     end
 
     it 'returns a list of supergroup details' do
+      section_details = %i(
+        title
+        promoted_content
+        documents
+        partial_template
+        promoted_content_count
+        see_more_link
+        show_section
+      )
+
       @sections.each do |section|
-        assert_equal(%i(title documents partial_template promoted_content_count see_more_link show_section), section.keys)
+        assert_equal(section_details, section.keys)
       end
     end
 

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -28,7 +28,6 @@ describe SupergroupSections::Sections do
         promoted_content
         documents
         partial_template
-        promoted_content_count
         see_more_link
         show_section
       )

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -242,16 +242,22 @@ module RummagerHelpers
       .returns(:some_results)
   end
 
-  def section_tagged_content_list(doc_type)
-    [
-      Document.new(
-        title: 'Tagged Content Title',
-        description: 'Description of tagged content',
-        public_updated_at: '2018-02-28T08:01:00.000+00:00',
-        base_path: '/government/tagged/content',
-        content_store_document_type: doc_type,
-        organisations: 'Tagged Content Organisation'
+  def section_tagged_content_list(doc_type, count = 1)
+    content_list = []
+
+    count.times do
+      content_list.push(
+        Document.new(
+          title: 'Tagged Content Title',
+          description: 'Description of tagged content',
+          public_updated_at: '2018-02-28T08:01:00.000+00:00',
+          base_path: '/government/tagged/content',
+          content_store_document_type: doc_type,
+          organisations: 'Tagged Content Organisation'
+        )
       )
-    ]
+    end
+
+    content_list
   end
 end

--- a/test/support/supergroups_helpers.rb
+++ b/test/support/supergroups_helpers.rb
@@ -6,40 +6,4 @@ module SupergroupHelpers
     end
     content_list
   end
-
-  def expected_results(document_types)
-    results = []
-    document_types.each do |document_type|
-      results.push(*expected_result(document_type))
-    end
-    results
-  end
-
-  def expected_result(document_type)
-    result = {
-      link: {
-        text: 'Tagged Content Title',
-        path: '/government/tagged/content'
-      },
-      metadata: {
-        public_updated_at: '2018-02-28T08:01:00.000+00:00',
-        organisations: 'Tagged Content Organisation',
-        document_type: document_type.humanize,
-      }
-    }
-
-    if consultation?(document_type)
-      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
-    end
-
-    [result]
-  end
-
-private
-
-  def consultation?(document_type)
-    document_type == 'open_consultation' ||
-      document_type == 'consultation_outcome' ||
-      document_type == 'closed_consultation'
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/xYWhPOMg/74-add-tracking-to-topic-pages

Adds tracking to all highlight boxes, document lists and featured items on topic pages.

##  Highlight Boxes
Each link should have the following attributes:

- __data-track-category="servicesHighlightBoxClicked"__ (where services is the name of the supergroup section)
- __data-track-action="[position within section]"__ (starting at 1)
- __data-track-label="[anchor value]"__ (the page the user will go to once the anchor is clicked)

Output from GA Debugger:
<img width="610" alt="screen shot 2018-05-14 at 10 27 20" src="https://user-images.githubusercontent.com/29889908/39989320-8917bd7c-5761-11e8-99e9-e414c6c73c36.png">

## Document List
Each link should have the following attributes:

- __data-track-category="servicesDocumentListClicked"__ (where services is the name of the supergroup section)
- __data-track-action="[position within section]"__ (starting at 1)
- __data-track-label="[anchor value]"__ (the page the user will go to once the anchor is clicked)

Output from GA Debugger:
<img width="613" alt="screen shot 2018-05-14 at 10 27 35" src="https://user-images.githubusercontent.com/29889908/39989376-abda48b6-5761-11e8-8115-957215d4b72b.png">

## News Featured Item
Same as document list, but with track category "newsAndCommunicationsFeaturedItemClicked"

Output from GA Debugger:
<img width="611" alt="screen shot 2018-05-14 at 10 27 52" src="https://user-images.githubusercontent.com/29889908/39989420-c63a21cc-5761-11e8-9bf8-9e9ba297813b.png">

## Organisations
All organisations should be treated as one list, regardless of having logos or not, and regardless of whether hidden under a Show More or not.

Output from GA Debugger:
<img width="612" alt="screen shot 2018-05-14 at 10 28 12" src="https://user-images.githubusercontent.com/29889908/39989467-ec7e39c2-5761-11e8-914f-c5a96e72eab2.png">

Component Guide: https://govuk-collections-pr-654.herokuapp.com/component-guide
Example Page: https://govuk-collections-pr-654.herokuapp.com/education

