### PR TITLE
Exclude stats from publications

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -116,7 +116,7 @@ module Organisations
 
   private
 
-    def search_rummager(filter_email_document_supertype: false, filter_government_document_supertype: false)
+    def search_rummager(filter_email_document_supertype: false, filter_government_document_supertype: false, reject_government_document_supertype: false)
       params = {
         count: 2,
         order: "-public_timestamp",
@@ -126,6 +126,7 @@ module Organisations
 
       params[:filter_email_document_supertype] = filter_email_document_supertype if filter_email_document_supertype
       params[:filter_government_document_supertype] = filter_government_document_supertype if filter_government_document_supertype
+      params[:reject_government_document_supertype] = reject_government_document_supertype if reject_government_document_supertype
 
       Services.rummager.search(params)["results"]
     end
@@ -205,7 +206,7 @@ module Organisations
     end
 
     def latest_publications
-      @latest_publications ||= search_rummager(filter_email_document_supertype: "publications")
+      @latest_publications ||= search_rummager(filter_email_document_supertype: "publications", reject_government_document_supertype: "statistics")
       search_results_to_documents(@latest_publications)
     end
 

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -17,7 +17,7 @@ module OrganisationHelpers
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [] }.to_json)
 
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype=statistics").
       to_return(body: { results: [] }.to_json)
 
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
@@ -61,7 +61,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_publications_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype=statistics").
       to_return(body: { results: [
         {
           title: "National Democracy Week: partner pack",


### PR DESCRIPTION
We're using the email document supertype for [publications][1], however this includes
[statistical documents][2] which we already show in another place.  This change
excludes them from the publications search results.

[1]: https://github.com/alphagov/govuk_document_types/blob/5d572a6439c20593d448c83cfc68e21e82d49b91/data/supertypes.yml#L259-L284
[2]: https://github.com/alphagov/govuk_document_types/blob/5d572a6439c20593d448c83cfc68e21e82d49b91/data/supertypes.yml#L328-L332