### PR TITLE
Add missing org page section anchors

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -7,6 +7,14 @@ module Organisations
       @org = organisation
     end
 
+    def has_people?
+      all_people.each do |people|
+        return true unless people[:people].empty?
+      end
+
+      false
+    end
+
     def all_people
       all_people = @org.all_people.map do |person_type, people|
         {

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -1,4 +1,4 @@
-<section class="organisation__section-wrap organisation__margin-bottom">
+<section class="organisation__section-wrap organisation__margin-bottom" id="featured-documents">
   <h2 class="visually-hidden"><%= @show.featured_news_title %></h2>
   <% if @organisation.is_news_organisation? %>
     <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>

--- a/app/views/organisations/_featured_policies.html.erb
+++ b/app/views/organisations/_featured_policies.html.erb
@@ -1,4 +1,4 @@
-<section class="grid-row organisation__margin-bottom">
+<section class="grid-row organisation__margin-bottom" id="policies">
   <div class="column-one-third">
     <%= render "govuk_publishing_components/components/heading", {
       text: t('organisations.our_policies'),

--- a/app/views/organisations/_freedom_of_information.html.erb
+++ b/app/views/organisations/_freedom_of_information.html.erb
@@ -1,4 +1,4 @@
-<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__margin-bottom">
+<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__margin-bottom" id="freedom-of-information">
   <% if @organisation.foi_exempt? %>
     <%= render "govuk_publishing_components/components/heading", {
       text: t('organisations.foi.freedom_of_information_act'),

--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -1,4 +1,4 @@
-<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__margin-bottom">
+<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__margin-bottom" id="latest-documents">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -26,19 +26,23 @@
 <% end %>
 
 <% unless @organisation.is_promotional_org? %>
-  <% @people.all_people.each do |people_data| %>
-    <%= render partial: 'related_people', locals: {
-      people: people_data[:people],
-      title: people_data[:title],
-      brand: @organisation.brand
-    } %>
+  <% if @people.has_people? %>
+    <div id="people">
+      <% @people.all_people.each do |people_data| %>
+        <%= render partial: 'related_people', locals: {
+          people: people_data[:people],
+          title: people_data[:title],
+          brand: @organisation.brand
+        } %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
     <% if @contacts.has_contacts? %>
-      <section class="brand--<%= @organisation.brand %> organisation__margin-bottom">
+      <section class="brand--<%= @organisation.brand %> organisation__margin-bottom" id="org-contacts">
         <%= render "govuk_publishing_components/components/heading", {
           text: t('organisations.contact.contact_organisation', organisation: @show.acronym),
           brand: @organisation.brand,
@@ -55,7 +59,7 @@
     <% end %>
 
     <% if @show.high_profile_groups[:items] && !@organisation.is_promotional_org? %>
-      <section class="organisation__margin-bottom">
+      <section class="organisation__margin-bottom" id="high-profile-groups">
         <%= render "govuk_publishing_components/components/heading", {
           text: @show.high_profile_groups[:title],
           brand: @organisation.brand,
@@ -69,7 +73,7 @@
     <% end %>
   </div>
   <% if @organisation.ordered_corporate_information && @organisation.ordered_corporate_information.any? %>
-    <div class="organisation__corporate-information">
+    <div class="organisation__corporate-information" id="corporate-info">
       <%= render partial: 'corporate_information' %>
     </div>
   <% end %>

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -1,4 +1,4 @@
-<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom">
+<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom" id="what-we-do">
   <div class="grid-row">
     <div class="column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -554,9 +554,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_css?(".app-c-topic-list")
 
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("section#featured-documents")
     assert page.has_css?(".app-c-topic-list.app-c-topic-list--small .app-c-topic-list__link", text: "Attorney General's guidance to the legal profession")
 
     visit "/government/organisations/charity-commission"
+    assert page.has_css?("section#featured-documents")
     assert page.has_css?(".app-c-topic-list .app-c-topic-list__link", text: "Find a charity")
     refute page.has_css?(".app-c-topic-list.app-c-topic-list--small")
   end
@@ -586,6 +588,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows the latest documents when it should" do
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("section#latest-documents")
     assert page.has_css?(".gem-c-heading", text: "Latest from the Attorney General's Office")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral']", text: "Rapist has sentence increased after Solicitor General’s referral")
     assert page.has_css?(".gem-c-document-list__attribute", text: "Press release")
@@ -605,9 +608,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows the 'what we do' section" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
+    assert page.has_css?("section#what-we-do")
     assert page.has_content?(/10 Downing Street is the official residence and the office of the British Prime Minister/i)
 
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("section#what-we-do")
     assert page.has_content?(/provides legal advice and support to the Attorney General/i)
   end
 
@@ -617,6 +622,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     visit "/government/organisations/charity-commission"
     assert page.has_content?(/Our policies/i)
+    assert page.has_css?("section#policies")
     assert page.has_css?(".gem-c-document-list__item-title", text: "Waste and recycling")
   end
 
@@ -644,6 +650,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows the ministers for an organisation" do
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("div#people")
     assert page.has_css?(".gem-c-heading", text: "Our ministers")
     assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Theresa May MP")
     assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Stuart Andrew MP")
@@ -651,6 +658,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "does not show the ministers section for no.10" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
+    refute page.has_css?("div#people")
     refute page.has_css?(".gem-c-heading", text: "Our ministers")
     refute page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Theresa May MP")
   end
@@ -693,10 +701,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     refute page.has_content?(/Freedom of Information (FOI) Act/i)
 
     visit "/government/organisations/charity-commission"
+    assert page.has_css?("section#freedom-of-information")
     assert page.has_content?(/This organisation is not covered by the Freedom of Information Act. To see which organisations are included, see the legislation./i)
 
     visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
     assert page.has_content?(/Gwneud cais DRhG/i)
+    assert page.has_css?("section#freedom-of-information")
     assert page.has_css?(".gem-c-heading", text: "FOI stuff")
     assert page.has_content?(/Office of the Secretary of State for Wales/i)
     assert page.has_content?(/Gwydyr House/i)
@@ -713,6 +723,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows high profile groups section" do
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("section#high-profile-groups")
     assert page.has_css?(".gem-c-heading", text: "High profile groups within AGO")
     assert page.has_css?(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-1']", text: "High Profile Group 1")
     assert page.has_css?(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-2']", text: "High Profile Group 2")
@@ -730,6 +741,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "displays corporate information pages" do
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("div#corporate-info")
     assert page.has_css?(".gem-c-heading", text: "Corporate information")
     assert page.has_css?(".app-c-topic-list__link[href='/complaints-procedure']", text: "Complaints procedure")
 
@@ -745,6 +757,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "displays contact information" do
     visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("section#org-contacts")
     assert page.has_css?("h2.gem-c-heading", text: "Contact AGO")
     assert page.has_css?("h3.gem-c-heading", text: "Department for International Trade")
     assert page.has_content?(/King Charles Street/i)


### PR DESCRIPTION
Trello: https://trello.com/c/JCSKhx4C/29-missing-org-contacts-anchor-on-organisation-pages

We were getting a few Zendesk tickets from people who rely on the organisation page section anchors which we didn't implement when migrating to Collections.

Examples:

- https://govuk-collections-pr-782.herokuapp.com/government/organisations/cabinet-office#org-contacts
- https://govuk-collections-pr-782.herokuapp.com/government/organisations/civil-service#featured-documents
- https://govuk-collections-pr-782.herokuapp.com/government/organisations/academy-for-social-justice-commissioning#latest-documents
- https://govuk-collections-pr-782.herokuapp.com/government/organisations/attorney-generals-office#what-we-do
- https://govuk-collections-pr-782.herokuapp.com/government/organisations/ofsted#people