### PR TITLE
Never allow taxon pages to be indexed

### DIFF
--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -1,10 +1,7 @@
 <% content_for :is_taxon_page, true %>
 <% content_for :title, presented_taxon.title %>
 <% content_for :meta_tags do %>
-  <% if !presented_taxon.live_taxon? %>
-    <% # prevent search engines from indexing this page %>
-    <meta name="robots" content="noindex, nofollow">
-  <% end %>
+  <meta name="robots" content="noindex">
   <meta name="description" content="<%= presented_taxon.description %>">
   <meta name="govuk:navigation-page-type" content="Taxon Page" />
 <% end %>
@@ -21,4 +18,3 @@
     </div>
   </div>
 <% end %>
-

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -253,9 +253,9 @@ private
     content = page.find('meta[name="robots"]', visible: false)['content']
 
     assert_equal(
-      "noindex, nofollow",
+      "noindex",
       content,
-      "The content of the robots meta tag should be 'noindex, nofollow'"
+      "The content of the robots meta tag should be 'noindex'"
     )
   end
 


### PR DESCRIPTION
Our hypothesis is that people from Google are not looking for topic pages, but for actual content.

https://trello.com/c/fwxUzNuj/22-google-and-our-topic-pages