### PR TITLE
Sanitizes data before displaying to avoid potential XSS attack

### DIFF
--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -15,7 +15,7 @@
         average_title_length: 'long',
         margin_bottom: 0 %>
 
-    <div class="govuk-govspeak"><%= raw(step_by_step.introduction) %></div>
+    <div class="govuk-govspeak"><%= sanitize(step_by_step.introduction, tags: %w(strong, em, a), attributes: %w(href)) %></div>
   </div>
 </div>
 <div class="grid-row">

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -15,7 +15,7 @@
         average_title_length: 'long',
         margin_bottom: 0 %>
 
-    <div class="govuk-govspeak"><%= sanitize(step_by_step.introduction, tags: %w(strong, em, a), attributes: %w(href)) %></div>
+    <div class="govuk-govspeak"><%= sanitize(step_by_step.introduction, tags: %w(strong em a), attributes: %w(href)) %></div>
   </div>
 </div>
 <div class="grid-row">


### PR DESCRIPTION
The risk of this was low as all user data is from Civil Service employees. However, it's generally good practice to sanitize all user input. This commit implements that sanitization.

[Related ticket](https://trello.com/c/aOOWxMxu/234-start-identifying-potential-security-vulnerabilities-in-applications)