### PR TITLE
Hide high profile groups on promotional orgs

### DIFF
--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -38,7 +38,7 @@
   <%= render partial: 'freedom_of_information' %>
 <% end %>
 
-<% if @show.high_profile_groups[:items] %>
+<% if @show.high_profile_groups[:items] && !@organisation.is_promotional_org? %>
   <section class="grid-row organisations__margin-bottom">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -59,7 +59,17 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         ]
       },
       links: {
-        available_translations: []
+        available_translations: [],
+        ordered_high_profile_groups: [
+          {
+            base_path: "/government/organisations/attorney-generals-office-1",
+            title: "High Profile Group 1",
+          },
+          {
+            base_path: "/government/organisations/attorney-generals-office-2",
+            title: "High Profile Group 2",
+          }
+        ]
       }
     }
 
@@ -579,5 +589,10 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   it 'does not show section for organisations without high profile groups' do
     visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
     refute page.has_css?(".gem-c-heading", text: "High profile groups within the Office of the Secretary of State for Wales")
+  end
+
+  it 'does not show high profile groups for promotional orgs' do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    refute page.has_css?(".gem-c-heading", text: "High profile groups within the Prime Minister's Office, 10 Downing Street")
   end
 end


### PR DESCRIPTION
Hide for No 10 and Civil Service

https://govuk-collections-pr-723.herokuapp.com/government/organisations/civil-service
https://govuk-collections-pr-723.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street

**Before:**
<img width="975" alt="screen shot 2018-06-21 at 15 54 36" src="https://user-images.githubusercontent.com/29889908/41727087-6d22fc44-756b-11e8-976f-6a52e4c59fc5.png">

**After:**
<img width="1014" alt="screen shot 2018-06-21 at 15 55 12" src="https://user-images.githubusercontent.com/29889908/41727117-809dde56-756b-11e8-8cb0-26797a518e94.png">

