### PR TITLE
Add organisation atom feeds

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,0 +1,28 @@
+class FeedsController < ApplicationController
+  enable_request_formats organisation: :atom
+
+  def organisation
+    set_access_control_allow_origin_header if request.format.atom?
+
+    path = "/government/organisations/#{organisation_name}#{locale}"
+    @organisation = Organisation.find!(path)
+
+    response = OrganisationFeedContent.fetch(organisation: organisation_name)
+    @items = response["results"].map { |result| OrganisationFeedEntryPresenter.new(result) }
+  end
+
+private
+
+  # allows ajax requests as per https://govuk.zendesk.com/agent/tickets/1935680
+  def set_access_control_allow_origin_header
+    response.headers["Access-Control-Allow-Origin"] = "*"
+  end
+
+  def organisation_name
+    params[:organisation_name]
+  end
+
+  def locale
+    ".#{params[:locale]}" if params[:locale]
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -26,6 +26,10 @@ class Organisation
     @content_item.content_item_data["base_path"]
   end
 
+  def web_url
+    Plek.current.website_root + base_path
+  end
+
   def ordered_featured_links
     details["ordered_featured_links"]
   end

--- a/app/presenters/organisation_feed_entry_presenter.rb
+++ b/app/presenters/organisation_feed_entry_presenter.rb
@@ -1,0 +1,35 @@
+class OrganisationFeedEntryPresenter
+  attr_reader :result
+
+  def initialize(result)
+    @result = result
+  end
+
+  def id
+    "#{url}##{updated.rfc3339}"
+  end
+
+  def url
+    Plek.current.website_root + result["link"]
+  end
+
+  def atom_url
+    "#{url}.atom"
+  end
+
+  def updated
+    Time.zone.parse(result["public_timestamp"])
+  end
+
+  def title
+    result["title"]
+  end
+
+  def description
+    result["description"]
+  end
+
+  def display_type
+    result["display_type"]
+  end
+end

--- a/app/services/organisation_feed_content.rb
+++ b/app/services/organisation_feed_content.rb
@@ -1,0 +1,35 @@
+class OrganisationFeedContent
+  include RummagerFields
+
+  attr_reader :organisation
+
+  def initialize(organisation:)
+    @organisation = organisation
+  end
+
+  def self.fetch(organisation:)
+    new(organisation: organisation).fetch
+  end
+
+  def fetch
+    search_response
+  end
+
+private
+
+  def search_response
+    params = {
+      start: 0,
+      count: 20,
+      fields: RummagerFields::FEED_SEARCH_FIELDS,
+      filter_organisations: organisation,
+      #using this as providing a list of the currently supported types is too big.
+      #email_document_supertype seems to fit with the ethos of what we're trying to
+      #provide.
+      reject_email_document_supertype: "other",
+      order: '-public_timestamp',
+    }
+
+    Services.rummager.search(params)
+  end
+end

--- a/app/services/rummager_fields.rb
+++ b/app/services/rummager_fields.rb
@@ -5,4 +5,10 @@ module RummagerFields
                            content_store_document_type
                            public_timestamp
                            organisations).freeze
+
+  FEED_SEARCH_FIELDS = %w(title
+                          link
+                          description
+                          display_type
+                          public_timestamp).freeze
 end

--- a/app/views/feeds/organisation.atom.builder
+++ b/app/views/feeds/organisation.atom.builder
@@ -1,0 +1,17 @@
+atom_feed(language: 'en-GB', root_url: @organisation.web_url) do |feed|
+  feed.title("#{@organisation.title} - Activity on GOV.UK")
+  feed.author do |author|
+    author.name('HM Government')
+  end
+  feed.updated(@items.first.updated) if @items.any?
+
+  @items.each do |item|
+    feed.entry(item, id: item.id, url: item.url, updated: item.updated) do |entry|
+      entry.title(item.title)
+      if item.display_type
+        entry.category(label: item.display_type, term: item.display_type)
+      end
+      entry.summary(item.description)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,12 @@ Rails.application.routes.draw do
 
   get "/government/organisations", to: "organisations#index"
 
+  get '/government/organisations/:organisation_name(.:locale).:format',
+    constraints: {
+      format: /atom/,
+      locale: /\w{2}(-[\d\w]{2,3})?/,
+    }, to: "feeds#organisation"
+
   get "/government/organisations/:organisation_name", to: "organisations#show"
 
   constraints DocumentTypeRoutingConstraint.new('step_by_step_nav') do

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class FeedsControllerTest < ActionController::TestCase
+  include OrganisationFeedHelpers
+
+  test "routing handles paths with just format" do
+    assert_routing(
+      "/government/organisations/ministry-of-magic.atom",
+      controller: "feeds",
+      action: "organisation",
+      organisation_name: "ministry-of-magic",
+      format: "atom",
+    )
+  end
+
+  test "routing handles paths with format and locale" do
+    assert_routing(
+      "/government/organisations/ministry-of-magic.cy.atom",
+      controller: "feeds",
+      action: "organisation",
+      organisation_name: "ministry-of-magic",
+      format: "atom",
+      locale: "cy"
+    )
+  end
+
+  test "renders atom feeds" do
+    content_item = content_store_has_schema_example("organisation")
+    stub_content_for_feed("ministry-of-magic", [])
+
+    get :organisation, params: { organisation_name: organisation_slug(content_item), format: "atom" }
+
+    assert_response :success
+    assert_select "feed title", "Ministry of Magic - Activity on GOV.UK"
+  end
+
+  test "sets the Access-Control-Allow-Origin header for atom pages" do
+    content_item = content_store_has_schema_example("organisation")
+    stub_content_for_feed("ministry-of-magic", [])
+
+    get :organisation, params: { organisation_name: organisation_slug(content_item), format: "atom" }
+
+    assert_equal "*", response.headers["Access-Control-Allow-Origin"]
+  end
+
+
+  def organisation_slug(content_item)
+    File.basename(content_item["base_path"])
+  end
+
+  def content_store_has_schema_example(schema_name)
+    document = GovukSchemas::Example.find(schema_name, example_name: schema_name)
+    document["base_path"] = "/government/organisations/ministry-of-magic"
+    document["title"] = "Ministry of Magic"
+    content_store_has_item(document["base_path"], document)
+    document
+  end
+end

--- a/test/integration/organisation_atom_feed_test.rb
+++ b/test/integration/organisation_atom_feed_test.rb
@@ -1,0 +1,157 @@
+require "integration_test_helper"
+
+class OrganisationAtomFeedTest < ActionDispatch::IntegrationTest
+  include OrganisationFeedHelpers
+
+  it "renders an atom feed when there is content" do
+    given_there_is_an_organisation_content_item
+    and_content_for_that_organisation
+    when_i_visit_the_atom_feed
+    then_i_can_see_the_feed
+    with_the_feed_updated_time_set_to_the_latest_item
+    and_feed_items
+  end
+
+  it "renders a valid atom feed when there is no content" do
+    given_there_is_an_organisation_content_item
+    but_no_content_for_that_organisation
+    when_i_visit_the_atom_feed
+    then_i_can_see_the_feed
+    but_no_feed_items
+  end
+
+  def given_there_is_an_organisation_content_item
+    @updated_at = "2018-12-25T00:00:00Z"
+    @organisation_slug = "ministry-of-magic"
+    @base_path = "/government/organisations/#{@organisation_slug}"
+
+    content_store_has_schema_example("organisation")
+  end
+
+  def and_content_for_that_organisation
+    stub_content_for_feed(@organisation_slug, results_from_rummager)
+  end
+
+  def but_no_content_for_that_organisation
+    stub_empty_results
+  end
+
+  def when_i_visit_the_atom_feed
+    visit "#{@base_path}.atom"
+  end
+
+  def then_i_can_see_the_feed
+    with_a_title
+    and_an_alternate_link
+  end
+
+  def with_a_title
+    title = page.first("feed>title").text(:all)
+    assert_equal title, "Ministry of Magic - Activity on GOV.UK"
+  end
+
+  def and_an_alternate_link
+    assert page.has_css?("feed>link[rel='alternate'][href$='#{@base_path}']")
+  end
+
+  def with_the_feed_updated_time_set_to_the_latest_item
+    updated = page.first("feed>updated").text(:all)
+    assert_equal updated, @updated_at
+  end
+
+  def and_feed_items
+    with_an_id
+    and_a_title
+    and_a_summary
+    and_an_updated_time
+  end
+
+  def with_an_id
+    id = page.first("feed>entry>id").text(:all)
+    assert id.end_with?("/government/collections/owl-and-newt-examinations-at-hogwarts##{@updated_at}")
+  end
+
+  def and_a_title
+    title = page.first("feed>entry>title").text(:all)
+    assert_equal title, "OWL and NEWT qualifications, Ministry of Magic"
+  end
+
+  def and_a_summary
+    summary = page.first("feed>entry>summary").text(:all)
+    assert_equal summary, "This series brings together all documents relating to OWL and NEWT syllabuses, examinations and grading"
+  end
+
+  def and_an_updated_time
+    updated = page.first("feed>entry>updated").text(:all)
+    assert_equal updated, @updated_at
+  end
+
+  def but_no_feed_items
+    refute page.has_css?("feed>entry")
+  end
+
+  def content_store_has_schema_example(schema_name)
+    document = GovukSchemas::Example.find(schema_name, example_name: schema_name)
+    document["base_path"] = "/government/organisations/ministry-of-magic"
+    document["title"] = "Ministry of Magic"
+    content_store_has_item(document["base_path"], document)
+    document
+  end
+
+  def results_from_rummager
+    [
+      {
+        "content_store_document_type" => "document_collection",
+        "description" => "This series brings together all documents relating to OWL and NEWT syllabuses, examinations and grading",
+        "display_type" => "Detailed guide",
+        "link" => "/government/collections/owl-and-newt-examinations-at-hogwarts",
+        "organisations" => [
+          {
+          "organisation_brand" => @organisation_slug,
+          "logo_formatted_title" => "Ministry of Magic",
+          "organisation_crest" => "single-identity",
+          "title" => "Ministry of Magic",
+          "content_id" => "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+          "link" => @base_path,
+          "slug" => @organisation_slug,
+          "organisation_type" => "ministerial_department",
+          "organisation_state" => "live"
+          }
+        ],
+        "public_timestamp" => @updated_at,
+        "title" => "OWL and NEWT qualifications, Ministry of Magic",
+        "index" => "government",
+        "es_score" => nil,
+        "_id" => "/government/collections/owl-and-newt-examinations-at-hogwarts",
+        "elasticsearch_type" => "edition",
+        "document_type" => "edition"
+      },
+      {
+        "content_store_document_type" => "detailed_guide",
+        "description" => "Defence against the dark arts: Angry acolytes to deepening dread",
+        "display_type" => "Detailed guide",
+        "link" => "/government/guidance/dark-arts-acolytes-to-dread",
+        "organisations" => [
+          {
+          "organisation_brand" => @organisation_slug,
+          "logo_formatted_title" => "Ministry of Magic",
+          "organisation_crest" => "single-identity",
+          "title" => "Ministry of Magic",
+          "content_id" => "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+          "link" => @base_path,
+          "slug" => @organisation_slug,
+          "organisation_type" => "ministerial_department",
+          "organisation_state" => "live"
+          }
+        ],
+        "public_timestamp" => "2018-12-26T12:23:34+01:00",
+        "title" => "Dealing with you know who, Ministry of Magic",
+        "index" => "government",
+        "es_score" => nil,
+        "_id" => "/government/guidance/dark-arts-acolytes-to-dread",
+        "elasticsearch_type" => "edition",
+        "document_type" => "edition"
+      },
+    ]
+  end
+end

--- a/test/support/organisation_feed_helpers.rb
+++ b/test/support/organisation_feed_helpers.rb
@@ -1,0 +1,29 @@
+module OrganisationFeedHelpers
+  def stub_content_for_feed(organisation, results)
+    params = {
+      start: 0,
+      count: 20,
+      fields: %w(title link description display_type public_timestamp),
+      filter_organisations: organisation,
+      reject_email_document_supertype: "other",
+      order: '-public_timestamp',
+    }
+
+    Services.rummager.stubs(:search)
+      .with(params)
+      .returns(
+        "results" => results,
+        "start" => 0,
+        "total" => results.size,
+      )
+  end
+
+  def stub_empty_results
+    Services.rummager.stubs(:search)
+      .returns(
+        "results" => [],
+        "start" => 0,
+        "total" => 0,
+      )
+  end
+end


### PR DESCRIPTION
We provide similar atom feeds to those in Whitehall - but not identical.

The ID format has changed from the current one of the form:
    `tag:www.gov.uk,2005:DocumentCollection/231443` (which is coupled to whitehall
    internals)
to:
    `https://www.gov.uk/government/publications/universal-credit-understanding-its-impact-on-the-labour-market#2018-06-08T11:29:52z`
    which will change when a document is updated or moved.  This is similar to
    that used by [travel advice feeds](https://github.com/alphagov/government-frontend/blob/9496ce14e3cbe117ea8ae9940504dd48e40dd5d1/app/views/content_items/travel_advice.atom.builder#L7).

Feeds works with locales, however the only thing that changes with the language is the feed information.  Entries in the feed are not locale sensitive (which is actually the same behaviour as Whitehall at present.).

We can no longer provide long form feed content as Rummager doesn't let us obtain that.  We fall back to providing a title and a summary.

A generated feed passes validation on https://validator.w3.org/feed/check.cgi

https://trello.com/c/uPsYFOgl/70-replicate-org-atom-feed