### PR TITLE
Address the "The" problem

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -112,10 +112,39 @@ module Organisations
     end
 
   private
+    NEED_A_THE = %w(
+      authority
+      agency
+      bank
+      board
+      body
+      centre
+      college
+      commission
+      committee
+      council
+      department
+      fund
+      group
+      hospital
+      inquiry
+      inspectorate
+      ministry
+      office
+      panel
+      review
+      service
+      team
+      tribunal
+    ).freeze
+
+    NO_THE = "civil service resourcing|civil service reform".freeze
 
     def needs_definite_article?(phrase)
-      exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/]
-      !has_definite_article?(phrase) && !(exceptions.any? { |e| e =~ phrase.downcase })
+      should_have = Regexp::new(NEED_A_THE.join("|"), true)
+      should_not_have = Regexp::new(NO_THE, true)
+
+      !has_definite_article?(phrase) && (should_have =~ phrase) && (should_not_have !~ phrase)
     end
 
     def has_definite_article?(phrase)


### PR DESCRIPTION
This should be a more comprehensive solution to the problem with determining whether a "the" should precede the name of the organisation.

There are existing tests to ensure this works with "Attorney General's Office" (should have a the) and "Civil Service Resourcing" (shouldn't).

I've checked Ofsted and that's OK too