### PR TITLE
Fix long text not wrapping on org pages

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -3,6 +3,10 @@
   border-top-style: solid;
 }
 
+.organisation__section-wrap {
+  word-wrap: break-word;
+}
+
 // This is only used to apply to promotional orgs where the border colour is always black
 // regardless of the link colour. This can be removed if we add the black border
 // colour as branding to the organisation.

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -1,4 +1,4 @@
-<section class="organisation__margin-bottom">
+<section class="organisation__section-wrap organisation__margin-bottom">
   <h2 class="visually-hidden"><%= @show.featured_news_title %></h2>
   <% if @organisation.is_news_organisation? %>
     <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -1,4 +1,4 @@
-<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__margin-bottom">
+<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
Trello: https://trello.com/c/jSlItzR1/92-long-text-in-news-items-do-not-wrap-so-overflow-container-on-small-screens

This was noticed in the news section, where long URLs were overflowing the container on mobile, causing a horizontal scroll. By wrapping this long text, we prevent this from happening.

## Before
<img width="396" alt="screen shot 2018-06-26 at 11 56 00" src="https://user-images.githubusercontent.com/29889908/41907167-f3f5a472-7937-11e8-9f5b-aa2fceb6071a.png">

## After
<img width="201" alt="screen shot 2018-06-26 at 11 55 34" src="https://user-images.githubusercontent.com/29889908/41907161-ef9fe2a2-7937-11e8-8708-5860db6803ea.png">
