### PR TITLE
Add people and role pages

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,0 +1,9 @@
+class PeopleController < ApplicationController
+  def show
+    @person = Person.find!("/government/people/#{params[:name]}")
+    setup_content_item_and_navigation_helpers(@person)
+    render :show, locals: {
+        person: @person
+    }
+  end
+end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,0 +1,10 @@
+class RolesController < ApplicationController
+  def show
+    # Only ministerial roles have base paths, other role types aren't rendered
+    @role = Role.find!("/government/ministers/#{params[:role_name]}")
+    setup_content_item_and_navigation_helpers(@role)
+    render :show, locals: {
+        role: @role
+    }
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,0 +1,50 @@
+require 'active_model'
+
+class Person
+  include ActiveModel::Model
+
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+
+  def base_path
+    @content_item.content_item_data["base_path"]
+  end
+
+  def title
+    @content_item.content_item_data["title"]
+  end
+
+  def roles
+    links["ordered_current_appointments"].map { |ra| ra["title"] }.to_sentence
+  end
+
+  def image_url
+    details.dig("image", "url")
+  end
+
+  def image_alt_text
+    details.dig("image", "alt_text")
+  end
+
+  def biography
+    details["body"]
+  end
+
+private
+
+  def links
+    @content_item.content_item_data["links"]
+  end
+
+  def details
+    @content_item.content_item_data["details"]
+  end
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,38 @@
+require 'active_model'
+
+class Role
+  include ActiveModel::Model
+
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+
+  def base_path
+    @content_item.content_item_data["base_path"]
+  end
+
+  def title
+    @content_item.content_item_data["title"]
+  end
+
+  def responsibilities
+    details["body"]
+  end
+
+private
+
+  def links
+    @content_item.content_item_data["links"]
+  end
+
+  def details
+    @content_item.content_item_data["details"]
+  end
+end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, person.title %>
+
+<p class="type"><%= person.roles %></p>
+<h1><%= person.title %></h1>
+
+<p><img src="<%= person.image_url %>" alt="<%= person.image_alt_text %>"></p>
+
+<p><%= person.biography %></p>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,0 +1,6 @@
+<% content_for :title, role.title %>
+
+<p class="type">Ministerial role</p>
+<h1><%= role.title %></h1>
+
+<p><%= role.responsibilities %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
     to: "services_and_information#index",
     as: :services_and_information
 
+  get "/government/people/:name", to: "people#show"
+  get "/government/ministers/:role_name", to: "roles#show"
+
   constraints DocumentTypeRoutingConstraint.new('step_by_step_nav') do
     get "/:slug", to: 'step_nav#show'
   end


### PR DESCRIPTION
This commit adds pages for people and roles. The views are barebones since they will be filled in with components.

Trello: https://trello.com/c/CeLJAdEq/182-add-people-and-role-pages-to-collections