### PR TITLE
Adds test for latest documents section

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -11,7 +11,7 @@ class OrganisationsController < ApplicationController
 
     @show = Organisations::ShowPresenter.new(@organisation)
     @header = Organisations::HeaderPresenter.new(@organisation)
-    @featured_news = Organisations::FeaturedNewsPresenter.new(@organisation)
+    @documents = Organisations::DocumentsPresenter.new(@organisation)
     @what_we_do = Organisations::WhatWeDoPresenter.new(@organisation)
     @people = Organisations::PeoplePresenter.new(@organisation)
 

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -1,5 +1,5 @@
 module Organisations
-  class FeaturedNewsPresenter
+  class DocumentsPresenter
     attr_reader :org
 
     def initialize(organisation)

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -9,80 +9,6 @@ module Organisations
       (prefix + @org.title)
     end
 
-    def has_latest_documents?
-      latest_documents.length.positive?
-    end
-
-    def latest_documents
-      @latest_documents ||= Services.rummager.search(
-        count: 3,
-        order: "-public_timestamp",
-        filter_organisations: @org.slug,
-        fields: %w[title link content_store_document_type public_timestamp]
-      )["results"]
-      search_results_to_documents(@latest_documents)
-    end
-
-    def has_latest_announcements?
-      latest_announcements.length.positive?
-    end
-
-    def latest_announcements
-      @latest_announcements ||= Services.rummager.search(
-        count: 2,
-        order: "-public_timestamp",
-        filter_organisations: @org.slug,
-        filter_email_document_supertype: "announcements",
-        fields: %w[title link content_store_document_type public_timestamp]
-      )["results"]
-      search_results_to_documents(@latest_announcements)
-    end
-
-    def has_latest_consultations?
-      latest_consultations.length.positive?
-    end
-
-    def latest_consultations
-      @latest_consultations ||= Services.rummager.search(
-        count: 2,
-        order: "-public_timestamp",
-        filter_organisations: @org.slug,
-        filter_government_document_supertype: "consultations",
-        fields: %w[title link content_store_document_type public_timestamp]
-      )["results"]
-      search_results_to_documents(@latest_consultations)
-    end
-
-    def has_latest_publications?
-      latest_publications.length.positive?
-    end
-
-    def latest_publications
-      @latest_publications ||= Services.rummager.search(
-        count: 2,
-        order: "-public_timestamp",
-        filter_organisations: @org.slug,
-        filter_email_document_supertype: "publications",
-        fields: %w[title link content_store_document_type public_timestamp]
-      )["results"]
-      search_results_to_documents(@latest_publications)
-    end
-
-    def has_latest_statistics?
-      latest_statistics.length.positive?
-    end
-
-    def latest_statistics
-      @latest_statistics ||= Services.rummager.search(
-        count: 2,
-        order: "-public_timestamp",
-        filter_organisations: @org.slug,
-        filter_government_document_supertype: "statistics",
-        fields: %w[title link content_store_document_type public_timestamp]
-      )["results"]
-      search_results_to_documents(@latest_statistics)
-    end
-
     def subscription_links
       {
         email_signup_link: "/government/email-signup/new?email_signup[feed]=#{@org.web_url}.atom",
@@ -121,32 +47,6 @@ module Organisations
     end
 
   private
-
-    def search_results_to_documents(search_results)
-      documents = []
-
-      search_results.each do |item|
-        metadata = {}
-        metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ")
-
-        if item["public_timestamp"]
-          metadata[:public_updated_at] = Date.parse(item["public_timestamp"])
-        end
-
-        documents << {
-          link: {
-            text: item["title"],
-            path: item["link"]
-          },
-          metadata: metadata
-        }
-      end
-
-      {
-        items: documents,
-        brand: @org.brand
-      }
-    end
 
     def needs_definite_article?(phrase)
       exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -41,7 +41,7 @@
   </div>
 <% end %>
 
-<% if @show.has_latest_documents? %>
+<% if @documents.has_latest_documents? %>
   <div class="organisations__brand-border-top brand--<%= @organisation.brand %> brand__border-color organisations__margin-bottom">
     <div class="grid-row">
       <div class="column-two-thirds">
@@ -55,7 +55,7 @@
 
     <div class="grid-row">
       <div class="column-two-thirds">
-        <%= render "govuk_publishing_components/components/document_list", @show.latest_documents %>
+        <%= render "govuk_publishing_components/components/document_list", @documents.latest_documents %>
 
         <p class="organisations__margin-bottom brand--<%= @organisation.brand %>">
           <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all') %></a>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -23,13 +23,13 @@
   </div>
 <% end %>
 
-<% if @featured_news.has_featured_news? %>
+<% if @documents.has_featured_news? %>
   <div class="organisations__margin-bottom">
     <% if @organisation.is_news_organisation? %>
-      <%= render "govuk_publishing_components/components/image_card", @featured_news.first_featured_news %>
+      <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>
     <% end %>
 
-    <% @featured_news.remaining_featured_news.in_groups_of(3, false) do |news| %>
+    <% @documents.remaining_featured_news.in_groups_of(3, false) do |news| %>
       <div class="grid-row">
         <% news.each do |news_item| %>
           <div class="column-one-third">

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -1,6 +1,8 @@
 require 'integration_test_helper'
 
 class OrganisationTest < ActionDispatch::IntegrationTest
+  include OrganisationHelpers
+
   before do
     @content_item_no10 = {
       title: "Prime Minister's Office, 10 Downing Street",
@@ -385,8 +387,23 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".gem-c-image-card.gem-c-image-card--large .gem-c-image-card__title", text: "Charity annual return 2018")
   end
 
-  it "shows the latest articles when it should" do
-    # TODO: can't write this test until the right content is being rendered in this section
+  it "shows the latest documents when it should" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-heading", text: "Latest from the Attorney General's Office")
+    assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral']", text: "Rapist has sentence increased after Solicitor General’s referral")
+    assert page.has_css?(".gem-c-document-list__attribute", text: "Press release")
+    assert page.has_css?(".gem-c-document-list__attribute time[datetime='2018-06-18']", text: "18 June 2018")
+  end
+
+  it "shows a see all link in the latest documents section" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("a[href='/government/latest?departments%5B%5D=attorney-generals-office']", text: "See all")
+  end
+
+  it "shows subscription links" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-subscription-links__link[href='/government/email-signup/new?email_signup%5Bfeed%5D=http://www.test.gov.uk/government/organisations/attorney-generals-office.atom']", text: "Get email alerts")
+    assert page.has_css?(".gem-c-subscription-links__link[href='#']", text: "Subscribe to feed")
   end
 
   it "shows the 'what we do' section" do
@@ -447,40 +464,5 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".gem-c-heading", text: "Chief professional officers")
     refute page.has_css?(".gem-c-heading", text: "Special representatives")
     refute page.has_css?(".gem-c-heading", text: "Traffic commissioners")
-  end
-
-private
-
-  def stub_rummager_latest_content_requests(organisation_slug)
-    stub_rummager_latest_documents_request(organisation_slug)
-    stub_rummager_latest_announcements_request(organisation_slug)
-    stub_rummager_latest_consultations_request(organisation_slug)
-    stub_rummager_latest_publications_request(organisation_slug)
-    stub_rummager_latest_statistics_request(organisation_slug)
-  end
-
-  def stub_rummager_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
-  end
-
-  def stub_rummager_latest_announcements_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
-  end
-
-  def stub_rummager_latest_consultations_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
-  end
-
-  def stub_rummager_latest_publications_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
-  end
-
-  def stub_rummager_latest_statistics_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
   end
 end

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
-describe Organisations::FeaturedNewsPresenter do
+describe Organisations::DocumentsPresenter do
   include RummagerHelpers
   include OrganisationHelpers
 
   before :each do
     content_item = ContentItem.new(organisation_with_ministers)
     organisation = Organisation.new(content_item)
-    @featured_news_presenter = Organisations::FeaturedNewsPresenter.new(organisation)
+    @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
   end
 
   it 'formats the main large news story correctly' do
@@ -21,7 +21,7 @@ describe Organisations::FeaturedNewsPresenter do
       brand: "attorney-generals-office",
       large: true
     }
-    assert_equal expected, @featured_news_presenter.first_featured_news
+    assert_equal expected, @documents_presenter.first_featured_news
   end
 
   it 'formats the remaining news stories correctly' do
@@ -34,6 +34,6 @@ describe Organisations::FeaturedNewsPresenter do
       description: "John Someone appointed new Director of the Other Office ",
       brand: "attorney-generals-office"
     }]
-    assert_equal expected, @featured_news_presenter.remaining_featured_news
+    assert_equal expected, @documents_presenter.remaining_featured_news
   end
 end

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -8,6 +8,8 @@ describe Organisations::DocumentsPresenter do
     content_item = ContentItem.new(organisation_with_ministers)
     organisation = Organisation.new(content_item)
     @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
+
+    stub_rummager_latest_content_requests("attorney-generals-office")
   end
 
   it 'formats the main large news story correctly' do
@@ -35,5 +37,26 @@ describe Organisations::DocumentsPresenter do
       brand: "attorney-generals-office"
     }]
     assert_equal expected, @documents_presenter.remaining_featured_news
+  end
+
+  it 'formats latest documents correctly' do
+    expected =
+      {
+        items: [
+          {
+            link: {
+              text: "Rapist has sentence increased after Solicitor General’s referral",
+              path: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral"
+            },
+            metadata: {
+              document_type: "Press release",
+              public_updated_at: Date.parse("2018-06-18T17:39:34.000+01:00")
+            }
+          }
+        ],
+        brand: "attorney-generals-office"
+      }
+
+    assert_equal expected, @documents_presenter.latest_documents
   end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -1,4 +1,44 @@
 module OrganisationHelpers
+  def stub_rummager_latest_content_requests(organisation_slug)
+    stub_rummager_latest_documents_request(organisation_slug)
+    stub_rummager_latest_announcements_request(organisation_slug)
+    stub_rummager_latest_consultations_request(organisation_slug)
+    stub_rummager_latest_publications_request(organisation_slug)
+    stub_rummager_latest_statistics_request(organisation_slug)
+  end
+
+  def stub_rummager_latest_documents_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [
+        {
+          title: "Rapist has sentence increased after Solicitor General’s referral",
+          link: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
+          content_store_document_type: "press release",
+          public_timestamp: "2018-06-18T17:39:34.000+01:00"
+        }
+      ] }.to_json)
+  end
+
+  def stub_rummager_latest_announcements_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_consultations_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_publications_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
+  def stub_rummager_latest_statistics_request(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+      to_return(body: { results: [] }.to_json)
+  end
+
   def organisation_with_no_people
     {
       title: "Attorney General's Office",


### PR DESCRIPTION
This PR includes the last of the work to finish: https://trello.com/c/BdGlYIwl/175-add-latest-documents-section-to-organisation-page

Methods were added in https://github.com/alphagov/collections/pull/702 to retrieve latest documents from Rummager.

This PR:

- Moves those methods into a DocumentsPresenter so they're not in the more general ShowPresenter
- Pulls Rummager call into a separate private method which can be used by the others
- Adds integration and presenter tests for this new logic and section of the organisation page.

Examples (to check I haven't broken anything!):

- https://govuk-collections-pr-706.herokuapp.com/government/organisations/charity-commission
- https://govuk-collections-pr-706.herokuapp.com/government/organisations/cabinet-office
- https://govuk-collections-pr-706.herokuapp.com/government/organisations/attorney-generals-office