### PR TITLE
Add content id to step navs

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys
+    details["step_by_step_nav"].deep_symbolize_keys.merge(tracking_id: content_id)
   end
 
   def self.find!(base_path)


### PR DESCRIPTION
This change adds the content id of the step nav to the component, via the `tracking_id` parameter of the component.

The component uses this value as the `data-id` attribute of the wrapping element, which is in turn used by some of the GA tracking in the component's JS.

- [Example page](https://govuk-collections-pr-778.herokuapp.com/learn-to-drive-a-car)
- [Details of tracking in the component](https://govuk-publishing-components.herokuapp.com/component-guide/step_by_step_nav/with_unique_tracking)
