### PR TITLE
Harden the code around consultation closing dates

### DIFF
--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -32,6 +32,10 @@ module Supergroups
 
     def consultation_closing_date(base_path)
       @consultation = ::Services.content_store.content_item(base_path)
+
+      # Don't continue if the Content Store returned something unexpected
+      return if @consultation["base_path"] != base_path
+
       date = Date.parse(@consultation["details"]["closing_date"])
 
       if date < Time.zone.today


### PR DESCRIPTION
The Content Store can redirect to another content item. When looking
up the consultation closing dates, if this happens, stop, as it means
that something's not quite right.

If this happens, the page will just omit the closing date.

This was spotted on Integration, as the Content Store was returning
the /government prefix route instead of a consultation, probably
because of issues with replicating data between environments.