### PR TITLE
Add corporate info

### DIFF
--- a/app/assets/stylesheets/components/_topic-list.scss
+++ b/app/assets/stylesheets/components/_topic-list.scss
@@ -21,3 +21,7 @@
     @include bold-16;
   }
 }
+
+.app-c-topic-list--margin-bottom {
+  @include responsive-bottom-margin;
+}

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -110,6 +110,17 @@
   border-top-style: solid;
 }
 
+.organisation__section-border-top {
+  border-top: 5px solid $black;
+  padding-top: $gutter-half;
+}
+
+.organisation__corporate-information .organisation__float-section {
+  @include media(tablet) {
+    float: right;
+  }
+}
+
 .organisations__margin-bottom {
   margin-bottom: $gutter-half;
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -190,6 +190,10 @@ class Organisation
     links["ordered_high_profile_groups"]
   end
 
+  def ordered_corporate_information
+    details["ordered_corporate_information_pages"]
+  end
+
 private
 
   def links
@@ -202,15 +206,5 @@ private
 
   def organisation_type
     details["organisation_type"]
-  end
-
-  # methods below are not in use yet, this comment to be removed once confirmed
-
-  def child_organisation_count
-    links["ordered_child_organisations"].count
-  end
-
-  def ordered_corporate_information_pages
-    details["ordered_corporate_information_pages"]
   end
 end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -101,6 +101,30 @@ module Organisations
       }
     end
 
+    def corporate_information
+      corporate_information_links = @org.ordered_corporate_information.map do |link|
+        {
+          text: link["title"],
+          path: link["href"],
+        }
+      end
+
+      job_links = separate_job_links(corporate_information_links)
+
+      {
+        corporate_information_links: {
+          items: corporate_information_links - job_links,
+          brand: @org.brand,
+          margin_bottom: true
+        },
+        job_links: {
+          items: job_links,
+          brand: @org.brand,
+          margin_bottom: true
+        }
+      }
+    end
+
   private
 
     def contact_line(line)
@@ -156,6 +180,18 @@ module Organisations
 
     def has_definite_article?(phrase)
       phrase.downcase.strip[0..2] == 'the'
+    end
+
+    def separate_job_links(corporate_information_links)
+      job_links = []
+
+      corporate_information_links.each do |link|
+        if link[:path].end_with?("/recruitment", "/procurement") || link[:text].eql?("Jobs")
+          job_links << link
+        end
+      end
+
+      job_links
     end
   end
 end

--- a/app/views/components/_topic-list.html.erb
+++ b/app/views/components/_topic-list.html.erb
@@ -2,13 +2,15 @@
   items ||= []
   see_more_link ||= false
   small ||= false
+  margin_bottom ||= false
   component_size = "app-c-topic-list--small" if small
+  margin_bottom_class = "app-c-topic-list--margin-bottom" if margin_bottom
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if items.any? %>
-  <ol class="app-c-topic-list <%= component_size %> <%= brand_helper.brand_class %>">
+  <ol class="app-c-topic-list <%= component_size %> <%= brand_helper.brand_class %> <%= margin_bottom_class %>">
     <% items.each do |item| %>
       <li class="app-c-topic-list__item">
         <%=

--- a/app/views/components/docs/topic-list.yml
+++ b/app/views/components/docs/topic-list.yml
@@ -75,3 +75,14 @@ examples:
       see_more_link:
         text: 'See more and more and more'
         path: '/more'
+  with_margin_bottom:
+    data:
+        items:
+        - text: 'Environmental taxes, reliefs and schemes for businesses'
+          path: '/green-taxes-and-reliefs'
+        - text: 'Aggregates Levy: register or change your details'
+          path: '/guidance/aggregates-levy-register-or-change-your-details'
+        - text: 'Pay environmental taxes'
+          path: '/guidance/pay-environmental-taxes'
+        margin_bottom: true
+

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -1,11 +1,22 @@
-<div class="organisation-corporate-info">
-  <%= render "govuk_publishing_components/components/heading", {
-      text: "Corporate Information",
-      heading_level: 4
-  } %>
-  <% corporate_info.each do |info| %>
-    <p>
-      <%= link_to info["title"], info["href"] %>
-    </p>
+<div class="column-one-third">
+  <% if @show.corporate_information[:corporate_information_links][:items].any? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t('organisations.corporate_information'),
+      margin_bottom: 2,
+      padding: true,
+      border_top: 5,
+      brand: @organisation.brand,
+    } %>
+    <%= render "components/topic-list", @show.corporate_information[:corporate_information_links] %>
+  <% end %>
+
+  <% if @show.corporate_information[:job_links][:items].any? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t('organisations.jobs_contracts'),
+      margin_bottom: 2,
+      heading_level: 3,
+      font_size: 24
+    } %>
+    <%= render "components/topic-list", @show.corporate_information[:job_links] %>
   <% end %>
 </div>

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -1,16 +1,20 @@
-<div class="column-one-third">
+<div class="column-one-third organisation__float-section">
   <% if @show.corporate_information[:corporate_information_links][:items].any? %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t('organisations.corporate_information'),
-      margin_bottom: 2,
-      padding: true,
-      border_top: 5,
-      brand: @organisation.brand,
-    } %>
-    <%= render "components/topic-list", @show.corporate_information[:corporate_information_links] %>
+    <% unless @organisation.is_promotional_org? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('organisations.corporate_information'),
+        margin_bottom: 2,
+        padding: true,
+        border_top: 5,
+        brand: @organisation.brand
+      } %>
+    <% end %>
+    <div class="<%= "organisation__section-border-top" if @organisation.is_promotional_org? %>">
+      <%= render "components/topic-list", @show.corporate_information[:corporate_information_links] %>
+    </div>
   <% end %>
 
-  <% if @show.corporate_information[:job_links][:items].any? %>
+  <% if @show.corporate_information[:job_links][:items].any? && !@organisation.is_no_10? %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t('organisations.jobs_contracts'),
       margin_bottom: 2,

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -34,23 +34,27 @@
   <% end %>
 <% end %>
 
-<% unless @organisation.is_promotional_org? %>
-  <%= render partial: 'freedom_of_information' %>
-<% end %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <% unless @organisation.is_promotional_org? %>
+      <%= render partial: 'freedom_of_information' %>
+    <% end %>
 
-<% if @show.high_profile_groups[:items] && !@organisation.is_promotional_org? %>
-  <section class="grid-row organisations__margin-bottom">
-    <div class="column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: @show.high_profile_groups[:title],
-        brand: @organisation.brand,
-        border_top: 5,
-        padding: true,
-        margin_bottom: 2
-      } %>
+    <% if @show.high_profile_groups[:items] && !@organisation.is_promotional_org? %>
+      <section class="organisations__margin-bottom">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: @show.high_profile_groups[:title],
+          brand: @organisation.brand,
+          border_top: 5,
+          padding: true,
+          margin_bottom: 2
+        } %>
 
-      <%= render "components/topic-list", @show.high_profile_groups %>
-    </div>
-  </section>
-<% end %>
-
+        <%= render "components/topic-list", @show.high_profile_groups %>
+      </section>
+    <% end %>
+  </div>
+  <% if @organisation.ordered_corporate_information && @organisation.ordered_corporate_information.any? %>
+    <%= render partial: 'corporate_information' %>
+  <% end %>
+</div>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -55,6 +55,8 @@
     <% end %>
   </div>
   <% if @organisation.ordered_corporate_information && @organisation.ordered_corporate_information.any? %>
-    <%= render partial: 'corporate_information' %>
+    <div class="organisation__corporate-information">
+      <%= render partial: 'corporate_information' %>
+    </div>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   view_all: "view all"
   view_less: "view less"
   organisations:
+    corporate_information: "Corporate information"
     document_types:
       documents: "Documents"
       announcements: "Our announcements"
@@ -49,6 +50,7 @@ en:
       contact_form: FOI contact form
     follow_us: "Follow us"
     high_profile_groups: High profile groups within %{title}
+    jobs_contracts: "Jobs and contracts"
     latest_from: "Latest from %{title}"
     notices:
       separate_website: "%{title} has a <a href='%{url}'>separate website</a>"
@@ -61,6 +63,7 @@ en:
       no_longer_exists: "%{title} has closed"
     our_policies: "Our policies"
     part_of: "Part of"
+    separate_website: "separate website"
     people:
       board_members: "Our management"
       chief_professional_officers: "Chief professional officers"

--- a/test/components/topic_list_test.rb
+++ b/test/components/topic_list_test.rb
@@ -61,4 +61,12 @@ class TopicListTest < ComponentTestCase
     render_component(items: simple_item, small: true)
     assert_select ".app-c-topic-list.app-c-topic-list--small"
   end
+
+  test "renders with margin-bottom" do
+    render_component(items: simple_item)
+    assert_select ".app-c-topic-list--margin-bottom", false, "Margin bottom should not be applied by default"
+
+    render_component(items: simple_item, margin_bottom: true)
+    assert_select ".app-c-topic-list--margin-bottom"
+  end
 end

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -88,6 +88,16 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         },
         organisation_type: "ministerial_department",
         organisation_featuring_priority: "news",
+        ordered_corporate_information_pages: [
+          {
+            title: "Complaints procedure",
+            href: "/complaints-procedure"
+          },
+          {
+            title: "Jobs",
+            href: "https://www.civilservicejobs.service.gov.uk/csr"
+          }
+        ],
         ordered_featured_links: [
           {
             title: "Attorney General's guidance to the legal profession",
@@ -603,5 +613,20 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   it 'does not show high profile groups for promotional orgs' do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     refute page.has_css?(".gem-c-heading", text: "High profile groups within the Prime Minister's Office, 10 Downing Street")
+  end
+
+  it "displays corporate information pages" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-heading", text: "Corporate information")
+    assert page.has_css?(".app-c-topic-list__link[href='/complaints-procedure']", text: "Complaints procedure")
+
+    assert page.has_css?(".gem-c-heading", text: "Jobs and contracts")
+    assert page.has_css?(".app-c-topic-list__link[href='https://www.civilservicejobs.service.gov.uk/csr']", text: "Jobs")
+  end
+
+  it "does not show corporate information pages if none available" do
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+    refute page.has_css?(".gem-c-heading", text: "Corporate information")
+    refute page.has_css?(".gem-c-heading", text: "Jobs and contracts")
   end
 end

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -174,4 +174,41 @@ describe Organisations::ShowPresenter do
 
     assert_equal expected, @show_presenter.high_profile_groups
   end
+
+  it "formats corporate information correctly" do
+    content_item = ContentItem.new(organisation_with_corporate_information)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected = {
+      corporate_information_links: {
+        items: [{
+          text: "Corporate Information page",
+          path: "/corporate-info"
+        }],
+        brand: "attorney-generals-office",
+        margin_bottom: true
+      },
+      job_links: {
+        items: [
+          {
+            text: "Jobs",
+            path: "/jobs"
+          },
+          {
+            text: "Working for Attorney General's Office",
+            path: "/government/attorney-general's-office/recruitment"
+          },
+          {
+            text: "Procurement at Attorney General's Office",
+            path: "/government/attorney-general's-office/procurement"
+          }
+        ],
+        brand: "attorney-generals-office",
+        margin_bottom: true
+      }
+    }
+
+    assert_equal expected, @show_presenter.corporate_information
+  end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -370,4 +370,31 @@ module OrganisationHelpers
       }
     }.with_indifferent_access
   end
+
+  def organisation_with_corporate_information
+    {
+      title: "Attorney General's Office",
+      details: {
+        brand: "attorney-generals-office",
+        ordered_corporate_information_pages: [
+          {
+            title: "Corporate Information page",
+            href: "/corporate-info"
+          },
+          {
+            title: "Jobs",
+            href: "/jobs"
+          },
+          {
+            title: "Working for Attorney General's Office",
+            href: "/government/attorney-general's-office/recruitment"
+          },
+          {
+            title: "Procurement at Attorney General's Office",
+            href: "/government/attorney-general's-office/procurement"
+          },
+        ]
+      }
+    }.with_indifferent_access
+  end
 end


### PR DESCRIPTION
Adds the corporate information page links to the right hand side of the page. As the contact information section has not been done yet, the links line up with FOI.

## Please read before reviewing
This PR is ready to review in terms of the visual appearance of the section, but some of the actual link content is different to what's on live:

- About Us and Social Media Use links are missing from Promotional Orgs
- Missing secondary corporate information links (paragraph at the bottom of the section)
- All orgs now show links to Transparency Data and Corporate Reports, regardless of whether they have published any.

These are being addressed by https://github.com/alphagov/whitehall/pull/4147, but this hasn't been merged yet.

## Design Changes
Design changes (using topic list instead of bulleted list) has been noted here: https://trello.com/c/tkhnPF8N/21-corporate-information-page-links-shown-without-bullets

**Before:**
<img width="327" alt="screen shot 2018-06-21 at 16 33 39" src="https://user-images.githubusercontent.com/29889908/41729334-e1ec66be-7570-11e8-9bde-5a2b6dc4b80e.png">

**After:**
<img width="316" alt="screen shot 2018-06-21 at 16 33 44" src="https://user-images.githubusercontent.com/29889908/41729347-e70e00a8-7570-11e8-97c1-207ffd8063e0.png">

- No 10: https://govuk-collections-pr-721.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
- Ministerial Org: https://govuk-collections-pr-721.herokuapp.com/government/organisations/department-for-exiting-the-european-union
- Organisation with 0 published transparency data docs: https://govuk-collections-pr-721.herokuapp.com/government/organisations/building-regulations-advisory-committee
- Organisation with custom jobs URL: https://govuk-collections-pr-721.herokuapp.com/government/organisations/competition-and-markets-authority