### PR TITLE
Change translation nav link order

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -76,7 +76,7 @@ module Organisations
         {
           brand: org.brand,
           no_margin_top: true,
-          translations: links
+          translations: links.sort_by { |t| t[:locale] == I18n.default_locale.to_s ? '' : t[:locale] }
         }
       end
     end

--- a/test/presenters/organisations/header_presenter_test.rb
+++ b/test/presenters/organisations/header_presenter_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+describe Organisations::HeaderPresenter do
+  include OrganisationHelpers
+
+  it 'formats data for the translation component correctly' do
+    content_item = ContentItem.new(organisation_with_translations)
+    organisation = Organisation.new(content_item)
+    @header_presenter = Organisations::HeaderPresenter.new(organisation)
+
+    expected = {
+      brand: "attorney-generals-office",
+      no_margin_top: true,
+      translations: [
+        {
+          locale: "en",
+          base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales",
+          text: "English",
+          active: true
+        },
+        {
+          locale: "cy",
+          base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+          text: "Cymraeg",
+          active: nil
+        }
+      ]
+    }
+    assert_equal expected, @header_presenter.translation_links
+  end
+end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -613,4 +613,26 @@ module OrganisationHelpers
       }
     }.with_indifferent_access
   end
+
+  def organisation_with_translations
+    {
+      title: "Office of the Secretary of State for Wales",
+      base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales",
+      details: {
+        brand: "attorney-generals-office",
+      },
+      links: {
+        available_translations: [
+          {
+            base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales.cy",
+            locale: "cy",
+          },
+          {
+            base_path: "/government/organisations/office-of-the-secretary-of-state-for-wales",
+            locale: "en",
+          }
+        ]
+      }
+    }.with_indifferent_access
+  end
 end


### PR DESCRIPTION
Change order of language list to match existing pages.

Looks like this:

![screen shot 2018-06-26 at 13 30 52](https://user-images.githubusercontent.com/861310/41911663-30ae6626-7945-11e8-939a-392f9bdddebc.png)

Example link: https://govuk-collections-pr-744.herokuapp.com/government/organisations/office-of-the-secretary-of-state-for-wales

Trello card: https://trello.com/c/DB72AxQM/67-cymraeg-english-toggle-is-inverted
