### PR TITLE
Switch from PhantomJS to Chrome for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,12 +16,14 @@ gem 'uglifier', '~> 4.1.13'
 
 group :test do
   gem 'capybara'
+  gem 'chromedriver-helper'
   gem 'cucumber-rails', require: false
   gem 'govuk_schemas', '~> 3.1.0'
   gem 'govuk-content-schema-test-helpers'
   gem 'minitest-spec-rails'
   gem 'mocha'
-  gem 'poltergeist'
+  gem 'puma'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-rcov'
   gem 'webmock', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     backports (3.11.3)
@@ -55,15 +57,19 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    byebug (10.0.1)
-    capybara (2.18.0)
+    byebug (10.0.2)
+    capybara (3.3.1)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
-    cliver (0.3.2)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     commander (4.4.5)
       highline (~> 1.7.2)
@@ -71,20 +77,20 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    cucumber (3.1.0)
+    cucumber (3.1.1)
       builder (>= 2.1.2)
       cucumber-core (~> 3.1.0)
-      cucumber-expressions (~> 5.0.4)
+      cucumber-expressions (~> 6.0.0)
       cucumber-wire (~> 0.0.1)
       diff-lcs (~> 1.3)
-      gherkin (~> 5.0)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
     cucumber-core (3.1.0)
       backports (>= 3.8.0)
       cucumber-tag_expressions (~> 1.1.0)
       gherkin (>= 5.0.0)
-    cucumber-expressions (5.0.17)
+    cucumber-expressions (6.0.1)
     cucumber-rails (1.6.0)
       capybara (>= 1.1.2, < 4)
       cucumber (>= 3.0.2, < 4)
@@ -95,7 +101,7 @@ GEM
     cucumber-wire (0.0.1)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
-    docile (1.3.0)
+    docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
@@ -111,7 +117,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gherkin (5.0.0)
+    gherkin (5.1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govspeak (5.6.0)
@@ -157,6 +163,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jasmine-core (2.99.2)
     jasmine-rails (0.14.7)
       jasmine-core (>= 1.3, < 3.0)
@@ -204,21 +211,17 @@ GEM
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.8.3)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     nokogumbo (1.5.0)
       nokogiri
     null_logger (0.0.1)
     parallel (1.12.1)
-    parser (2.5.0.5)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -226,6 +229,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.2)
+    puma (3.11.4)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -279,6 +283,7 @@ GEM
     rubocop-rspec (1.19.0)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sanitize (4.6.5)
       crass (~> 1.0.2)
@@ -298,6 +303,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.13.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.16.1)
@@ -329,12 +337,12 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.13)
+    uglifier (4.1.14)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -345,7 +353,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.0.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
@@ -355,6 +363,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara
+  chromedriver-helper
   cucumber-rails
   gds-api-adapters (~> 52.6)
   govuk-content-schema-test-helpers
@@ -368,11 +377,12 @@ DEPENDENCIES
   minitest-spec-rails
   mocha
   plek (~> 2.1.1)
-  poltergeist
   pry-byebug
+  puma
   rails (= 5.2.0)
   rinku
   sass-rails (~> 5.0.3)
+  selenium-webdriver
   simplecov
   simplecov-rcov
   slimmer (~> 13.0.0)
@@ -384,4 +394,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -78,11 +78,11 @@ Then(/^I should see the second level browse page$/) do
 end
 
 Then(/^the A to Z label should be present$/) do
-  assert page.has_content?('A to Z')
+  assert page.has_content?("A\u200Ato\u200AZ")
 end
 
 Then(/^the A to Z label should not be present$/) do
-  assert page.has_no_content?('A to Z')
+  assert page.has_no_content?("A\u200Ato\u200AZ")
 end
 
 When(/^I visit that browse page$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,9 +13,9 @@ ENV["RAILS_ENV"] ||= "test"
 
 require 'cucumber/rails'
 require_relative 'mocha'
+require_relative 'selenium'
 require 'slimmer/test'
 
 ActionController::Base.allow_rescue = false
 
-require 'capybara/poltergeist'
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :headless_chrome

--- a/features/support/selenium.rb
+++ b/features/support/selenium.rb
@@ -1,8 +1,3 @@
-require_relative "test_helper"
-
-require 'capybara/rails'
-require 'slimmer/test'
-
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu) }
@@ -13,10 +8,4 @@ Capybara.register_driver :headless_chrome do |app|
     browser: :chrome,
     desired_capabilities: capabilities
   )
-end
-
-Capybara.javascript_driver = :headless_chrome
-
-class ActionDispatch::IntegrationTest
-  include Capybara::DSL
 end


### PR DESCRIPTION
This PR switches from PhantomJS to Chrome running in headless mode for integration and feature tests, since PhantomJS development has now been stopped.

Trello: https://trello.com/c/M7KeYcSp/83-phantomjs-development-has-been-abandoned, https://trello.com/c/DRnuOYPL/175-enable-moving-from-phantomjs-to-chrome-for-integration-and-feature-testing