### PR TITLE
Add latest news and what we do section to new org pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -12,6 +12,7 @@ class OrganisationsController < ApplicationController
     @show = Organisations::ShowPresenter.new(@organisation)
     @header = Organisations::HeaderPresenter.new(@organisation)
     @featured_news = Organisations::FeaturedNewsPresenter.new(@organisation)
+    @what_we_do = Organisations::WhatWeDoPresenter.new(@organisation)
     @people = Organisations::PeoplePresenter.new(@organisation)
 
     respond_to do |f|

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -9,6 +9,7 @@ class OrganisationsController < ApplicationController
     @organisation = Organisation.find!("/government/organisations/#{params[:organisation_name]}#{locale}")
     setup_content_item_and_navigation_helpers(@organisation)
 
+    @show = Organisations::ShowPresenter.new(@organisation)
     @header = Organisations::HeaderPresenter.new(@organisation)
     @featured_news = Organisations::FeaturedNewsPresenter.new(@organisation)
     @people = Organisations::PeoplePresenter.new(@organisation)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -63,6 +63,10 @@ class Organisation
     Plek.current.website_root + base_path
   end
 
+  def slug
+    base_path.gsub("/government/organisations/", "")
+  end
+
   def ordered_featured_links
     details["ordered_featured_links"]
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -51,6 +51,10 @@ class Organisation
     logo["formatted_title"]
   end
 
+  def body
+    details["body"]
+  end
+
   def organisation_image_url
     logo["image"]["url"] if logo["image"].present?
   end
@@ -95,11 +99,11 @@ class Organisation
     details["social_media_links"]
   end
 
-  # methods below are not in use yet, this comment to be removed once confirmed
-
-  def body
-    details["body"]
+  def ordered_featured_policies
+    links["ordered_featured_policies"]
   end
+
+  # methods below are not in use yet, this comment to be removed once confirmed
 
   def child_organisation_count
     links["ordered_child_organisations"].count
@@ -119,10 +123,6 @@ class Organisation
 
   def ordered_parent_organisations
     links["ordered_parent_organisations"]
-  end
-
-  def ordered_featured_policies
-    links["ordered_featured_policies"]
   end
 
 private

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,6 +18,10 @@ class Organisation
     @content_item.content_item_data["title"]
   end
 
+  def acronym
+    details["acronym"]
+  end
+
   def organisation_type
     details["organisation_type"]
   end
@@ -83,6 +87,10 @@ class Organisation
     details["ordered_ministers"]
   end
 
+  def social_media_links
+    details["social_media_links"]
+  end
+
   # methods below are not in use yet, this comment to be removed once confirmed
 
   def body
@@ -91,10 +99,6 @@ class Organisation
 
   def child_organisation_count
     links["ordered_child_organisations"].count
-  end
-
-  def social_media_links
-    details["social_media_links"]
   end
 
   def board_members

--- a/app/presenters/organisations/featured_news_presenter.rb
+++ b/app/presenters/organisations/featured_news_presenter.rb
@@ -6,6 +6,10 @@ module Organisations
       @org = organisation
     end
 
+    def has_featured_news?
+      org.ordered_featured_documents.length.positive?
+    end
+
     def first_featured_news
       main_story = featured_news([org.ordered_featured_documents.first])[0]
       main_story[:large] = true

--- a/app/presenters/organisations/featured_news_presenter.rb
+++ b/app/presenters/organisations/featured_news_presenter.rb
@@ -29,7 +29,7 @@ module Organisations
         news_stories << {
           href: news["href"],
           image_src: news["image"]["url"],
-          image_alt: news["image"]["alt"],
+          image_alt: news["image"]["alt_text"],
           context: "#{human_date}#{divider}#{document_type}",
           heading_text: news["title"],
           description: news["summary"],

--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -27,7 +27,7 @@ module Organisations
 
       if has_services_and_information_link?
         see_more_link = {
-          text: "All #{org.title} services and information", # TODO: need to use acronym where available
+          text: "All #{org.acronym} services and information",
           path: "/government/organisations/#{slug}/services-information"
         }
       end

--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -28,7 +28,7 @@ module Organisations
       if has_services_and_information_link?
         see_more_link = {
           text: "All #{org.acronym} services and information",
-          path: "/government/organisations/#{slug}/services-information"
+          path: "/government/organisations/#{org.slug}/services-information"
         }
       end
 
@@ -81,10 +81,6 @@ module Organisations
 
   private
 
-    def slug
-      org.base_path.gsub("/government/organisations/", "")
-    end
-
     def has_services_and_information_link?
       orgs_with_services_and_information_link = %w{
         charity-commission
@@ -101,7 +97,7 @@ module Organisations
         natural-england
         planning-inspectorate
       }
-      return true if orgs_with_services_and_information_link.include?(slug)
+      return true if orgs_with_services_and_information_link.include?(org.slug)
     end
   end
 end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -11,8 +11,12 @@ module Organisations
       (prefix + org.title)
     end
 
-    def latest
-      stories = []
+    def has_latest_documents?
+      org.ordered_featured_documents.length.positive?
+    end
+
+    def latest_documents
+      documents = []
 
       org.ordered_featured_documents.each do |story|
         metadata = {}
@@ -22,7 +26,7 @@ module Organisations
           metadata[:public_updated_at] = Date.parse(story["public_updated_at"])
         end
 
-        stories << {
+        documents << {
           link: {
             text: story["title"],
             path: story["href"]
@@ -32,15 +36,15 @@ module Organisations
       end
 
       {
-        items: stories,
+        items: documents,
         brand: org.brand
       }
     end
 
     def subscription_links
       {
-        email_signup_link: "TODO",
-        feed_link_box_value: "TODO",
+        email_signup_link: "/government/email-signup/new?email_signup[feed]=#{org.web_url}.atom",
+        feed_link_box_value: "#{org.web_url}.atom",
         brand: org.brand
       }
     end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -1,0 +1,59 @@
+module Organisations
+  class ShowPresenter
+    attr_reader :org
+
+    def initialize(organisation)
+      @org = organisation
+    end
+
+    def prefixed_title
+      prefix = needs_definite_article?(org.title) ? "the " : ""
+      (prefix + org.title)
+    end
+
+    def latest
+      stories = []
+
+      org.ordered_featured_documents.each do |story|
+        metadata = {}
+        metadata[:document_type] = story["document_type"]
+
+        if story["public_updated_at"]
+          metadata[:public_updated_at] = Date.parse(story["public_updated_at"])
+        end
+
+        stories << {
+          link: {
+            text: story["title"],
+            path: story["href"]
+          },
+          metadata: metadata
+        }
+      end
+
+      {
+        items: stories,
+        brand: org.brand
+      }
+    end
+
+    def subscription_links
+      {
+        email_signup_link: "TODO",
+        feed_link_box_value: "TODO",
+        brand: org.brand
+      }
+    end
+
+  private
+
+    def needs_definite_article?(phrase)
+      exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]
+      !has_definite_article?(phrase) && !(exceptions.any? { |e| e =~ phrase.downcase })
+    end
+
+    def has_definite_article?(phrase)
+      phrase.downcase.strip[0..2] == 'the'
+    end
+  end
+end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -1,24 +1,22 @@
 module Organisations
   class ShowPresenter
-    attr_reader :org
-
     def initialize(organisation)
       @org = organisation
     end
 
     def prefixed_title
-      prefix = needs_definite_article?(org.title) ? "the " : ""
-      (prefix + org.title)
+      prefix = needs_definite_article?(@org.title) ? "the " : ""
+      (prefix + @org.title)
     end
 
     def has_latest_documents?
-      org.ordered_featured_documents.length.positive?
+      @org.ordered_featured_documents.length.positive?
     end
 
     def latest_documents
       documents = []
 
-      org.ordered_featured_documents.each do |story|
+      @org.ordered_featured_documents.each do |story|
         metadata = {}
         metadata[:document_type] = story["document_type"]
 
@@ -37,15 +35,44 @@ module Organisations
 
       {
         items: documents,
-        brand: org.brand
+        brand: @org.brand
       }
     end
 
     def subscription_links
       {
-        email_signup_link: "/government/email-signup/new?email_signup[feed]=#{org.web_url}.atom",
-        feed_link_box_value: "#{org.web_url}.atom",
-        brand: org.brand
+        email_signup_link: "/government/email-signup/new?email_signup[feed]=#{@org.web_url}.atom",
+        feed_link_box_value: "#{@org.web_url}.atom",
+        brand: @org.brand
+      }
+    end
+
+    def has_featured_policies?
+      true if @org.ordered_featured_policies && @org.ordered_featured_policies.length.positive?
+    end
+
+    def featured_policies
+      policies = []
+
+      @org.ordered_featured_policies.each do |policy|
+        policies << {
+          link: {
+            text: policy["title"],
+            path: policy["base_path"]
+          }
+        }
+      end
+
+      policies << {
+        link: {
+          text: "See all our policies",
+          path: "/government/policies?organisations[]=#{@org.slug}"
+        }
+      }
+
+      {
+        items: policies,
+        brand: @org.brand
       }
     end
 

--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -1,0 +1,27 @@
+module Organisations
+  class WhatWeDoPresenter
+    attr_reader :org
+
+    def initialize(organisation)
+      @org = organisation
+    end
+
+    def share_links
+      links = []
+
+      org.social_media_links.each do |link|
+        links << {
+          href: link["href"],
+          text: link["title"],
+          icon: link["service_type"]
+        }
+      end
+
+      {
+        stacked: true,
+        brand: org.brand,
+        links: links
+      }
+    end
+  end
+end

--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -6,6 +6,10 @@ module Organisations
       @org = organisation
     end
 
+    def has_share_links?
+      org.social_media_links.length.positive?
+    end
+
     def share_links
       links = []
 

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -23,81 +23,84 @@
   </div>
 <% end %>
 
-<div class="organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color">
+<% if @featured_news.has_featured_news? %>
+  <div class="organisations__margin-bottom">
+    <% if @organisation.is_news_organisation? %>
+      <%= render "govuk_publishing_components/components/image_card", @featured_news.first_featured_news %>
+    <% end %>
+
+    <% @featured_news.remaining_featured_news.in_groups_of(3, false) do |news| %>
+      <div class="grid-row">
+        <% news.each do |news_item| %>
+          <div class="column-one-third">
+            <%= render "govuk_publishing_components/components/image_card", news_item %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @show.has_latest_documents? %>
+  <div class="organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color organisations__margin-bottom">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Latest from #{@show.prefixed_title}",
+          padding: true,
+          margin_bottom: 2
+        } %>
+      </div>
+    </div>
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render "govuk_publishing_components/components/document_list", @show.latest_documents %>
+
+        <p class="organisations__margin-bottom brand--<%= @organisation.brand %>">
+          <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color">See all</a>
+        </p>
+
+        <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color organisations__margin-bottom">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-        text: "What #{@show.prefixed_title} is doing",
+        text: "What #{@what_we_do.what_we_do_title} does",
         padding: true,
-        margin_bottom: 4
+        margin_bottom: 2
       } %>
     </div>
   </div>
 
-  <% if @organisation.is_news_organisation? %>
-    <%= render "govuk_publishing_components/components/image_card", @featured_news.first_featured_news %>
-  <% end %>
-
-  <% @featured_news.remaining_featured_news.in_groups_of(3, false) do |news| %>
-    <div class="grid-row">
-      <% news.each do |news_item| %>
-        <div class="column-one-third">
-          <%= render "govuk_publishing_components/components/image_card", news_item %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: "What #{@what_we_do.what_we_do_title} does",
-  brand: @organisation.brand,
-  padding: true,
-  border_top: 5,
-  margin_bottom: 2
-} %>
-
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-        <p><%= @organisation.body %></p>
-        <p>TODO: add the rest</p>
-        <p><a href="<%= @organisation.base_path %>/about">Read more about what we do</a></p>
-    <% end %>
-  </div>
-
-  <div class="column-one-third">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Follow us",
-      margin_bottom: 2,
-      heading_level: 3,
-      font_size: 19
-    } %>
-    <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
-  </div>
-</div>
-
-<% if @organisation.ordered_featured_documents.length %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Latest from #{@show.prefixed_title}",
-    brand: @organisation.brand,
-    padding: true,
-    border_top: 5,
-    margin_bottom: 2
-  } %>
-
   <div class="grid-row">
     <div class="column-two-thirds">
-      <%= render "govuk_publishing_components/components/document_list", @show.latest %>
-
-      <p class="organisations__margin-bottom brand--<%= @organisation.brand %>">
-        <a href="/" class="brand__color">See all</a>
-      </p>
-
-      <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>
+      <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <p><%= @organisation.body %></p>
+          <p>TODO: add the rest</p>
+          <p><a href="<%= @organisation.base_path %>/about">Read more about what we do</a></p>
+      <% end %>
     </div>
+
+    <% if @what_we_do.has_share_links? %>
+      <div class="column-one-third">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Follow us",
+          margin_bottom: 2,
+          heading_level: 3,
+          font_size: 19
+        } %>
+        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>
 
 <% if @people.ministers.any? && !@organisation.is_no_10? %>
   <div class="organisations__section organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color">
@@ -129,15 +132,6 @@
     # above, however it is still needed for reference. It will be updated and removed later
   %>
 
-<%= render 'organisation_description',
-           organisation: organisation %>
-
-<div class="organisation-documents">
-  <%= render "govuk_publishing_components/components/heading", {
-      text: "Documents",
-      heading_level: 2
-  } %>
-</div>
 
 <%= render partial: 'contact',
            locals: {

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -79,12 +79,16 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-two-thirds brand--<%= @organisation.brand %>">
       <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
           <p><%= @organisation.body %></p>
           <p>TODO: add the rest</p>
-          <p><a href="<%= @organisation.base_path %>/about"><%= t('organisations.read_more') %></a></p>
+          <p>
+            <a href="<%= @organisation.base_path %>/about" class="brand__color">
+              <%= t('organisations.read_more') %>
+            </a>
+          </p>
       <% end %>
     </div>
 

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -27,7 +27,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-        text: "What #{@organisation.title} is doing",
+        text: "What #{@show.prefixed_title} is doing",
         padding: true,
         margin_bottom: 4
       } %>
@@ -48,6 +48,28 @@
     </div>
   <% end %>
 </div>
+
+<% if @organisation.ordered_featured_documents.length %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Latest from #{@show.prefixed_title}",
+    brand: @organisation.brand,
+    padding: true,
+    border_top: 5,
+    margin_bottom: 2
+  } %>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/document_list", @show.latest %>
+
+      <p class="organisations__margin-bottom brand--<%= @organisation.brand %>">
+        <a href="/" class="brand__color">See all</a>
+      </p>
+
+      <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>
+    </div>
+  </div>
+<% end %>
 
 <% if @people.ministers.any? && !@organisation.is_no_10? %>
   <div class="organisations__section organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color">
@@ -78,10 +100,6 @@
     # the code below is currently disabled as it will break following changes to accommodate the code
     # above, however it is still needed for reference. It will be updated and removed later
   %>
-
-<%= render "govuk_publishing_components/components/subscription-links", {
-    email_signup_link: "#{params[:organisation_name]}/email-signup",
-    feed_link: "#{params[:organisation_name]}.atom" } %>
 
 <%= render 'organisation_description',
            organisation: organisation %>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -47,6 +47,34 @@
       <% end %>
     </div>
   <% end %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "What #{@what_we_do.what_we_do_title} does",
+  brand: @organisation.brand,
+  padding: true,
+  border_top: 5,
+  margin_bottom: 2
+} %>
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <p><%= @organisation.body %></p>
+        <p>TODO: add the rest</p>
+        <p><a href="<%= @organisation.base_path %>/about">Read more about what we do</a></p>
+    <% end %>
+  </div>
+
+  <div class="column-one-third">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Follow us",
+      margin_bottom: 2,
+      heading_level: 3,
+      font_size: 19
+    } %>
+    <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
+  </div>
 </div>
 
 <% if @organisation.ordered_featured_documents.length %>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -82,8 +82,7 @@
     <div class="column-two-thirds brand--<%= @organisation.brand %>">
       <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <p><%= @organisation.body %></p>
-          <p>TODO: add the rest</p>
+          <p><%= @organisation.body.html_safe %></p>
           <p>
             <a href="<%= @organisation.base_path %>/about" class="brand__color">
               <%= t('organisations.read_more') %>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -102,6 +102,21 @@
   </div>
 </div>
 
+<% if @show.has_featured_policies? %>
+  <div class="grid-row">
+    <div class="column-one-third">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('organisations.our_policies'),
+        margin_bottom: 2
+      } %>
+    </div>
+
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/document_list", @show.featured_policies %>
+    </div>
+  </div>
+<% end %>
+
 <% if @people.ministers.any? && !@organisation.is_no_10? %>
   <div class="organisations__section organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color">
     <div class="grid-row">

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -46,7 +46,7 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
-          text: "Latest from #{@show.prefixed_title}",
+          text: t('organisations.latest_from', title: @show.prefixed_title),
           padding: true,
           margin_bottom: 2
         } %>
@@ -58,7 +58,7 @@
         <%= render "govuk_publishing_components/components/document_list", @show.latest_documents %>
 
         <p class="organisations__margin-bottom brand--<%= @organisation.brand %>">
-          <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color">See all</a>
+          <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all') %></a>
         </p>
 
         <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>
@@ -71,7 +71,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-        text: "What #{@what_we_do.what_we_do_title} does",
+        text: t('organisations.what_we_do', title: @show.prefixed_title),
         padding: true,
         margin_bottom: 2
       } %>
@@ -84,14 +84,14 @@
         } do %>
           <p><%= @organisation.body %></p>
           <p>TODO: add the rest</p>
-          <p><a href="<%= @organisation.base_path %>/about">Read more about what we do</a></p>
+          <p><a href="<%= @organisation.base_path %>/about"><%= t('organisations.read_more') %></a></p>
       <% end %>
     </div>
 
     <% if @what_we_do.has_share_links? %>
       <div class="column-one-third">
         <%= render "govuk_publishing_components/components/heading", {
-          text: "Follow us",
+          text: t('organisations.follow_us'),
           margin_bottom: 2,
           heading_level: 3,
           font_size: 19

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     what_we_do: "What %{title} does"
     read_more: "Read more about what we do"
     follow_us: "Follow us"
+    our_policies: "Our policies"
   language_names:
     en: English
     cy: Cymraeg

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,11 @@ en:
       public_corporation: "Public corporation"
       tribunal_ndpb: "Tribunal non-departmental public body"
       other: "Other"
+    latest_from: "Latest from %{title}"
+    see_all: "See all"
+    what_we_do: "What %{title} does"
+    read_more: "Read more about what we do"
+    follow_us: "Follow us"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -43,6 +43,18 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             }
           }
         ],
+        social_media_links: [
+          {
+            service_type: "twitter",
+            title: "Twitter - @10DowningStreet",
+            href: "https://twitter.com/@10DowningStreet"
+          },
+          {
+            service_type: "facebook",
+            title: "Facebook",
+            href: "https://www.facebook.com/10downingstreet"
+          },
+        ]
       },
       links: {
         available_translations: []
@@ -102,6 +114,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             role_href: "/government/ministers/parliamentary-under-secretary-of-state--94"
           }
         ],
+        social_media_links: [
+          {
+            service_type: "twitter",
+            title: "Twitter - @attorneygeneral",
+            href: "https://twitter.com/@attorneygeneral"
+          }
+        ]
       },
       links: {
         available_translations: []
@@ -148,6 +167,18 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             public_updated_at: "2018-06-06T10:56:00.000+01:00",
             document_type: "News story"
           }
+        ],
+        social_media_links: [
+          {
+            service_type: "twitter",
+            title: "Twitter",
+            href: "https://twitter.com/chtycommission"
+          },
+          {
+            service_type: "youtube",
+            title: "YouTube",
+            href: "http://www.youtube.com/TheCharityCommission"
+          },
         ]
       },
       links: {
@@ -194,6 +225,18 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             public_updated_at: "2018-06-08T23:23:11.000+01:00",
             document_type: "Press release"
           },
+        ],
+        social_media_links: [
+          {
+            service_type: "twitter",
+            title: "Twitter",
+            href: "https://twitter.com/UKGovWales"
+          },
+          {
+            service_type: "twitter",
+            title: "Trydar",
+            href: "https://twitter.com/LlywDUCymru"
+          }
         ]
       },
       links: {
@@ -210,10 +253,32 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       }
     }
 
+    @content_item_blank = {
+      title: "An empty content item to test everything checks before trying to render things",
+      base_path: "/government/organisations/an-empty-thing",
+      details: {
+        body: "",
+        brand: "",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "",
+        },
+      },
+      links: {
+      }
+    }
+
     content_store_has_item("/government/organisations/prime-ministers-office-10-downing-street", @content_item_no10)
     content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
+    content_store_has_item("/government/organisations/an-empty-thing", @content_item_blank)
+  end
+
+  it "doesn't fail if the content item is missing any data" do
+    visit "/government/organisations/an-empty-thing"
+    assert page.has_css?(".content")
   end
 
   it "sets the page title" do

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -182,7 +182,24 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         ]
       },
       links: {
-        available_translations: []
+        available_translations: [],
+        ordered_featured_policies: [
+          {
+            api_path: "/api/content/government/policies/waste-and-recycling",
+            base_path: "/government/policies/waste-and-recycling",
+            content_id: "5d5e9324-7631-11e4-a3cb-005056011aef",
+            description: "What the government’s doing about waste and recycling.",
+            document_type: "policy",
+            locale: "en",
+            public_updated_at: "2015-05-14T16:39:48Z",
+            schema_name: "policy",
+            title: "Waste and recycling",
+            withdrawn: false,
+            links: {},
+            api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
+            web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
+          },
+        ]
       }
     }
 
@@ -371,6 +388,14 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/civil-service-resourcing"
     refute page.has_css?(".gem-c-govspeak.govuk-govspeak")
+  end
+
+  it "shows 'our policies' when it should" do
+    visit "/government/organisations/attorney-generals-office"
+    refute page.has_content?(/Our policies/i)
+
+    visit "/government/organisations/charity-commission"
+    assert page.has_content?(/Our policies/i)
   end
 
   it "shows the ministers for an organisation" do

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -342,14 +342,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".app-c-topic-list")
 
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".app-c-topic-list.app-c-topic-list--small")
+    assert page.has_css?(".app-c-topic-list.app-c-topic-list--small .app-c-topic-list__link", text: "Attorney General's guidance to the legal profession")
 
     visit "/government/organisations/charity-commission"
-    assert page.has_css?(".app-c-topic-list")
+    assert page.has_css?(".app-c-topic-list .app-c-topic-list__link", text: "Find a charity")
     refute page.has_css?(".app-c-topic-list.app-c-topic-list--small")
-
-    visit "/government/organisations/civil-service-resourcing"
-    refute page.has_css?(".app-c-topic-list")
   end
 
   it "shows the translation nav if required" do
@@ -379,15 +376,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     # TODO: can't write this test until the right content is being rendered in this section
   end
 
-  it "shows the 'what we do' section when it should" do
+  it "shows the 'what we do' section" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     assert page.has_content?(/10 Downing Street is the official residence and the office of the British Prime Minister/i)
 
     visit "/government/organisations/attorney-generals-office"
     assert page.has_content?(/provides legal advice and support to the Attorney General/i)
-
-    visit "/government/organisations/civil-service-resourcing"
-    refute page.has_css?(".gem-c-govspeak.govuk-govspeak")
   end
 
   it "shows 'our policies' when it should" do
@@ -396,6 +390,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     assert page.has_content?(/Our policies/i)
+    assert page.has_css?(".gem-c-document-list__item-title", text: "Waste and recycling")
   end
 
   it "shows the ministers for an organisation" do

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -255,7 +255,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     @content_item_blank = {
       title: "An empty content item to test everything checks before trying to render things",
-      base_path: "/government/organisations/an-empty-thing",
+      base_path: "/government/organisations/civil-service-resourcing",
       details: {
         body: "",
         brand: "",
@@ -273,11 +273,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
-    content_store_has_item("/government/organisations/an-empty-thing", @content_item_blank)
+    content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
   end
 
   it "doesn't fail if the content item is missing any data" do
-    visit "/government/organisations/an-empty-thing"
+    visit "/government/organisations/civil-service-resourcing"
     assert page.has_css?(".content")
   end
 
@@ -301,6 +301,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     refute page.has_css?(".no10-banner")
+
+    visit "/government/organisations/civil-service-resourcing"
+    refute page.has_css?(".no10-banner")
   end
 
   it "renders the logo and logo brand correctly" do
@@ -312,6 +315,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     assert page.has_css?(".gem-c-organisation-logo.brand--department-for-business-innovation-skills img[alt='The Charity Commission']")
+
+    visit "/government/organisations/civil-service-resourcing"
+    refute page.has_css?(".gem-c-organisation-logo")
   end
 
   it "shows featured links correctly if present" do
@@ -324,6 +330,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/charity-commission"
     assert page.has_css?(".app-c-topic-list")
     refute page.has_css?(".app-c-topic-list.app-c-topic-list--small")
+
+    visit "/government/organisations/civil-service-resourcing"
+    refute page.has_css?(".app-c-topic-list")
   end
 
   it "shows the translation nav if required" do
@@ -335,14 +344,33 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
     assert page.has_css?(".gem-c-translation-nav")
+
+    visit "/government/organisations/civil-service-resourcing"
+    refute page.has_css?(".gem-c-translation-nav")
   end
 
   it "shows a large news item only on news organisations" do
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".gem-c-image-card.gem-c-image-card--large")
+    assert page.has_css?(".gem-c-image-card.gem-c-image-card--large .gem-c-image-card__title", text: "New head of the Serious Fraud Office announced")
 
     visit "/government/organisations/charity-commission"
-    refute page.has_css?(".gem-c-image-card.gem-c-image-card--large")
+    assert page.has_css?(".gem-c-image-card .gem-c-image-card__title", text: "Charity annual return 2018")
+    refute page.has_css?(".gem-c-image-card.gem-c-image-card--large .gem-c-image-card__title", text: "Charity annual return 2018")
+  end
+
+  it "shows the latest articles when it should" do
+    # TODO: can't write this test until the right content is being rendered in this section
+  end
+
+  it "shows the 'what we do' section when it should" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_content?(/10 Downing Street is the official residence and the office of the British Prime Minister/i)
+
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_content?(/provides legal advice and support to the Attorney General/i)
+
+    visit "/government/organisations/civil-service-resourcing"
+    refute page.has_css?(".gem-c-govspeak.govuk-govspeak")
   end
 
   it "shows the ministers for an organisation" do

--- a/test/presenters/organisations/featured_news_presenter_test.rb
+++ b/test/presenters/organisations/featured_news_presenter_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+describe Organisations::FeaturedNewsPresenter do
+  include RummagerHelpers
+  include OrganisationHelpers
+
+  before :each do
+    content_item = ContentItem.new(organisation_with_ministers)
+    organisation = Organisation.new(content_item)
+    @featured_news_presenter = Organisations::FeaturedNewsPresenter.new(organisation)
+  end
+
+  it 'formats the main large news story correctly' do
+    expected = {
+      href: "/government/news/new-head-of-the-serious-fraud-office-announced",
+      image_src: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+      image_alt: "Attorney General Jeremy Wright QC MP",
+      context: "4 June 2018 — Press release",
+      heading_text: "New head of the Serious Fraud Office announced",
+      description: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+      brand: "attorney-generals-office",
+      large: true
+    }
+    assert_equal expected, @featured_news_presenter.first_featured_news
+  end
+
+  it 'formats the remaining news stories correctly' do
+    expected = [{
+      href: "/government/news/new-head-of-a-different-office-announced",
+      image_src: "https://assets.publishing.service.gov.uk/john.jpg",
+      image_alt: "John Someone MP",
+      context: "4 June 2017 — Policy paper",
+      heading_text: "New head of a different office announced",
+      description: "John Someone appointed new Director of the Other Office ",
+      brand: "attorney-generals-office"
+    }]
+    assert_equal expected, @featured_news_presenter.remaining_featured_news
+  end
+end

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+describe Organisations::ShowPresenter do
+  include RummagerHelpers
+  include OrganisationHelpers
+
+  it 'adds a prefix to a title when it should' do
+    content_item = ContentItem.new({ title: "Attorney General's Office" }.with_indifferent_access)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = "the Attorney General's Office"
+    assert_equal expected, @show_presenter.prefixed_title
+  end
+
+  it 'does not add a prefix to a title when it should not' do
+    content_item = ContentItem.new({ title: "The Charity Commission" }.with_indifferent_access)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = "The Charity Commission"
+    assert_equal expected, @show_presenter.prefixed_title
+
+    content_item = ContentItem.new({ title: "civil service resourcing" }.with_indifferent_access)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = "civil service resourcing"
+    assert_equal expected, @show_presenter.prefixed_title
+  end
+
+  it 'formats policies correctly' do
+    content_item = ContentItem.new(organisation_with_ministers)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = {
+      items: [
+        {
+          link: {
+            text: "Waste and recycling",
+            path: "/government/policies/waste-and-recycling"
+          }
+        },
+        {
+          link: {
+            text: "See all our policies",
+            path: "/government/policies?organisations[]=attorney-generals-office"
+          }
+        }
+      ],
+      brand: "attorney-generals-office"
+    }
+
+    assert_equal expected, @show_presenter.featured_policies
+  end
+end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -2,8 +2,10 @@ module OrganisationHelpers
   def organisation_with_ministers
     {
       title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
       details: {
         brand: "attorney-generals-office",
+        organisation_featuring_priority: "news",
         ordered_ministers: [
           {
             name: "Oliver Dowden CBE MP",
@@ -43,6 +45,49 @@ module OrganisationHelpers
               alt_text: "Theresa May MP"
             }
           }
+        ],
+        ordered_featured_documents: [
+          {
+            title: "New head of the Serious Fraud Office announced",
+            href: "/government/news/new-head-of-the-serious-fraud-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+              alt_text: "Attorney General Jeremy Wright QC MP"
+            },
+            summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+            public_updated_at: "2018-06-04T11:30:03.000+01:00",
+            document_type: "Press release"
+          },
+          {
+            title: "New head of a different office announced",
+            href: "/government/news/new-head-of-a-different-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/john.jpg",
+              alt_text: "John Someone MP"
+            },
+            summary: "John Someone appointed new Director of the Other Office ",
+            public_updated_at: "2017-06-04T11:30:03.000+01:00",
+            document_type: "Policy paper"
+          }
+        ],
+      },
+      links: {
+        ordered_featured_policies: [
+          {
+            api_path: "/api/content/government/policies/waste-and-recycling",
+            base_path: "/government/policies/waste-and-recycling",
+            content_id: "5d5e9324-7631-11e4-a3cb-005056011aef",
+            description: "What the government’s doing about waste and recycling.",
+            document_type: "policy",
+            locale: "en",
+            public_updated_at: "2015-05-14T16:39:48Z",
+            schema_name: "policy",
+            title: "Waste and recycling",
+            withdrawn: false,
+            links: {},
+            api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
+            web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
+          },
         ]
       }
     }.with_indifferent_access


### PR DESCRIPTION
This PR adds the 'latest news', 'what we do' and 'our policies' sections to the new organisation pages.

![screen shot 2018-06-14 at 15 13 57](https://user-images.githubusercontent.com/861310/41417553-999acdaa-6fe5-11e8-9d2a-098e3d4bd69a.png)

The code is currently not returning data for the 'latest' section from the correct source, but this will be addressed in a later PR.

URLs to test with:
- [org page with all three sections](https://govuk-collections-pr-690.herokuapp.com/government/organisations/office-of-the-secretary-of-state-for-wales)
- [org page with just the first two](https://govuk-collections-pr-690.herokuapp.com/government/organisations/attorney-generals-office)

Trello cards:
- https://trello.com/c/BdGlYIwl/175-add-latest-news-and-communication-section-to-organisation-page
- https://trello.com/c/vlrxzeFp/174-add-what-we-do-section-to-organisation-page
- https://trello.com/c/Qw7Y6CKE/177-add-our-policies-list-to-what-we-do-section