### PR TITLE
Make linter run consistent with CI

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,6 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --rails --diff --format clang app test lib config"
+  unless ENV["JENKINS"]
+    sh "bundle exec govuk-lint-ruby --diff --cached --format clang app spec lib"
+  end
 end


### PR DESCRIPTION
We're currently running the linter twice in CI, once via the default Jenkinsfile `buildProject` and once via the rakefile. This skips the linter in the rake task on CI, and makes the command consistent with CI (which means we're no longer running the extra `--rails` checks).