### PR TITLE
Add Link header to organisations API

### DIFF
--- a/app/controllers/organisations_api_controller.rb
+++ b/app/controllers/organisations_api_controller.rb
@@ -2,17 +2,21 @@ class OrganisationsApiController < ApplicationController
   enable_request_formats index: :json, show: :json
 
   def index
+    presented_organisations = presented_organisations(start: start_index)
+    set_link_header(links: presented_organisations[:_response_info][:links])
     respond_to do |f|
       f.json do
-        render json: presented_organisations(start: start_index)
+        render json: presented_organisations
       end
     end
   end
 
   def show
+    presented_organisation = presented_organisation(slug: params[:organisation_name])
+    set_link_header(links: presented_organisation[:_response_info][:links])
     respond_to do |f|
       f.json do
-        render json: presented_organisation(slug: params[:organisation_name])
+        render json: presented_organisation
       end
     end
   rescue OrganisationNotFound
@@ -65,6 +69,10 @@ private
       count: 1,
       start: 0
     )
+  end
+
+  def set_link_header(links:)
+    response.headers["Link"] = LinkHeaderPresenter.new(links).present
   end
 
   def start_index

--- a/app/presenters/link_header_presenter.rb
+++ b/app/presenters/link_header_presenter.rb
@@ -1,0 +1,15 @@
+class LinkHeaderPresenter
+  attr_reader :links
+
+  def initialize(links)
+    @links = links
+  end
+
+  def present
+    link_header = []
+    links.each do |link|
+      link_header << "<#{link[:href]}>; rel=\"#{link[:rel]}\""
+    end
+    link_header.join(", ")
+  end
+end

--- a/test/controllers/organisations_api_controller_test.rb
+++ b/test/controllers/organisations_api_controller_test.rb
@@ -9,6 +9,13 @@ describe OrganisationsApiController do
         count: 20,
         start: 0,
       ).returns(rummager_organisations_results)
+
+      Services.rummager.stubs(:search).with(
+        filter_format: "organisation",
+        order: "title",
+        count: 20,
+        start: 20,
+      ).returns(rummager_organisations_many_results)
     end
 
     it "renders JSON" do
@@ -26,6 +33,12 @@ describe OrganisationsApiController do
 
       assert_equal 1, body["current_page"]
       assert_equal "ok", body["_response_info"]["status"]
+    end
+
+    it "sets the Link HTTP header" do
+      get :index, format: :json, params: { page: 2 }
+
+      assert_equal '<http://test.host/api/organisations?page=1>; rel="previous", <http://test.host/api/organisations?page=3>; rel="next", <http://test.host/api/organisations?page=2>; rel="self"', response.headers["Link"]
     end
   end
 
@@ -59,6 +72,12 @@ describe OrganisationsApiController do
       body = JSON.parse(response.body)
 
       assert_nil body["current_page"]
+    end
+
+    it "sets the Link HTTP header" do
+      get :show, params: { organisation_name: "hm-revenue-customs" }, format: :json
+
+      assert_equal '<http://test.host/api/organisations/hm-revenue-customs>; rel="self"', response.headers["Link"]
     end
 
     it "adds _response_info" do
@@ -143,6 +162,14 @@ describe OrganisationsApiController do
         },
       ],
       total: 2,
+      start: 0,
+    }.deep_stringify_keys
+  end
+
+  def rummager_organisations_many_results
+    {
+      results: [],
+      total: 1000,
       start: 0,
     }.deep_stringify_keys
   end


### PR DESCRIPTION
This commit adds the HTTP `Link` header to the organisations API, which mirrors the links in the `_response_info` section of the response. This allows gds-api-adapters to correctly collect paginated results.