### PR TITLE
Add secondary corp info

### DIFF
--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -115,9 +115,15 @@
   padding-top: $gutter-half;
 }
 
-.organisation__corporate-information .organisation__float-section {
-  @include media(tablet) {
-    float: right;
+.organisation__corporate-information {
+  .organisation__float-section {
+    @include media(tablet) {
+      float: right;
+    }
+  }
+
+  .organisation__secondary-corporate-information {
+    @include core-16;
   }
 }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -194,6 +194,10 @@ class Organisation
     details["ordered_corporate_information_pages"]
   end
 
+  def secondary_corporate_information
+    details["secondary_corporate_information_pages"]
+  end
+
 private
 
   def links

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -120,7 +120,7 @@ module Organisations
         job_links: {
           items: job_links,
           brand: @org.brand,
-          margin_bottom: true
+          margin_bottom: @org.secondary_corporate_information.present?
         }
       }
     end

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -23,4 +23,10 @@
     } %>
     <%= render "components/topic-list", @show.corporate_information[:job_links] %>
   <% end %>
+
+  <% if @organisation.secondary_corporate_information %>
+    <p class="organisation__secondary-corporate-information">
+      <%= @organisation.secondary_corporate_information.html_safe %>
+    </p>
+  <% end %>
 </div>

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -20,11 +20,11 @@
   <%= render partial: 'featured_policies' %>
 <% end %>
 
-<% if @documents.has_latest_documents_by_type? && !@organisation.is_no_10?  %>
+<% if @documents.has_latest_documents_by_type? && !@organisation.is_promotional_org?  %>
   <%= render partial: 'latest_documents_by_type' %>
 <% end %>
 
-<% unless @organisation.is_no_10? %>
+<% unless @organisation.is_promotional_org? %>
   <% @people.all_people.each do |people_data| %>
     <%= render partial: 'related_people', locals: {
       people: people_data[:people],

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -393,7 +393,8 @@ module OrganisationHelpers
             title: "Procurement at Attorney General's Office",
             href: "/government/attorney-general's-office/procurement"
           },
-        ]
+        ],
+        secondary_corporate_information_pages: "Read more about our pages"
       }
     }.with_indifferent_access
   end


### PR DESCRIPTION
Adds the secondary corporate information links paragraph to the bottom of the Corporate Information section

<img width="320" alt="screen shot 2018-06-22 at 13 21 55" src="https://user-images.githubusercontent.com/29889908/41776339-4a8b4448-761f-11e8-9245-4665eeb4bd98.png">

Examples:

- Ministerial Org: https://govuk-collections-pr-725.herokuapp.com/government/organisations/department-for-exiting-the-european-union
- Promotional Org: https://govuk-collections-pr-725.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
- Without secondary corp info: https://govuk-collections-pr-725.herokuapp.com/government/organisations/advisory-group-on-military-medicine