### PR TITLE
Increase general spacing on mobile

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -77,11 +77,7 @@
 }
 
 .organisation__margin-bottom {
-  margin-bottom: $gutter-half;
-
-  @include media(tablet) {
-    margin-bottom: $gutter;
-  }
+  margin-bottom: $gutter;
 }
 
 .organisation__no10-banner {

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -73,7 +73,7 @@
 
 .organisation__contact-section--border-top {
   border-top: 1px solid $grey-2;
-  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 }
 
 .organisation__margin-bottom {

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -3,7 +3,6 @@
     <% unless @organisation.is_promotional_org? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: t('organisations.corporate_information'),
-        margin_bottom: 2,
         padding: true,
         border_top: 5,
         brand: @organisation.brand

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -43,8 +43,7 @@
           text: t('organisations.contact.contact_organisation', organisation: @show.acronym),
           brand: @organisation.brand,
           border_top: 5,
-          padding: true,
-          margin_bottom: 2
+          padding: true
         } %>
 
         <%= render partial: 'contacts', locals: { contacts: @contacts.contacts, border: true } %>


### PR DESCRIPTION
Make spacing on the organisation pages a bit more consistent and bigger, particularly on mobile.

Before:

![screen shot 2018-06-26 at 12 19 36](https://user-images.githubusercontent.com/861310/41908265-45d8d6bc-793b-11e8-8ca5-a905e836396c.png)

After:

![screen shot 2018-06-26 at 12 19 44](https://user-images.githubusercontent.com/861310/41908272-4b0e0972-793b-11e8-917b-5c4f364cc2d3.png)

Before:

![screen shot 2018-06-26 at 12 18 55](https://user-images.githubusercontent.com/861310/41908276-50253b7e-793b-11e8-98ac-f381b7c88704.png)

After:

![screen shot 2018-06-26 at 12 19 07](https://user-images.githubusercontent.com/861310/41908283-57245450-793b-11e8-8a8a-7c3fdaa7a524.png)


Trello cards: 

- https://trello.com/c/MrpHiBY3/215-spacing-between-sections-can-be-quite-tight-on-mobile
- https://trello.com/c/RTArMscQ/216-spacing-between-first-links-list-and-featured-news-stories-on-mobile
