### PR TITLE
Adjust heading structure on organisation pages

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -35,13 +35,11 @@ module Organisations
           parent_column_class: "column-#{number_of_items}",
           child_column_class: promotions_child_column_class(number_of_items),
           items: feature["items"].map do |item|
-            {
-              title: "",
+            data = {
               description: item["summary"].gsub("\r\n", "<br/>").html_safe,
               href: promotional_feature_link(item["href"]),
               image_src: item["image"]["url"],
               image_alt: item["image"]["alt_text"],
-              heading_text: item["title"],
               extra_links: item["links"].map do |link|
                 {
                   text: link["title"],
@@ -51,6 +49,12 @@ module Organisations
               brand: org.brand,
               heading_level: 3
             }
+
+            if item["title"].length.positive?
+              data[:heading_text] = item["title"]
+            end
+
+            data
           end
         }
       end
@@ -167,7 +171,8 @@ module Organisations
           context: "#{human_date}#{divider}#{document_type}",
           heading_text: news["title"],
           description: news["summary"],
-          brand: org.brand
+          brand: org.brand,
+          heading_level: 3
         }
       end
 

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -7,6 +7,10 @@ module Organisations
       @org = organisation
     end
 
+    def featured_news_title
+      I18n.t('organisations.featured_news', title: prefixed_title)
+    end
+
     def prefixed_title
       prefix = needs_definite_article?(@org.title) ? "the " : ""
       (prefix + @org.title)

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -1,4 +1,6 @@
 <section class="organisations__margin-bottom">
+  <h2 class="visually-hidden"><%= @show.featured_news_title %></h2>
+
   <% if @organisation.is_news_organisation? %>
     <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
       publications: "Our publications"
       statistics: "Our statistics"
       see_all_documents: "See all %{type}"
+    featured_news: "What %{title} is doing"
     foi:
       make_an_foi_request: Make an FOI request
       freedom_of_information_act: Freedom of Information (FOI) Act

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -22,7 +22,8 @@ describe Organisations::DocumentsPresenter do
         heading_text: "New head of the Serious Fraud Office announced",
         description: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
         brand: "attorney-generals-office",
-        large: true
+        large: true,
+        heading_level: 3
       }
       assert_equal expected, @documents_presenter.first_featured_news
     end
@@ -35,7 +36,8 @@ describe Organisations::DocumentsPresenter do
         context: "4 June 2017 — Policy paper",
         heading_text: "New head of a different office announced",
         description: "John Someone appointed new Director of the Other Office ",
-        brand: "attorney-generals-office"
+        brand: "attorney-generals-office",
+        heading_level: 3
       }]
       assert_equal expected, @documents_presenter.remaining_featured_news
     end
@@ -185,12 +187,10 @@ describe Organisations::DocumentsPresenter do
         child_column_class: nil,
         items: [
           {
-            title: "",
             description: "Story 1-1",
             href: "https://www.gov.uk/government/policies/1-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
             image_alt: "Image 1-1",
-            heading_text: "",
             extra_links: [
               {
                 text: "Single departmental plans",
@@ -213,12 +213,10 @@ describe Organisations::DocumentsPresenter do
         child_column_class: "column-half",
         items: [
           {
-            title: "",
             description: "Story 2-1",
             href: "https://www.gov.uk/government/policies/2-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
             image_alt: "Image 2-1",
-            heading_text: "",
             extra_links: [
               {
                 text: "Single departmental plans",
@@ -233,12 +231,10 @@ describe Organisations::DocumentsPresenter do
             heading_level: 3
           },
           {
-            title: "",
             description: "Story 2-2",
             href: "https://www.gov.uk/government/policies/2-2",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
             image_alt: "Image 2-2",
-            heading_text: "",
             extra_links: [
               {
                 text: "Single departmental plans",
@@ -261,12 +257,10 @@ describe Organisations::DocumentsPresenter do
         child_column_class: "column-one-third",
         items: [
           {
-            title: "",
             description: "Story 3-1<br/><br/>And a new line",
             href: "https://www.gov.uk/government/policies/3-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
             image_alt: "Image 3-1",
-            heading_text: "",
             extra_links: [
               {
                 text: "Single departmental plans",
@@ -281,12 +275,10 @@ describe Organisations::DocumentsPresenter do
             heading_level: 3
           },
           {
-            title: "",
             description: "Story 3-2",
             href: "https://www.gov.uk/government/policies/3-3",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
             image_alt: "Image 3-2",
-            heading_text: "",
             extra_links: [
               {
                 text: "Single departmental plans",
@@ -301,12 +293,11 @@ describe Organisations::DocumentsPresenter do
             heading_level: 3
           },
           {
-            title: "",
             description: "Story 3-3",
             href: "https://www.gov.uk/government/policies/3-3",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
             image_alt: "Image 3-3",
-            heading_text: "",
+            heading_text: "An unexpected title",
             extra_links: [
               {
                 text: "Single departmental plans",

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -551,7 +551,7 @@ module OrganisationHelpers
                 ]
               },
               {
-                title: "",
+                title: "An unexpected title",
                 href: "https://www.gov.uk/government/policies/3-3",
                 summary: "Story 3-3",
                 image: {


### PR DESCRIPTION
- create a new, hidden H2 above the featured news stories at the top of the page (using the text from the [original design](https://trello.com/c/6unhNfHL/45-no-clear-distinction-between-featured-content-latest-news), before this heading was removed)
- change the news stories so they use a H3 instead of a H2

Heading structure now looks like this...

<img width="332" alt="screen shot 2018-06-25 at 12 06 59" src="https://user-images.githubusercontent.com/861310/41846949-5267d110-7870-11e8-99d1-6f74aa06d41f.png">

Previously all the H3s above were H2s, making the heading structure inconsistent between org pages (varying numbers of these stories) but also the headings were not doing a great job of explaining how the page was structured.

Trello card: https://trello.com/c/2rlD6Dxn/26-heading-structure-of-org-pages
