### PR TITLE
Exclude non-alertable documents

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -69,6 +69,7 @@ module Organisations
         count: 3,
         order: "-public_timestamp",
         filter_organisations: @org.slug,
+        reject_email_document_supertype: "other",
         fields: %w[title link content_store_document_type public_timestamp]
       )["results"]
       search_results_to_documents(@latest_documents)

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -25,7 +25,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_email_document_supertype=other").
       to_return(body: { results: [
         {
           title: "Rapist has sentence increased after Solicitor General’s referral",


### PR DESCRIPTION
This should stop things like finders appearing in the latest docs list and
becomes consistent with what appears in the atom feeds.

https://trello.com/c/uYPCRfUG/83-latest-news-stories-inconsistent-dwp
https://trello.com/c/oZ53vWzt/59-irrelevant-content-in-the-latest-feed