### PR TITLE
Hide toggle button when javascript disabled

### DIFF
--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -36,7 +36,12 @@
   }
 
   .organisation-list__works-with-toggle {
-    @include core-16;
+    display: none;
+
+    .js-enabled & {
+      @include core-16;
+      display: inline;
+    }
   }
 
   .organisation-list__works-with {


### PR DESCRIPTION
When Javascript is disabled, we show the "Works With" organisation info by default.
This makes the 'view all' toggle redundant. We can therefore hide unless JS is enabled.

**Before (with JS disabled):**
<img width="659" alt="screen shot 2018-06-13 at 13 22 50" src="https://user-images.githubusercontent.com/29889908/41351012-f7e1269a-6f0c-11e8-9d85-e6057a4d0cb9.png">

**After (with JS disabled:**
<img width="653" alt="screen shot 2018-06-13 at 13 23 16" src="https://user-images.githubusercontent.com/29889908/41351016-fba874e0-6f0c-11e8-8b94-8e21f845e87f.png">