### PR TITLE
Add high profile groups

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -134,6 +134,10 @@ class Organisation
     details["organisation_govuk_status"]["url"]
   end
 
+  def ordered_high_profile_groups
+    links["ordered_high_profile_groups"]
+  end
+
 private
 
   def links

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -77,6 +77,21 @@ module Organisations
       "/government/publications?departments[]=#{@org.slug}&publication_type=foi-releases"
     end
 
+    def high_profile_groups
+      high_profile_groups = @org.ordered_high_profile_groups && @org.ordered_high_profile_groups.map do |group|
+        {
+          text: group["title"],
+          path: group["base_path"]
+        }
+      end
+
+      {
+        title: I18n.t('organisations.high_profile_groups', title: acronym),
+        brand: @org.brand,
+        items: high_profile_groups
+      }
+    end
+
   private
 
     def contact_line(line)
@@ -95,6 +110,14 @@ module Organisations
 
     def foi_description(contact)
       content_tag(:p, contact.gsub("\r\n", "<br/>").html_safe) if contact
+    end
+
+    def acronym
+      if @org.acronym && !@org.acronym.empty?
+        @org.acronym
+      else
+        prefixed_title
+      end
     end
 
     def needs_definite_article?(phrase)

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -134,6 +134,22 @@
   <%= render partial: 'freedom_of_information' %>
 <% end %>
 
+<% if @show.high_profile_groups[:items] %>
+  <div class="grid-row organisations__section">
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: @show.high_profile_groups[:title],
+        brand: @organisation.brand,
+        border_top: 5,
+        padding: true,
+        margin_bottom: 2
+      } %>
+
+      <%= render "components/topic-list", @show.high_profile_groups %>
+    </div>
+  </div>
+<% end %>
+
 <% if false %>
   <%
     # the code below is currently disabled as it will break following changes to accommodate the code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   view_all: "view all"
   view_less: "view less"
   organisations:
+    high_profile_groups: High profile groups within %{title}
     separate_website: "separate website"
     people:
       board_members: "Our management"

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -132,7 +132,17 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         ]
       },
       links: {
-        available_translations: []
+        available_translations: [],
+        ordered_high_profile_groups: [
+          {
+            base_path: "/government/organisations/attorney-generals-office-1",
+            title: "High Profile Group 1",
+          },
+          {
+            base_path: "/government/organisations/attorney-generals-office-2",
+            title: "High Profile Group 2",
+          }
+        ]
       }
     }
 
@@ -562,5 +572,17 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_content?(/walesofficefoi@walesoffice.gsi.gov.uk/i)
     assert page.has_content?(/foiwales@walesoffice.gsi.gov.uk/i)
     assert page.has_content?(/welshofficefoi@walesoffice.gsi.gov.uk/i)
+  end
+
+  it "shows high profile groups section" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-heading", text: "High profile groups within the Attorney General\'s Office")
+    assert page.has_css?(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-1']", text: "High Profile Group 1")
+    assert page.has_css?(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-2']", text: "High Profile Group 2")
+  end
+
+  it 'does not show section for organisations without high profile groups' do
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+    refute page.has_css?(".gem-c-heading", text: "High profile groups within the Office of the Secretary of State for Wales")
   end
 end

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -5,7 +5,7 @@ describe Organisations::DocumentsPresenter do
   include OrganisationHelpers
 
   before :each do
-    content_item = ContentItem.new(organisation_with_ministers)
+    content_item = ContentItem.new(organisation_with_featured_documents)
     organisation = Organisation.new(content_item)
     @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
 

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -95,4 +95,27 @@ describe Organisations::ShowPresenter do
 
     assert_equal expected, @show_presenter.foi_contacts
   end
+
+  it 'formats high profile groups correctly' do
+    content_item = ContentItem.new(organisation_with_high_profile_groups)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = {
+      title: "High profile groups within Defra",
+      brand: "department-for-environment-food-rural-affairs",
+      items: [
+        {
+          text: "Rural Development Programme for England Network",
+          path: "/government/organisations/rural-development-programme-for-england-network"
+        },
+        {
+          text: "Rural Development Programme for England Network 2",
+          path: "/government/organisations/rural-development-programme-for-england-network-2"
+        }
+      ]
+    }
+
+    assert_equal expected, @show_presenter.high_profile_groups
+  end
 end

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -30,7 +30,7 @@ describe Organisations::ShowPresenter do
   end
 
   it 'formats policies correctly' do
-    content_item = ContentItem.new(organisation_with_ministers)
+    content_item = ContentItem.new(organisation_with_policies)
     organisation = Organisation.new(content_item)
     @show_presenter = Organisations::ShowPresenter.new(organisation)
 

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -268,4 +268,28 @@ module OrganisationHelpers
       }
     }.with_indifferent_access
   end
+
+  def organisation_with_high_profile_groups
+    {
+      title: "Department for Environment, Food & Rural Affairs",
+      base_path: "/government/organisations/department-for-environment-food-rural-affairs",
+      details: {
+        acronym: "Defra",
+        brand: "department-for-environment-food-rural-affairs",
+        organisation_featuring_priority: "news",
+      },
+      links: {
+        ordered_high_profile_groups: [
+          {
+            base_path: "/government/organisations/rural-development-programme-for-england-network",
+            title: "Rural Development Programme for England Network",
+          },
+          {
+            base_path: "/government/organisations/rural-development-programme-for-england-network-2",
+            title: "Rural Development Programme for England Network 2",
+          }
+        ]
+      }
+    }.with_indifferent_access
+  end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -99,50 +99,9 @@ module OrganisationHelpers
               alt_text: "Theresa May MP"
             }
           }
-        ],
-        ordered_featured_documents: [
-          {
-            title: "New head of the Serious Fraud Office announced",
-            href: "/government/news/new-head-of-the-serious-fraud-office-announced",
-            image: {
-              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
-              alt_text: "Attorney General Jeremy Wright QC MP"
-            },
-            summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
-            public_updated_at: "2018-06-04T11:30:03.000+01:00",
-            document_type: "Press release"
-          },
-          {
-            title: "New head of a different office announced",
-            href: "/government/news/new-head-of-a-different-office-announced",
-            image: {
-              url: "https://assets.publishing.service.gov.uk/john.jpg",
-              alt_text: "John Someone MP"
-            },
-            summary: "John Someone appointed new Director of the Other Office ",
-            public_updated_at: "2017-06-04T11:30:03.000+01:00",
-            document_type: "Policy paper"
-          }
-        ],
+        ]
       },
       links: {
-        ordered_featured_policies: [
-          {
-            api_path: "/api/content/government/policies/waste-and-recycling",
-            base_path: "/government/policies/waste-and-recycling",
-            content_id: "5d5e9324-7631-11e4-a3cb-005056011aef",
-            description: "What the government’s doing about waste and recycling.",
-            document_type: "policy",
-            locale: "en",
-            public_updated_at: "2015-05-14T16:39:48Z",
-            schema_name: "policy",
-            title: "Waste and recycling",
-            withdrawn: false,
-            links: {},
-            api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
-            web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
-          },
-        ],
         ordered_foi_contacts: [
           {
             withdrawn: false,
@@ -240,6 +199,71 @@ module OrganisationHelpers
               alt_text: "John Manzoni"
             }
           },
+        ]
+      }
+    }.with_indifferent_access
+  end
+
+  def organisation_with_policies
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        brand: "attorney-generals-office",
+        organisation_featuring_priority: "news"
+      },
+      links: {
+        ordered_featured_policies: [
+          {
+            api_path: "/api/content/government/policies/waste-and-recycling",
+            base_path: "/government/policies/waste-and-recycling",
+            content_id: "5d5e9324-7631-11e4-a3cb-005056011aef",
+            description: "What the government’s doing about waste and recycling.",
+            document_type: "policy",
+            locale: "en",
+            public_updated_at: "2015-05-14T16:39:48Z",
+            schema_name: "policy",
+            title: "Waste and recycling",
+            withdrawn: false,
+            links: {},
+            api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
+            web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
+          },
+        ]
+      }
+    }.with_indifferent_access
+  end
+
+  def organisation_with_featured_documents
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        brand: "attorney-generals-office",
+        organisation_featuring_priority: "news",
+        ordered_featured_documents: [
+          {
+            title: "New head of the Serious Fraud Office announced",
+            href: "/government/news/new-head-of-the-serious-fraud-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+              alt_text: "Attorney General Jeremy Wright QC MP"
+            },
+            summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+            public_updated_at: "2018-06-04T11:30:03.000+01:00",
+            document_type: "Press release"
+          },
+          {
+            title: "New head of a different office announced",
+            href: "/government/news/new-head-of-a-different-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/john.jpg",
+              alt_text: "John Someone MP"
+            },
+            summary: "John Someone appointed new Director of the Other Office ",
+            public_updated_at: "2017-06-04T11:30:03.000+01:00",
+            document_type: "Policy paper"
+          }
         ]
       }
     }.with_indifferent_access


### PR DESCRIPTION
Trello: https://trello.com/c/mNhHikIy/195-add-high-profile-groups-section-to-organisation-page

<img width="672" alt="screen shot 2018-06-18 at 16 11 15" src="https://user-images.githubusercontent.com/29889908/41545125-59b50a36-7312-11e8-9451-de2936608908.png">

Examples:

- https://govuk-collections-pr-704.herokuapp.com/government/organisations/cabinet-office
- https://govuk-collections-pr-704.herokuapp.com/government/organisations/department-for-environment-food-rural-affairs
- (no high profile groups): https://govuk-collections-pr-704.herokuapp.com/government/organisations/ofsted