### PR TITLE
Always show see more link for supergroup section

### DIFF
--- a/app/views/taxons/_document_list_with_grid.html.erb
+++ b/app/views/taxons/_document_list_with_grid.html.erb
@@ -1,18 +1,16 @@
-<% if documents.any? %>
-  <div class="grid-row">
-    <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(documents) %>>
-      <%= render 'govuk_publishing_components/components/document_list',
-        items: documents,
-        margin_top: true,
-        margin_bottom: true
-      %>
+<div class="grid-row">
+  <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(documents) %>>
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: documents,
+      margin_top: true,
+      margin_bottom: true
+    %>
 
-      <% if local_assigns[:see_more_link] %>
-        <%= link_to(
-          see_more_link[:text],
-          see_more_link[:url]
-        )%>
-      <% end %>
-    </div>
+    <% if local_assigns[:see_more_link] %>
+      <%= link_to(
+        see_more_link[:text],
+        see_more_link[:url]
+      )%>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -314,23 +314,23 @@ private
   end
 
   def tagged_content_for_services
-    @tagged_content_for_services ||= generate_search_results(5, "services")
+    @tagged_content_for_services ||= generate_search_results(2, "services")
   end
 
   def tagged_content_for_guidance_and_regulation
-    @tagged_content_for_guidance_and_regulation ||= generate_search_results(5, 'guidance_and_regulation')
+    @tagged_content_for_guidance_and_regulation ||= generate_search_results(2, 'guidance_and_regulation')
   end
 
   def tagged_content_for_news_and_communications
-    @tagged_content_for_news_and_communications ||= generate_search_results(5, "news_and_communications")
+    @tagged_content_for_news_and_communications ||= generate_search_results(2, "news_and_communications")
   end
 
   def tagged_content_for_policy_and_engagement
-    @tagged_content_for_policy_and_engagement ||= generate_search_results(5, "policy_and_engagement")
+    @tagged_content_for_policy_and_engagement ||= generate_search_results(2, "policy_and_engagement")
   end
 
   def tagged_content_for_transparency
-    @tagged_content_for_transparency ||= generate_search_results(5, "transparency")
+    @tagged_content_for_transparency ||= generate_search_results(2, "transparency")
   end
 
   def finder_query_string(supergroup)


### PR DESCRIPTION
Trello: https://trello.com/c/k4PyktdL/85-figure-out-why-see-all-isnt-showing-all-when-there-are-boxes-in-place

**Before:**
<img width="767" alt="screen shot 2018-05-18 at 11 56 14" src="https://user-images.githubusercontent.com/29889908/40231675-ebb3c13a-5a93-11e8-980c-217980bf571d.png">

**After:**
<img width="687" alt="screen shot 2018-05-18 at 11 56 02" src="https://user-images.githubusercontent.com/29889908/40231678-f0a23186-5a93-11e8-9a78-b47be7a4a016.png">

We always want to show the see more link for each supergroup section, even if there are only enough documents for the highlight boxes.
This removes the documents.any? check which was hiding the see more link if there were no documents for the document list.
We can remove this as the document list component has it's own check for items.any?

Also amended the taxon browsing test so the stubbing methods only returns 2 documents. Taxon browsing test checks whether the see more link is present, so this test will fail if we manage to introduce this bug again.

Component Guide: https://govuk-collections-pr-660.herokuapp.com/component-guide
Example page: https://govuk-collections-pr-660.herokuapp.com/education/teacher-records