### PR TITLE
Fix title in feed items

### DIFF
--- a/app/presenters/organisation_feed_entry_presenter.rb
+++ b/app/presenters/organisation_feed_entry_presenter.rb
@@ -22,7 +22,11 @@ class OrganisationFeedEntryPresenter
   end
 
   def title
-    result["title"]
+    if display_type.present?
+      "#{display_type}: #{result['title']}"
+    else
+      result['title']
+    end
   end
 
   def description

--- a/test/integration/organisation_atom_feed_test.rb
+++ b/test/integration/organisation_atom_feed_test.rb
@@ -73,7 +73,7 @@ class OrganisationAtomFeedTest < ActionDispatch::IntegrationTest
 
   def and_a_title
     title = page.first("feed>entry>title").text(:all)
-    assert_equal title, "OWL and NEWT qualifications, Ministry of Magic"
+    assert_equal title, "Detailed guide: OWL and NEWT qualifications, Ministry of Magic"
   end
 
   def and_a_summary


### PR DESCRIPTION
We precede the title with the display type if it's present.  This helps
users decide if they need to read the article.