### PR TITLE
Reduce page cache for organisation pages

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,4 +1,6 @@
 class OrganisationsController < ApplicationController
+  skip_before_action :set_expiry
+  before_action -> { set_expiry(5.minutes) }
   before_action :set_locale, only: :show
 
   def index

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+describe OrganisationsController do
+  describe "GET index" do
+    before do
+      content_store_has_item("/government/organisations/ministry-of-magic",
+        title: "Ministry of magic",
+        base_path: "/government/organisations/ministry-of-magic",
+        details: {
+          body: "This organisation has a status of exempt.",
+          logo: {
+          },
+          organisation_govuk_status: {
+            status: "exempt",
+            url: "https://ministry-of-magic.gov.uk"
+          },
+        })
+
+      Services.rummager.stubs(:search)
+        .returns(
+          "results" => [],
+          "start" => 0,
+          "total" => 0,
+        )
+    end
+
+    it "set correct expiry headers" do
+      get :show, params: { organisation_name: "ministry-of-magic" }
+
+      assert_equal "max-age=300, public", response.headers["Cache-Control"]
+    end
+  end
+end


### PR DESCRIPTION
It's important to show org pages reasonably promptly particularly when there's a reshuffle. Currently this page is set to expire after 30 minutes.  Whitehall had these pages set to 5 minutes, so we'll replicate that.

https://trello.com/c/7QYLAggr/151-drop-org-pages-cache-to-5-minutes