### PR TITLE
Ability to filter organisation list page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //
 //= require support
 //= require browse-columns
+//= require organisation-list-filter
 //= require modules/current-location
 //= require modules/feeds.js
 //= require components/accordion

--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -6,6 +6,9 @@
 
   window.GOVUK.filter = {
     init: function() {
+      // Form should only appear if the JS is working
+      $('[data-filter="form"]').addClass('filter-organisations-list__form--active');
+
       // We don't want the form to submit/refresh the page on enter key
       $('[data-filter="form"]').on('submit', function() { return false; })
 

--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -1,0 +1,79 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  var filterTimeout = null;
+
+  window.GOVUK.filter = {
+    init: function() {
+      // We don't want the form to submit/refresh the page on enter key
+      $('[data-filter="form"]').on('submit', function() { return false; })
+
+      $('[data-filter="form"] input').on('keyup', window.GOVUK.filter.filterViaTimeout);
+    },
+
+    filterViaTimeout: function(e) {
+      clearTimeout(filterTimeout);
+
+      filterTimeout = setTimeout(function() {
+        window.GOVUK.filter.filterList(e);
+      }, 200);
+    },
+
+    filterList: function(e) {
+      var itemsToFilter = $('[data-filter="item"]');
+      var listsToFilter = $('[data-filter="list"]');
+      var searchTerm = $(e.target).val();
+
+      itemsToFilter.not(function() {
+        var currentOrganisation = $(this);
+        return window.GOVUK.filter.matchSearchTerm(currentOrganisation, searchTerm);
+      }).addClass('js-hidden');
+
+      window.GOVUK.filter.updateDepartmentCount(listsToFilter);
+    },
+
+    matchSearchTerm: function(organisation, term) {
+      var organisationText = "";
+
+      organisation.removeClass('js-hidden');
+
+      if (organisation.find('.logo-container').length > 0) {
+        organisationText = organisation.find('.logo-container').text();
+      }
+      else {
+        organisationText = organisation.find('.organisation-list__item-title').text();
+      }
+
+      var searchTermRegexp = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      if (searchTermRegexp.exec(organisationText) !== null) {
+        return true;
+      }
+    },
+
+    updateDepartmentCount: function(listsToFilter) {
+      var totalMatchingOrgs = 0;
+
+      listsToFilter.each(function() {
+        var matchingOrgCount = $(this).find('[data-filter="item"]:visible').length;
+        var departmentSection = $(this).closest('[data-filter="block"]');
+        var departmentCountWrapper = departmentSection.find('[data-filter="count"]');
+        var departmentCount = departmentSection.find('.js-department-count');
+        var accessibleDepartmentCount = departmentSection.find('.js-accessible-department-count');
+
+        departmentCountWrapper.toggleClass('js-hidden', matchingOrgCount == 0 );
+
+        if (matchingOrgCount > 0) {
+          departmentCount.text(matchingOrgCount);
+          accessibleDepartmentCount.text(matchingOrgCount);
+        }
+
+        totalMatchingOrgs += matchingOrgCount;
+      });
+
+      $('.js-no-filter-matches').toggleClass('js-hidden', totalMatchingOrgs > 0);
+    }
+  };
+
+  $(function(){ GOVUK.filter.init(); })
+}());

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -63,6 +63,41 @@
       float: right;
     }
   }
+
+  .organisations__no-filter-match {
+    display: none;
+
+    .js-enabled & {
+      @include core-19;
+      display: block;
+      text-align: center;
+      margin-bottom: $gutter * 2;
+    }
+  }
+}
+
+.filter-organisations-list__form {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+    margin-bottom: $gutter * 1.5;
+  }
+
+  .filter-organisations-list__label {
+    @include bold-36;
+    margin-right: $gutter-one-third;
+  }
+
+  .filter-organisations-list__input {
+    @include core-16;
+    width: 30%;
+    min-width: 150px;
+    vertical-align: text-bottom;
+    padding: 5px;
+    border: 1px solid $grey-2;
+    margin: 0 5px 5px 0;
+  }
 }
 
 .organisations__margin-bottom {

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -79,11 +79,6 @@
 .filter-organisations-list__form {
   display: none;
 
-  .js-enabled & {
-    display: block;
-    margin-bottom: $gutter * 1.5;
-  }
-
   .filter-organisations-list__label {
     @include bold-36;
     margin-right: $gutter-one-third;
@@ -98,6 +93,11 @@
     border: 1px solid $grey-2;
     margin: 0 5px 5px 0;
   }
+}
+
+.filter-organisations-list__form--active {
+  display: block;
+  margin-bottom: $gutter * 1.5;
 }
 
 .organisations__margin-bottom {

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -3,7 +3,7 @@
     margin-bottom: $gutter * 2;
   }
 
-  .department-count {
+  .organisations__department-count-wrapper {
     @include bold-80;
   }
 

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -1,23 +1,23 @@
 <% all_organisations.each do |organisation_type, organisations| %>
-  <div class="grid-row organisations-list__section">
+  <div class="grid-row organisations-list__section" data-filter="block">
 
-    <div class="column-one-third">
+    <div class="column-one-third" data-filter="count">
       <% unless @presented_organisations.executive_office?(organisation_type) %>
         <%= render "govuk_publishing_components/components/heading", {
           text: organisation_type.to_s.humanize,
           heading_level: 2
         } %>
-        <div class="department-count">
-          <p class="visuallyhidden">There are <%= organisations.count %> <%= organisation_type.to_s.humanize %></p>
-          <span aria-hidden="true"><%= organisations.count %></span>
+        <div class="organisations__department-count-wrapper">
+          <p class="visuallyhidden">There are <span class="js-accessible-department-count"><%= organisations.count %></span> <%= organisation_type.to_s.humanize %></p>
+          <span class="js-department-count" aria-hidden="true"><%= organisations.count %></span>
         </div>
       <% end %>
     </div>
 
     <div class="column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
-      <ol>
+      <ol data-filter="list">
         <% organisations.each do |organisation| %>
-          <li class="organisations-list__item" >
+          <li class="organisations-list__item" data-filter="item">
             <% if @presented_organisations.ministerial_organisation?(organisation_type) %>
               <%= render "govuk_component/organisation_logo", {
                 organisation: {

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -8,10 +8,18 @@
   </div>
 </div>
 
+<form class="filter-organisations-list__form" data-filter="form">
+  <label class="filter-organisations-list__label" for="filter-organisations-list">What's the latest<br />from</label>
+  <input class="filter-organisations-list__input" type="text" id="filter-organisations-list" placeholder="For example, Home Office">
+  <span class="filter-organisations-list__label" aria-hidden="true">?</span>
+</form>
+
 <div class="organisations">
   <%= render partial: 'organisations_list', locals: {
     all_organisations: @presented_organisations.all_organisations
   } %>
+
+  <p class="organisations__no-filter-match js-hidden js-no-filter-matches">No departments match that filter.</p>
 </div>
 
 <p>Errors or omissions? <a href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a href="/government/collections/public-bodies">see public bodies</a>.</p>

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -1,0 +1,122 @@
+describe('organisation-list-filter.js', function() {
+  "use strict";
+
+  var timeout = 210;
+
+  var stubStyling =
+    '<style>' +
+      '.js-hidden {' +
+        'display: none;' +
+        'visibility: none' +
+      '}' +
+    '</style>'
+
+  var form = '\
+    <form data-filter="form"></div>\
+      <input type="search" id="filter-organisations-list" />\
+    </form>\
+  ';
+
+  var organisations = '\
+    <div data-filter="block">\
+      <div data-filter="count" class="count-for-logos">\
+        <h2>Ministerial Departments</h2>\
+        <p>There are <span class="js-accessible-department-count">2</span> Ministerial Departments</p>\
+        <span class="js-department-count">2</span>\
+      </div>\
+      <ol data-filter="list">\
+        <li data-filter="item" class="org-logo-1">\
+          <div class="logo-container">Cabinet Office</div>\
+        </li>\
+        <li data-filter="item" class="org-logo-2">\
+          <div class="logo-container">Cabinet Office</div>\
+        </li>\
+      </ol>\
+    </div>\
+    <div data-filter="block">\
+      <div data-filter="count" class="count-for-no-logos">\
+        <h2>Non Ministerial Departments</h2>\
+        <p>There are <span class="js-accessible-department-count">2</span> Non Ministerial Departments</p>\
+        <span class="js-department-count">2</span>\
+      </div>\
+      <ol data-filter="list">\
+        <li data-filter="item" class="org-no-logo-1">\
+          <a class="organisation-list__item-title">Advisory Committee on Releases to the Environment</a>\
+        </li>\
+        <li data-filter="item" class="org-no-logo-2">\
+          <a class="organisation-list__item-title">Advisory Council on the Misuse of Drugs</a>\
+        </li>\
+      </ol>\
+      <p class="js-hidden js-no-filter-matches">No departments match that filter.</p>\
+    </div>\
+  ';
+
+  beforeAll(function () {
+    $(document.body).append(stubStyling);
+    $(document.body).append(form);
+    $(document.body).append(organisations);
+    GOVUK.filter.init();
+  });
+
+  afterEach(function(done) {
+    setTimeout(function() {
+      $('[data-filter="form"] input').val("");
+      $('[data-filter="form"] input').trigger('keyup');
+      done();
+    }, 1);
+  });
+
+  it("hide items that do not match the search term", function(done) {
+    $('[data-filter="form"] input').val("Advisory cou");
+    $('[data-filter="form"] input').trigger('keyup');
+
+    setTimeout(function () {
+      expect($('.org-logo-1')).toHaveClass("js-hidden");
+      expect($('.org-logo-2')).toHaveClass("js-hidden");
+      expect($('.org-no-logo-1')).toHaveClass("js-hidden");
+      done();
+    }, timeout);
+  });
+
+  it("show items that do match the search term", function(done) {
+    $('[data-filter="form"] input').val("Advisory cou");
+    $('[data-filter="form"] input').trigger('keyup');
+
+    setTimeout(function () {
+      expect($('.org-no-logo-2')).not.toHaveClass("js-hidden");
+      done();
+    }, timeout);
+  });
+
+  it("hide department counts and names if they have no matching organisations", function(done) {
+    $('[data-filter="form"] input').val("Advisory cou");
+    $('[data-filter="form"] input').trigger('keyup');
+
+    setTimeout(function () {
+      expect($('.count-for-logos')).toHaveClass("js-hidden");
+      done();
+    }, timeout);
+  });
+
+  it("update the department count", function(done) {
+    $('[data-filter="form"] input').val("Advisory cou");
+    $('[data-filter="form"] input').trigger('keyup');
+
+    setTimeout(function () {
+      expect($('.count-for-no-logos')).not.toHaveClass("js-hidden");
+      expect($('.count-for-no-logos .js-accessible-department-count')).toHaveText(1);
+      expect($('.count-for-no-logos .js-department-count')).toHaveText(1);
+      done();
+    }, timeout);
+  });
+
+  it("shows a message if there are no matching organisations", function(done) {
+    $('[data-filter="form"] input').val("Nothing will match this");
+    $('[data-filter="form"] input').trigger('keyup');
+
+    setTimeout(function () {
+      expect($('.js-no-filter-matches')).not.toHaveClass("js-hidden");
+      done();
+    }, timeout);
+  });
+});

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -18,17 +18,23 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-title__text', text: "Departments, agencies and public bodies")
   end
 
+  it "renders organisation filter" do
+    assert page.has_css?('.filter-organisations-list__form')
+    assert page.has_css?('.filter-organisations-list__label', text: "What's the latestfrom")
+    assert page.has_css?('.filter-organisations-list__input')
+  end
+
   it "renders an organisation_type heading" do
     assert page.has_css?('.gem-c-heading', text: 'Ministerial departments')
   end
 
   it "renders organisation count" do
-    assert page.has_css?('.department-count span', text: '1')
+    assert page.has_css?('.organisations__department-count-wrapper span', text: '1')
   end
 
   it "renders an accessible version of organisation count" do
-    assert page.has_css?('.department-count span[aria-hidden="true"]')
-    assert page.has_css?('.department-count p.visuallyhidden', text: 'There are 2 Non ministerial departments')
+    assert page.has_css?('.organisations__department-count-wrapper span[aria-hidden="true"]')
+    assert page.has_css?('.organisations__department-count-wrapper p.visuallyhidden', text: 'There are 2 Non ministerial departments')
   end
 
   it "renders ministerial organisation with crest" do


### PR DESCRIPTION
Trello: https://trello.com/c/B0y0wiYy/173-implement-filter-on-organisation-list-page

There has been a change in design due to the component we're using on the new page:
<img width="1250" alt="screen shot 2018-06-12 at 16 42 29" src="https://user-images.githubusercontent.com/29889908/41301298-a02b6896-6e5f-11e8-9545-5164c50d2ce6.png">

Review app: https://govuk-collections-pr-687.herokuapp.com/government/organisations