### PR TITLE
 Cope with merged orgs with no date

### DIFF
--- a/app/presenters/organisations/not_live_presenter.rb
+++ b/app/presenters/organisations/not_live_presenter.rb
@@ -41,7 +41,11 @@ module Organisations
     end
 
     def merged_notice
-      I18n.t('organisations.notices.merged', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title, updated: notice_successor_updated).html_safe
+      if status_updated_at
+        I18n.t('organisations.notices.merged', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title, updated: notice_successor_updated).html_safe
+      else
+        I18n.t('organisations.notices.merged_no_date', title: @org.title, link_href: notice_successor_link, link_text: notice_successor_title).html_safe
+      end
     end
 
     def split_notice
@@ -65,7 +69,11 @@ module Organisations
     end
 
     def notice_successor_updated
-      Date.parse(@org.status_updated_at).strftime("%B %Y")
+      Date.parse(status_updated_at).strftime("%B %Y")
+    end
+
+    def status_updated_at
+      @org.status_updated_at
     end
   end
 end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -36,6 +36,7 @@ cy:
       contact_form: "Ffurflen cysylltu DRhG"
     follow_us: "Dilynwch ni"
     high_profile_groups: High profile groups within %{title}
+    jobs_contracts: "Swyddi a chontractau"
     latest_from: "Gweithgaredd diweddaraf gan %{title}"
     notices:
       separate_website: "%{title} has a <a href='%{url}'>separate website</a>"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -43,6 +43,7 @@ cy:
       joining: "%{title} will soon be incorporated into GOV.UK"
       devolved: "%{title} is a body of <a href='%{link_href}'>%{link_text}</a>"
       left_gov: "%{title} is now independent of the UK government"
+      merged_no_date: "%{title} is now part of <a href='%{link_href}'>%{link_text}</a>"
       merged: "%{title} became part of <a href='%{link_href}'>%{link_text}</a> in %{updated}"
       split: "%{title} was replaced by %{links}"
       no_longer_exists: "%{title} has closed"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
       joining: "%{title} will soon be incorporated into GOV.UK"
       devolved: "%{title} is a body of <a href='%{link_href}'>%{link_text}</a>"
       left_gov: "%{title} is now independent of the UK government"
+      merged_no_date: "%{title} is now part of <a href='%{link_href}'>%{link_text}</a>"
       merged: "%{title} became part of <a href='%{link_href}'>%{link_text}</a> in %{updated}"
       split: "%{title} was replaced by %{links}"
       no_longer_exists: "%{title} has closed"


### PR DESCRIPTION
It's not mandatory for orgs to have a status updated date.  Our new page breaks when this is the case

https://trello.com/c/cGeodLfy/93-fix-merged-orgs-with-no-close-date