### PR TITLE
Exclude consultations from publications

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -206,7 +206,8 @@ module Organisations
     end
 
     def latest_publications
-      @latest_publications ||= search_rummager(filter_email_document_supertype: "publications", reject_government_document_supertype: "statistics")
+      @latest_publications ||= search_rummager(filter_email_document_supertype: "publications",
+        reject_government_document_supertype: %w(consultations statistics))
       search_results_to_documents(@latest_publications)
     end
 

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -17,7 +17,7 @@ module OrganisationHelpers
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [] }.to_json)
 
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype=statistics").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
       to_return(body: { results: [] }.to_json)
 
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
@@ -61,7 +61,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_publications_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype=statistics").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
       to_return(body: { results: [
         {
           title: "National Democracy Week: partner pack",


### PR DESCRIPTION
Consultations and statistics each have their own sections so should not appear in the list of latest
publications.