### PR TITLE
Add contact GOV.UK link to bottom of org list page

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -16,3 +16,5 @@
     ]
   } %>
 </div>
+
+<p>Errors or omissions? <a href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a href="/government/collections/public-bodies">see public bodies</a>.</p>


### PR DESCRIPTION
Trello: https://trello.com/c/yhMFPmJy/169-add-help-text-to-bottom-of-organisation-list-page

<img width="984" alt="screen shot 2018-06-08 at 13 57 27" src="https://user-images.githubusercontent.com/29889908/41159282-e5f4142a-6b23-11e8-9280-f5b08c8c2095.png">

Review app: https://govuk-collections-pr-681.herokuapp.com/government/organisations