### PR TITLE
Capitalise 'FOI' in document metadata

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -141,7 +141,7 @@ module Organisations
         end
 
         if item["content_store_document_type"]
-          metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ")
+          metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ").gsub("Foi ", "FOI ")
         end
 
         documents << {


### PR DESCRIPTION
Changes 'Foi release' to 'FOI release'. Looks like this:

![screen shot 2018-06-26 at 16 46 17](https://user-images.githubusercontent.com/861310/41923909-9bf27c72-7960-11e8-8bab-421a0aea2394.png)

Example URL: /government/organisations/defence-electronics-and-components-agency

Trello card: https://trello.com/c/dvBgJyhv/227-document-type-of-foi-release-is-being-output-as-foi-release
