### PR TITLE
Use metadata component from gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'plek', '~> 2.1.1'
 gem 'rails', '5.2.0'
 gem 'rinku', require: 'rails_rinku'
 gem 'sass-rails', '~> 5.0.3'
-gem 'slimmer', '~> 12.1.0'
+gem 'slimmer', '~> 13.0.0'
 gem 'uglifier', '~> 4.1.11'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (12.1.0)
+    slimmer (13.0.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -375,7 +375,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   simplecov
   simplecov-rcov
-  slimmer (~> 12.1.0)
+  slimmer (~> 13.0.0)
   timecop
   uglifier (~> 4.1.11)
   webmock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  include Slimmer::GovukComponents
 
   protect_from_forgery with: :exception
 

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -5,7 +5,7 @@
     <div class="column-two-thirds">
       <%= yield :page_title %>
       <% if organisations.any? %>
-        <%= render "govuk_component/metadata", from: organisations.array_of_links %>
+        <%= render "govuk_publishing_components/components/metadata", from: organisations.array_of_links %>
       <% end %>
     </div>
 

--- a/features/step_definitions/browsing_topics_steps.rb
+++ b/features/step_definitions/browsing_topics_steps.rb
@@ -7,7 +7,7 @@ When(/^I view the browse page for that subtopic$/) do
 end
 
 Then(/^I see a list of organisations associated with content in the subtopic$/) do
-  @organisations.each do |slug|
-    assert page.has_text?(slug)
+  within '.gem-c-metadata' do
+    assert page.has_text?("Department of Energy & Climate Change")
   end
 end

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,6 +1,4 @@
 Given(/^there is an alphabetical browse page set up with links$/) do
-  stub_browse_lookups
-
   second_level_browse_pages = [{
     content_id: 'judges-content-id',
     title: 'Judges',
@@ -24,8 +22,6 @@ Given(/^there is an alphabetical browse page set up with links$/) do
 end
 
 Given(/^that there are curated second level browse pages$/) do
-  stub_browse_lookups
-
   second_level_browse_pages = [
     {
       content_id: 'judges-content-id',

--- a/features/support/browse_test_helpers.rb
+++ b/features/support/browse_test_helpers.rb
@@ -1,13 +1,7 @@
 require 'gds_api/test_helpers/content_store'
-require 'slimmer/test_helpers/govuk_components'
 
 module BrowseTestHelpers
   include GdsApi::TestHelpers::ContentStore
-  include Slimmer::TestHelpers::GovukComponents
-
-  def stub_browse_lookups
-    stub_shared_component_locales
-  end
 
   def assert_can_see_linked_item(name)
     assert page.has_selector?('a', text: name)

--- a/features/support/services_and_information_helper.rb
+++ b/features/support/services_and_information_helper.rb
@@ -1,12 +1,10 @@
 require 'gds_api/test_helpers/rummager'
-require 'slimmer/test_helpers/govuk_components'
 
 require_relative '../../test/support/rummager_helpers'
 
 module ServicesAndInformationHelpers
   include GdsApi::TestHelpers::Rummager
   include RummagerHelpers
-  include Slimmer::TestHelpers::GovukComponents
 
   def stub_services_and_information_lookups
     @services_and_information = %w{
@@ -31,8 +29,6 @@ module ServicesAndInformationHelpers
         ]
       },
     )
-
-    stub_shared_component_locales
   end
 end
 

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -1,12 +1,9 @@
 require 'gds_api/test_helpers/rummager'
-require 'slimmer/test_helpers/govuk_components'
-
 require_relative '../../test/support/rummager_helpers'
 
 module TopicHelper
   include GdsApi::TestHelpers::Rummager
   include RummagerHelpers
-  include Slimmer::TestHelpers::GovukComponents
 
   def stub_topic_lookups
     rummager_has_documents_for_subtopic(
@@ -57,8 +54,6 @@ module TopicHelper
       'oil-and-gas/fields-and-wells',
       'content-id-for-fields-and-wells'
     )
-
-    stub_shared_component_locales
   end
 end
 

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -9,11 +9,6 @@ module TopicHelper
   include Slimmer::TestHelpers::GovukComponents
 
   def stub_topic_lookups
-    @organisations = %w{
-      government/organisations/department-of-energy-climate-change
-      government/organisations/air-accidents-investigation-branch
-    }
-
     rummager_has_documents_for_subtopic(
       'content-id-for-fields-and-wells',
       %w{

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -70,10 +70,10 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         assert page.has_css?(".gem-c-title__context-link[href='/topic/oil-and-gas']", text: "Oil and Gas")
       end
 
-      within_static_component('metadata') do
+      within '.gem-c-metadata' do
         # The orgs are fixed in the rummager test helpers
-        assert page.has_text?("Department of Energy &amp; Climate Change")
-        assert page.has_text?("Foreign &amp; Commonwealth Office")
+        assert page.has_text?("Department of Energy & Climate Change")
+        assert page.has_text?("Foreign & Commonwealth Office")
       end
     end
 
@@ -105,9 +105,9 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         assert page.has_css?(".gem-c-title__context-link[href='/topic/oil-and-gas']", text: "Oil and Gas")
       end
 
-      within_static_component('metadata') do
-        assert page.has_text?("Department of Energy &amp; Climate Change")
-        assert page.has_text?("Foreign &amp; Commonwealth Office")
+      within '.gem-c-metadata' do
+        assert page.has_text?("Department of Energy & Climate Change")
+        assert page.has_text?("Foreign & Commonwealth Office")
       end
     end
 
@@ -146,10 +146,10 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
           assert page.has_css?(".gem-c-title__context-link[href='/topic/oil-and-gas/offshore']", text: "Offshore")
         end
 
-        within_static_component('metadata') do
+        within '.gem-c-metadata' do
           # The orgs are fixed in the rummager test helpers
-          assert page.has_text?("Department of Energy &amp; Climate Change")
-          assert page.has_text?("Foreign &amp; Commonwealth Office")
+          assert page.has_text?("Department of Energy & Climate Change")
+          assert page.has_text?("Foreign & Commonwealth Office")
         end
       end
 

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -1,10 +1,8 @@
 require 'integration_test_helper'
-require 'slimmer/test_helpers/govuk_components'
 
 class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
   include TaxonHelpers
-  include Slimmer::TestHelpers::GovukComponents
 
   it 'contains both the atom and email signup url if we are browsing a world location' do
     @base_path = '/world/usa'

--- a/test/integration/world_wide_taxon_browsing_test.rb
+++ b/test/integration/world_wide_taxon_browsing_test.rb
@@ -1,5 +1,4 @@
 require 'integration_test_helper'
-require 'slimmer/test_helpers/govuk_components'
 
 class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
   it "renders a leaf page for world content" do
@@ -67,7 +66,6 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
 
   def then_i_see_the_taxon_page
     assert page.has_selector?('title', text: "Japan", visible: false)
-    assert_not_nil shared_component_selector('breadcrumbs')
   end
 
   def and_i_can_see_the_content_tagged_to_the_taxon

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -2,7 +2,6 @@ require_relative "test_helper"
 
 require 'capybara/rails'
 require 'slimmer/test'
-require 'slimmer/test_helpers/govuk_components'
 require 'capybara/poltergeist'
 require 'phantomjs/poltergeist'
 
@@ -10,16 +9,4 @@ Capybara.javascript_driver = :poltergeist
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-  include Slimmer::TestHelpers::GovukComponents
-
-  before do
-    stub_shared_component_locales
-  end
-
-  def within_static_component(component)
-    within(shared_component_selector(component)) do
-      component_args = JSON.parse(page.text).with_indifferent_access
-      yield component_args
-    end
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,7 +21,6 @@ WebMock.disable_net_connect!
 Dir[Rails.root.join('test/support/*.rb')].each { |f| require f }
 
 require 'gds_api/test_helpers/content_store'
-require 'slimmer/test_helpers/govuk_components'
 require 'gds_api/test_helpers/rummager'
 
 # Most tests use ActiveSupport TestCase behaviour, so we configure this here.
@@ -34,12 +33,7 @@ end
 
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
-  include Slimmer::TestHelpers::GovukComponents
   include GdsApi::TestHelpers::Rummager
-
-  before do
-    stub_shared_component_locales
-  end
 
   after do
     WebMock.reset!


### PR DESCRIPTION
This makes the app use the metadata component from the gem (https://trello.com/c/HPvqjaYP). Since this is the last usage of Static components, we can clean up the code and test helpers.

https://trello.com/c/pU7YINt1