### PR TITLE
Add organisations API

### DIFF
--- a/app/controllers/organisations_api_controller.rb
+++ b/app/controllers/organisations_api_controller.rb
@@ -1,0 +1,88 @@
+class OrganisationsApiController < ApplicationController
+  enable_request_formats index: :json, show: :json
+
+  def index
+    respond_to do |f|
+      f.json do
+        render json: presented_organisations(start: start_index)
+      end
+    end
+  end
+
+  def show
+    respond_to do |f|
+      f.json do
+        render json: presented_organisation(slug: params[:organisation_name])
+      end
+    end
+  rescue OrganisationNotFound
+    return error_404
+  end
+
+private
+
+  RESULTS_PER_PAGE = 20
+
+  def presented_organisations(start:)
+    organisations = get_organisations(count: RESULTS_PER_PAGE, start: start)
+    OrganisationsApiPresenter.new(
+      organisations["results"],
+      current_page: current_page,
+      results_per_page: RESULTS_PER_PAGE,
+      total_results: organisations["total"],
+      current_url_without_parameters: current_url_without_parameters
+    ).present
+  end
+
+  def presented_organisation(slug:)
+    organisation = get_organisation(slug: slug)
+
+    raise OrganisationNotFound if organisation["total"].zero?
+
+    OrganisationsApiPresenter.new(
+      organisation["results"],
+      current_page: 1,
+      results_per_page: 1,
+      total_results: 1,
+      current_url_without_parameters: current_url_without_parameters,
+      wrap_in_results_array: false
+    ).present
+  end
+
+  def get_organisations(count:, start:)
+    Services.rummager.search(
+      filter_format: "organisation",
+      order: "title",
+      count: count,
+      start: start
+    )
+  end
+
+  def get_organisation(slug:)
+    Services.rummager.search(
+      filter_format: "organisation",
+      filter_slug: slug,
+      count: 1,
+      start: 0
+    )
+  end
+
+  def start_index
+    (current_page - 1) * RESULTS_PER_PAGE
+  end
+
+  def current_page
+    return page_param if page_param.positive?
+    1
+  end
+
+  def page_param
+    params[:page].to_i
+  end
+
+  def current_url_without_parameters
+    request.base_url + request.path
+  end
+
+  class OrganisationNotFound < StandardError; end
+end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,4 +1,22 @@
 module OrganisationHelper
+  ORGANISATION_TYPES = {
+    executive_office:            { name: "Executive office" },
+    ministerial_department:      { name: "Ministerial department" },
+    non_ministerial_department:  { name: "Non-ministerial department" },
+    executive_agency:            { name: "Executive agency" },
+    executive_ndpb:              { name: "Executive non-departmental public body" },
+    advisory_ndpb:               { name: "Advisory non-departmental public body" },
+    tribunal_ndpb:               { name: "Tribunal non-departmental public body" },
+    public_corporation:          { name: "Public corporation" },
+    independent_monitoring_body: { name: "Independent monitoring body" },
+    adhoc_advisory_group:        { name: "Ad-hoc advisory group" },
+    devolved_administration:     { name: "Devolved administration" },
+    sub_organisation:            { name: "Sub-organisation" },
+    other:                       { name: "Other" },
+    civil_service:               { name: "Civil Service" },
+    court:                       { name: "Court" },
+  }.freeze
+
   def child_organisation_count(organisation)
     child_orgs = organisation.content_item.content_item_data["links"]["ordered_child_organisations"]
     child_orgs.present? ? child_orgs.count : 0
@@ -12,5 +30,9 @@ module OrganisationHelper
       render partial: 'separate_website',
              locals: { organisation: @organisation }
     end
+  end
+
+  def organisation_type_name(organisation_type)
+    ORGANISATION_TYPES.dig(organisation_type.to_sym, :name) || ORGANISATION_TYPES[:other][:name]
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,78 @@
+module PaginationHelper
+  def paginate(results, wrap_in_results_array)
+    if wrap_in_results_array
+      {
+        results: results,
+        previous_page_url: previous_page_url,
+        next_page_url: next_page_url,
+        current_page: current_page,
+        total: total_results,
+        pages: number_of_pages,
+        page_size: results_per_page,
+        start_index: start_index,
+        _response_info: response_info,
+      }.compact
+    else
+      results[0][:_response_info] = response_info
+      results[0]
+    end
+  end
+
+private
+
+  def current_page_url
+    return current_url_without_parameters if first_page? && last_page?
+    "#{current_url_without_parameters}?page=#{current_page}"
+  end
+
+  def previous_page_url
+    unless first_page?
+      "#{current_url_without_parameters}?page=#{prev_page}"
+    end
+  end
+
+  def next_page_url
+    unless last_page?
+      "#{current_url_without_parameters}?page=#{next_page}"
+    end
+  end
+
+  def number_of_pages
+    (total_results.to_f / results_per_page.to_f).ceil
+  end
+
+  def start_index
+    (current_page - 1) * results_per_page + 1
+  end
+
+  def prev_page
+    [current_page - 1, 1].max
+  end
+
+  def next_page
+    [current_page + 1, number_of_pages].min
+  end
+
+  def first_page?
+    current_page == 1
+  end
+
+  def last_page?
+    current_page == number_of_pages
+  end
+
+  def links
+    links = []
+    links << { href: previous_page_url, rel: "previous" } if previous_page_url
+    links << { href: next_page_url, rel: "next" } if next_page_url
+    links << { href: current_page_url, rel: "self" }
+    links
+  end
+
+  def response_info
+    {
+      status: "ok",
+      links: links,
+    }
+  end
+end

--- a/app/presenters/organisations_api_presenter.rb
+++ b/app/presenters/organisations_api_presenter.rb
@@ -1,0 +1,77 @@
+class OrganisationsApiPresenter
+  include OrganisationHelper
+  include PaginationHelper
+
+  attr_reader :organisations,
+              :current_page,
+              :results_per_page,
+              :total_results,
+              :current_url_without_parameters,
+              :wrap_in_results_array
+
+  def initialize(organisations,
+    current_page:,
+    results_per_page:,
+    total_results:,
+    current_url_without_parameters:,
+    wrap_in_results_array: true)
+    @organisations = organisations
+    @current_page = current_page
+    @results_per_page = results_per_page
+    @total_results = total_results
+    @current_url_without_parameters = current_url_without_parameters
+    @wrap_in_results_array = wrap_in_results_array
+  end
+
+  def present
+    o = organisations.map do |organisation|
+      organisation = organisation["organisations"][0]
+      {
+        id: api_url_from_slug(organisation["slug"]),
+        title: organisation["title"],
+        format: organisation_type_name(organisation["organisation_type"]),
+        updated_at: organisation["public_timestamp"],
+        web_url: web_url_from_slug(organisation["slug"]),
+        details: {
+          slug: organisation["slug"],
+          abbreviation: organisation["acronym"],
+          logo_formatted_name: organisation["logo_formatted_title"],
+          organisation_brand_colour_class_name: organisation["organisation_brand"],
+          organisation_logo_type_class_name: organisation["organisation_crest"],
+          closed_at: organisation["closed_at"],
+          govuk_status: organisation["organisation_state"],
+          govuk_closed_status: organisation["organisation_closed_state"],
+          content_id: organisation["content_id"],
+        },
+        analytics_identifier: organisation["analytics_identifier"],
+        parent_organisations: summary_organisations(organisation, "parent_organisations"),
+        child_organisations: summary_organisations(organisation, "child_organisations"),
+        superseded_organisations: summary_organisations(organisation, "superseded_organisations"),
+        superseding_organisations: summary_organisations(organisation, "superseding_organisations"),
+      }
+    end
+
+    paginate(o, wrap_in_results_array)
+  end
+
+private
+
+  def api_url_from_slug(slug)
+    "#{Plek.new.website_root}#{Rails.application.routes.url_helpers.api_organisation_path(organisation_name: slug)}"
+  end
+
+  def web_url_from_slug(slug)
+    "#{Plek.new.website_root}#{Rails.application.routes.url_helpers.organisation_path(organisation_name: slug)}"
+  end
+
+  def summary_organisations(organisation, type)
+    return [] if organisation[type].nil?
+
+    organisation[type].map do |slug|
+      {
+        id: api_url_from_slug(slug),
+        web_url: web_url_from_slug(slug),
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,20 +29,32 @@ Rails.application.routes.draw do
   post "/topic/:topic_slug/:subtopic_slug/email-signup",
     to: "email_signups#create"
 
-  get "/government/organisations", to: "organisations#index"
+  get "/government/organisations",
+    to: "organisations#index",
+    as: :organisations
   get '/government/organisations/:organisation_name(.:locale).:format',
     constraints: {
       format: /atom/,
       locale: /\w{2}(-[\d\w]{2,3})?/,
     }, to: "feeds#organisation"
   get "/government/organisations/:organisation_name(.:locale)",
-    to: "organisations#show"
+    to: "organisations#show",
+    as: :organisation
   get "/government/organisations/:organisation_id/services-information",
     to: "services_and_information#index",
     as: :services_and_information
 
   get "/government/people/:name", to: "people#show"
   get "/government/ministers/:role_name", to: "roles#show"
+
+  scope :api, defaults: { format: :json } do
+    get "/organisations",
+      to: "organisations_api#index",
+      as: :api_organisations
+    get "/organisations/:organisation_name",
+      to: "organisations_api#show",
+      as: :api_organisation
+  end
 
   constraints DocumentTypeRoutingConstraint.new('step_by_step_nav') do
     get "/:slug", to: 'step_nav#show'

--- a/test/controllers/organisations_api_controller_test.rb
+++ b/test/controllers/organisations_api_controller_test.rb
@@ -1,0 +1,202 @@
+require "test_helper"
+
+describe OrganisationsApiController do
+  describe "GET index" do
+    setup do
+      Services.rummager.stubs(:search).with(
+        filter_format: "organisation",
+        order: "title",
+        count: 20,
+        start: 0,
+      ).returns(rummager_organisations_results)
+    end
+
+    it "renders JSON" do
+      get :index, format: :json
+      assert_equal 200, response.status
+
+      body = JSON.parse(response.body)
+      assert_equal 2, body["results"].count
+      assert_equal "HM Revenue & Customs", body["results"][1]["title"]
+    end
+
+    it "paginates the results" do
+      get :index, format: :json
+      body = JSON.parse(response.body)
+
+      assert_equal 1, body["current_page"]
+      assert_equal "ok", body["_response_info"]["status"]
+    end
+  end
+
+  describe "GET show" do
+    setup do
+      Services.rummager.stubs(:search).with(
+        filter_format: "organisation",
+        filter_slug: "hm-revenue-customs",
+        count: 1,
+        start: 0,
+      ).returns(rummager_organisation_results)
+
+      Services.rummager.stubs(:search).with(
+        filter_format: "organisation",
+        filter_slug: "something-else",
+        count: 1,
+        start: 0,
+      ).returns(rummager_organisation_no_results)
+    end
+
+    it "renders JSON" do
+      get :show, params: { organisation_name: "hm-revenue-customs" }, format: :json
+      assert_equal 200, response.status
+
+      body = JSON.parse(response.body)
+      assert_equal "HM Revenue & Customs", body["title"]
+    end
+
+    it "does not paginate the results" do
+      get :show, params: { organisation_name: "hm-revenue-customs" }, format: :json
+      body = JSON.parse(response.body)
+
+      assert_nil body["current_page"]
+    end
+
+    it "adds _response_info" do
+      get :show, params: { organisation_name: "hm-revenue-customs" }, format: :json
+      body = JSON.parse(response.body)
+
+      assert_equal "ok", body["_response_info"]["status"]
+    end
+
+    it "renders a 404 error if the organisation is not found" do
+      get :show, params: { organisation_name: "something-else" }, format: :json
+      assert_equal 404, response.status
+    end
+  end
+
+  def rummager_organisations_results
+    {
+      results: [
+        {
+          description: "Established to disrupt organised criminal enterprises through the recovery of criminal assets, and which aims to promote financial investigation as a part of criminal investigation. The Agency ceased to exist on 1 April 2008",
+          format: "organisation",
+          link: "/government/organisations/assets-recovery-agency",
+          organisations: [
+            {
+              logo_formatted_title: "Assets Recovery Agency",
+              organisation_crest: "single-identity",
+              title: "Closed organisation: Assets Recovery Agency",
+              content_id: "01046836-de95-43aa-9b36-941e705bcdf4",
+              link: "/government/organisations/assets-recovery-agency",
+              slug: "assets-recovery-agency",
+              analytics_identifier: "EA698",
+              public_timestamp: "2014-10-15T15:37:20.000+01:00",
+              organisation_type: "executive_agency",
+              organisation_closed_state: "no_longer_exists",
+              organisation_state: "closed",
+            },
+          ],
+          public_timestamp: "2014-10-15T15:37:20.000+01:00",
+          slug: "assets-recovery-agency",
+          title: "Closed organisation: Assets Recovery Agency",
+          index: "government",
+          es_score: nil,
+          _id: "/government/organisations/assets-recovery-agency",
+          elasticsearch_type: "edition",
+          document_type: "edition",
+        },
+        {
+          description: "The home of HM Revenue & Customs on GOV.UK. We are the UK’s tax, payments and customs authority, and we have a vital purpose: we collect the money that pays for the UK’s public services and help families and individuals with targeted financial support. We do this by being impartial and increasingly effective and efficient in our administration. We help the honest majority to get their tax right and make it hard for the dishonest minority to cheat the system.",
+          format: "organisation",
+          link: "/government/organisations/hm-revenue-customs",
+          organisations: [
+            {
+              organisation_crest: "hmrc",
+              superseded_organisations: [
+                "department-of-inland-revenue",
+              ],
+              acronym: "HMRC",
+              link: "/government/organisations/hm-revenue-customs",
+              analytics_identifier: "D25",
+              public_timestamp: "2015-05-13T11:09:06.000+01:00",
+              child_organisations: [
+                "valuation-office-agency",
+                "the-adjudicator-s-office",
+              ],
+              organisation_brand: "hm-revenue-customs",
+              logo_formatted_title: "HM Revenue\r\n& Customs",
+              title: "HM Revenue & Customs",
+              content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+              slug: "hm-revenue-customs",
+              organisation_type: "non_ministerial_department",
+              organisation_state: "live",
+            },
+          ],
+          public_timestamp: "2015-05-13T11:09:06.000+01:00",
+          slug: "hm-revenue-customs",
+          title: "HM Revenue & Customs",
+          index: "government",
+          es_score: nil,
+          _id: "/government/organisations/hm-revenue-customs",
+          elasticsearch_type: "edition",
+          document_type: "edition",
+        },
+      ],
+      total: 2,
+      start: 0,
+    }.deep_stringify_keys
+  end
+
+  def rummager_organisation_results
+    {
+      results: [
+        {
+          description: "The home of HM Revenue & Customs on GOV.UK. We are the UK’s tax, payments and customs authority, and we have a vital purpose: we collect the money that pays for the UK’s public services and help families and individuals with targeted financial support. We do this by being impartial and increasingly effective and efficient in our administration. We help the honest majority to get their tax right and make it hard for the dishonest minority to cheat the system.",
+          format: "organisation",
+          link: "/government/organisations/hm-revenue-customs",
+          organisations: [
+            {
+              organisation_crest: "hmrc",
+              superseded_organisations: [
+                "department-of-inland-revenue",
+              ],
+              acronym: "HMRC",
+              link: "/government/organisations/hm-revenue-customs",
+              analytics_identifier: "D25",
+              public_timestamp: "2015-05-13T11:09:06.000+01:00",
+              child_organisations: [
+                "valuation-office-agency",
+                "the-adjudicator-s-office",
+              ],
+              organisation_brand: "hm-revenue-customs",
+              logo_formatted_title: "HM Revenue\r\n& Customs",
+              title: "HM Revenue & Customs",
+              content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+              slug: "hm-revenue-customs",
+              organisation_type: "non_ministerial_department",
+              organisation_state: "live",
+            },
+          ],
+          public_timestamp: "2015-05-13T11:09:06.000+01:00",
+          slug: "hm-revenue-customs",
+          title: "HM Revenue & Customs",
+          index: "government",
+          es_score: nil,
+          _id: "/government/organisations/hm-revenue-customs",
+          elasticsearch_type: "edition",
+          document_type: "edition",
+        },
+      ],
+      total: 1,
+      start: 0,
+    }.deep_stringify_keys
+  end
+
+  def rummager_organisation_no_results
+    {
+      results: [],
+      total: 0,
+      start: 0,
+    }.deep_stringify_keys
+  end
+end

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require "test_helper"
 
 describe ServicesAndInformationController do
   include RummagerHelpers

--- a/test/presenters/organisations_api_presenter_test.rb
+++ b/test/presenters/organisations_api_presenter_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+describe OrganisationsApiPresenter do
+  let(:results) do
+    [
+      {
+        description: "The home of HM Revenue & Customs on GOV.UK. We are the UK’s tax, payments and customs authority, and we have a vital purpose: we collect the money that pays for the UK’s public services and help families and individuals with targeted financial support. We do this by being impartial and increasingly effective and efficient in our administration. We help the honest majority to get their tax right and make it hard for the dishonest minority to cheat the system.",
+        format: "organisation",
+        link: "/government/organisations/hm-revenue-customs",
+        organisations: [
+          {
+            organisation_crest: "hmrc",
+            superseded_organisations: [
+              "department-of-inland-revenue",
+            ],
+            acronym: "HMRC",
+            link: "/government/organisations/hm-revenue-customs",
+            analytics_identifier: "D25",
+            public_timestamp: "2015-05-13T11:09:06.000+01:00",
+            child_organisations: [
+              "valuation-office-agency",
+              "the-adjudicator-s-office",
+            ],
+            organisation_brand: "hm-revenue-customs",
+            logo_formatted_title: "HM Revenue\r\n& Customs",
+            title: "HM Revenue & Customs",
+            content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+            slug: "hm-revenue-customs",
+            organisation_type: "non_ministerial_department",
+            organisation_state: "live",
+          },
+        ],
+        public_timestamp: "2015-05-13T11:09:06.000+01:00",
+        slug: "hm-revenue-customs",
+        title: "HM Revenue & Customs",
+        index: "government",
+        es_score: nil,
+        _id: "/government/organisations/hm-revenue-customs",
+        elasticsearch_type: "edition",
+        document_type: "edition",
+      }.deep_stringify_keys,
+    ]
+  end
+
+  let(:presenter_wrapped) do
+    OrganisationsApiPresenter.new(
+      results,
+      current_page: 1,
+      results_per_page: 20,
+      total_results: 1,
+      current_url_without_parameters: "https://www.gov.uk/api/organisations",
+    )
+  end
+
+  let(:presenter_not_wrapped) do
+    OrganisationsApiPresenter.new(
+      results,
+      current_page: 1,
+      results_per_page: 20,
+      total_results: 1,
+      current_url_without_parameters: "https://www.gov.uk/api/organisations",
+      wrap_in_results_array: false,
+    )
+  end
+
+  describe "#present with wrapped results" do
+    it "returns a presented result set" do
+      paginated_results = presenter_wrapped.present
+      assert_equal "HM Revenue & Customs", paginated_results[:results][0][:title]
+      assert_equal "hm-revenue-customs", paginated_results[:results][0][:details][:slug]
+    end
+  end
+
+  describe "#present without wrapped results" do
+    it "returns a presented result set" do
+      paginated_results = presenter_not_wrapped.present
+      assert_equal "HM Revenue & Customs", paginated_results[:title]
+      assert_equal "hm-revenue-customs", paginated_results[:details][:slug]
+    end
+  end
+end

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -1,8 +1,6 @@
-require 'test_helper'
+require "test_helper"
 
-class ApplicationHelperTest < ActionView::TestCase
-  tests ApplicationHelper
-
+describe ApplicationHelper do
   describe "#current_path_without_query_string" do
     it "returns the path of the current request" do
       self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/foo/bar'))

--- a/test/unit/email_helper_test.rb
+++ b/test/unit/email_helper_test.rb
@@ -1,6 +1,7 @@
-require 'test_helper'
-class EmailHelperTest < ActionView::TestCase
-  test "should return true if we are browsing a taxon that is live" do
+require "test_helper"
+
+describe EmailHelper do
+  it "should return true if we are browsing a taxon that is live" do
     presented_taxon = stub(
       live_taxon?: true
     )
@@ -8,7 +9,7 @@ class EmailHelperTest < ActionView::TestCase
     assert taxon_is_live?(presented_taxon)
   end
 
-  test "should return false if we are browsing a taxon that is not live" do
+  it "should return false if we are browsing a taxon that is not live" do
     presented_taxon = stub(
       live_taxon?: false
     )
@@ -16,7 +17,7 @@ class EmailHelperTest < ActionView::TestCase
     refute taxon_is_live?(presented_taxon)
   end
 
-  test "should return a valid whitehall .atom url in the form /government/{url}.atom" do
+  it "should return a valid whitehall .atom url in the form /government/{url}.atom" do
     self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/world/blefuscu'))
 
     expected_atom_url = Plek.new.website_root + "/world/blefuscu.atom"
@@ -24,7 +25,7 @@ class EmailHelperTest < ActionView::TestCase
     assert_equal expected_atom_url, whitehall_atom_url
   end
 
-  test "should return a valid whitehall email signup link" do
+  it "should return a valid whitehall email signup link" do
     self.stubs(:request).returns(ActionDispatch::TestRequest.create("PATH_INFO" => '/world/blefuscu'))
 
     atom_url = Plek.new.website_root + "/world/blefuscu.atom"

--- a/test/unit/organisation_helper_test.rb
+++ b/test/unit/organisation_helper_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+describe OrganisationHelper do
+  describe "#organisation_type_name" do
+    it "returns a human-readable name given an organisation_type" do
+      assert_equal "Executive non-departmental public body", organisation_type_name("executive_ndpb")
+    end
+
+    it "returns 'other' for an unrecognised organisation_type" do
+      assert_equal "Other", organisation_type_name("something_else")
+    end
+  end
+end

--- a/test/unit/pagination_helper_test.rb
+++ b/test/unit/pagination_helper_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+describe PaginationHelper do
+  let(:presented_results) do
+    [
+      {
+        id: "https://www.gov.uk/api/organisations/hm-revenue-customs",
+        title: "HM Revenue & Customs",
+        format: "Non-ministerial department",
+        updated_at: "2015-05-13T11:09:06.000+01:00",
+        web_url: "https://www.gov.uk/government/organisations/hm-revenue-customs",
+        details: {
+          slug: "hm-revenue-customs",
+          abbreviation: "HMRC",
+          logo_formatted_name: "HM Revenue\r\n& Customs",
+          organisation_brand_colour_class_name: "hm-revenue-customs",
+          organisation_logo_type_class_name: "hmrc",
+          closed_at: nil,
+          govuk_status: "live",
+          govuk_closed_status: nil,
+          content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        },
+        analytics_identifier: "D25",
+        parent_organisations: [],
+        child_organisations: [
+          {
+            id: "https://www.gov.uk/api/organisations/valuation-office-agency",
+            web_url: "https://www.gov.uk/government/organisations/valuation-office-agency"
+          },
+          {
+            id: "https://www.gov.uk/api/organisations/the-adjudicator-s-office",
+            web_url: "https://www.gov.uk/government/organisations/the-adjudicator-s-office"
+          }
+        ],
+        superseded_organisations: [
+          {
+            id: "https://www.gov.uk/api/organisations/department-of-inland-revenue",
+            web_url: "https://www.gov.uk/government/organisations/department-of-inland-revenue"
+          }
+        ],
+        superseding_organisations: [],
+      }
+    ]
+  end
+  let(:current_page) { 1 }
+  let(:results_per_page) { 20 }
+
+  describe "#paginate with wrapped results" do
+    let(:total_results) { 21 } # Do this so we get page numbers in the links
+    let(:current_url_without_parameters) { "https://www.gov.uk/api/organisations" }
+
+    it "returns a hash with results and pagination details" do
+      paginated_results = paginate(presented_results, true)
+
+      assert_equal presented_results, paginated_results[:results]
+      assert_nil paginated_results[:previous_page_url]
+      assert_equal "#{current_url_without_parameters}?page=2", paginated_results[:next_page_url]
+      assert_equal current_page, paginated_results[:current_page]
+      assert_equal total_results, paginated_results[:total]
+      assert_equal 2, paginated_results[:pages]
+      assert_equal results_per_page, paginated_results[:page_size]
+      assert_equal 1, paginated_results[:start_index]
+      # next_page_url
+      assert_equal "#{current_url_without_parameters}?page=2", paginated_results[:_response_info][:links][0][:href]
+      # current_page_url
+      assert_equal "#{current_url_without_parameters}?page=1", paginated_results[:_response_info][:links][1][:href]
+    end
+  end
+
+  describe "#paginate without wrapped results" do
+    let(:total_results) { 1 }
+    let(:current_url_without_parameters) { "https://www.gov.uk/api/organisations/hm-revenue-customs" }
+
+    it "returns a hash with results and no pagination details" do
+      paginated_results = paginate(presented_results, false)
+
+      assert_equal "HM Revenue & Customs", paginated_results[:title]
+      assert_nil paginated_results[:results]
+      # current_page_url
+      assert_equal current_url_without_parameters, paginated_results[:_response_info][:links][0][:href]
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the `/api/organisations` API to collections, keeping the same result format as the current API served by whitehall. All results are sourced from rummager.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api