### PR TITLE
Exempt orgs may not have a URL

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -142,6 +142,10 @@ class Organisation
     details["organisation_govuk_status"]["url"]
   end
 
+  def no_website?
+    separate_website_url.blank?
+  end
+
   def is_live?
     details["organisation_govuk_status"]["status"] == "live"
   end

--- a/app/presenters/organisations/not_live_presenter.rb
+++ b/app/presenters/organisations/not_live_presenter.rb
@@ -7,6 +7,7 @@ module Organisations
     end
 
     def non_live_organisation_notice
+      return has_no_website if @org.is_exempt? && @org.no_website?
       return separate_website_notice if @org.is_exempt?
       return changed_name_notice if @org.is_changed_name? || @org.is_closed?
       return joining_notice if @org.is_joining?
@@ -19,6 +20,10 @@ module Organisations
     end
 
   private
+
+    def has_no_website
+      I18n.t('organisations.notices.no_website', title: @org.title).html_safe
+    end
 
     def separate_website_notice
       I18n.t('organisations.notices.separate_website', title: @org.title, url: @org.separate_website_url).html_safe

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -39,6 +39,7 @@ cy:
     jobs_contracts: "Swyddi a chontractau"
     latest_from: "Gweithgaredd diweddaraf gan %{title}"
     notices:
+      no_website: "%{title} has no website"
       separate_website: "%{title} has a <a href='%{url}'>separate website</a>"
       changed_name: "%{title} is now called <a href='%{link_href}'>%{link_text}</a>"
       joining: "%{title} will soon be incorporated into GOV.UK"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
     jobs_contracts: "Jobs and contracts"
     latest_from: "Latest from %{title}"
     notices:
+      no_website: "%{title} has no website"
       separate_website: "%{title} has a <a href='%{url}'>separate website</a>"
       changed_name: "%{title} is now called <a href='%{link_href}'>%{link_text}</a>"
       joining: "%{title} will soon be incorporated into GOV.UK"

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -46,6 +46,20 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
       }
     }
 
+    @content_item_exempt_no_url = {
+      title: "Exempt organisation",
+      base_path: "/government/organisations/exempt-no-url",
+      details: {
+        body: "This organisation has a status of exempt.",
+        logo: {
+        },
+        organisation_govuk_status: {
+          status: "exempt",
+          url: ""
+        },
+      }
+    }
+
     @content_item_exempt = {
       title: "Exempt organisation",
       base_path: "/government/organisations/exempt",
@@ -191,6 +205,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     content_store_has_item("/government/organisations/changed_name", @content_item_changed_name)
     content_store_has_item("/government/organisations/devolved", @content_item_devolved)
     content_store_has_item("/government/organisations/exempt", @content_item_exempt)
+    content_store_has_item("/government/organisations/exempt-no-url", @content_item_exempt_no_url)
     content_store_has_item("/government/organisations/joining", @content_item_joining)
     content_store_has_item("/government/organisations/left_gov", @content_item_left_gov)
     content_store_has_item("/government/organisations/merged", @content_item_merged)
@@ -202,6 +217,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     stub_rummager_latest_content_requests("changed_name")
     stub_rummager_latest_content_requests("devolved")
     stub_rummager_latest_content_requests("exempt")
+    stub_rummager_latest_content_requests("exempt-no-url")
     stub_rummager_latest_content_requests("joining")
     stub_rummager_latest_content_requests("left_gov")
     stub_rummager_latest_content_requests("merged")
@@ -234,6 +250,14 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-organisation-logo")
     assert page.has_css?(".gem-c-notice", text: "Exempt organisation has a separate website")
     assert page.has_css?(".gem-c-notice a[href='http://www.google.com']", text: "separate website")
+    assert page.has_css?(".gem-c-govspeak")
+    assert page.has_content?(/This organisation has a status of exempt./i)
+  end
+
+  it 'displays an exempt organisation page with no URL correctly' do
+    visit "/government/organisations/exempt-no-url"
+    assert page.has_css?(".gem-c-organisation-logo")
+    assert page.has_css?(".gem-c-notice__title", text: "Exempt organisation has no website")
     assert page.has_css?(".gem-c-govspeak")
     assert page.has_content?(/This organisation has a status of exempt./i)
   end


### PR DESCRIPTION
We have discovered that we have at least one organisation which is exempt, but
does not have another website.  We should display a message to indicate this.

See: https://www.gov.uk/government/organisations/bpdts-ltd
vs
http://webarchive.nationalarchives.gov.uk/20180310163553/https://www.gov.uk/government/organisations/bpdts-ltd

https://govuk.zendesk.com/agent/tickets/2887147