### PR TITLE
Add breadcrumb to organisation pages

### DIFF
--- a/app/views/organisations/_breadcrumb.html.erb
+++ b/app/views/organisations/_breadcrumb.html.erb
@@ -1,0 +1,17 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: "Home",
+        url: "/"
+      },
+      {
+        title: "Organisations",
+        url: "/government/organisations/"
+      },
+      {
+        title: @header.org.title
+      }
+    ]
+  } %>
+<% end %>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -1,21 +1,27 @@
-<div class="grid-row">
-  <div class="<%= @header.logo_wrapper_class %> organisation__margin-bottom">
-    <%= render "govuk_publishing_components/components/organisation_logo", {
-      organisation: @header.organisation_logo
-    } %>
+<% if @organisation.is_no_10? %>
+  <h1 class="organisation__no10-banner organisation__margin-bottom"><%= @header.org.title %></h1>
+<% else %>
+  <h1 class="visually-hidden"><%= @header.org.title %></h1>
 
-    <% if @organisation.is_sub_organisation? %>
-      <div class="organisation__parent-organisations">
-        <%= t('organisations.part_of') %>
-        <%= @show.parent_organisations %>
+  <div class="grid-row">
+    <div class="<%= @header.logo_wrapper_class %> organisation__margin-bottom">
+      <%= render "govuk_publishing_components/components/organisation_logo", {
+        organisation: @header.organisation_logo
+      } %>
+
+      <% if @organisation.is_sub_organisation? %>
+        <div class="organisation__parent-organisations">
+          <%= t('organisations.part_of') %>
+          <%= @show.parent_organisations %>
+        </div>
+      <% end %>
+    </div>
+
+    <% if @organisation.is_live? %>
+      <div class="<%= @header.link_wrapper_class %> organisation__margin-bottom">
+        <%= render "govuk_publishing_components/components/translation-nav", @header.translation_links %>
+        <%= render "components/topic-list", @header.ordered_featured_links %>
       </div>
     <% end %>
   </div>
-
-  <% if @organisation.is_live? %>
-    <div class="<%= @header.link_wrapper_class %> organisation__margin-bottom">
-      <%= render "govuk_publishing_components/components/translation-nav", @header.translation_links %>
-      <%= render "components/topic-list", @header.ordered_featured_links %>
-    </div>
-  <% end %>
-</div>
+<% end %>

--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'title' %>
+<%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
 
 <%= render "govuk_publishing_components/components/notice", {

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -1,8 +1,5 @@
-<%= render partial: 'title' %>
-
-<% unless @organisation.is_no_10? %>
-  <%= render partial: 'header' %>
-<% end %>
+<%= render partial: 'breadcrumb' %>
+<%= render partial: 'header' %>
 
 <% if @documents.has_featured_news? %>
   <%= render partial: 'featured_news' %>

--- a/app/views/organisations/_title.html.erb
+++ b/app/views/organisations/_title.html.erb
@@ -1,9 +1,0 @@
-<% content_for :breadcrumbs do %>
-  <div class="organisation__margin-bottom">
-    <% if @organisation.is_no_10? %>
-      <h1 class="organisation__no10-banner organisation__margin-bottom"><%= @header.org.title %></h1>
-    <% else %>
-      <h1 class="visually-hidden"><%= @header.org.title %></h1>
-    <% end %>
-  </div>
-<% end %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -496,6 +496,17 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".content")
   end
 
+  it "displays breadcrumbs" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "Prime Minister's Office, 10 Downing Street")
+
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "Attorney General's Office")
+
+    visit "/government/organisations/charity-commission"
+    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "The Charity Commission")
+  end
+
   it "sets the page title" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     assert page.has_title?("Prime Minister's Office, 10 Downing Street - GOV.UK")


### PR DESCRIPTION
The new org pages don't have the old whitehall header, which had some problems but critically provided a link back to the list of organisations. This change adds the breadcrumb to the org pages, restoring that navigational route.

![screen shot 2018-06-26 at 11 24 50](https://user-images.githubusercontent.com/861310/41905608-9c5980b6-7933-11e8-906a-9adf640eb46c.png)

![screen shot 2018-06-26 at 11 24 57](https://user-images.githubusercontent.com/861310/41905617-a003c474-7933-11e8-9d77-dc2d2ecb98e6.png)

![screen shot 2018-06-26 at 11 25 06](https://user-images.githubusercontent.com/861310/41905620-a37aaa96-7933-11e8-93fc-b6d9688e2a64.png)

Review link: https://govuk-collections-pr-740.herokuapp.com/government/organisations

Trello card: https://trello.com/c/Mq0wrt5v/2-collections-does-not-have-the-same-header-as-existing-organisation-pages
