### PR TITLE
Move Organisation to RummagerOrganisation

### DIFF
--- a/app/models/rummager_organisation.rb
+++ b/app/models/rummager_organisation.rb
@@ -1,6 +1,6 @@
 require 'active_model'
 
-class Organisation
+class RummagerOrganisation
   include ActiveModel::Model
 
   attr_accessor(

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -43,7 +43,7 @@ class RummagerSearch
   def organisations
     @_organisations ||= search_result.dig('aggregates', 'organisations', 'options').map do |option|
       organisation = option['value']
-      Organisation.new(
+      RummagerOrganisation.new(
         title: organisation['title'],
         content_id: organisation['content_id'],
         link: organisation['link'],

--- a/test/models/rummager_organisation_test.rb
+++ b/test/models/rummager_organisation_test.rb
@@ -1,15 +1,15 @@
 require 'test_helper'
 
-describe Organisation do
+describe RummagerOrganisation do
   it 'returns the state of an organisation' do
-    organisation = Organisation.new(
+    organisation = RummagerOrganisation.new(
       organisation_state: 'live'
     )
     assert(organisation.live?)
   end
 
   it 'returns false if the state of an organisation is not live' do
-    organisation = Organisation.new(
+    organisation = RummagerOrganisation.new(
       organisation_state: 'closed'
     )
     refute(organisation.live?)
@@ -17,7 +17,7 @@ describe Organisation do
 
   describe '#has_logo?' do
     it 'returns true if logo attributes are present' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         logo_formatted_title: "some\ntitle",
         brand: 'ministry-of-blah',
         crest: 'single-identity'
@@ -26,7 +26,7 @@ describe Organisation do
     end
 
     it 'returns false if the crest is missing' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         logo_formatted_title: "some\ntitle",
         brand: 'ministry-of-blah',
         crest: ''
@@ -35,7 +35,7 @@ describe Organisation do
     end
 
     it 'returns false if the it is a custom logo' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         crest: 'custom',
         logo_url: '/logo.png'
       )
@@ -45,7 +45,7 @@ describe Organisation do
 
   describe '#custom_logo?' do
     it 'returns true if the crest is "custom"' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         crest: 'custom',
         logo_url: '/logo.png'
       )
@@ -53,7 +53,7 @@ describe Organisation do
     end
 
     it 'returns false if the crest is not "custom"' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         crest: 'somethingelse',
         logo_url: '/logo.png'
       )
@@ -61,7 +61,7 @@ describe Organisation do
     end
 
     it 'returns false if the logo url is missing' do
-      organisation = Organisation.new(
+      organisation = RummagerOrganisation.new(
         crest: 'somethingelse'
       )
       refute(organisation.custom_logo?)

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -230,7 +230,7 @@ private
 
   def tagged_organisation
     [
-      Organisation.new(
+      RummagerOrganisation.new(
         title: 'Department for Education',
         content_id: 'ebd15ade-73b2-4eaf-b1c3-43034a42eb37',
         link: '/government/organisations/department-for-education',
@@ -247,7 +247,7 @@ private
 
   def tagged_organisation_with_logo
     [
-      Organisation.new(
+      RummagerOrganisation.new(
         title: 'Department for Education',
         content_id: 'ebd15ade-73b2-4eaf-b1c3-43034a42eb37',
         link: '/government/organisations/department-for-education',
@@ -264,7 +264,7 @@ private
 
   def tagged_custom_organisation
     [
-      Organisation.new(
+      RummagerOrganisation.new(
         title: 'Department for Education',
         content_id: 'ebd15ade-73b2-4eaf-b1c3-43034a42eb37',
         link: '/government/organisations/department-for-education',
@@ -284,7 +284,7 @@ private
 
     number_of_organisations.times do
       organisations.push(
-        Organisation.new(
+        RummagerOrganisation.new(
           title: 'Department for Education',
           content_id: 'ebd15ade-73b2-4eaf-b1c3-43034a42eb37',
           link: '/government/organisations/department-for-education',


### PR DESCRIPTION
We're doing things around organisations from the content store, so we want to be explicit about the source of the data for any particular model.