### PR TITLE
Amend check for any latest documents

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -62,7 +62,7 @@ module Organisations
     end
 
     def has_latest_documents?
-      latest_documents.length.positive?
+      latest_documents[:items].length.positive?
     end
 
     def latest_documents

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -10,6 +10,10 @@ describe Organisations::DocumentsPresenter do
       organisation = Organisation.new(content_item)
       @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
 
+      content_item = ContentItem.new(organisation_with_no_documents)
+      organisation = Organisation.new(content_item)
+      @no_documents_presenter = Organisations::DocumentsPresenter.new(organisation)
+      stub_empty_rummager_requests("org-with-no-docs")
       stub_rummager_latest_content_requests("attorney-generals-office")
     end
 
@@ -42,6 +46,14 @@ describe Organisations::DocumentsPresenter do
       assert_equal expected, @documents_presenter.remaining_featured_news
     end
 
+    it 'returns true if there are latest documents' do
+      assert @documents_presenter.has_latest_documents?
+    end
+
+    it 'returns false if there are no latest documents' do
+      assert_equal false, @no_documents_presenter.has_latest_documents?
+    end
+
     it 'formats latest documents correctly' do
       expected =
         {
@@ -68,9 +80,7 @@ describe Organisations::DocumentsPresenter do
     end
 
     it 'returns false if no latest documents by type exist for an organisation' do
-      stub_empty_rummager_requests("attorney-generals-office")
-
-      assert_equal false, @documents_presenter.has_latest_documents_by_type?
+      assert_equal false, @no_documents_presenter.has_latest_documents_by_type?
     end
 
     it 'formats latest announcements correctly' do

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -8,8 +8,8 @@ module OrganisationHelpers
   end
 
   def stub_empty_rummager_requests(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp").
-      to_return(body: { results: [] }.to_json)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_email_document_supertype=other").
+    to_return(body: { results: [] }.to_json)
 
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [] }.to_json)
@@ -289,6 +289,20 @@ module OrganisationHelpers
             title: "Policy 6"
           },
         ]
+      }
+    }.with_indifferent_access
+  end
+
+  def organisation_with_no_documents
+    {
+      title: "Org with No Docs",
+      base_path: "/government/organisations/org-with-no-docs",
+      details: {
+        organisation_govuk_status: {
+          status: "live",
+        },
+        brand: "org-with-no-docs",
+        organisation_featuring_priority: "news",
       }
     }.with_indifferent_access
   end


### PR DESCRIPTION
Trello: https://trello.com/c/yDg0el9n/100-latest-documents-section-is-shown-even-when-there-are-no-documents

This check was always returning true because the brand is always included in the latest documents. So we were showing something like this:

<img width="677" alt="screen shot 2018-06-27 at 13 21 55" src="https://user-images.githubusercontent.com/29889908/41974679-8457f4f6-7a10-11e8-8870-efd8b3829078.png">

We need to specifically check the items instead. 

Example: /government/organisations/central-advisory-committee-on-compensation