### PR TITLE
Limit the number of featured policies

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -36,13 +36,13 @@ module Organisations
     end
 
     def has_featured_policies?
-      true if @org.ordered_featured_policies && @org.ordered_featured_policies.length.positive?
+      @org.ordered_featured_policies && @org.ordered_featured_policies.length.positive?
     end
 
     def featured_policies
       policies = []
 
-      @org.ordered_featured_policies.each do |policy|
+      @org.ordered_featured_policies.first(5).each do |policy|
         policies << {
           link: {
             text: policy["title"],

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -106,6 +106,22 @@ describe Organisations::ShowPresenter do
     assert_equal expected, @show_presenter.featured_policies
   end
 
+  it 'only displays the first 5 policies plus a see all link' do
+    content_item = ContentItem.new(organisation_with_multiple_policies)
+    organisation = Organisation.new(content_item)
+    @show_presenter = Organisations::ShowPresenter.new(organisation)
+
+    expected_last_link = {
+      link: {
+        text: "See all our policies",
+        path: "/government/policies?organisations[]=attorney-generals-office"
+      }
+    }
+
+    assert_equal expected_last_link, @show_presenter.featured_policies[:items].last
+    assert_equal 6, @show_presenter.featured_policies[:items].length
+  end
+
   it 'formats high profile groups correctly' do
     content_item = ContentItem.new(organisation_with_high_profile_groups)
     organisation = Organisation.new(content_item)

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -200,19 +200,57 @@ module OrganisationHelpers
       links: {
         ordered_featured_policies: [
           {
-            api_path: "/api/content/government/policies/waste-and-recycling",
             base_path: "/government/policies/waste-and-recycling",
-            content_id: "5d5e9324-7631-11e4-a3cb-005056011aef",
-            description: "What the government’s doing about waste and recycling.",
             document_type: "policy",
-            locale: "en",
-            public_updated_at: "2015-05-14T16:39:48Z",
-            schema_name: "policy",
-            title: "Waste and recycling",
-            withdrawn: false,
-            links: {},
-            api_url: "https://www.gov.uk/api/content/government/policies/waste-and-recycling",
-            web_url: "https://www.gov.uk/government/policies/waste-and-recycling"
+            title: "Waste and recycling"
+          },
+        ]
+      }
+    }.with_indifferent_access
+  end
+
+  def organisation_with_multiple_policies
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        organisation_govuk_status: {
+          status: "live",
+        },
+        brand: "attorney-generals-office",
+        organisation_featuring_priority: "news"
+      },
+      links: {
+        ordered_featured_policies: [
+          {
+            base_path: "/government/policies/policy-1",
+            document_type: "policy",
+            title: "Policy 1"
+          },
+          {
+            base_path: "/government/policies/policy-2",
+            document_type: "policy",
+            title: "Policy 2"
+          },
+          {
+            base_path: "/government/policies/policy-3",
+            document_type: "policy",
+            title: "Policy 3"
+          },
+          {
+            base_path: "/government/policies/policy-4",
+            document_type: "policy",
+            title: "Policy 4"
+          },
+          {
+            base_path: "/government/policies/policy-5",
+            document_type: "policy",
+            title: "Policy 5"
+          },
+          {
+            base_path: "/government/policies/policy-6",
+            document_type: "policy",
+            title: "Policy 6"
           },
         ]
       }


### PR DESCRIPTION
Trello: https://trello.com/c/GRGSAagO/214-our-policies-list-longer-than-production

This limits the number of featured policies on an org page to 5, to match the behaviour of the current live pages

## Before
<img width="661" alt="screen shot 2018-06-26 at 11 19 13" src="https://user-images.githubusercontent.com/29889908/41906292-6cb14464-7935-11e8-9d5f-d0923ce2a07f.png">

## After
<img width="657" alt="screen shot 2018-06-26 at 11 18 45" src="https://user-images.githubusercontent.com/29889908/41906347-8c03373c-7935-11e8-8d92-d4e4d010cc39.png">