### PR TITLE
Update the latest docs link

### DIFF
--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -14,7 +14,7 @@
       <%= render "govuk_publishing_components/components/document_list", @documents.latest_documents %>
 
       <p class="organisation__margin-bottom brand--<%= @organisation.brand %>">
-        <a href="<%= "/government/latest?departments[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all_latest_documents') %></a>
+        <a href="<%= "/government/organisations/latest?organisations[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all_latest_documents') %></a>
       </p>
 
       <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -594,7 +594,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows a see all link in the latest documents section" do
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?("a[href='/government/latest?departments%5B%5D=attorney-generals-office']", text: "See all")
+    assert page.has_css?("a[href='/government/organisations/latest?organisations%5B%5D=attorney-generals-office']", text: "See all")
   end
 
   it "shows subscription links" do


### PR DESCRIPTION
This now links to a finder which uses the same document filter as the "Latest
from <department>" section and the atom feed for the org.

https://trello.com/c/fSv9RhjE/199-migrate-latest-pages-from-organisations

https://govuk.zendesk.com/agent/tickets/2891477