### PR TITLE
Only show images for important board members

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -110,6 +110,10 @@ class Organisation
     }
   end
 
+  def important_board_member_count
+    details["important_board_members"]
+  end
+
   def ordered_featured_policies
     links["ordered_featured_policies"]
   end

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -8,12 +8,15 @@ module Organisations
     end
 
     def all_people
-      @org.all_people.map do |person_type, people|
+      all_people = @org.all_people.map do |person_type, people|
         {
+          type: person_type,
           title: I18n.t('organisations.people.' + person_type.to_s),
           people: handle_duplicate_roles(people, person_type)
         }
       end
+
+      images_for_important_board_members(all_people)
     end
 
   private
@@ -42,6 +45,21 @@ module Organisations
       end
 
       all_people
+    end
+
+    def images_for_important_board_members(people)
+      people.map do |people_group|
+        if people_group[:type].eql?(:board_members)
+          people_group[:people].map.with_index(1) do |person, i|
+            if @org.important_board_member_count && i > @org.important_board_member_count
+              person.delete(:image_src)
+              person.delete(:image_alt)
+            end
+          end
+        end
+
+        people_group
+      end
     end
 
     def multiple_role_links(existing_person_info, new_person_info)

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -109,26 +109,32 @@ describe Organisations::PeoplePresenter do
 
       expected = [
         {
+          type: :ministers,
           title: "Our ministers",
           people: []
         },
         {
+          type: :military_personnel,
           title: "Our senior military officials",
           people: []
         },
         {
+          type: :board_members,
           title: "Our management",
           people: []
         },
         {
+          type: :traffic_commissioners,
           title: "Traffic commissioners",
           people: []
         },
         {
+          type: :special_representatives,
           title: "Special representatives",
           people: []
         },
         {
+          type: :chief_professional_officers,
           title: "Chief professional officers",
           people: []
         }
@@ -146,6 +152,40 @@ describe Organisations::PeoplePresenter do
       expected = "Chief Executive of the Civil Service , Permanent Secretary (Cabinet Office)"
 
       assert_equal expected, @people_presenter.all_people.third[:people][1][:description]
+    end
+
+    it 'does not show images for non-important board members' do
+      content_item = ContentItem.new(organisation_with_non_important_board_members)
+      organisation = Organisation.new(content_item)
+      @non_important_board_members = Organisations::PeoplePresenter.new(organisation)
+
+      expected_important = {
+        brand: "attorney-generals-office",
+        href: "/government/people/jeremy-heywood",
+        description: "Cabinet Secretary",
+        metadata: nil,
+        context: nil,
+        heading_text: "Sir Jeremy Heywood",
+        heading_level: 3,
+        extra_links_no_indent: true,
+        image_src: "/photo/s465_jeremy-heywood",
+        image_alt: "Sir Jeremy Heywood"
+      }
+
+
+      expected_non_important = {
+        brand: "attorney-generals-office",
+        href: "/government/people/john-manzoni",
+        description: "Chief Executive of the Civil Service ",
+        metadata: nil,
+        context: nil,
+        heading_text: "John Manzoni",
+        heading_level: 3,
+        extra_links_no_indent: true
+      }
+
+      assert_equal expected_important, @non_important_board_members.all_people.third[:people][0]
+      assert_equal expected_non_important, @non_important_board_members.all_people.third[:people][1]
     end
 
     it 'fetches small image' do

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -188,6 +188,40 @@ module OrganisationHelpers
     }.with_indifferent_access
   end
 
+  def organisation_with_non_important_board_members
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        brand: "attorney-generals-office",
+        organisation_govuk_status: {
+          status: "live",
+        },
+        important_board_members: 1,
+        ordered_board_members: [
+          {
+            name: "Sir Jeremy Heywood",
+            role: "Cabinet Secretary",
+            href: "/government/people/jeremy-heywood",
+            image: {
+              url: "/photo/jeremy-heywood",
+              alt_text: "Sir Jeremy Heywood"
+            }
+          },
+          {
+            name: "John Manzoni",
+            role: "Chief Executive of the Civil Service ",
+            href: "/government/people/john-manzoni",
+            image: {
+              url: "/photo/john-manzoni",
+              alt_text: "John Manzoni"
+            }
+          },
+        ]
+      }
+    }.with_indifferent_access
+  end
+
   def organisation_with_policies
     {
       title: "Attorney General's Office",


### PR DESCRIPTION
Trello: https://trello.com/c/bQTgWtGh/43-img-missing

We've added a field in the content_item which shows how many important board members that org has. This commit uses that field to hide images for non-important board members

## Before
<img width="990" alt="screen shot 2018-06-27 at 10 51 39" src="https://user-images.githubusercontent.com/29889908/41966858-20b69abe-79f8-11e8-803e-019211caedfe.png">

## After
<img width="995" alt="screen shot 2018-06-27 at 10 51 25" src="https://user-images.githubusercontent.com/29889908/41966852-1a824062-79f8-11e8-9e20-a63c0cc2aea4.png">

Examples: 

- Ministerial: https://govuk-collections-pr-754.herokuapp.com/government/organisations/cabinet-office
- Non Ministerial: https://govuk-collections-pr-754.herokuapp.com/government/organisations/charity-commission