### PR TITLE
Don't use email supertypes

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -70,7 +70,7 @@ module Organisations
         count: 3,
         order: "-public_timestamp",
         filter_organisations: @org.slug,
-        reject_email_document_supertype: "other",
+        reject_content_purpose_supergroup: "other",
         fields: %w[title link content_store_document_type public_timestamp]
       )["results"]
       search_results_to_documents(@latest_documents)
@@ -116,7 +116,7 @@ module Organisations
 
   private
 
-    def search_rummager(filter_email_document_supertype: false, filter_government_document_supertype: false, reject_government_document_supertype: false)
+    def search_rummager(filter_content_purpose_supergroup: false, filter_government_document_supertype: false, reject_government_document_supertype: false)
       params = {
         count: 2,
         order: "-public_timestamp",
@@ -124,7 +124,7 @@ module Organisations
         fields: %w[title link content_store_document_type public_timestamp]
       }
 
-      params[:filter_email_document_supertype] = filter_email_document_supertype if filter_email_document_supertype
+      params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup
       params[:filter_government_document_supertype] = filter_government_document_supertype if filter_government_document_supertype
       params[:reject_government_document_supertype] = reject_government_document_supertype if reject_government_document_supertype
 
@@ -201,12 +201,13 @@ module Organisations
     end
 
     def latest_announcements
-      @latest_announcements ||= search_rummager(filter_email_document_supertype: "announcements")
+      @latest_announcements ||= search_rummager(filter_content_purpose_supergroup: "news_and_communications")
       search_results_to_documents(@latest_announcements)
     end
 
     def latest_publications
-      @latest_publications ||= search_rummager(filter_email_document_supertype: "publications",
+      @latest_publications ||= search_rummager(
+        filter_content_purpose_supergroup: %w(guidance_and_regulation policy_and_engagement transparency),
         reject_government_document_supertype: %w(consultations statistics))
       search_results_to_documents(@latest_publications)
     end

--- a/app/services/organisation_feed_content.rb
+++ b/app/services/organisation_feed_content.rb
@@ -23,10 +23,7 @@ private
       count: 20,
       fields: RummagerFields::FEED_SEARCH_FIELDS,
       filter_organisations: organisation,
-      #using this as providing a list of the currently supported types is too big.
-      #email_document_supertype seems to fit with the ethos of what we're trying to
-      #provide.
-      reject_email_document_supertype: "other",
+      reject_content_purpose_supergroup: "other",
       order: '-public_timestamp',
     }
 

--- a/test/support/organisation_feed_helpers.rb
+++ b/test/support/organisation_feed_helpers.rb
@@ -5,7 +5,7 @@ module OrganisationFeedHelpers
       count: 20,
       fields: %w(title link description display_type public_timestamp),
       filter_organisations: organisation,
-      reject_email_document_supertype: "other",
+      reject_content_purpose_supergroup: "other",
       order: '-public_timestamp',
     }
 

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -8,16 +8,16 @@ module OrganisationHelpers
   end
 
   def stub_empty_rummager_requests(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_email_document_supertype=other").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other").
     to_return(body: { results: [] }.to_json)
 
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_content_purpose_supergroup=news_and_communications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [] }.to_json)
 
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=consultations&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [] }.to_json)
 
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_content_purpose_supergroup%5B%5D=guidance_and_regulation&filter_content_purpose_supergroup%5B%5D=policy_and_engagement&filter_content_purpose_supergroup%5B%5D=transparency&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
       to_return(body: { results: [] }.to_json)
 
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_government_document_supertype=statistics&filter_organisations=#{organisation_slug}&order=-public_timestamp").
@@ -25,7 +25,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_email_document_supertype=other").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other").
       to_return(body: { results: [
         {
           title: "Rapist has sentence increased after Solicitor General’s referral",
@@ -37,7 +37,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_announcements_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=announcements&filter_organisations=#{organisation_slug}&order=-public_timestamp").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_content_purpose_supergroup=news_and_communications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [
         {
           title: "First events announced for National Democracy Week",
@@ -61,7 +61,7 @@ module OrganisationHelpers
   end
 
   def stub_rummager_latest_publications_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_email_document_supertype=publications&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_content_purpose_supergroup%5B%5D=guidance_and_regulation&filter_content_purpose_supergroup%5B%5D=policy_and_engagement&filter_content_purpose_supergroup%5B%5D=transparency&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_government_document_supertype%5B%5D=consultations&reject_government_document_supertype%5B%5D=statistics").
       to_return(body: { results: [
         {
           title: "National Democracy Week: partner pack",


### PR DESCRIPTION
The email supertypes for publications and announcements don't contain all the document types we need.  We should use the content_purpose_supergroups instead particularly as these have been more heavily user tested.

https://github.com/alphagov/govuk_document_types/blob/5d572a6439c20593d448c83cfc68e21e82d49b91/data/supertypes.yml#L486-L572