### PR TITLE
Add separate website notice to org page

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -10,6 +10,7 @@ class OrganisationsController < ApplicationController
     setup_content_item_and_navigation_helpers(@organisation)
 
     @header = Organisations::HeaderPresenter.new(@organisation)
+    @separate_website = Organisations::SeparateWebsitePresenter.new(@organisation)
 
     respond_to do |f|
       f.html do

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -62,6 +62,10 @@ class Organisation
     @content_item.content_item_data["base_path"]
   end
 
+  def ordered_parent_organisations
+    @content_item.content_item_data["links"]["ordered_parent_organisations"]
+  end
+
   # methods below are not in use yet, this comment to be removed once confirmed
 
   def body

--- a/app/presenters/organisations/separate_website_presenter.rb
+++ b/app/presenters/organisations/separate_website_presenter.rb
@@ -1,0 +1,82 @@
+module Organisations
+  class SeparateWebsitePresenter
+    include ActionView::Helpers::UrlHelper
+
+    attr_reader :org
+
+    def initialize(organisation)
+      @org = organisation
+    end
+
+    def organisation_display_name_and_parental_relationship
+      name = org.title
+      type_name = organisation_type_name
+      relationship = ERB::Util.h(add_indefinite_article(type_name))
+      parents = org.ordered_parent_organisations.map { |parent| organisation_relationship_html(parent) }
+
+      description = if parents.any?
+                      case type_name
+                      when 'other'
+                        "#{name} works with #{parents.to_sentence}."
+                      when 'non-ministerial department'
+                        "#{name} is #{relationship}."
+                      when 'sub-organisation'
+                        "#{name} is part of #{parents.to_sentence}."
+                      when 'executive non-departmental public body', 'advisory non-departmental public body', 'tribunal non-departmental public body', 'executive agency'
+                        "#{name} is #{relationship}, sponsored by #{parents.to_sentence}."
+                      else
+                        "#{name} is #{relationship} of #{parents.to_sentence}."
+                      end
+                    else
+                      type_name != 'other' ? "#{name} is #{relationship}." : name.to_s
+                    end
+
+      description.html_safe
+    end
+
+    def organisation_relationship_html(organisation)
+      prefix = needs_definite_article?(organisation["title"]) ? "the " : ""
+      (prefix + link_to(organisation["title"], organisation["base_path"]))
+    end
+
+    def needs_definite_article?(phrase)
+      exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]
+      !has_definite_article?(phrase) && !(exceptions.any? { |e| e =~ phrase.downcase })
+    end
+
+    def has_definite_article?(phrase)
+      phrase.downcase.strip[0..2] == 'the'
+    end
+
+    def add_indefinite_article(noun)
+      indefinite_article = starts_with_vowel?(noun) ? 'an' : 'a'
+      "#{indefinite_article} #{noun}"
+    end
+
+    def starts_with_vowel?(word_or_phrase)
+      'aeiou'.include?(word_or_phrase.downcase[0])
+    end
+
+    def organisation_type_name
+      ActiveSupport::Inflector.singularize(org.organisation_type.downcase)
+    end
+
+    def organisation_display_name_including_parental_and_child_relationships
+      organisation_name = organisation_display_name_and_parental_relationship
+      # child_organisations = organisation.supporting_bodies
+
+      # if child_organisations.any?
+      #   organisation_name.chomp!('.')
+      #   organisation_name += organisation_type_name(organisation) != 'other' ? ", supported by " : " is supported by "
+
+      #   child_relationships_link_text = child_organisations.size.to_s
+      #   child_relationships_link_text += child_organisations.size == 1 ? " public body" : " agencies and public bodies"
+
+      #   organisation_name += link_to(child_relationships_link_text, organisations_path(anchor: organisation.slug))
+      #   organisation_name += "."
+      # end
+
+      organisation_name.html_safe
+    end
+  end
+end

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,25 +1,26 @@
-<%= render "govuk_publishing_components/components/heading", {
-    text: organisation.title,
-    heading_level: 2
+<div class="grid-row">
+  <div class="column-one-third organisations__margin-bottom">
+    <%= render "govuk_publishing_components/components/organisation_logo", {
+      organisation: @header.organisation_logo
+    } %>
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/notice", {
+  title: "#{organisation.title} has a <a href='/'>separate website</a>".html_safe
 } %>
 
-<div class="separate-website-label">
-  <%= "#{organisation.title} has a" %> <%= link_to "separate website", "#" %>
-</div>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <p><%= organisation.body %></p>
 
-<div class="organisation-body">
-  <%= organisation.body %>
+      <% if organisation.ordered_parent_organisations.presence %>
+        <%= "#{organisation.title} works with the" %>
+        <%= link_to organisation.ordered_parent_organisations[0]["title"],
+                    organisation.ordered_parent_organisations[0]["base_path"] %>
+      <% end %>
+    <% end %>
+  </div>
 </div>
-
-<div class="parent-organisations">
-  <% if organisation.ordered_parent_organisations.presence %>
-    <%= "#{organisation.title} works with the" %>
-    <%= link_to organisation.ordered_parent_organisations[0]["title"],
-                organisation.ordered_parent_organisations[0]["base_path"] %>
-  <% end %>
-</div>
-
-<%= render "govuk_publishing_components/components/heading", {
-    text: "Documents",
-    heading_level: 2
-} %>

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,3 +1,9 @@
+<% content_for :breadcrumbs do %>
+  <div class="organisations__margin-bottom">
+    <h1 class="visually-hidden"><%= @header.org.title %></h1>
+  </div>
+<% end %>
+
 <div class="grid-row">
   <div class="column-one-third organisations__margin-bottom">
     <%= render "govuk_publishing_components/components/organisation_logo", {
@@ -15,6 +21,15 @@
     <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
       <p><%= organisation.body %></p>
+
+      <%# unless @separate_website.closed? || @separate_website.court_or_hmcts_tribunal? %>
+        <% if @organisation.ordered_parent_organisations.any? || @separate_website.supporting_bodies.any? %>
+          <p class="parent_organisations">
+            <%= @separate_website.organisation_display_name_including_parental_and_child_relationships %>
+          </p>
+        <% end %>
+        <p><%#= link_to @separate_website.url, @separate_website.url, class: 'url-link' %></p>
+      <%# end %>
 
       <% if organisation.ordered_parent_organisations.presence %>
         <%= "#{organisation.title} works with the" %>


### PR DESCRIPTION
Example: https://govuk-collections-pr-684.herokuapp.com/government/organisations/advisory-committee-on-animal-feedingstuffs

Trello card: https://trello.com/c/iloDHtyy/170-add-separate-website-notice-to-organisation-page
