### PR TITLE
Non live org pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -14,6 +14,7 @@ class OrganisationsController < ApplicationController
     @documents = Organisations::DocumentsPresenter.new(@organisation)
     @what_we_do = Organisations::WhatWeDoPresenter.new(@organisation)
     @people = Organisations::PeoplePresenter.new(@organisation)
+    @not_live = Organisations::NotLivePresenter.new(@organisation)
 
     respond_to do |f|
       f.html do

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -134,8 +134,56 @@ class Organisation
     details["organisation_govuk_status"]["url"]
   end
 
-  def has_separate_website?
+  def is_live?
+    details["organisation_govuk_status"]["status"] == "live"
+  end
+
+  def is_changed_name?
+    details["organisation_govuk_status"]["status"] == "changed_name"
+  end
+
+  def is_exempt?
     details["organisation_govuk_status"]["status"] == "exempt"
+  end
+
+  def is_joining?
+    details["organisation_govuk_status"]["status"] == "joining"
+  end
+
+  def is_devolved?
+    details["organisation_govuk_status"]["status"] == "devolved"
+  end
+
+  def is_closed?
+    details["organisation_govuk_status"]["status"] == "closed"
+  end
+
+  def is_left_gov?
+    details["organisation_govuk_status"]["status"] == "left_gov"
+  end
+
+  def is_merged?
+    details["organisation_govuk_status"]["status"] == "merged"
+  end
+
+  def is_split?
+    details["organisation_govuk_status"]["status"] == "split"
+  end
+
+  def is_no_longer_exists?
+    details["organisation_govuk_status"]["status"] == "no_longer_exists"
+  end
+
+  def is_replaced?
+    details["organisation_govuk_status"]["status"] == "replaced"
+  end
+
+  def status_updated_at
+    details["organisation_govuk_status"]["updated_at"]
+  end
+
+  def ordered_successor_organisations
+    links["ordered_successor_organisations"]
   end
 
   def ordered_high_profile_groups

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -114,7 +114,7 @@ module Organisations
 
       {
         items: documents,
-        brand: (@org.brand unless @org.has_separate_website?)
+        brand: (@org.brand if @org.is_live?)
       }
     end
 

--- a/app/presenters/organisations/not_live_presenter.rb
+++ b/app/presenters/organisations/not_live_presenter.rb
@@ -1,0 +1,71 @@
+module Organisations
+  class NotLivePresenter
+    include ActionView::Helpers::UrlHelper
+
+    def initialize(organisation)
+      @org = organisation
+    end
+
+    def non_live_organisation_notice
+      return separate_website_notice if @org.is_exempt?
+      return changed_name_notice if @org.is_changed_name? || @org.is_closed?
+      return joining_notice if @org.is_joining?
+      return devolved_notice if @org.is_devolved?
+      return left_gov_notice if @org.is_left_gov?
+      return merged_notice if @org.is_merged?
+      return split_notice if @org.is_split? || @org.is_replaced?
+      return no_longer_exists_notice if @org.is_no_longer_exists?
+      @org.title
+    end
+
+  private
+
+    def separate_website_notice
+      I18n.t('organisations.notices.separate_website', title: @org.title, url: @org.separate_website_url).html_safe
+    end
+
+    def changed_name_notice
+      I18n.t('organisations.notices.changed_name', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
+    end
+
+    def joining_notice
+      I18n.t('organisations.notices.joining', title: @org.title)
+    end
+
+    def devolved_notice
+      I18n.t('organisations.notices.devolved', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
+    end
+
+    def left_gov_notice
+      I18n.t('organisations.notices.left_gov', title: @org.title)
+    end
+
+    def merged_notice
+      I18n.t('organisations.notices.merged', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title, updated: notice_successor_updated).html_safe
+    end
+
+    def split_notice
+      successors = @org.ordered_successor_organisations.map do |successor|
+        link_to(successor["title"], successor["base_path"])
+      end
+
+      I18n.t('organisations.notices.split', title: @org.title, links: successors.to_sentence).html_safe
+    end
+
+    def no_longer_exists_notice
+      I18n.t('organisations.notices.no_longer_exists', title: @org.title)
+    end
+
+    def notice_successor_title
+      @org.ordered_successor_organisations[0]["title"]
+    end
+
+    def notice_successor_link
+      @org.ordered_successor_organisations[0]["base_path"]
+    end
+
+    def notice_successor_updated
+      Date.parse(@org.status_updated_at).strftime("%B %Y")
+    end
+  end
+end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -103,6 +103,18 @@ module Organisations
       }
     end
 
+    def non_live_organisation_notice
+      return separate_website_notice if @org.is_exempt?
+      return changed_name_notice if @org.is_changed_name? || @org.is_closed?
+      return joining_notice if @org.is_joining?
+      return devolved_notice if @org.is_devolved?
+      return left_gov_notice if @org.is_left_gov?
+      return merged_notice if @org.is_merged?
+      return split_notice if @org.is_split? || @org.is_replaced?
+      return no_longer_exists_notice if @org.is_no_longer_exists?
+      @org.title
+    end
+
   private
 
     def contact_line(line)
@@ -138,6 +150,54 @@ module Organisations
 
     def has_definite_article?(phrase)
       phrase.downcase.strip[0..2] == 'the'
+    end
+
+    def separate_website_notice
+      I18n.t('organisations.notices.separate_website', title: @org.title, url: @org.separate_website_url).html_safe
+    end
+
+    def changed_name_notice
+      I18n.t('organisations.notices.changed_name', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
+    end
+
+    def joining_notice
+      I18n.t('organisations.notices.joining', title: @org.title)
+    end
+
+    def devolved_notice
+      I18n.t('organisations.notices.devolved', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
+    end
+
+    def left_gov_notice
+      I18n.t('organisations.notices.left_gov', title: @org.title)
+    end
+
+    def merged_notice
+      I18n.t('organisations.notices.merged', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title, updated: notice_successor_updated).html_safe
+    end
+
+    def split_notice
+      successors = @org.ordered_successor_organisations.map do |successor|
+        link_to(successor["title"], successor["base_path"])
+      end
+
+      I18n.t('organisations.notices.split', title: @org.title, links: successors.to_sentence).html_safe
+    end
+
+    def no_longer_exists_notice
+      I18n.t('organisations.notices.no_longer_exists', title: @org.title)
+    end
+
+    def notice_successor_title
+      @org.ordered_successor_organisations[0]["title"]
+    end
+
+    def notice_successor_link
+      @org.ordered_successor_organisations[0]["base_path"]
+    end
+
+    def notice_successor_updated
+      Date.parse(@org.status_updated_at).strftime("%B %Y")
     end
   end
 end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -103,18 +103,6 @@ module Organisations
       }
     end
 
-    def non_live_organisation_notice
-      return separate_website_notice if @org.is_exempt?
-      return changed_name_notice if @org.is_changed_name? || @org.is_closed?
-      return joining_notice if @org.is_joining?
-      return devolved_notice if @org.is_devolved?
-      return left_gov_notice if @org.is_left_gov?
-      return merged_notice if @org.is_merged?
-      return split_notice if @org.is_split? || @org.is_replaced?
-      return no_longer_exists_notice if @org.is_no_longer_exists?
-      @org.title
-    end
-
   private
 
     def contact_line(line)
@@ -150,54 +138,6 @@ module Organisations
 
     def has_definite_article?(phrase)
       phrase.downcase.strip[0..2] == 'the'
-    end
-
-    def separate_website_notice
-      I18n.t('organisations.notices.separate_website', title: @org.title, url: @org.separate_website_url).html_safe
-    end
-
-    def changed_name_notice
-      I18n.t('organisations.notices.changed_name', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
-    end
-
-    def joining_notice
-      I18n.t('organisations.notices.joining', title: @org.title)
-    end
-
-    def devolved_notice
-      I18n.t('organisations.notices.devolved', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
-    end
-
-    def left_gov_notice
-      I18n.t('organisations.notices.left_gov', title: @org.title)
-    end
-
-    def merged_notice
-      I18n.t('organisations.notices.merged', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title, updated: notice_successor_updated).html_safe
-    end
-
-    def split_notice
-      successors = @org.ordered_successor_organisations.map do |successor|
-        link_to(successor["title"], successor["base_path"])
-      end
-
-      I18n.t('organisations.notices.split', title: @org.title, links: successors.to_sentence).html_safe
-    end
-
-    def no_longer_exists_notice
-      I18n.t('organisations.notices.no_longer_exists', title: @org.title)
-    end
-
-    def notice_successor_title
-      @org.ordered_successor_organisations[0]["title"]
-    end
-
-    def notice_successor_link
-      @org.ordered_successor_organisations[0]["base_path"]
-    end
-
-    def notice_successor_updated
-      Date.parse(@org.status_updated_at).strftime("%B %Y")
     end
   end
 end

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   </div>
 
-  <% unless @organisation.has_separate_website? %>
+  <% if @organisation.is_live? %>
     <div class="<%= @header.link_wrapper_class %> organisations__margin-bottom">
       <%= render "govuk_publishing_components/components/translation-nav", @header.translation_links %>
       <%= render "components/topic-list", @header.ordered_featured_links %>

--- a/app/views/organisations/_latest_documents_by_type.html.erb
+++ b/app/views/organisations/_latest_documents_by_type.html.erb
@@ -1,4 +1,4 @@
-<section class="<%= "brand--#{@organisation.brand} brand__border-color" unless @organisation.has_separate_website? %> organisations__brand-border-top organisations__margin-bottom">
+<section class="<%= "brand--#{@organisation.brand} brand__border-color" if @organisation.is_live? %> organisations__brand-border-top organisations__margin-bottom">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -2,7 +2,7 @@
 <%= render partial: 'header' %>
 
 <%= render "govuk_publishing_components/components/notice", {
-  title: "#{organisation.title} has a <a href='#{@organisation.separate_website_url}'>separate website</a>".html_safe
+  title: @show.non_live_organisation_notice
 } %>
 
 <div class="grid-row organisations__margin-bottom">

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -2,7 +2,7 @@
 <%= render partial: 'header' %>
 
 <%= render "govuk_publishing_components/components/notice", {
-  title: @show.non_live_organisation_notice
+  title: @not_live.non_live_organisation_notice
 } %>
 
 <div class="grid-row organisations__margin-bottom">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,15 @@ en:
     follow_us: "Follow us"
     high_profile_groups: High profile groups within %{title}
     latest_from: "Latest from %{title}"
+    notices:
+      separate_website: "%{title} has a <a href='%{url}'>separate website</a>"
+      changed_name: "%{title} is now called <a href='%{link_href}'>%{link_text}</a>"
+      joining: "%{title} will soon be incorporated into GOV.UK"
+      devolved: "%{title} is a body of <a href='%{link_href}'>%{link_text}</a>"
+      left_gov: "%{title} is now independent of the UK government"
+      merged: "%{title} became part of <a href='%{link_href}'>%{link_text}</a> in %{updated}"
+      split: "%{title} was replaced by %{links}"
+      no_longer_exists: "%{title} has closed"
     our_policies: "Our policies"
     part_of: "Part of"
     people:

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -170,6 +170,24 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
         ]
       }
     }
+
+    @content_item_documents = {
+      title: "Fire Service College",
+      base_path: "/government/organisations/fire-service-college",
+      details: {
+        body: "The Fire Service College (FSC) supplies specialist fire and rescue training to the UK's own fire and rescue services, the private security sector and the international market.\r\n\r\nThe college was formerly an executive agency of the Department for Communities and Local Government and was sold to Capita on 28 February 2013.<abbr title=\"Fire Service College\">FSC</abbr>",
+        brand: "null",
+        logo: {
+          formatted_title: "Fire Service College",
+        },
+        organisation_govuk_status: {
+          status: "exempt",
+          url: "http://www.google.com",
+          updated_at: "null"
+        },
+      }
+    }
+
     content_store_has_item("/government/organisations/changed_name", @content_item_changed_name)
     content_store_has_item("/government/organisations/devolved", @content_item_devolved)
     content_store_has_item("/government/organisations/exempt", @content_item_exempt)
@@ -179,6 +197,18 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/split", @content_item_split)
     content_store_has_item("/government/organisations/no_longer_exists", @content_item_no_longer_exists)
     content_store_has_item("/government/organisations/replaced", @content_item_replaced)
+    content_store_has_item("/government/organisations/fire-service-college", @content_item_documents)
+
+    stub_rummager_latest_content_requests("changed_name")
+    stub_rummager_latest_content_requests("devolved")
+    stub_rummager_latest_content_requests("exempt")
+    stub_rummager_latest_content_requests("joining")
+    stub_rummager_latest_content_requests("left_gov")
+    stub_rummager_latest_content_requests("merged")
+    stub_rummager_latest_content_requests("split")
+    stub_rummager_latest_content_requests("no_longer_exists")
+    stub_rummager_latest_content_requests("replaced")
+    stub_rummager_latest_content_requests("fire-service-college")
   end
 
   it 'displays a changed_name organisation page correctly' do
@@ -262,5 +292,20 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-notice a[href='/replaced/successor']", text: "Replaced Successor")
     assert page.has_css?(".gem-c-govspeak")
     assert page.has_content?(/This organisation has a status of replaced./i)
+  end
+
+  it "shows latest documents by type on separate website page" do
+    visit "/government/organisations/fire-service-college"
+    assert page.has_css?(".gem-c-heading", text: "Documents")
+    assert page.has_css?(".gem-c-heading", text: "Our announcements")
+    assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/first-events-announced-for-national-democracy-week']", text: "First events announced for National Democracy Week")
+
+    assert page.has_css?(".gem-c-heading", text: "Our consultations")
+    assert page.has_css?(".gem-c-document-list__item-title[href='/government/consultations/consultation-on-revised-code-of-data-matching-practice']", text: "Consultation on revised Code of Data Matching Practice")
+
+    assert page.has_css?(".gem-c-heading", text: "Our publications")
+    assert page.has_css?(".gem-c-document-list__item-title[href='/government/publications/national-democracy-week-partner-pack']", text: "National Democracy Week: partner pack")
+
+    refute page.has_css?(".gem-c-heading", text: "Our statistics")
   end
 end

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -1,0 +1,266 @@
+require 'integration_test_helper'
+
+class OrganisationStatusTest < ActionDispatch::IntegrationTest
+  include OrganisationHelpers
+
+  before do
+    @content_item_changed_name = {
+      title: "Changed name organisation",
+      base_path: "/government/organisations/changed_name",
+      details: {
+        body: "This organisation has a status of changed_name.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "changed_name"
+        },
+      },
+      links: {
+        ordered_successor_organisations: [
+          {
+            title: "Successor",
+            base_path: "/changed/name/successor"
+          }
+        ]
+      }
+    }
+
+    @content_item_devolved = {
+      title: "Devolved organisation",
+      base_path: "/government/organisations/devolved",
+      details: {
+        body: "This organisation has a status of devolved.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "devolved"
+        },
+      },
+      links: {
+        ordered_successor_organisations: [
+          {
+            title: "Devolved Successor",
+            base_path: "/devolved/successor"
+          }
+        ]
+      }
+    }
+
+    @content_item_exempt = {
+      title: "Exempt organisation",
+      base_path: "/government/organisations/exempt",
+      details: {
+        body: "This organisation has a status of exempt.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "exempt",
+          url: "http://www.google.com"
+        },
+      }
+    }
+
+    @content_item_joining = {
+      title: "Joining organisation",
+      base_path: "/government/organisations/joining",
+      details: {
+        body: "This organisation has a status of joining.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "joining"
+        },
+      }
+    }
+
+    @content_item_left_gov = {
+      title: "Left_gov organisation",
+      base_path: "/government/organisations/left_gov",
+      details: {
+        body: "This organisation has a status of left_gov.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "left_gov"
+        },
+      }
+    }
+
+    @content_item_merged = {
+      title: "Merged organisation",
+      base_path: "/government/organisations/merged",
+      details: {
+        body: "This organisation has a status of merged.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "merged",
+          updated_at: "2016-03-31T00:00:00.000+01:00"
+        },
+      },
+      links: {
+        ordered_successor_organisations: [
+          {
+            title: "Merged Successor",
+            base_path: "/merged/successor"
+          }
+        ]
+      }
+    }
+
+    @content_item_split = {
+      title: "Split organisation",
+      base_path: "/government/organisations/split",
+      details: {
+        body: "This organisation has a status of split.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "split"
+        },
+      },
+      links: {
+        ordered_successor_organisations: [
+          {
+            title: "Split Successor1",
+            base_path: "/split/successor1"
+          },
+          {
+            title: "Split Successor2",
+            base_path: "/split/successor2"
+          },
+          {
+            title: "Split Successor3",
+            base_path: "/split/successor3"
+          },
+        ]
+      }
+    }
+
+    @content_item_no_longer_exists = {
+      title: "No_longer_exists organisation",
+      base_path: "/government/organisations/no_longer_exists",
+      details: {
+        body: "This organisation has a status of no_longer_exists.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "no_longer_exists"
+        },
+      }
+    }
+
+    @content_item_replaced = {
+      title: "Replaced organisation",
+      base_path: "/government/organisations/replaced",
+      details: {
+        body: "This organisation has a status of replaced.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "replaced"
+        },
+      },
+      links: {
+        ordered_successor_organisations: [
+          {
+            title: "Replaced Successor",
+            base_path: "/replaced/successor"
+          }
+        ]
+      }
+    }
+    content_store_has_item("/government/organisations/changed_name", @content_item_changed_name)
+    content_store_has_item("/government/organisations/devolved", @content_item_devolved)
+    content_store_has_item("/government/organisations/exempt", @content_item_exempt)
+    content_store_has_item("/government/organisations/joining", @content_item_joining)
+    content_store_has_item("/government/organisations/left_gov", @content_item_left_gov)
+    content_store_has_item("/government/organisations/merged", @content_item_merged)
+    content_store_has_item("/government/organisations/split", @content_item_split)
+    content_store_has_item("/government/organisations/no_longer_exists", @content_item_no_longer_exists)
+    content_store_has_item("/government/organisations/replaced", @content_item_replaced)
+  end
+
+  it 'displays a changed_name organisation page correctly' do
+    visit "/government/organisations/changed_name"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Changed name organisation is now called Successor")
+    assert page.has_css?(".gem-c-notice a[href='/changed/name/successor']", text: "Successor")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of changed_name./i)
+  end
+
+  it 'displays a closed and devolved organisation page correctly' do
+    visit "/government/organisations/devolved"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Devolved organisation is a body of Devolved Successor")
+    assert page.has_css?(".gem-c-notice a[href='/devolved/successor']", text: "Devolved Successor")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of devolved./i)
+  end
+
+  it 'displays an exempt organisation page correctly' do
+    visit "/government/organisations/exempt"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Exempt organisation has a separate website")
+    assert page.has_css?(".gem-c-notice a[href='http://www.google.com']", text: "separate website")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of exempt./i)
+  end
+
+  it 'displays a joining organisation page correctly' do
+    visit "/government/organisations/joining"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Joining organisation will soon be incorporated into GOV.UK")
+    refute page.has_css?(".gem-c-notice a")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of joining./i)
+  end
+
+  it 'displays a left_gov organisation page correctly' do
+    visit "/government/organisations/left_gov"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Left_gov organisation is now independent of the UK government")
+    refute page.has_css?(".gem-c-notice a")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of left_gov./i)
+  end
+
+  it 'displays a merged organisation page correctly' do
+    visit "/government/organisations/merged"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Merged organisation became part of Merged Successor in March 2016")
+    assert page.has_css?(".gem-c-notice a[href='/merged/successor']", text: "Merged Successor")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of merged./i)
+  end
+
+  it 'displays a split organisation page correctly' do
+    visit "/government/organisations/split"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Split organisation was replaced by Split Successor1, Split Successor2, and Split Successor3")
+    assert page.has_css?(".gem-c-notice a[href='/split/successor1']", text: "Split Successor1")
+    assert page.has_css?(".gem-c-notice a[href='/split/successor2']", text: "Split Successor2")
+    assert page.has_css?(".gem-c-notice a[href='/split/successor3']", text: "Split Successor3")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of split./i)
+  end
+
+  it 'displays a no_longer_exists organisation page correctly' do
+    visit "/government/organisations/no_longer_exists"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "No_longer_exists organisation has closed")
+    refute page.has_css?(".gem-c-notice a")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of no_longer_exists./i)
+  end
+
+  it 'displays a replaced organisation page correctly' do
+    visit "/government/organisations/replaced"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice", text: "Replaced organisation was replaced by Replaced Successor")
+    assert page.has_css?(".gem-c-notice a[href='/replaced/successor']", text: "Replaced Successor")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of replaced./i)
+  end
+end

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -366,7 +366,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     stub_rummager_latest_content_requests("attorney-generals-office")
     stub_rummager_latest_content_requests("charity-commission")
     stub_rummager_latest_content_requests("office-of-the-secretary-of-state-for-wales")
-    stub_rummager_latest_content_requests("fire-service-college")
     stub_rummager_latest_content_requests("civil-service-resourcing")
   end
 
@@ -409,19 +408,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     assert page.has_css?(".gem-c-organisation-logo.brand--department-for-business-innovation-skills img[alt='The Charity Commission']")
-  end
-
-  it "displays the logo on separate website pages" do
-    visit "/government/organisations/fire-service-college"
-    assert page.has_css?(".gem-c-organisation-logo")
-  end
-
-  it "renders the separate website notice" do
-    visit "/government/organisations/fire-service-college"
-    assert page.has_css?(".gem-c-notice", text: "Fire Service College has a separate website")
-    assert page.has_css?(".gem-c-notice a[href='http://www.google.com']", text: "separate website")
-    assert page.has_css?(".gem-c-govspeak")
-    assert page.has_content?(/The college was formerly an executive agency of the Department for Communities and Local Government/i)
   end
 
   it "shows featured links correctly if present" do
@@ -515,21 +501,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     stub_empty_rummager_requests("attorney-generals-office")
     visit "/government/organisations/attorney-generals-office"
     refute page.has_css?(".gem-c-heading", text: "Documents")
-  end
-
-  it "shows latest documents by type on separate website page" do
-    visit "/government/organisations/fire-service-college"
-    assert page.has_css?(".gem-c-heading", text: "Documents")
-    assert page.has_css?(".gem-c-heading", text: "Our announcements")
-    assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/first-events-announced-for-national-democracy-week']", text: "First events announced for National Democracy Week")
-
-    assert page.has_css?(".gem-c-heading", text: "Our consultations")
-    assert page.has_css?(".gem-c-document-list__item-title[href='/government/consultations/consultation-on-revised-code-of-data-matching-practice']", text: "Consultation on revised Code of Data Matching Practice")
-
-    assert page.has_css?(".gem-c-heading", text: "Our publications")
-    assert page.has_css?(".gem-c-document-list__item-title[href='/government/publications/national-democracy-week-partner-pack']", text: "National Democracy Week: partner pack")
-
-    refute page.has_css?(".gem-c-heading", text: "Our statistics")
   end
 
   it "shows the ministers for an organisation" do

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -340,23 +340,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       }
     }
 
-    @content_item_separate_website = {
-      title: "Fire Service College",
-      base_path: "/government/organisations/fire-service-college",
-      details: {
-        body: "The Fire Service College (FSC) supplies specialist fire and rescue training to the UK's own fire and rescue services, the private security sector and the international market.\r\n\r\nThe college was formerly an executive agency of the Department for Communities and Local Government and was sold to Capita on 28 February 2013.<abbr title=\"Fire Service College\">FSC</abbr>",
-        brand: "null",
-        logo: {
-          formatted_title: "Fire Service College",
-        },
-        organisation_govuk_status: {
-          status: "exempt",
-          url: "http://www.google.com",
-          updated_at: "null"
-        },
-      }
-    }
-
     @content_item_blank = {
       title: "An empty content item to test everything checks before trying to render things",
       base_path: "/government/organisations/civil-service-resourcing",
@@ -377,7 +360,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
-    content_store_has_item("/government/organisations/fire-service-college", @content_item_separate_website)
     content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
 
     stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")


### PR DESCRIPTION
Adds notices to organisation pages that have a status that is not `live`, i.e. `changed_name`, `devolved`, `exempt`, `joining`, `left_gov`, `merged`, `split`, `no_longer_exists`, or `replaced`.

Examples for testing:

- [changed_name](https://govuk-collections-pr-717.herokuapp.com/government/organisations/treasury-solicitor-s-department)
- [closed and devolved](https://govuk-collections-pr-717.herokuapp.com/government/organisations/national-records-of-scotland)
- [exempt](https://govuk-collections-pr-717.herokuapp.com/government/organisations/arts-council-england)
- [joining](https://govuk-collections-pr-717.herokuapp.com/government/organisations/regulator-of-social-housing)
- [left_gov](https://govuk-collections-pr-717.herokuapp.com/government/organisations/the-food-and-environment-research-agency)
- [merged](https://govuk-collections-pr-717.herokuapp.com/government/organisations/national-measurement-and-regulation-office)
- [split](https://govuk-collections-pr-717.herokuapp.com/government/organisations/department-of-the-environment-transport-and-the-regions)
- [no_longer_exists](https://govuk-collections-pr-717.herokuapp.com/government/organisations/third-party-campaigning-review)
- [replaced](https://govuk-collections-pr-717.herokuapp.com/government/organisations/counter-fraud-and-security-management-service)

Trello card: https://trello.com/c/72fz1aAM/207-org-pages-with-status-live