### PR TITLE
Add organisations "Works With" view all toggle

### DIFF
--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -1,24 +1,33 @@
 .organisations {
-  .organisations__section {
+  .organisations-list__section {
     margin-bottom: $gutter * 2;
 
     .department-count {
       @include bold-80;
     }
 
-    .organisations__logo-wrapper {
+    .organisations-list__item {
       list-style-type: none;
-      padding-bottom: $gutter-two-thirds;
       margin-bottom: $gutter-two-thirds;
       border-bottom: 1px solid $grey-2;
 
-      .organisation__works-with {
+      .organisation-list__item-title {
+        @include core-19;
+        margin-right: $gutter-one-third;
+      }
+
+      .organisation-list__item-context {
+        color: $grey-1;
+      }
+
+      .organisation-list__item-works-with {
         @include core-16;
-        margin-top: $gutter-half;
+        margin-top: $gutter-one-third;
+        margin-bottom: $gutter-one-third;
       }
     }
 
-    .organisations__list-without-number {
+    .organisations-list__without-number {
       @include media(tablet) {
         float: right;
       }

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -1,36 +1,66 @@
 .organisations {
   .organisations-list__section {
     margin-bottom: $gutter * 2;
+  }
 
-    .department-count {
-      @include bold-80;
+  .department-count {
+    @include bold-80;
+  }
+
+  .organisations-list__item {
+    list-style-type: none;
+    padding-bottom: $gutter-half;
+    margin-bottom: $gutter-half;
+    border-bottom: 1px solid $grey-2;
+  }
+
+  .organisation-list__item-title {
+    @include core-19;
+    margin-right: $gutter-one-third;
+  }
+
+  .organisation-list__item-context {
+    color: $grey-1;
+    white-space: nowrap;
+  }
+
+  .organisation-list__item-works-with {
+    @include core-16;
+    display: block;
+    margin-top: $gutter-half;
+    margin-right: $gutter-two-thirds;
+
+    @include media(tablet) {
+      display: inline-block;
     }
+  }
 
-    .organisations-list__item {
-      list-style-type: none;
-      margin-bottom: $gutter-two-thirds;
-      border-bottom: 1px solid $grey-2;
+  .organisation-list__works-with-toggle {
+    @include core-16;
+  }
 
-      .organisation-list__item-title {
-        @include core-19;
-        margin-right: $gutter-one-third;
-      }
+  .organisation-list__works-with {
+    background-color: $panel-colour;
+    margin-top: $gutter-one-third;
+    padding: $gutter-one-third;
+  }
 
-      .organisation-list__item-context {
-        color: $grey-1;
-      }
+  .organisation-list__works-with-title {
+    font-size: 16px;
+    font-weight: bold;
+  }
 
-      .organisation-list__item-works-with {
-        @include core-16;
-        margin-top: $gutter-one-third;
-        margin-bottom: $gutter-one-third;
-      }
-    }
+  .organisation-list__works-with-list {
+    margin-bottom: $gutter-half;
+  }
 
-    .organisations-list__without-number {
-      @include media(tablet) {
-        float: right;
-      }
+  .organisation-list__works-with-list-item {
+    padding-bottom: 5px;
+  }
+
+  .organisations-list__without-number {
+    @include media(tablet) {
+      float: right;
     }
   }
 }

--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -1,5 +1,7 @@
 module Organisations
   class IndexPresenter
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::UrlHelper
     include OrganisationsHelper
 
     def initialize(organisations)
@@ -22,7 +24,7 @@ module Organisations
       }
     end
 
-    def works_with(organisation)
+    def works_with_statement(organisation)
       if organisation["works_with"].present? && organisation["works_with"].any?
         works_with_count = child_organisations_count(organisation)
         works_with_text = "Works with #{works_with_count}"
@@ -33,6 +35,14 @@ module Organisations
           works_with_text << " agencies and public bodies"
         end
       end
+    end
+
+    def executive_office?(organisation_type)
+      organisation_type.eql?(:number_10)
+    end
+
+    def ministerial_organisation?(organisation_type)
+      executive_office?(organisation_type) || organisation_type.eql?(:ministerial_departments)
     end
   end
 end

--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -10,20 +10,15 @@ module Organisations
       @organisations.content_item.title
     end
 
-    def ministerial_departments
+    def all_organisations
       {
         number_10: @organisations.number_10,
-        ministerial_departments: @organisations.ministerial_departments
-      }
-    end
-
-    def non_ministerial_departments
-      {
-        non_ministerial_departments: non_ministerial_document_list(@organisations.non_ministerial_departments),
-        agencies_and_other_public_bodies: non_ministerial_document_list(@organisations.ordered_agencies_and_other_public_bodies),
-        high_profile_groups: non_ministerial_document_list(@organisations.ordered_high_profile_groups),
-        public_corporations: non_ministerial_document_list(@organisations.ordered_public_corporations),
-        devolved_administrations: non_ministerial_document_list(@organisations.ordered_devolved_administrations)
+        ministerial_departments: @organisations.ministerial_departments,
+        non_ministerial_departments: @organisations.non_ministerial_departments,
+        agencies_and_other_public_bodies: @organisations.ordered_agencies_and_other_public_bodies,
+        high_profile_groups: @organisations.ordered_high_profile_groups,
+        public_corporations: @organisations.ordered_public_corporations,
+        devolved_administrations: @organisations.ordered_devolved_administrations
       }
     end
 
@@ -37,27 +32,6 @@ module Organisations
         elsif works_with_count > 1
           works_with_text << " agencies and public bodies"
         end
-      end
-    end
-
-  private
-
-    def non_ministerial_document_list(organisation_list)
-      if organisation_list
-        organisation_list.each.map do |organisation|
-          data = {
-            link: {
-              text: organisation["title"],
-              path: organisation["href"],
-              context: (I18n.t("organisations.separate_website") if organisation["separate_website"]),
-              description: works_with(organisation)
-            }
-          }
-
-          data
-        end
-      else
-        []
       end
     end
   end

--- a/app/views/organisations/_expanded_works_with_organisations.html.erb
+++ b/app/views/organisations/_expanded_works_with_organisations.html.erb
@@ -1,0 +1,17 @@
+<a href="#" class="organisation-list__works-with-toggle" data-controls="toggle_<%= current_organisation.parameterize %>" data-expanded="false" data-toggled-text="<%= t('view_less') %>">
+  <%= t('view_all') %>
+</a>
+
+<div class="organisation-list__works-with js-hidden" id="toggle_<%= current_organisation.parameterize %>">
+  <% works_with_organisations.each do |type, work_with_organisations| %>
+    <p class="organisation-list__works-with-title"><%=  t('organisations.type.' + type) %></p>
+    <ul class="organisation-list__works-with-list">
+      <% work_with_organisations.each do |work_with_organisation| %>
+        <li class="organisation-list__works-with-list-item">
+          <%= link_to(work_with_organisation["title"], work_with_organisation["href"]) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -1,7 +1,8 @@
 <% all_organisations.each do |organisation_type, organisations| %>
   <div class="grid-row organisations-list__section">
+
     <div class="column-one-third">
-      <% unless organisation_type.eql?(:number_10) %>
+      <% unless @presented_organisations.executive_office?(organisation_type) %>
         <%= render "govuk_publishing_components/components/heading", {
           text: organisation_type.to_s.humanize,
           heading_level: 2
@@ -12,31 +13,42 @@
         </div>
       <% end %>
     </div>
-    <div class="column-two-thirds <%= " organisations-list__without-number" if organisation_type.eql?(:number_10) %>">
-      <ul>
+
+    <div class="column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
+      <ol>
         <% organisations.each do |organisation| %>
           <li class="organisations-list__item" >
-              <% if organisation_type.eql?(:number_10) || organisation_type.eql?(:ministerial_departments) %>
-                <%= render "govuk_component/organisation_logo", {
-                  organisation: {
-                    name: organisation["logo"]["formatted_title"],
-                    url: organisation["href"],
-                    brand: organisation["brand"],
-                    crest: organisation["logo"]["crest"]
-                  }
-                } %>
-              <% else %>
-                <a class="organisation-list__item-title" href="<%= organisation["href"] %>"><%= organisation["title"] %></a>
+            <% if @presented_organisations.ministerial_organisation?(organisation_type) %>
+              <%= render "govuk_component/organisation_logo", {
+                organisation: {
+                  name: organisation["logo"]["formatted_title"],
+                  url: organisation["href"],
+                  brand: organisation["brand"],
+                  crest: organisation["logo"]["crest"]
+                }
+              } %>
+            <% else %>
+              <%= link_to(organisation["title"], organisation["href"], class: "organisation-list__item-title") %>
 
-                <% if organisation["separate_website"] %>
-                  <span class="organisation-list__item-context">separate website</span>
-                <% end %>
+              <% if organisation["separate_website"] %>
+                <span class="organisation-list__item-context"><%= t('organisations.separate_website') %></span>
               <% end %>
+            <% end %>
 
-              <p class="organisation-list__item-works-with"><%= @presented_organisations.works_with(organisation) %></p>
+            <% if @presented_organisations.works_with_statement(organisation) %>
+              <div data-module="gem-toggle">
+                <p class="organisation-list__item-works-with"><%= @presented_organisations.works_with_statement(organisation) %></p>
+                <%= render partial: 'expanded_works_with_organisations',
+                  locals: {
+                    works_with_organisations: organisation["works_with"],
+                    current_organisation: organisation["title"]
+                  } %>
+              </div>
+            <% end %>
           </li>
         <% end %>
-      </ul>
+      </ol>
     </div>
+
   </div>
 <% end %>

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -1,25 +1,22 @@
-<% organisations_list.each do |departments| %>
-  <% departments.each do |department_type, organisations| %>
-    <% organisations.each do |organisation_type, organisation_list| %>
-      <div class="grid-row organisations__section">
-        <div class="column-one-third">
-          <% unless organisation_type.eql?(:number_10) %>
-            <%= render "govuk_publishing_components/components/heading", {
-                text: organisation_type.to_s.humanize,
-                heading_level: 2
-            } %>
-            <div class="department-count">
-              <p class="visuallyhidden">There are <%= organisation_list.count %> <%= organisation_type.to_s.humanize %></p>
-              <span aria-hidden="true"><%= organisation_list.count %></span>
-            </div>
-          <% end %>
+<% all_organisations.each do |organisation_type, organisations| %>
+  <div class="grid-row organisations-list__section">
+    <div class="column-one-third">
+      <% unless organisation_type.eql?(:number_10) %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: organisation_type.to_s.humanize,
+          heading_level: 2
+        } %>
+        <div class="department-count">
+          <p class="visuallyhidden">There are <%= organisations.count %> <%= organisation_type.to_s.humanize %></p>
+          <span aria-hidden="true"><%= organisations.count %></span>
         </div>
-
-        <div class="column-two-thirds <%= "organisations__list-without-number" if organisation_type.eql?(:number_10) %>">
-          <% if department_type.eql?(:ministerial_departments) %>
-            <ul>
-            <% organisation_list.each do |organisation| %>
-              <li class="organisations__logo-wrapper">
+      <% end %>
+    </div>
+    <div class="column-two-thirds <%= " organisations-list__without-number" if organisation_type.eql?(:number_10) %>">
+      <ul>
+        <% organisations.each do |organisation| %>
+          <li class="organisations-list__item" >
+              <% if organisation_type.eql?(:number_10) || organisation_type.eql?(:ministerial_departments) %>
                 <%= render "govuk_component/organisation_logo", {
                   organisation: {
                     name: organisation["logo"]["formatted_title"],
@@ -28,18 +25,18 @@
                     crest: organisation["logo"]["crest"]
                   }
                 } %>
-                <% if @presented_organisations.works_with(organisation) %>
-                  <p class="organisation__works-with"><%= @presented_organisations.works_with(organisation) %></p>
-                <% end %>
-              </li>
-            <% end %>
-            </ul>
-          <% else %>
-            <%= render "govuk_publishing_components/components/document_list", items: organisation_list %>
-          <% end %>
-        </div>
+              <% else %>
+                <a class="organisation-list__item-title" href="<%= organisation["href"] %>"><%= organisation["title"] %></a>
 
-      </div>
-    <% end %>
-  <% end %>
+                <% if organisation["separate_website"] %>
+                  <span class="organisation-list__item-context">separate website</span>
+                <% end %>
+              <% end %>
+
+              <p class="organisation-list__item-works-with"><%= @presented_organisations.works_with(organisation) %></p>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
 <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -10,10 +10,7 @@
 
 <div class="organisations">
   <%= render partial: 'organisations_list', locals: {
-    organisations_list: [
-      ministerial_departments: @presented_organisations.ministerial_departments,
-      non_ministerial_departments: @presented_organisations.non_ministerial_departments
-    ]
+    all_organisations: @presented_organisations.all_organisations
   } %>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,8 +21,21 @@
 
 en:
   hello: "Hello world"
+  view_all: "view all"
+  view_less: "view less"
   organisations:
     separate_website: "separate website"
+    type:
+      adhoc_advisory_group: "Ad-hoc advisory group"
+      advisory_ndpb: "Advisory non-departmental public body"
+      civil_service: "Civil service"
+      executive_agency: "Executive agency"
+      executive_ndpb: "Executive non-departmental public body"
+      independent_monitoring_body: "Independent monitoring body"
+      non_ministerial_department: "Non-ministerial department"
+      public_corporation: "Public corporation"
+      tribunal_ndpb: "Tribunal non-departmental public body"
+      other: "Other"
   language_names:
     ar: Arabic
     de: German
@@ -74,3 +87,4 @@ en:
     tk: Turkmen
     uz: Uzbeki
     id: Indonesian
+

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -40,9 +40,8 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
   end
 
   it "renders non-ministerial organisation without crest" do
-    assert page.has_css?('.gem-c-document-list__item-title[href="/government/organisations/arts-and-humanities-research-council"]', text: 'Arts and Humanities Research Council')
-    assert page.has_css?('.gem-c-document-list__item-title', text: 'Arts and Humanities Research Council')
-    assert page.has_css?('.gem-c-document-list__item-context', text: 'separate website')
+    assert page.has_css?('.organisation-list__item-title[href="/government/organisations/arts-and-humanities-research-council"]', text: 'Arts and Humanities Research Council')
+    assert page.has_css?('.organisation-list__item-context', text: 'separate website')
   end
 
   it "displays child organisations count" do

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -40,12 +40,29 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
   end
 
   it "renders non-ministerial organisation without crest" do
-    assert page.has_css?('.organisation-list__item-title[href="/government/organisations/arts-and-humanities-research-council"]', text: 'Arts and Humanities Research Council')
+    assert page.has_css?('a.organisation-list__item-title[href="/government/organisations/arts-and-humanities-research-council"]', text: 'Arts and Humanities Research Council')
     assert page.has_css?('.organisation-list__item-context', text: 'separate website')
   end
 
   it "displays child organisations count" do
     assert page.has_content?("Works with 4 agencies and public bodies")
+  end
+
+  it "renders a view all link with toggle attributes" do
+    assert page.has_css?("a[data-controls='toggle_attorney-general-s-office']", text: "view all")
+    assert page.has_css?("a[data-controls='toggle_attorney-general-s-office'][data-expanded='false']")
+  end
+
+  it "renders a list of organisations that an organisation works with" do
+    assert page.has_css?(".organisation-list__works-with#toggle_attorney-general-s-office")
+    assert page.has_css?("#toggle_attorney-general-s-office .organisation-list__works-with-title", text: "Non-ministerial department")
+    assert page.has_css?("#toggle_attorney-general-s-office .organisation-list__works-with-title", text: "Other")
+
+    assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/crown-prosecution-service']", text: "Crown Prosecution Service")
+    assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/government-legal-department']", text: "Government Legal Department")
+    assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/serious-fraud-office']", text: "Serious Fraud Office")
+
+    assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/hm-crown-prosecution-service-inspectorate']", text: "HM Crown Prosecution Service Inspectorate")
   end
 
 private
@@ -98,7 +115,15 @@ private
         {
           title: "Competition and Markets Authority",
           href: "/government/organisations/competition-and-markets-authority",
-          separate_website: true
+          separate_website: true,
+          works_with: {
+            non_ministerial_department: [
+              {
+                title: "Crown Prosecution Service",
+                href: "/government/organisations/crown-prosecution-service"
+              }
+            ]
+          }
         }
       ],
       ordered_executive_offices: [],

--- a/test/presenters/organisations_presenter_test.rb
+++ b/test/presenters/organisations_presenter_test.rb
@@ -106,7 +106,7 @@ describe Organisations::IndexPresenter do
     end
 
     it 'returns nil when organisation does not work with others' do
-      assert_nil @organisations_presenter.works_with({})
+      assert_nil @organisations_presenter.works_with_statement({})
     end
 
     it 'returns string when organisation works with one other' do
@@ -121,7 +121,7 @@ describe Organisations::IndexPresenter do
         }
       }.with_indifferent_access
 
-      assert_equal "Works with 1 public body", @organisations_presenter.works_with(test_org)
+      assert_equal "Works with 1 public body", @organisations_presenter.works_with_statement(test_org)
     end
 
     it 'returns string when organisation works with multiple others' do
@@ -142,7 +142,7 @@ describe Organisations::IndexPresenter do
         }
       }.with_indifferent_access
 
-      assert_equal "Works with 2 agencies and public bodies", @organisations_presenter.works_with(test_org)
+      assert_equal "Works with 2 agencies and public bodies", @organisations_presenter.works_with_statement(test_org)
     end
   end
 end

--- a/test/presenters/organisations_presenter_test.rb
+++ b/test/presenters/organisations_presenter_test.rb
@@ -4,7 +4,7 @@ describe Organisations::IndexPresenter do
   include RummagerHelpers
   include OrganisationsHelpers
 
-  describe '#ministerial_departments' do
+  describe 'ministerial departments' do
     before :each do
       content_item = ContentItem.new(ministerial_departments_hash)
       content_store_organisations = ContentStoreOrganisations.new(content_item)
@@ -15,7 +15,7 @@ describe Organisations::IndexPresenter do
       assert_equal "Departments, agencies and public bodies", @organisations_presenter.title
     end
 
-    it 'returns executive offices as part of ministerial_departments hash' do
+    it 'returns executive offices as part of all_organisations hash' do
       expected = [{
         "title": "Prime Minister's Office, 10 Downing Street",
         "href": "/government/organisations/prime-ministers-office-10-downing-street",
@@ -26,116 +26,75 @@ describe Organisations::IndexPresenter do
         }
       }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.ministerial_departments[:number_10]
+      assert_equal expected, @organisations_presenter.all_organisations[:number_10]
     end
 
-    it 'returns ministerial departments as part of ministerial_departments hash' do
+    it 'returns ministerial departments as part of all_organisations hash' do
       expected = [{
         "title": "Attorney General's Office",
         "href": "/government/organisations/attorney-generals-office"
       }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.ministerial_departments[:ministerial_departments]
+      assert_equal expected, @organisations_presenter.all_organisations[:ministerial_departments]
     end
   end
 
-  describe '#non_ministerial_departments' do
+  describe 'non_ministerial_departments' do
     before :each do
       content_item = ContentItem.new(non_ministerial_departments_hash)
       content_store_organisations = ContentStoreOrganisations.new(content_item)
       @organisations_presenter = Organisations::IndexPresenter.new(content_store_organisations)
     end
 
-    it 'formats data for document list component' do
+    it 'returns agencies_and_other_public_bodies departments as part of all_organisations hash' do
       expected = [{
-        link: {
-          text: "The Charity Commission",
-          path: "/government/organisations/charity-commission",
-          context: "separate website",
-          description: nil
-        }
-      }]
+          "title": "The Charity Commission",
+          "href": "/government/organisations/charity-commission",
+          "brand": "department-for-business-innovation-skills",
+          "separate_website": true
+    }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.non_ministerial_departments[:non_ministerial_departments]
+      assert_equal expected, @organisations_presenter.all_organisations[:non_ministerial_departments]
     end
 
-    it 'returns agencies_and_other_public_bodies departments as part of non_ministerial_departments hash' do
+    it 'returns agencies_and_other_public_bodies departments as part of all_organisations hash' do
       expected = [{
-        link: {
-          text: "Academy for Social Justice Commissioning",
-          path: "/government/organisations/academy-for-social-justice-commissioning",
-          context: nil,
-          description: nil
-        }
-      }]
+        "title": "Academy for Social Justice Commissioning",
+        "href": "/government/organisations/academy-for-social-justice-commissioning",
+        "brand": "ministry-of-justice"
+      }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.non_ministerial_departments[:agencies_and_other_public_bodies]
+      assert_equal expected, @organisations_presenter.all_organisations[:agencies_and_other_public_bodies]
     end
 
-    it 'returns high_profile_groups departments as part of non_ministerial_departments hash' do
+    it 'returns high_profile_groups departments as part of all_organisations hash' do
       expected = [{
-        link: {
-          text: "Bona Vacantia",
-          path: "/government/organisations/bona-vacantia",
-          context: nil,
-          description: nil
-        }
-      }]
+        "title": "Bona Vacantia",
+        "href": "/government/organisations/bona-vacantia",
+        "brand": "attorney-generals-office"
+      }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.non_ministerial_departments[:high_profile_groups]
+      assert_equal expected, @organisations_presenter.all_organisations[:high_profile_groups]
     end
 
-    it 'returns public_corporations departments as part of non_ministerial_departments hash' do
+    it 'returns public_corporations departments as part of all_organisations hash' do
       expected = [{
-        link: {
-          text: "BBC",
-          path: "/government/organisations/bbc",
-          context: nil,
-          description: nil
-        }
-      }]
+        "title": "BBC",
+        "href": "/government/organisations/bbc",
+        "brand": "department-for-culture-media-sport"
+      }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.non_ministerial_departments[:public_corporations]
+      assert_equal expected, @organisations_presenter.all_organisations[:public_corporations]
     end
 
-    it 'returns devolved_administrations departments as part of non_ministerial_departments hash' do
+    it 'returns devolved_administrations departments as part of all_organisations hash' do
       expected = [{
-        link: {
-          text: "Northern Ireland Executive ",
-          path: "/government/organisations/northern-ireland-executive",
-          context: nil,
-          description: nil
-        }
-      }]
+        "title": "Northern Ireland Executive ",
+        "href": "/government/organisations/northern-ireland-executive",
+        "brand": nil
+      }.with_indifferent_access]
 
-      assert_equal expected, @organisations_presenter.non_ministerial_departments[:devolved_administrations]
-    end
-  end
-
-  describe 'some non_ministerial_departments' do
-    before :each do
-      content_item = ContentItem.new(some_non_ministerial_departments_hash)
-      content_store_organisations = ContentStoreOrganisations.new(content_item)
-      @organisations_presenter = Organisations::IndexPresenter.new(content_store_organisations)
-    end
-
-    it 'returns empty arrays where there are no organisations' do
-      expected = {
-        non_ministerial_departments: [{
-          link: {
-            text: "The Charity Commission",
-            path: "/government/organisations/charity-commission",
-            context: nil,
-            description: nil
-          }
-        }],
-        agencies_and_other_public_bodies: [],
-        high_profile_groups: [],
-        public_corporations: [],
-        devolved_administrations: []
-      }
-
-      assert_equal expected, @organisations_presenter.non_ministerial_departments
+      assert_equal expected, @organisations_presenter.all_organisations[:devolved_administrations]
     end
   end
 

--- a/test/presenters/organisations_presenter_test.rb
+++ b/test/presenters/organisations_presenter_test.rb
@@ -145,4 +145,43 @@ describe Organisations::IndexPresenter do
       assert_equal "Works with 2 agencies and public bodies", @organisations_presenter.works_with_statement(test_org)
     end
   end
+
+  describe 'organisation type' do
+    before :each do
+      content_item = ContentItem.new(ministerial_departments_hash)
+      content_store_organisations = ContentStoreOrganisations.new(content_item)
+      @organisations_presenter = Organisations::IndexPresenter.new(content_store_organisations)
+    end
+
+    it 'executive_office? returns true if organisation is number_10' do
+      test_organisation_type = :number_10
+      assert @organisations_presenter.executive_office?(test_organisation_type)
+    end
+
+    it 'executive_office? returns false if organisation is not number_10' do
+      test_organisation_type_ministerial = :ministerial_departments
+      test_organisation_type_non_ministerial = :public_corporations
+
+      refute @organisations_presenter.executive_office?(test_organisation_type_ministerial)
+      refute @organisations_presenter.executive_office?(test_organisation_type_non_ministerial)
+    end
+
+    it 'ministerial_organisation? returns true if organisation is number_10' do
+      test_organisation_type = :number_10
+
+      assert @organisations_presenter.ministerial_organisation?(test_organisation_type)
+    end
+
+    it 'ministerial_organisation? returns true if organisation is ministerial department' do
+      test_organisation_type = :ministerial_departments
+
+      assert @organisations_presenter.ministerial_organisation?(test_organisation_type)
+    end
+
+    it 'ministerial_organisation? returns false if organisation is non ministerial department' do
+      test_organisation_type = :agencies_and_other_public_bodies
+
+      refute @organisations_presenter.ministerial_organisation?(test_organisation_type)
+    end
+  end
 end

--- a/test/support/organisations_helpers.rb
+++ b/test/support/organisations_helpers.rb
@@ -79,8 +79,6 @@ module OrganisationsHelpers
     {
       "title": "Departments, agencies and public bodies",
       details: {
-        ordered_executive_offices: [],
-        ordered_ministerial_departments: [],
         ordered_non_ministerial_departments: [
           {
             title: "The Charity Commission",


### PR DESCRIPTION
Implements the View All toggle that currently exists on the Whitehall /government/organisations page.

<img width="642" alt="screen shot 2018-06-08 at 10 55 43" src="https://user-images.githubusercontent.com/29889908/41152094-926506ac-6b0a-11e8-90ff-c537d854f0ce.png">
<img width="648" alt="screen shot 2018-06-08 at 13 39 08" src="https://user-images.githubusercontent.com/29889908/41158576-597c1292-6b21-11e8-98d5-30392b86f2f3.png">

Note: The first commit for this PR is a cleanup commit to stop using the document list component on the organisation list page. Using this component was putting limitations in place when it came to building the View All toggle and, as it's only a simple list, we decided it would be better to stop using the component and add the styling into `organisations.scss` itself.

Review App: https://govuk-collections-pr-680.herokuapp.com/government/organisations
