### PR TITLE
Add Welsh translations to org pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,4 +1,6 @@
 class OrganisationsController < ApplicationController
+  before_action :set_locale, only: :show
+
   def index
     @organisations = ContentStoreOrganisations.find!("/government/organisations")
     @presented_organisations = presented_organisations
@@ -44,5 +46,9 @@ private
 
   def locale
     ".#{params[:locale]}" if params[:locale]
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -71,8 +71,12 @@ class Organisation
     Plek.current.website_root + base_path
   end
 
-  def slug
+  def slug_with_locale
     base_path.gsub("/government/organisations/", "")
+  end
+
+  def slug
+    File.basename(slug_with_locale, File.extname(slug_with_locale))
   end
 
   def ordered_featured_links

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,35 +1,35 @@
-en:
-  view_all: "view all"
-  view_less: "view less"
+cy:
+  common:
+    translations: Cyfieithiadau
+  view_all: gwelir holl
+  view_less: gwelir llai
   organisations:
-    corporate_information: "Corporate information"
     document_types:
-      documents: "Documents"
-      announcements: "Our announcements"
-      consultations: "Our consultations"
-      publications: "Our publications"
-      statistics: "Our statistics"
-      see_all_documents: "See all %{type}"
+      documents: "Dogfennau"
+      announcements: "Ein cyhoeddiadau"
+      consultations: "Ein ymgynghoriadau"
+      publications: "Ein cyhoeddiadau"
+      statistics: "Ein hystadegau"
+      see_all_documents: "Gweld ein holl %{type}"
     foi:
-      make_an_foi_request: Make an FOI request
+      make_an_foi_request: Gwneud cais DRhG
       freedom_of_information_act: Freedom of Information (FOI) Act
       freedom_of_information_requests: Freedom of Information requests
-      foi_release: See all our FOI releases
+      foi_release: Gweld ein holl datganiadau rhyddid gwybodaeth
       foi_releases:
-        one: FOI release
-        other: FOI releases
+        one: Datganiad Rhyddid Gwybodaeth
+        other: Datganiad Rhyddid Gwybodaeth
       making_foi_requests:
-        step1_html: Read about the Freedom of Information (FOI) Act and <a href="%{how_to_path}" class="brand__color">how to make a request</a>.
-        step2_html: Check <a href="%{our_releases_path}" class="brand__color">our previous releases</a> to see if we’ve already answered your question.
-        step3_html: Make a new request by contacting us using the details below.
+        step1_html: Darllenwch am y Ddeddf Rhyddid Gwybodaeth (DRhG) a <a href="%{how_to_path}" class="brand__color">sut i wneud cais</a>.
+        step2_html: Ymchwiliwch <a href="%{our_releases_path}" class="brand__color">ein datganiadau blaenorol</a> i weld os ydym eisioes wedi ateb eich cwestiwn.
+        step3_html: Gwnewch cais newydd drwy gysylltu a ni ar.
       foi_exemption_html: |
         This organisation is not covered by the Freedom of Information Act.
         To see which organisations are included, see <a href="%{foi_url}" class="brand__color">the legislation</a>.
       contact_form: FOI contact form
-    follow_us: "Follow us"
+    follow_us: "Dilynwch ni"
     high_profile_groups: High profile groups within %{title}
-    jobs_contracts: "Jobs and contracts"
-    latest_from: "Latest from %{title}"
+    latest_from: "Gweithgaredd diweddaraf gan %{title}"
     notices:
       separate_website: "%{title} has a <a href='%{url}'>separate website</a>"
       changed_name: "%{title} is now called <a href='%{link_href}'>%{link_text}</a>"
@@ -39,19 +39,18 @@ en:
       merged: "%{title} became part of <a href='%{link_href}'>%{link_text}</a> in %{updated}"
       split: "%{title} was replaced by %{links}"
       no_longer_exists: "%{title} has closed"
-    our_policies: "Our policies"
-    part_of: "Part of"
-    separate_website: "separate website"
+    our_policies: "Ein polisïau"
+    part_of: Rhan o
     people:
-      board_members: "Our management"
+      board_members: "Ein rheolaeth"
       chief_professional_officers: "Chief professional officers"
-      ministers: "Our ministers"
-      military_personnel: "Our senior military officials"
-      special_representatives: "Special representatives"
-      traffic_commissioners: "Traffic commissioners"
-    read_more: "Read more about what we do"
-    see_all: "See all"
-    separate_website: "separate website"
+      ministers: "Ein gweinidogion"
+      military_personnel: "Ein huwch swyddogion milwrol"
+      special_representatives: "Cynrychiolwyr arbennig"
+      traffic_commissioners: "Comisiynwyr traffig"
+    read_more: "Darllen mwy am yr hyn rydyn ni'n ei wneud"
+    see_all: "Gweld holl"
+    separate_website: "gwefan ar wahân"
     type:
       adhoc_advisory_group: "Ad-hoc advisory group"
       advisory_ndpb: "Advisory non-departmental public body"
@@ -63,7 +62,7 @@ en:
       public_corporation: "Public corporation"
       tribunal_ndpb: "Tribunal non-departmental public body"
       other: "Other"
-    what_we_do: "What %{title} does"
+    what_we_do: "Yr hyn rydym ni'n ei wneud"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -368,6 +368,10 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       }
     }
 
+    @content_item_wales_office_cy = @content_item_wales_office.deep_dup.tap do |cy|
+      cy[:base_path] = "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    end
+
     @content_item_blank = {
       title: "An empty content item to test everything checks before trying to render things",
       base_path: "/government/organisations/civil-service-resourcing",
@@ -388,6 +392,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
     content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
     content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
+    content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales.cy", @content_item_wales_office_cy)
     content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
 
     stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
@@ -457,7 +462,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/attorney-generals-office"
     refute page.has_css?(".gem-c-translation-nav")
 
-    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
     assert page.has_css?(".gem-c-translation-nav")
 
     visit "/government/organisations/civil-service-resourcing"
@@ -553,9 +558,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/attorney-generals-office"
     assert page.has_css?(".gem-c-heading", text: "Our management")
     assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Sir Jeremy Heywood")
+  end
 
-    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
-    assert page.has_css?(".gem-c-heading", text: "Our senior military officials")
+  it "shows translated text on welsh pages" do
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    assert page.has_css?(".gem-c-heading", text: "Ein huwch swyddogion milwrol")
     assert page.has_css?(".gem-c-image-card__title .gem-c-image-card__title-link[href='/government/people/stuart-peach']")
     assert page.has_css?(".gem-c-image-card__description", text: "Chief of the Defence Staff")
   end
@@ -582,8 +589,8 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/charity-commission"
     assert page.has_content?(/This organisation is not covered by the Freedom of Information Act. To see which organisations are included, see the legislation./i)
 
-    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
-    assert page.has_content?(/Make an FOI request/i)
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    assert page.has_content?(/Gwneud cais DRhG/i)
     assert page.has_css?(".gem-c-heading", text: "FOI stuff")
     assert page.has_content?(/Office of the Secretary of State for Wales/i)
     assert page.has_content?(/Gwydyr House/i)


### PR DESCRIPTION
We were previously showing Welsh content items for translated content, but not the bits that were part of the page framework.

I've brought over translations from cy.yml in Whitehall where appropriate and set up the controller to switch locales if needed.

We should get cy.yml reviewed to fill in the gaps if we can, but this should be an improvement.

NB Not every title in Whitehall org pages is translated, so we're not losing by not being 100% covered. See "High profile groups" on https://www.gov.uk/government/organisations/department-for-work-pensions.cy for an example

https://trello.com/c/AaKC1Eck/22-fix-translations-on-org-show-pages