### PR TITLE
Specify resolution of photos for news section

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -35,4 +35,12 @@ module OrganisationHelper
   def organisation_type_name(organisation_type)
     ORGANISATION_TYPES.dig(organisation_type.to_sym, :name) || ORGANISATION_TYPES[:other][:name]
   end
+
+  def image_url_by_size(image_url, size)
+    image_url_array = image_url.split('/')
+    image_by_size_name = "s#{size}_" + image_url_array[-1]
+    image_url_array[-1] = image_by_size_name
+
+    image_url_array.join("/")
+  end
 end

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -1,5 +1,6 @@
 module Organisations
   class DocumentsPresenter
+    include OrganisationHelper
     attr_reader :org
 
     def initialize(organisation)
@@ -11,7 +12,7 @@ module Organisations
     end
 
     def first_featured_news
-      main_story = featured_news([org.ordered_featured_documents.first])[0]
+      main_story = featured_news([org.ordered_featured_documents.first], first_featured: true)[0]
       main_story[:large] = true
       main_story
     end
@@ -158,8 +159,10 @@ module Organisations
       }
     end
 
-    def featured_news(featured)
+    def featured_news(featured, first_featured: false)
       news_stories = []
+      image_size = first_featured ? 712 : 465
+
       featured.each do |news|
         human_date = Date.parse(news["public_updated_at"]).strftime("%-d %B %Y") if news["public_updated_at"]
         document_type = news["document_type"]
@@ -167,7 +170,7 @@ module Organisations
 
         news_stories << {
           href: news["href"],
-          image_src: news["image"]["url"],
+          image_src: image_url_by_size(news["image"]["url"], image_size),
           image_alt: news["image"]["alt_text"],
           context: "#{human_date}#{divider}#{document_type}",
           heading_text: news["title"],

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -1,5 +1,6 @@
 module Organisations
   class PeoplePresenter
+    include OrganisationHelper
     include ActionView::Helpers::UrlHelper
 
     def initialize(organisation)
@@ -66,14 +67,6 @@ module Organisations
       type.eql?(:ministers)
     end
 
-    def small_image_url(image_url)
-      image_url_array = image_url.split('/')
-      small_image_name = "s465_" + image_url_array[-1]
-      image_url_array[-1] = small_image_name
-
-      image_url_array.join("/")
-    end
-
     def formatted_person_data(person, type)
       data = {
         brand: @org.brand,
@@ -94,7 +87,7 @@ module Organisations
       end
 
       if person["image"]
-        data[:image_src] = small_image_url(person["image"]["url"])
+        data[:image_src] = image_url_by_size(person["image"]["url"], 465)
         data[:image_alt] = person["image"]["alt_text"]
       end
 

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -16,7 +16,7 @@ describe Organisations::DocumentsPresenter do
     it 'formats the main large news story correctly' do
       expected = {
         href: "/government/news/new-head-of-the-serious-fraud-office-announced",
-        image_src: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+        image_src: "https://assets.publishing.service.gov.uk/s712_jeremy.jpg",
         image_alt: "Attorney General Jeremy Wright QC MP",
         context: "4 June 2018 — Press release",
         heading_text: "New head of the Serious Fraud Office announced",
@@ -31,7 +31,7 @@ describe Organisations::DocumentsPresenter do
     it 'formats the remaining news stories correctly' do
       expected = [{
         href: "/government/news/new-head-of-a-different-office-announced",
-        image_src: "https://assets.publishing.service.gov.uk/john.jpg",
+        image_src: "https://assets.publishing.service.gov.uk/s465_john.jpg",
         image_alt: "John Someone MP",
         context: "4 June 2017 — Policy paper",
         heading_text: "New head of a different office announced",


### PR DESCRIPTION
Trello: https://trello.com/c/nag99Gy6/82-image-resolution-higher-on-staging-that-production

Previously we were not specifying the image resolution for any of the news items on the new organisation pages which meant we were using the original image sizes which are very large.

This commit changes that so we now:

- Use S712_ for large news
- Use S465_ for other news items

Example URLs:

- https://govuk-collections-pr-746.herokuapp.com/government/organisations/department-for-digital-culture-media-sport
- https://govuk-collections-pr-746.herokuapp.com/government/organisations/cabinet-office