### PR TITLE
Always show corporate information heading

### DIFF
--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -1,5 +1,4 @@
 <div class="column-one-third organisation__float-section">
-  <% if @show.corporate_information[:corporate_information_links][:items].any? %>
     <% unless @organisation.is_promotional_org? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: t('organisations.corporate_information'),
@@ -8,6 +7,7 @@
         brand: @organisation.brand
       } %>
     <% end %>
+  <% if @show.corporate_information[:corporate_information_links][:items].any? %>
     <div class="<%= "organisation__section-border-top" if @organisation.is_promotional_org? %>">
       <%= render "components/topic-list", @show.corporate_information[:corporate_information_links] %>
     </div>


### PR DESCRIPTION
Trello: https://trello.com/c/QRRVRTLV/102-corporate-information-heading-is-hidden-when-there-are-only-jobs-and-contracts-links

We always want to show the corporate information heading, regardless of if there are corporate information links or just job links.

## Before
<img width="219" alt="screen shot 2018-06-27 at 14 48 17" src="https://user-images.githubusercontent.com/29889908/41978888-a872cb22-7a1a-11e8-81f9-66e72a6384ba.png">

## After
<img width="321" alt="screen shot 2018-06-27 at 14 59 56" src="https://user-images.githubusercontent.com/29889908/41978950-c791652c-7a1a-11e8-8407-1094f2d8b2f2.png">

Example: https://govuk-collections-pr-763.herokuapp.com/government/organisations/british-cattle-movement-service
