### PR TITLE
Remove closed org from org titles in the api

### DIFF
--- a/app/presenters/organisations_api_presenter.rb
+++ b/app/presenters/organisations_api_presenter.rb
@@ -28,7 +28,7 @@ class OrganisationsApiPresenter
       organisation = organisation["organisations"][0]
       {
         id: api_url_from_slug(organisation["slug"]),
-        title: organisation["title"],
+        title: organisation["title"].gsub("Closed organisation: ", ""),
         format: organisation_type_name(organisation["organisation_type"]),
         updated_at: organisation["public_timestamp"],
         web_url: web_url_from_slug(organisation["slug"]),

--- a/test/presenters/organisations_api_presenter_test.rb
+++ b/test/presenters/organisations_api_presenter_test.rb
@@ -39,6 +39,36 @@ describe OrganisationsApiPresenter do
         elasticsearch_type: "edition",
         document_type: "edition",
       }.deep_stringify_keys,
+      {
+        description: "The home of the Who Framed Roger Rabbit enquiry",
+        format: "organisation",
+        link: "/government/organisations/who-framed-roger-rabbit",
+        organisations: [
+          {
+            organisation_crest: "hmrc",
+            acronym: "WFRR",
+            link: "/government/organisations/who-framed-roger-rabbit",
+            analytics_identifier: "D26",
+            public_timestamp: "2015-05-13T11:09:06.000+01:00",
+            organisation_brand: "hm-revenue-customs",
+            logo_formatted_title: "Who Framed\r\nRoger Rabbit",
+            title: "Closed organisation: Who Framed Roger Rabbit",
+            content_id: "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+            slug: "hm-revenue-customs",
+            organisation_type: "non_ministerial_department",
+            organisation_state: "closed",
+            organisation_closed_state: "no_longer_exists",
+          },
+        ],
+        public_timestamp: "2015-05-13T11:09:06.000+01:00",
+        slug: "who-framed-roger-rabbit",
+        title: "Closed organisation: Who Framed Roger Rabbit",
+        index: "government",
+        es_score: nil,
+        _id: "/government/organisations/who-framed-roger-rabbit",
+        elasticsearch_type: "edition",
+        document_type: "edition",
+      }.deep_stringify_keys
     ]
   end
 
@@ -47,7 +77,7 @@ describe OrganisationsApiPresenter do
       results,
       current_page: 1,
       results_per_page: 20,
-      total_results: 1,
+      total_results: 2,
       current_url_without_parameters: "https://www.gov.uk/api/organisations",
     )
   end
@@ -68,6 +98,11 @@ describe OrganisationsApiPresenter do
       paginated_results = presenter_wrapped.present
       assert_equal "HM Revenue & Customs", paginated_results[:results][0][:title]
       assert_equal "hm-revenue-customs", paginated_results[:results][0][:details][:slug]
+    end
+
+    it "sets the appropriate title for closed orgs" do
+      paginated_results = presenter_wrapped.present
+      assert_equal "Who Framed Roger Rabbit", paginated_results[:results][1][:title]
     end
   end
 


### PR DESCRIPTION
This is intended for human reference in search results, but is clearly indicated by the closed status.

This was a change from the behaviour when Whitehall presented the API and there's no good reason for us to keep it, so we should fix it.

Referred to in https://github.com/alphagov/whitehall/issues/4186