### PR TITLE
Present data on organisation show view

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,5 +1,16 @@
 module OrganisationHelper
-  def child_organisations_count(organisation)
-    organisation["works_with"].values.flatten.count
+  def child_organisation_count(organisation)
+    child_orgs = organisation.content_item.content_item_data["links"]["ordered_child_organisations"]
+    child_orgs.present? ? child_orgs.count : 0
+  end
+
+  def show_organisation(organisation)
+    if organisation.content_item.content_item_data["details"]["organisation_govuk_status"]["status"] == "live"
+      render partial: 'show_organisation',
+             locals: { organisation: @organisation }
+    else
+      render partial: 'separate_website',
+             locals: { organisation: @organisation }
+    end
   end
 end

--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,0 +1,6 @@
+# this is for an organisations_homepage content item, so will not work with an organisation content item
+module OrganisationsHelper
+  def child_organisations_count(organisation)
+    organisation["works_with"].values.flatten.count
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,8 +18,60 @@ class Organisation
     @content_item.content_item_data["title"]
   end
 
+  def logo
+    details["logo"]
+  end
+
+  def base_path
+    @content_item.content_item_data["base_path"]
+  end
+
+  def ordered_featured_links
+    details["ordered_featured_links"]
+  end
+
+  def body
+    details["body"]
+  end
+
+  def ordered_featured_documents
+    details["ordered_featured_documents"]
+  end
+
+  def child_organisation_count
+    links["ordered_child_organisations"].count
+  end
+
+  def social_media_links
+    details["social_media_links"]
+  end
+
+  def organisation_type
+    details["organisation_type"].tr("_", " ")
+  end
+
+  def ordered_ministers
+    details["ordered_ministers"]
+  end
+
+  def board_members
+    details["ordered_board_members"]
+  end
+
+  def ordered_contacts
+    links["ordered_contacts"]
+  end
+
+  def ordered_corporate_information_pages
+    details["ordered_corporate_information_pages"]
+  end
+
   def ordered_parent_organisations
     links["ordered_parent_organisations"]
+  end
+
+  def ordered_featured_policies
+    links["ordered_featured_policies"]
   end
 
 private

--- a/app/views/organisations/_contact.html.erb
+++ b/app/views/organisations/_contact.html.erb
@@ -1,0 +1,15 @@
+<% if organisation.ordered_contacts.presence %>
+  <div class="organisation-contact-details">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Contact #{organisation.title}",
+        heading_level: 2
+    } %>
+    <% contact.each do |contact_info| %>
+      <%= render "govuk_publishing_components/components/heading", {
+          text: contact_info["title"],
+          heading_level: 4,
+          font_size: 19
+      } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -1,0 +1,11 @@
+<div class="organisation-corporate-info">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Corporate Information",
+      heading_level: 4
+  } %>
+  <% corporate_info.each do |info| %>
+    <p>
+      <%= link_to info["title"], info["href"] %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/organisations/_featured_documents.html.erb
+++ b/app/views/organisations/_featured_documents.html.erb
@@ -1,0 +1,21 @@
+<div class="organisation-featured-documents">
+  <% featured_documents.each do |document| %>
+    <%= link_to image_tag(document["image"]["url"], alt: document["image"]["alt_text"],
+                          height: 300, width: 400),
+                document["href"]%>
+    <%= render "govuk_publishing_components/components/document_list", {
+        items: [
+            {
+                link: {
+                    text: document["title"],
+                    path: document["href"],
+                },
+                metadata: {
+                    public_updated_at: Time.iso8601(document["public_updated_at"]),
+                    document_type: document["document_type"]
+                }
+            }
+        ]
+    } %>
+  <% end %>
+</div>

--- a/app/views/organisations/_featured_links.html.erb
+++ b/app/views/organisations/_featured_links.html.erb
@@ -1,0 +1,5 @@
+<div class="organisation-featured-links">
+  <% featured_links.each do |featured_link| %>
+    <%= link_to featured_link["title"], featured_link["href"] %>
+  <% end %>
+</div>

--- a/app/views/organisations/_ministers_and_management.html.erb
+++ b/app/views/organisations/_ministers_and_management.html.erb
@@ -1,0 +1,31 @@
+<div class="organisation-ministers">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Our ministers",
+      heading_level: 2
+  } %>
+  <% ministers.each do |minister| %>
+    <%= image_tag minister["image"]["url"], alt: minister["image"]["alt_text"],height: 200, width: 250 %>
+    <p>
+      <%= minister["name_prefix"] %>
+      <%= link_to minister["name"], minister["href"] %>
+      <%= link_to minister["role"], minister["role_href"] %>
+    </p>
+  <% end %>
+</div>
+
+<div class="organisation-management">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Our management",
+      heading_level: 2
+  } %>
+  <% board_members.each do |board_member| %>
+    <%= image_tag(board_member["image"]["url"],
+                  alt: board_member["image"]["alt_text"],
+                  height: 200,
+                  width: 250) if board_member["image"].present? %>
+    <p>
+      <%= link_to board_member["name"], board_member["href"] %>
+      <%= board_member["role"] %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/organisations/_organisation_description.html.erb
+++ b/app/views/organisations/_organisation_description.html.erb
@@ -1,0 +1,36 @@
+<div class="organisation-body">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "What we do",
+      heading_level: 2
+  } %>
+  <div>
+    <%= organisation.body %>
+    <% if child_organisation_count(organisation).nonzero? %>
+      <p class="child-organisation-count">
+        <%= "#{organisation.title} is a #{organisation.organisation_type}, supported by" %>
+        <%= link_to "#{child_organisation_count(organisation)} agencies and public bodies" %>.
+      </p>
+    <% end %>
+    <%= link_to "Read more about what we do", "#{organisation.base_path}/about" %>
+  </div>
+</div>
+
+<div class="organisation-social-media">
+  Follow us
+  <% organisation.social_media_links.each do |link| %>
+    <%= link_to link["title"], link["href"] %>
+  <% end %>
+</div>
+
+<% if organisation.ordered_featured_policies.present? %>
+  <div class="organisation-policies">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Our policies",
+        heading_level: 2
+    } %>
+    <% organisation.ordered_featured_policies.each do |policy| %>
+      <%= link_to policy["title"], policy["base_path"] %>
+      <hr>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,0 +1,25 @@
+<%= render "govuk_publishing_components/components/heading", {
+    text: organisation.title,
+    heading_level: 2
+} %>
+
+<div class="separate-website-label">
+  <%= "#{organisation.title} has a" %> <%= link_to "separate website", "#" %>
+</div>
+
+<div class="organisation-body">
+  <%= organisation.body %>
+</div>
+
+<div class="parent-organisations">
+  <% if organisation.ordered_parent_organisations.presence %>
+    <%= "#{organisation.title} works with the" %>
+    <%= link_to organisation.ordered_parent_organisations[0]["title"],
+                organisation.ordered_parent_organisations[0]["base_path"] %>
+  <% end %>
+</div>
+
+<%= render "govuk_publishing_components/components/heading", {
+    text: "Documents",
+    heading_level: 2
+} %>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -1,3 +1,41 @@
-<div>
-  <%= organisation.title %>
+<div class="organisation-logo">
+  <%= organisation.logo["formatted_title"] %>
 </div>
+
+<%= render 'featured_links',
+           featured_links: organisation.ordered_featured_links %>
+
+<%= render 'featured_documents',
+           featured_documents: organisation.ordered_featured_documents %>
+
+<hr>
+Latest
+<hr>
+
+<%= render "govuk_publishing_components/components/subscription-links", {
+    email_signup_link: "#{params[:organisation_name]}/email-signup",
+    feed_link: "#{params[:organisation_name]}.atom" } %>
+
+<%= render 'organisation_description',
+           organisation: organisation %>
+
+<div class="organisation-documents">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Documents",
+      heading_level: 2
+  } %>
+</div>
+
+<%= render partial: 'ministers_and_management',
+           locals: { ministers: organisation.ordered_ministers,
+                     board_members: organisation.board_members } %>
+
+<%= render partial: 'contact',
+           locals: {
+               organisation: organisation,
+               contact: organisation.ordered_contacts } %>
+
+<%= render partial: 'corporate_information',
+           locals: {
+               organisation: organisation,
+               corporate_info: organisation.ordered_corporate_information_pages } %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,6 +1,3 @@
 <% content_for :title, organisation.title %>
 
-<div id="section" class="section-pane pane">
-  <%= render 'show_organisation',
-             organisation: organisation %>
-</div>
+<%= show_organisation(organisation) %>

--- a/test/integration/content_store_organisation_test.rb
+++ b/test/integration/content_store_organisation_test.rb
@@ -5,7 +5,51 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     @content_item = {
         title: "Prime Minister's Office, 10 Downing Street",
         base_path: "/government/organisations/prime-ministers-office-10-downing-street",
-        details: {}
+        links: {
+            ordered_contacts: [],
+            ordered_parent_organisations: [],
+            ordered_featured_policies: [],
+            ordered_child_organisations: [
+                {
+                    title: "Committee on Standards in Public Life"
+                },
+                {
+                    title: "Office of the Leader of the House of Commons"
+                }
+            ]
+        },
+        details: {
+            body: "10 Downing Street is the official residence and the office of the British Prime Minister.",
+            brand: "cabinet-office",
+            logo: {
+                formatted_title: "Prime Minister&#39;s Office, 10 Downing Street",
+                crest: "eo"
+            },
+            foi_exempt: false,
+            ordered_corporate_information_pages: [],
+            ordered_featured_links: [],
+            ordered_featured_documents: [],
+            ordered_ministers: [
+                {
+                    name_prefix: "The Rt Hon",
+                    name: "Theresa May MP",
+                    role: "Prime Minister",
+                    href: "/government/people/theresa-may",
+                    role_href: "/government/ministers/prime-minister",
+                    image: {
+                        url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/
+                              person/image/6/PM_portrait_960x640.jpg",
+                        alt_text: "Theresa May MP"
+                    }
+                }
+            ],
+            ordered_board_members: [],
+            organisation_govuk_status: {
+                status: "live",
+            },
+            organisation_type: "executive_office",
+            social_media_links: []
+        }
     }
 
     content_store_has_item('/government/organisations/prime-ministers-office-10-downing-street', @content_item)
@@ -29,5 +73,94 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   it "current path matches base path" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     assert_equal page.current_path, @content_item[:base_path]
+  end
+
+  it "displays ministers" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_selector?(".organisation-ministers", text: "Theresa May MP")
+  end
+
+  it "displays child organisations count" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_selector?(".child-organisation-count", text: "2")
+  end
+
+  it "does not display child organisations count" do
+    content_item_without_child_orgs = {
+        title: "Prime Minister's Office, 10 Downing Street",
+        base_path: "/government/organisations/prime-ministers-office-10-downing-street",
+        links: {
+            ordered_contacts: [],
+            ordered_parent_organisations: []
+        },
+        details: {
+            body: "",
+            logo: {
+                formatted_title: "Prime Minister&#39;s Office, 10 Downing Street",
+                crest: "eo"
+            },
+            foi_exempt: false,
+            ordered_corporate_information_pages: [],
+            ordered_featured_links: [],
+            ordered_featured_documents: [],
+            ordered_ministers: [],
+            ordered_board_members: [],
+            organisation_govuk_status: {
+                status: "live",
+            },
+            organisation_type: "executive_office",
+            social_media_links: []
+        }
+    }
+    content_store_has_item('/government/organisations/prime-ministers-office-10-downing-street', content_item_without_child_orgs)
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_no_css?(".child-organisation-count")
+  end
+
+  it "does not display featured policies" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_no_css?(".organisation-policies")
+  end
+
+  it "displays featured policies" do
+    content_item_with_empty_featured_policies = {
+        title: "Prime Minister's Office, 10 Downing Street",
+        base_path: "/government/organisations/prime-ministers-office-10-downing-street",
+        links: {
+            ordered_contacts: [],
+            ordered_parent_organisations: [],
+            ordered_featured_policies: [
+                {
+                    title: "Counter-terrorism",
+                    base_path: "/government/policies/counter-terrorism"
+                },
+                {
+                    title: "Central government efficiency",
+                    base_path: "/government/policies/central-government-efficiency"
+                }
+            ]
+        },
+        details: {
+            body: "",
+            logo: {
+                formatted_title: "Prime Minister&#39;s Office, 10 Downing Street",
+                crest: "eo"
+            },
+            foi_exempt: false,
+            ordered_corporate_information_pages: [],
+            ordered_featured_links: [],
+            ordered_featured_documents: [],
+            ordered_ministers: [],
+            ordered_board_members: [],
+            organisation_govuk_status: {
+                status: "live",
+            },
+            organisation_type: "executive_office",
+            social_media_links: []
+        }
+    }
+    content_store_has_item('/government/organisations/prime-ministers-office-10-downing-street', content_item_with_empty_featured_policies)
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_css?(".organisation-policies")
   end
 end


### PR DESCRIPTION
Render organisation content store data on show view
- There are two organisation show page templates.
- The view that is rendered depends on the govuk status given by the content store.
- The govuk status of exempt displays a link to a separate website, whereas the
status of live does not.

https://trello.com/c/k74yKHtG/107-present-data-on-organisations-show-view