### PR TITLE
Add ID to organisation list item on index page

### DIFF
--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -17,7 +17,7 @@
     <div class="column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
       <ol data-filter="list">
         <% organisations.each do |organisation| %>
-          <li class="organisations-list__item" data-filter="item">
+          <li class="organisations-list__item" id="<%= organisation['slug'] %>" data-filter="item">
             <% if @presented_organisations.ministerial_organisation?(organisation_type) %>
               <%= render "govuk_publishing_components/components/organisation_logo", {
                 organisation: {

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -28,6 +28,10 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-heading', text: 'Ministerial departments')
   end
 
+  it "adds an id to each organisation item" do
+    assert page.has_css?('.organisations-list__item#attorney-generals-office')
+  end
+
   it "renders organisation count" do
     assert page.has_css?('.organisations__department-count-wrapper span', text: '1')
   end
@@ -78,6 +82,7 @@ private
           title: "Attorney General's Office",
           href: "/government/organisations/attorney-generals-office",
           brand: "attorney-generals-office",
+          slug: "attorney-generals-office",
           logo: {
             formatted_title: "Attorney General's Office",
             crest: "single-identity"
@@ -112,11 +117,13 @@ private
         {
           title: "Arts and Humanities Research Council",
           href: "/government/organisations/arts-and-humanities-research-council",
-          separate_website: true
+          separate_website: true,
+          slug: "arts-and-humanities-research-council",
         },
         {
           title: "Competition and Markets Authority",
           href: "/government/organisations/competition-and-markets-authority",
+          slug: "competition-and-markets-authority",
           separate_website: true,
           works_with: {
             non_ministerial_department: [


### PR DESCRIPTION
We missed this when migrating over the organisations index page. The old page had an ID on each organisation list item so it could be linked to.

Ministerial departments tend to have this to show what agencies and public bodies they work with (link in the What We Do section).

Example: https://govuk-collections-pr-758.herokuapp.com/government/organisations#uk-export-finance