### PR TITLE
Reword 'see all' link to be more accessible

### DIFF
--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -14,7 +14,7 @@
       <%= render "govuk_publishing_components/components/document_list", @documents.latest_documents %>
 
       <p class="organisation__margin-bottom brand--<%= @organisation.brand %>">
-        <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all') %></a>
+        <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all_latest_documents') %></a>
       </p>
 
       <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
       special_representatives: "Special representatives"
       traffic_commissioners: "Traffic commissioners"
     read_more: "Read more about what we do"
-    see_all: "See all"
+    see_all_latest_documents: "See all latest documents"
     separate_website: "separate website"
     type:
       adhoc_advisory_group: "Ad-hoc advisory group"


### PR DESCRIPTION
- underneath 'latest documents'

![screen shot 2018-06-26 at 14 59 28](https://user-images.githubusercontent.com/861310/41917122-8c9b4fe2-7951-11e8-94c9-770acc214ced.png)


Trello card: https://trello.com/c/qly00TPa/221-screenreader-see-all-link-for-latest-documents-isnt-very-descriptive