### PR TITLE
Fix organisation filter not searching ministerial departments

### DIFF
--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -41,8 +41,8 @@
 
       organisation.removeClass('js-hidden');
 
-      if (organisation.find('.logo-container').length > 0) {
-        organisationText = organisation.find('.logo-container').text();
+      if (organisation.find('.gem-c-organisation-logo__name').length > 0) {
+        organisationText = organisation.find('.gem-c-organisation-logo__name').text();
       }
       else {
         organisationText = organisation.find('.organisation-list__item-title').text();

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -26,10 +26,10 @@ describe('organisation-list-filter.js', function() {
       </div>\
       <ol data-filter="list">\
         <li data-filter="item" class="org-logo-1">\
-          <div class="logo-container">Cabinet Office</div>\
+          <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
         </li>\
         <li data-filter="item" class="org-logo-2">\
-          <div class="logo-container">Cabinet Office</div>\
+          <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
         </li>\
       </ol>\
     </div>\


### PR DESCRIPTION
The organisation index page filter broke when we moved the organisation logo component to the gem, because it needs to look for a specific class within that component.

Our JS tests didn't pick this up because we stub all the markup. This isn't ideal, but for now we can update the JS to look for the new updated class (which hopefully won't change).