### PR TITLE
Get latest documents from rummager for organisations

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -10,33 +10,77 @@ module Organisations
     end
 
     def has_latest_documents?
-      @org.ordered_featured_documents.length.positive?
+      latest_documents.length.positive?
     end
 
     def latest_documents
-      documents = []
+      @latest_documents ||= Services.rummager.search(
+        count: 3,
+        order: "-public_timestamp",
+        filter_organisations: @org.slug,
+        fields: %w[title link content_store_document_type public_timestamp]
+      )["results"]
+      search_results_to_documents(@latest_documents)
+    end
 
-      @org.ordered_featured_documents.each do |story|
-        metadata = {}
-        metadata[:document_type] = story["document_type"]
+    def has_latest_announcements?
+      latest_announcements.length.positive?
+    end
 
-        if story["public_updated_at"]
-          metadata[:public_updated_at] = Date.parse(story["public_updated_at"])
-        end
+    def latest_announcements
+      @latest_announcements ||= Services.rummager.search(
+        count: 2,
+        order: "-public_timestamp",
+        filter_organisations: @org.slug,
+        filter_email_document_supertype: "announcements",
+        fields: %w[title link content_store_document_type public_timestamp]
+      )["results"]
+      search_results_to_documents(@latest_announcements)
+    end
 
-        documents << {
-          link: {
-            text: story["title"],
-            path: story["href"]
-          },
-          metadata: metadata
-        }
-      end
+    def has_latest_consultations?
+      latest_consultations.length.positive?
+    end
 
-      {
-        items: documents,
-        brand: @org.brand
-      }
+    def latest_consultations
+      @latest_consultations ||= Services.rummager.search(
+        count: 2,
+        order: "-public_timestamp",
+        filter_organisations: @org.slug,
+        filter_government_document_supertype: "consultations",
+        fields: %w[title link content_store_document_type public_timestamp]
+      )["results"]
+      search_results_to_documents(@latest_consultations)
+    end
+
+    def has_latest_publications?
+      latest_publications.length.positive?
+    end
+
+    def latest_publications
+      @latest_publications ||= Services.rummager.search(
+        count: 2,
+        order: "-public_timestamp",
+        filter_organisations: @org.slug,
+        filter_email_document_supertype: "publications",
+        fields: %w[title link content_store_document_type public_timestamp]
+      )["results"]
+      search_results_to_documents(@latest_publications)
+    end
+
+    def has_latest_statistics?
+      latest_statistics.length.positive?
+    end
+
+    def latest_statistics
+      @latest_statistics ||= Services.rummager.search(
+        count: 2,
+        order: "-public_timestamp",
+        filter_organisations: @org.slug,
+        filter_government_document_supertype: "statistics",
+        fields: %w[title link content_store_document_type public_timestamp]
+      )["results"]
+      search_results_to_documents(@latest_statistics)
     end
 
     def subscription_links
@@ -77,6 +121,32 @@ module Organisations
     end
 
   private
+
+    def search_results_to_documents(search_results)
+      documents = []
+
+      search_results.each do |item|
+        metadata = {}
+        metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ")
+
+        if item["public_timestamp"]
+          metadata[:public_updated_at] = Date.parse(item["public_timestamp"])
+        end
+
+        documents << {
+          link: {
+            text: item["title"],
+            path: item["link"]
+          },
+          metadata: metadata
+        }
+      end
+
+      {
+        items: documents,
+        brand: @org.brand
+      }
+    end
 
     def needs_definite_article?(phrase)
       exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -298,6 +298,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
     content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
+
+    stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
+    stub_rummager_latest_content_requests("attorney-generals-office")
+    stub_rummager_latest_content_requests("charity-commission")
+    stub_rummager_latest_content_requests("office-of-the-secretary-of-state-for-wales")
+    stub_rummager_latest_content_requests("civil-service-resourcing")
   end
 
   it "doesn't fail if the content item is missing any data" do
@@ -441,5 +447,40 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".gem-c-heading", text: "Chief professional officers")
     refute page.has_css?(".gem-c-heading", text: "Special representatives")
     refute page.has_css?(".gem-c-heading", text: "Traffic commissioners")
+  end
+
+private
+
+  def stub_rummager_latest_content_requests(organisation_slug)
+    stub_rummager_latest_documents_request(organisation_slug)
+    stub_rummager_latest_announcements_request(organisation_slug)
+    stub_rummager_latest_consultations_request(organisation_slug)
+    stub_rummager_latest_publications_request(organisation_slug)
+    stub_rummager_latest_statistics_request(organisation_slug)
+  end
+
+  def stub_rummager_latest_documents_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_announcements_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_consultations_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_publications_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_statistics_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
   end
 end


### PR DESCRIPTION
This commit fetches the latest documents, announcements, consultations, publications and statistics for an organisation from rummager.

Trello: https://trello.com/c/NKfFvvsn/188-add-an-organisations-tagged-documents-to-collections-via-rummager