### PR TITLE
Add missing Documents translation

### DIFF
--- a/app/views/organisations/_latest_documents_by_type.html.erb
+++ b/app/views/organisations/_latest_documents_by_type.html.erb
@@ -2,7 +2,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-        text: t('organisations.documents'),
+        text: t('organisations.document_types.documents'),
         padding: true
       } %>
     </div>


### PR DESCRIPTION
Trello: https://trello.com/c/W7zdnGp2/81-missing-translation-for-documents

This was showing an error "translation missing" when the element was inspected.