### PR TITLE
Add foi links

### DIFF
--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -131,3 +131,7 @@
   @include core-16;
   margin-top: $gutter-half;
 }
+
+.organisation__address {
+  font-style: normal;
+}

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -69,15 +69,13 @@ module Organisations
         {
           title: foi_title(foi_contact["details"]["title"]),
           post_addresses: foi_contact["details"]["post_addresses"].map do |post|
-            data = ""
-            data << contact_line(post["title"])
-            data << contact_line(post["street_address"].gsub("\r\n", "<br/>"))
-            data << contact_line(post["locality"])
-            data << contact_line(post["postal_code"])
-            data << contact_line(post["world_location"])
+            foi_address(post)
           end,
           email_addresses: foi_contact["details"]["email_addresses"].map do |email|
             make_email_link(email["email"])
+          end,
+          links: foi_contact["details"]["contact_form_links"].map do |link|
+            make_link(link)
           end,
           description: foi_description(foi_contact["details"]["description"])
         }
@@ -110,6 +108,15 @@ module Organisations
       ""
     end
 
+    def make_link(link)
+      return link_to(make_link_text(link["description"]), link["link"], class: "brand__color") if link["link"].length.positive?
+      nil
+    end
+
+    def make_link_text(text)
+      text.length.positive? ? text : I18n.t('organisations.foi.contact_form')
+    end
+
     def make_email_link(email)
       mail_to(email, email, class: "brand__color")
     end
@@ -119,8 +126,19 @@ module Organisations
       I18n.t('organisations.foi.freedom_of_information_requests')
     end
 
-    def foi_description(contact)
-      content_tag(:p, contact.gsub("\r\n", "<br/>").html_safe) if contact
+    def foi_address(post)
+      data = ""
+      data << contact_line(post["title"])
+      data << contact_line(post["street_address"].gsub("\r\n", "<br/>"))
+      data << contact_line(post["locality"])
+      data << contact_line(post["postal_code"])
+      data << contact_line(post["world_location"])
+      data = data.gsub("<br/><br/>", "<br/>")
+      data if data.length.positive?
+    end
+
+    def foi_description(description)
+      return content_tag(:p, description.gsub("\r\n", "<br/>").html_safe) if description.length.positive?
     end
 
     def acronym

--- a/app/views/organisations/_freedom_of_information.html.erb
+++ b/app/views/organisations/_freedom_of_information.html.erb
@@ -36,20 +36,32 @@
           font_size: 19,
         } %>
 
-        <div class="grid-row organisations__margin-bottom">
+        <div class="grid-row">
           <% if contact[:post_addresses].any? %>
-            <div class="column-half">
+            <address class="column-half organisations__margin-bottom organisation__address">
               <% contact[:post_addresses].each do |post| %>
-                <p><%= post.html_safe %></p>
+                <%= post.html_safe %>
               <% end %>
-            </div>
+            </address>
           <% end %>
 
-          <% if contact[:email_addresses].any? %>
+          <% if contact[:email_addresses].any? || contact[:links].any? %>
             <div class="column-half">
-              <p>Email</p>
-              <% contact[:email_addresses].each do |email| %>
-                <p><%= email.html_safe %></p>
+              <% if contact[:email_addresses].any? %>
+                <div class="organisations__margin-bottom">
+                  <p>Email</p>
+                  <% contact[:email_addresses].each do |email| %>
+                    <p><%= email.html_safe %></p>
+                  <% end %>
+                </div>
+              <% end %>
+
+              <% if contact[:links].any? %>
+                <div class="organisations__margin-bottom">
+                  <% contact[:links].each do |link| %>
+                    <p><%= link.html_safe %></p>
+                  <% end %>
+                </div>
               <% end %>
             </div>
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
       foi_exemption_html: |
         This organisation is not covered by the Freedom of Information Act.
         To see which organisations are included, see <a href="%{foi_url}" class="brand__color">the legislation</a>.
+      contact_form: FOI contact form
     follow_us: "Follow us"
     high_profile_groups: High profile groups within %{title}
     latest_from: "Latest from %{title}"

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -314,6 +314,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 {
                   email: "foiwales@walesoffice.gsi.gov.uk"
                 }
+              ],
+              contact_form_links: [
+                {
+                  title: "",
+                  link: "/foi_contact_link",
+                  description: ""
+                }
               ]
             }
           },
@@ -333,7 +340,8 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 {
                   email: "welshofficefoi@walesoffice.gsi.gov.uk"
                 }
-              ]
+              ],
+              contact_form_links: []
             }
           }
         ]
@@ -567,6 +575,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_content?(/walesofficefoi@walesoffice.gsi.gov.uk/i)
     assert page.has_content?(/foiwales@walesoffice.gsi.gov.uk/i)
     assert page.has_content?(/welshofficefoi@walesoffice.gsi.gov.uk/i)
+    assert page.has_css?("a[href='/foi_contact_link']", text: "FOI contact form")
   end
 
   it "shows high profile groups section" do

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -122,6 +122,9 @@ describe Organisations::ShowPresenter do
           "<a class=\"brand__color\" href=\"mailto:walesofficefoi@walesoffice.gsi.gov.uk\">walesofficefoi@walesoffice.gsi.gov.uk</a>",
           "<a class=\"brand__color\" href=\"mailto:foiwales@walesoffice.gsi.gov.uk\">foiwales@walesoffice.gsi.gov.uk</a>"
         ],
+        links: [
+          "<a class=\"brand__color\" href=\"/to/some/foi/stuff\">Click me</a>"
+        ],
         description: "<p>FOI requests<br/><br/>are possible</p>"
       },
       {
@@ -132,14 +135,16 @@ describe Organisations::ShowPresenter do
         email_addresses: [
           "<a class=\"brand__color\" href=\"mailto:welshofficefoi@walesoffice.gsi.gov.uk\">welshofficefoi@walesoffice.gsi.gov.uk</a>"
         ],
+        links: [
+          "<a class=\"brand__color\" href=\"/foi/stuff\">FOI contact form</a>"
+        ],
         description: "<p>Something here<br/><br/>Something there</p>"
       },
       {
         title: "Freedom of Information requests",
-        post_addresses: [
-          "Red House<br/>Slough<br/>S1 9NN<br/>"
-        ],
+        post_addresses: [],
         email_addresses: [],
+        links: [],
         description: nil
       }
     ]

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -302,6 +302,13 @@ module OrganisationHelpers
             details: {
               title: "FOI stuff",
               description: "FOI requests\r\n\r\nare possible",
+              contact_form_links: [
+                {
+                  title: "title",
+                  link: "/to/some/foi/stuff",
+                  description: "Click me"
+                }
+              ],
               post_addresses: [
                 {
                   title: "Office of the Secretary of State for Wales",
@@ -329,6 +336,13 @@ module OrganisationHelpers
             withdrawn: false,
             details: {
               description: "Something here\r\n\r\nSomething there",
+              contact_form_links: [
+                {
+                  title: "",
+                  link: "/foi/stuff",
+                  description: ""
+                }
+              ],
               post_addresses: [
                 {
                   title: "The Welsh Office",
@@ -346,12 +360,9 @@ module OrganisationHelpers
           {
             withdrawn: false,
             details: {
-              post_addresses: [
-                {
-                  street_address: "Red House\r\nSlough",
-                  postal_code: "S1 9NN",
-                }
-              ],
+              description: "",
+              contact_form_links: [],
+              post_addresses: [],
               email_addresses: []
             }
           }


### PR DESCRIPTION
Adds the optional 'contact form' link to the foi section for the new organisations pages.

Examples:
- [with contact link](https://govuk-collections-pr-722.herokuapp.com/government/organisations/ministry-of-defence)
- [without](https://govuk-collections-pr-722.herokuapp.com/government/organisations/hm-courts-and-tribunals-service)
- [without contact link and without address](https://govuk-collections-pr-722.herokuapp.com/government/organisations/charity-commission)

<img width="780" alt="screen shot 2018-06-21 at 15 29 32" src="https://user-images.githubusercontent.com/861310/41725532-f093f30c-7567-11e8-8c72-770d571ca307.png">

This includes a slight change from the original to have some more descriptive text for the link in question. Original shown here:

<img width="690" alt="screen shot 2018-06-21 at 15 30 07" src="https://user-images.githubusercontent.com/861310/41725591-17e0ffc2-7568-11e8-8ddb-84a6266f68a1.png">


Trello card: https://trello.com/c/gD2hhE0K/193-foi-request-section
