### PR TITLE
Add region to contacts presenter

### DIFF
--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -97,6 +97,7 @@ module Organisations
       data << contact_line(post["title"])
       data << contact_line(post["street_address"].gsub("\r\n", "<br/>"))
       data << contact_line(post["locality"])
+      data << contact_line(post["region"])
       data << contact_line(post["postal_code"])
       data << contact_line(post["world_location"])
       data = data.gsub("<br/><br/>", "<br/>")


### PR DESCRIPTION
This commit adds the contact region to the contacts presenter.

Trello: https://trello.com/c/Ra3Co8Nv/66-all-addresses-contain-united-kingdom-on-integration