### PR TITLE
Add separate website notice page

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -114,6 +114,10 @@ class Organisation
     links["ordered_parent_organisations"]
   end
 
+  def separate_website_url
+    details["organisation_govuk_status"]["url"]
+  end
+
 private
 
   def links

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,25 +1,26 @@
-<%= render "govuk_publishing_components/components/heading", {
-    text: organisation.title,
-    heading_level: 2
+<% content_for :breadcrumbs do %>
+  <div class="organisations__margin-bottom">
+    <h1 class="visually-hidden"><%= @header.org.title %></h1>
+  </div>
+<% end %>
+
+<div class="grid-row">
+  <div class="column-one-third organisations__margin-bottom">
+    <%= render "govuk_publishing_components/components/organisation_logo", {
+      organisation: @header.organisation_logo
+    } %>
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/notice", {
+  title: "#{organisation.title} has a <a href='#{@organisation.separate_website_url}'>separate website</a>".html_safe
 } %>
 
-<div class="separate-website-label">
-  <%= "#{organisation.title} has a" %> <%= link_to "separate website", "#" %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <p><%= organisation.body.html_safe %></p>
+    <% end %>
+  </div>
 </div>
-
-<div class="organisation-body">
-  <%= organisation.body %>
-</div>
-
-<div class="parent-organisations">
-  <% if organisation.ordered_parent_organisations.presence %>
-    <%= "#{organisation.title} works with the" %>
-    <%= link_to organisation.ordered_parent_organisations[0]["title"],
-                organisation.ordered_parent_organisations[0]["base_path"] %>
-  <% end %>
-</div>
-
-<%= render "govuk_publishing_components/components/heading", {
-    text: "Documents",
-    heading_level: 2
-} %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -279,6 +279,23 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       }
     }
 
+    @content_item_separate_website = {
+      title: "Fire Service College",
+      base_path: "/government/organisations/fire-service-college",
+      details: {
+        body: "The Fire Service College (FSC) supplies specialist fire and rescue training to the UK's own fire and rescue services, the private security sector and the international market.\r\n\r\nThe college was formerly an executive agency of the Department for Communities and Local Government and was sold to Capita on 28 February 2013.<abbr title=\"Fire Service College\">FSC</abbr>",
+        brand: "null",
+        logo: {
+          formatted_title: "Fire Service College",
+        },
+        organisation_govuk_status: {
+          status: "exempt",
+          url: "http://www.google.com",
+          updated_at: "null"
+        },
+      }
+    }
+
     @content_item_blank = {
       title: "An empty content item to test everything checks before trying to render things",
       base_path: "/government/organisations/civil-service-resourcing",
@@ -299,6 +316,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
+    content_store_has_item("/government/organisations/fire-service-college", @content_item_separate_website)
     content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
 
     stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
@@ -347,9 +365,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     assert page.has_css?(".gem-c-organisation-logo.brand--department-for-business-innovation-skills img[alt='The Charity Commission']")
-
-    visit "/government/organisations/civil-service-resourcing"
-    refute page.has_css?(".gem-c-organisation-logo")
   end
 
   it "shows featured links correctly if present" do
@@ -464,5 +479,14 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".gem-c-heading", text: "Chief professional officers")
     refute page.has_css?(".gem-c-heading", text: "Special representatives")
     refute page.has_css?(".gem-c-heading", text: "Traffic commissioners")
+  end
+
+  it 'displays the separate website page correctly' do
+    visit "/government/organisations/fire-service-college"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Fire Service College has a separate website")
+    assert page.has_css?(".gem-c-notice a[href='http://www.google.com']", text: "separate website")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/The college was formerly an executive agency of the Department for Communities and Local Government/i)
   end
 end


### PR DESCRIPTION
Adds this page to the organisation pages in collections:

![screen shot 2018-06-18 at 09 45 29](https://user-images.githubusercontent.com/861310/41526509-62172b68-72dc-11e8-9180-50d0c214df9b.png)

Example page: https://govuk-collections-pr-701.herokuapp.com/government/organisations/advisory-committee-on-animal-feedingstuffs

There are some minor visual differences between the old page and the new, these are detailed here: https://trello.com/c/xXp5sHXs/10-separate-website-notice-smaller

Trello card: https://trello.com/c/iloDHtyy/170-add-separate-website-notice-to-organisation-page
