### PR TITLE
Add other people sections

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -94,6 +94,11 @@ class Organisation
   def all_people
     {
       ministers: details["ordered_ministers"],
+      military_personnel: details["ordered_military_personnel"],
+      board_members: details["ordered_board_members"],
+      traffic_commissioners: details["ordered_traffic_commissioners"],
+      special_representatives: details["ordered_special_representatives"],
+      chief_professional_officers: details["ordered_chief_professional_officers"]
     }
   end
 
@@ -123,10 +128,6 @@ private
 
   def child_organisation_count
     links["ordered_child_organisations"].count
-  end
-
-  def board_members
-    details["ordered_board_members"]
   end
 
   def ordered_contacts

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -91,16 +91,32 @@ class Organisation
     details["organisation_featuring_priority"] == "news"
   end
 
-  def ordered_ministers
-    details["ordered_ministers"]
+  def all_people
+    {
+      ministers: details["ordered_ministers"],
+    }
+  end
+
+  def ordered_featured_policies
+    links["ordered_featured_policies"]
   end
 
   def social_media_links
     details["social_media_links"]
   end
 
-  def ordered_featured_policies
-    links["ordered_featured_policies"]
+  def ordered_parent_organisations
+    links["ordered_parent_organisations"]
+  end
+
+private
+
+  def links
+    @content_item.content_item_data["links"]
+  end
+
+  def details
+    @content_item.content_item_data["details"]
   end
 
   # methods below are not in use yet, this comment to be removed once confirmed
@@ -119,19 +135,5 @@ class Organisation
 
   def ordered_corporate_information_pages
     details["ordered_corporate_information_pages"]
-  end
-
-  def ordered_parent_organisations
-    links["ordered_parent_organisations"]
-  end
-
-private
-
-  def links
-    @content_item.content_item_data["links"]
-  end
-
-  def details
-    @content_item.content_item_data["details"]
   end
 end

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -66,6 +66,14 @@ module Organisations
       type.eql?(:ministers)
     end
 
+    def small_image_url(image_url)
+      image_url_array = image_url.split('/')
+      small_image_name = "s465_" + image_url_array[-1]
+      image_url_array[-1] = small_image_name
+
+      image_url_array.join("/")
+    end
+
     def formatted_person_data(person, type)
       data = {
         brand: @org.brand,
@@ -86,7 +94,7 @@ module Organisations
       end
 
       if person["image"]
-        data[:image_src] = person["image"]["url"]
+        data[:image_src] = small_image_url(person["image"]["url"])
         data[:image_alt] = person["image"]["alt_text"]
       end
 

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -1,68 +1,93 @@
 module Organisations
   class PeoplePresenter
     include ActionView::Helpers::UrlHelper
-    attr_reader :org
 
     def initialize(organisation)
       @org = organisation
     end
 
-    def ministers
-      all_ministers = []
+    def all_people
+      @org.all_people.map do |person_type, people|
+        {
+          title: I18n.t('organisations.people.' + person_type.to_s),
+          people: handle_duplicate_roles(people, person_type)
+        }
+      end
+    end
 
-      @org.ordered_ministers && @org.ordered_ministers.each do |minister|
-        minister_multiple_roles = all_ministers.select do |all_ministers_item|
-          all_ministers_item[:heading_text] === minister["name"]
+  private
+
+    def handle_duplicate_roles(people, person_type)
+      all_people = []
+
+      people && people.each do |person|
+        person_multiple_roles = all_people.select do |all_people_item|
+          all_people_item[:heading_text] === person["name"]
         end
 
-        if minister_multiple_roles.empty?
-          all_ministers.push(formatted_minister_data(minister))
+        if person_multiple_roles.empty?
+          all_people.push(formatted_person_data(person, person_type))
         else
-          all_ministers.map do |all_ministers_item|
-            if all_ministers_item[:heading_text].eql?(minister_multiple_roles.first[:heading_text])
-              all_ministers_item[:extra_links] = multiple_role_links(all_ministers_item, minister)
+          all_people.map do |all_people_item|
+            if all_people_item[:heading_text].eql?(person_multiple_roles.first[:heading_text])
+              if is_person_ministerial?(person_type)
+                all_people_item[:extra_links] = multiple_role_links(all_people_item, person)
+              else
+                all_people_item[:description] = multiple_role_description(all_people_item, person)
+              end
             end
           end
         end
       end
 
-      all_ministers
+      all_people
     end
 
-  private
-
-    def multiple_role_links(existing_minister_info, new_minister_info)
-      existing_role_links = existing_minister_info[:extra_links]
+    def multiple_role_links(existing_person_info, new_person_info)
+      existing_role_links = existing_person_info[:extra_links]
       new_role_links = [
         {
-          text: new_minister_info["role"],
-          href: new_minister_info["role_href"]
+          text: new_person_info["role"],
+          href: new_person_info["role_href"]
         }
       ]
 
       existing_role_links.concat(new_role_links)
     end
 
-    def formatted_minister_data(minister)
+    def multiple_role_description(existing_person_info, new_person_info)
+      existing_role_description = existing_person_info[:description]
+      new_role_description = new_person_info["role"]
+
+      existing_role_description + ', ' + new_role_description
+    end
+
+    def is_person_ministerial?(type)
+      type.eql?(:ministers)
+    end
+
+    def formatted_person_data(person, type)
       data = {
         brand: @org.brand,
-        href: minister["href"],
-        extra_links: [
-          {
-            text: minister["role"],
-            href: minister["role_href"]
-          }
-        ],
-        metadata: minister["payment_type"],
-        context: minister["name_prefix"],
-        heading_text: minister["name"],
+        href: person["href"],
+        description: (person["role"] unless is_person_ministerial?(type)),
+        metadata: person["payment_type"],
+        context: person["name_prefix"],
+        heading_text: person["name"],
         heading_level: 3,
         extra_links_no_indent: true
       }
 
-      if minister["image"]
-        data[:image_src] = minister["image"]["url"]
-        data[:image_alt] = minister["image"]["alt_text"]
+      if is_person_ministerial?(type)
+        data[:extra_links] = [{
+          text: person["role"],
+          href: person["role_href"]
+        }]
+      end
+
+      if person["image"]
+        data[:image_src] = person["image"]["url"]
+        data[:image_alt] = person["image"]["alt_text"]
       end
 
       data

--- a/app/views/organisations/_related_people.html.erb
+++ b/app/views/organisations/_related_people.html.erb
@@ -1,0 +1,23 @@
+<% if people.any? %>
+  <div class="organisations__section organisations__brand-border-top brand--<%= brand %> brand__border-color">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: title,
+          padding: true,
+          margin_bottom: 2
+        } %>
+      </div>
+    </div>
+
+    <% people.in_groups_of(4, false) do |people| %>
+      <div class="grid-row">
+        <% people.each do |person| %>
+          <div class="column-quarter">
+            <%= render "govuk_publishing_components/components/image_card", person %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div >
+<% end %>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -120,28 +120,14 @@
   </div>
 <% end %>
 
-<% if @people.ministers.any? && !@organisation.is_no_10? %>
-  <div class="organisations__section organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color">
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: I18n.t('organisations.our_ministers'),
-          padding: true,
-          margin_bottom: 2
-        } %>
-      </div>
-    </div>
-
-    <% @people.ministers.in_groups_of(4, false) do |ministers| %>
-      <div class="grid-row">
-        <% ministers.each do |minister| %>
-          <div class="column-quarter">
-            <%= render "govuk_publishing_components/components/image_card", minister %>
-          </div>
-        <% end %>
-      </div>
-    <% end %>
-  </div >
+<% unless @organisation.is_no_10? %>
+  <% @people.all_people.each do |people_data| %>
+    <%= render partial: 'related_people', locals: {
+      people: people_data[:people],
+      title: people_data[:title],
+      brand: @organisation.brand
+    } %>
+  <% end %>
 <% end %>
 
 <% if false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,9 @@ en:
   view_all: "view all"
   view_less: "view less"
   organisations:
-    our_ministers: "Our ministers"
     separate_website: "separate website"
+    people:
+      ministers: "Our ministers"
     type:
       adhoc_advisory_group: "Ad-hoc advisory group"
       advisory_ndpb: "Advisory non-departmental public body"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,12 @@ en:
   organisations:
     separate_website: "separate website"
     people:
+      board_members: "Our management"
+      chief_professional_officers: "Chief professional officers"
       ministers: "Our ministers"
+      military_personnel: "Our senior military officials"
+      special_representatives: "Special representatives"
+      traffic_commissioners: "Traffic commissioners"
     type:
       adhoc_advisory_group: "Ad-hoc advisory group"
       advisory_ndpb: "Advisory non-departmental public body"

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -211,17 +211,14 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     }
 
     @content_item_wales_office = {
-      title: "The Charity Commission",
-      base_path: "/government/organisations/charity-commission",
+      title: "Office of the Secretary of State for Wales",
+      base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales",
       details: {
-        body: "We register and regulate charities in England and Wales, to ensure that the public can support charities with confidence.\r\n",
-        brand: "department-for-business-innovation-skills",
+        body: "The Office of the Secretary of State for Wales supports the Welsh Secretary",
+        brand: "wales-office",
         logo: {
-          formatted_title: "Charity Commission",
-          image: {
-            url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/98/Home_page.jpg",
-            alt_text: "The Charity Commission"
-          }
+          formatted_title: "Office of the Secretary of State for Wales<br/>Swyddfa Ysgrifennydd Gwladol Cymru",
+          crest: "single-identity"
         },
         organisation_govuk_status: {
           status: "live",
@@ -229,13 +226,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         organisation_type: "non_ministerial_department",
         ordered_featured_links: [
           {
-            title: "Find a charity",
-            href: "http://apps.charitycommission.gov.uk/showcharity/registerofcharities/RegisterHomePage.aspx"
-          },
-          {
-            title: "Online services and contact forms",
-            href: "https://www.gov.uk/government/organisations/charity-commission/about/about-our-services"
-          },
+            title: "Wales Office Featured Link",
+            href: "/wales/link/1"
+          }
         ],
         ordered_featured_documents: [
           {

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -120,6 +120,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             title: "Twitter - @attorneygeneral",
             href: "https://twitter.com/@attorneygeneral"
           }
+        ],
+        ordered_board_members: [
+          {
+            name: "Sir Jeremy Heywood",
+            role: "Cabinet Secretary",
+            href: "/government/people/jeremy-heywood",
+          }
         ]
       },
       links: {
@@ -253,6 +260,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             service_type: "twitter",
             title: "Trydar",
             href: "https://twitter.com/LlywDUCymru"
+          }
+        ],
+        ordered_military_personnel: [
+          {
+            name: "Air Chief Marshal Sir  Stuart Peach GBE KCB ADC DL",
+            role: "Chief of the Defence Staff",
+            href: "/government/people/stuart-peach",
           }
         ]
       },
@@ -396,18 +410,43 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   it "shows the ministers for an organisation" do
     visit "/government/organisations/attorney-generals-office"
     assert page.has_css?(".gem-c-heading", text: "Our ministers")
-    assert page.has_css?('.gem-c-image-card .gem-c-image-card__title-link', text: 'Theresa May MP')
-    assert page.has_css?('.gem-c-image-card .gem-c-image-card__title-link', text: 'Stuart Andrew MP')
+    assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Theresa May MP")
+    assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Stuart Andrew MP")
   end
 
-  it 'does not show the ministers section for no.10' do
+  it "does not show the ministers section for no.10" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
-    refute page.has_css?('.gem-c-heading', text: 'Our ministers')
-    refute page.has_css?('.gem-c-image-card .gem-c-image-card__title-link', text: 'Theresa May MP')
+    refute page.has_css?(".gem-c-heading", text: "Our ministers")
+    refute page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Theresa May MP")
   end
 
-  it 'does not display ministers for organisations without minister data' do
+  it "does not display ministers for organisations without minister data" do
     visit "/government/organisations/charity-commission"
-    refute page.has_css?('.gem-c-heading', text: 'Our ministers')
+    refute page.has_css?(".gem-c-heading", text: "Our ministers")
+  end
+
+  it "shows the non-ministers for an organisation" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-heading", text: "Our management")
+    assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Sir Jeremy Heywood")
+
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+    assert page.has_css?(".gem-c-heading", text: "Our senior military officials")
+    assert page.has_css?(".gem-c-image-card__title .gem-c-image-card__title-link[href='/government/people/stuart-peach']")
+    assert page.has_css?(".gem-c-image-card__description", text: "Chief of the Defence Staff")
+  end
+
+  it "does not display non-ministers for an organisation if data not present" do
+    visit "/government/organisations/attorney-generals-office"
+    refute page.has_css?(".gem-c-heading", text: "Our senior military officials")
+    refute page.has_css?(".gem-c-heading", text: "Chief professional officers")
+    refute page.has_css?(".gem-c-heading", text: "Special representatives")
+    refute page.has_css?(".gem-c-heading", text: "Traffic commissioners")
+
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+    refute page.has_css?(".gem-c-heading", text: "Our management")
+    refute page.has_css?(".gem-c-heading", text: "Chief professional officers")
+    refute page.has_css?(".gem-c-heading", text: "Special representatives")
+    refute page.has_css?(".gem-c-heading", text: "Traffic commissioners")
   end
 end

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -17,7 +17,7 @@ describe Organisations::PeoplePresenter do
         people: {
           brand: "attorney-generals-office",
           href: "/government/people/oliver-dowden",
-          image_src: "/photo/oliver-dowden",
+          image_src: "/photo/s465_oliver-dowden",
           image_alt: "Oliver Dowden CBE MP",
           description: nil,
           metadata: nil,
@@ -44,7 +44,7 @@ describe Organisations::PeoplePresenter do
         people: {
           brand: "attorney-generals-office",
           href: "/government/people/theresa-may",
-          image_src: "/photo/theresa-may",
+          image_src: "/photo/s465_theresa-may",
           image_alt: "Theresa May MP",
           description: nil,
           metadata: nil,
@@ -146,6 +146,10 @@ describe Organisations::PeoplePresenter do
       expected = "Chief Executive of the Civil Service , Permanent Secretary (Cabinet Office)"
 
       assert_equal expected, @people_presenter.all_people.third[:people][1][:description]
+    end
+
+    it 'fetches small image' do
+      assert_equal "/photo/s465_jeremy-heywood", @people_presenter.all_people.third[:people][0][:image_src]
     end
   end
 end

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -13,70 +13,85 @@ describe Organisations::PeoplePresenter do
 
     it 'formats data for image card component' do
       expected = {
-        brand: "attorney-generals-office",
-        href: "/government/people/oliver-dowden",
-        image_src: "/photo/oliver-dowden",
-        image_alt: "Oliver Dowden CBE MP",
-        extra_links: [
-          {
-            text: "Parliamentary Secretary (Minister for Implementation)",
-            href: "/government/ministers/parliamentary-secretary"
-          }
-        ],
-        metadata: nil,
-        context: nil,
-        heading_text: "Oliver Dowden CBE MP",
-        heading_level: 3,
-        extra_links_no_indent: true
+        title: "Our ministers",
+        people: {
+          brand: "attorney-generals-office",
+          href: "/government/people/oliver-dowden",
+          image_src: "/photo/oliver-dowden",
+          image_alt: "Oliver Dowden CBE MP",
+          description: nil,
+          metadata: nil,
+          context: nil,
+          heading_text: "Oliver Dowden CBE MP",
+          heading_level: 3,
+          extra_links_no_indent: true,
+          extra_links: [
+            {
+              text: "Parliamentary Secretary (Minister for Implementation)",
+              href: "/government/ministers/parliamentary-secretary"
+            }
+          ]
+        }
       }
 
-      assert_equal expected, @people_presenter.ministers[0]
+      assert_equal expected[:title], @people_presenter.all_people.first[:title]
+      assert_equal expected[:people], @people_presenter.all_people.first[:people][0]
     end
 
     it 'handles ministers with multiple roles' do
       expected = {
-        brand: "attorney-generals-office",
-        href: "/government/people/theresa-may",
-        image_src: "/photo/theresa-may",
-        image_alt: "Theresa May MP",
-        extra_links: [
-          {
-            text: "Prime Minister",
-            href: "/government/ministers/prime-minister"
-          },
-          {
-            text: "Minister for the Civil Service",
-            href: "/government/ministers/minister-for-the-civil-service"
-          }
-        ],
-        metadata: nil,
-        context: "The Rt Hon",
-        heading_text: "Theresa May MP",
-        heading_level: 3,
-        extra_links_no_indent: true
+        title: "Our ministers",
+        people: {
+          brand: "attorney-generals-office",
+          href: "/government/people/theresa-may",
+          image_src: "/photo/theresa-may",
+          image_alt: "Theresa May MP",
+          description: nil,
+          metadata: nil,
+          context: "The Rt Hon",
+          heading_text: "Theresa May MP",
+          heading_level: 3,
+          extra_links_no_indent: true,
+          extra_links: [
+            {
+              text: "Prime Minister",
+              href: "/government/ministers/prime-minister"
+            },
+            {
+              text: "Minister for the Civil Service",
+              href: "/government/ministers/minister-for-the-civil-service"
+            }
+          ]
+        }
       }
 
-      assert_equal expected, @people_presenter.ministers[2]
+      assert_equal expected[:title], @people_presenter.all_people.first[:title]
+      assert_equal expected[:people], @people_presenter.all_people.first[:people][2]
     end
 
     it 'returns minister without image if no image available' do
       expected = {
-        brand: "attorney-generals-office",
-        href: "/government/people/stuart-andrew",
-        extra_links: [
-          {
-            text: "Parliamentary Under Secretary of State",
-            href: "/government/ministers/parliamentary-under-secretary-of-state--94"
-          },
-        ],
-        metadata: nil,
-        context: nil,
-        heading_text: "Stuart Andrew MP",
-        heading_level: 3,
-        extra_links_no_indent: true
+        title: "Our ministers",
+        people: {
+          brand: "attorney-generals-office",
+          href: "/government/people/stuart-andrew",
+          description: nil,
+          metadata: nil,
+          context: nil,
+          heading_text: "Stuart Andrew MP",
+          heading_level: 3,
+          extra_links_no_indent: true,
+          extra_links: [
+            {
+              text: "Parliamentary Under Secretary of State",
+              href: "/government/ministers/parliamentary-under-secretary-of-state--94"
+            },
+          ]
+        }
       }
 
-      assert_equal expected, @people_presenter.ministers[1]
+      assert_equal expected[:title], @people_presenter.all_people.first[:title]
+      assert_equal expected[:people], @people_presenter.all_people.first[:people][1]
     end
   end
 end

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -4,7 +4,7 @@ describe Organisations::PeoplePresenter do
   include RummagerHelpers
   include OrganisationHelpers
 
-  describe '#formatted_minister_data' do
+  describe 'ministers' do
     before :each do
       content_item = ContentItem.new(organisation_with_ministers)
       organisation = Organisation.new(content_item)
@@ -92,6 +92,60 @@ describe Organisations::PeoplePresenter do
 
       assert_equal expected[:title], @people_presenter.all_people.first[:title]
       assert_equal expected[:people], @people_presenter.all_people.first[:people][1]
+    end
+  end
+
+  describe 'non-ministers' do
+    before :each do
+      content_item = ContentItem.new(organisation_with_board_members)
+      organisation = Organisation.new(content_item)
+      @people_presenter = Organisations::PeoplePresenter.new(organisation)
+    end
+
+    it 'keeps the order for types of people' do
+      content_item = ContentItem.new(organisation_with_no_people)
+      organisation = Organisation.new(content_item)
+      @no_people_presenter = Organisations::PeoplePresenter.new(organisation)
+
+      expected = [
+        {
+          title: "Our ministers",
+          people: []
+        },
+        {
+          title: "Our senior military officials",
+          people: []
+        },
+        {
+          title: "Our management",
+          people: []
+        },
+        {
+          title: "Traffic commissioners",
+          people: []
+        },
+        {
+          title: "Special representatives",
+          people: []
+        },
+        {
+          title: "Chief professional officers",
+          people: []
+        }
+    ]
+
+      assert_equal expected, @no_people_presenter.all_people
+    end
+
+    it 'displays role as descriptions rather than links' do
+      assert_equal "Cabinet Secretary", @people_presenter.all_people.third[:people][0][:description]
+      assert_nil @people_presenter.all_people.third[:people][0][:extra_links]
+    end
+
+    it 'handles non-ministers with multiple roles' do
+      expected = "Chief Executive of the Civil Service , Permanent Secretary (Cabinet Office)"
+
+      assert_equal expected, @people_presenter.all_people.third[:people][1][:description]
     end
   end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -1,4 +1,18 @@
 module OrganisationHelpers
+  def organisation_with_no_people
+    {
+      title: "Attorney General's Office",
+      details: {
+        brand: "attorney-generals-office",
+        ordered_ministers: [],
+        ordered_board_members: [],
+        ordered_military_personnel: [],
+        ordered_chief_professional_officers: [],
+        ordered_special_representatives: []
+      }
+    }.with_indifferent_access
+  end
+
   def organisation_with_ministers
     {
       title: "Attorney General's Office",
@@ -87,6 +101,44 @@ module OrganisationHelpers
             links: {},
             api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
             web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
+          },
+        ]
+      }
+    }.with_indifferent_access
+  end
+
+  def organisation_with_board_members
+    {
+      title: "Attorney General's Office",
+      details: {
+        brand: "attorney-generals-office",
+        ordered_board_members: [
+          {
+            name: "Sir Jeremy Heywood",
+            role: "Cabinet Secretary",
+            href: "/government/people/jeremy-heywood",
+            image: {
+              url: "/photo/jeremy-heywood",
+              alt_text: "Sir Jeremy Heywood"
+            }
+          },
+          {
+            name: "John Manzoni",
+            role: "Chief Executive of the Civil Service ",
+            href: "/government/people/john-manzoni",
+            image: {
+              url: "/photo/john-manzoni",
+              alt_text: "John Manzoni"
+            }
+          },
+          {
+            name: "John Manzoni",
+            role: "Permanent Secretary (Cabinet Office)",
+            href: "/government/people/john-manzoni",
+            image: {
+              url: "/photo/john-manzoni",
+              alt_text: "John Manzoni"
+            }
           },
         ]
       }


### PR DESCRIPTION
Trello: https://trello.com/c/erJ9BaEy/179-add-other-people-roles-sections-to-organisation-page

<img width="988" alt="screen shot 2018-06-18 at 13 10 11" src="https://user-images.githubusercontent.com/29889908/41535190-58d8de08-72f9-11e8-9009-0f2a09354df5.png">

<img width="993" alt="screen shot 2018-06-18 at 13 14 23" src="https://user-images.githubusercontent.com/29889908/41535252-8afe0052-72f9-11e8-8806-9ad65025cb74.png">


Types of people (taken from Whitehall code):

- Ministers: done in previous PR (https://github.com/alphagov/collections/pull/696)
- Board Members ("Our Management"): https://govuk-collections-pr-700.herokuapp.com/government/organisations/cabinet-office
- Special representatives: https://govuk-collections-pr-700.herokuapp.com/government/organisations/foreign-commonwealth-office
- Senior military officials:https://govuk-collections-pr-700.herokuapp.com/government/organisations/ministry-of-defence
- Traffic commissioners: https://govuk-collections-pr-700.herokuapp.com/government/organisations/traffic-commissioners
- Chief Professional Officers: https://govuk-collections-pr-700.herokuapp.com/government/organisations/chief-fire-and-rescue-adviser-unit
- Judges: These were added in Whitehall here https://github.com/alphagov/whitehall/pull/2114, as Courts and Tribunals use the same template as organisations. We're not moving those pages over yet, so we don't need to render this section.
- No people: https://govuk-collections-pr-700.herokuapp.com/government/organisations/accelerated-access-review

**Note: at the moment, if a person has an image, we will always display that image. However, we don't want to show images for all board members. Ruben is doing some work to remove the image information from people in the content item where we don't want to show them (important board members vs board members)**