### PR TITLE
Set alternate atom and api links

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,4 +1,8 @@
-<% content_for :title, "Departments, agencies and public bodies - GOV.UK" %>
+<% content_for :title, "#{@presented_organisations.title} - GOV.UK" %>
+
+<% content_for :meta_tags do %>
+  <%= auto_discovery_link_tag(:json, api_organisations_url, title: @presented_organisations.title) %>
+<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,3 +1,8 @@
 <% content_for :title, organisation.title %>
 
+<% content_for :meta_tags do %>
+  <%= auto_discovery_link_tag(:json, api_organisation_url(organisation.slug), title: organisation.title) %>
+  <%= auto_discovery_link_tag(:atom, feed_organisation_url(organisation.slug, format: :atom), title: organisation.title) %>
+<% end %>
+
 <%= show_organisation(organisation) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,8 @@ Rails.application.routes.draw do
     constraints: {
       format: /atom/,
       locale: /\w{2}(-[\d\w]{2,3})?/,
-    }, to: "feeds#organisation"
+    }, to: "feeds#organisation",
+    as: :feed_organisation
   get "/government/organisations/:organisation_name(.:locale)",
     to: "organisations#show",
     as: :organisation

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -18,6 +18,10 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
     assert page.has_css?('.gem-c-title__text', text: "Departments, agencies and public bodies")
   end
 
+  it "has autodiscovery links to the API" do
+    assert page.has_css?("link[rel='alternate'][type='application/json'][href$='/api/organisations']", visible: false)
+  end
+
   it "renders organisation filter" do
     assert page.has_css?('.filter-organisations-list__form')
     assert page.has_css?('.filter-organisations-list__label', text: "What's the latestfrom")

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -496,6 +496,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".content")
   end
 
+  it "has autodiscovery links to the RSS feed and the API" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_css?("link[rel='alternate'][type='application/json'][href$='/api/organisations/prime-ministers-office-10-downing-street']", visible: false)
+    assert page.has_css?("link[rel='alternate'][type='application/atom+xml'][href$='/government/organisations/prime-ministers-office-10-downing-street.atom']", visible: false)
+  end
+
   it "displays breadcrumbs" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "Prime Minister's Office, 10 Downing Street")


### PR DESCRIPTION
The atom link lets RSS readers autodetect feeds.  The alternate api links allow for discovery of the api's similar to before on Whitehall.