### PR TITLE
Turn on step nav remember open step option

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys.merge(tracking_id: content_id)
+    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id)
   end
 
   def self.find!(base_path)


### PR DESCRIPTION
Uses the component option to remember which steps the user has opened on the main step nav page, so if they return to that page in the same session the page will look as it did when they left it

Documentation: https://govuk-publishing-components.herokuapp.com/component-guide/step_by_step_nav/remember_last_opened_step

Trello card: https://trello.com/c/0Ww8Eep9/710-leave-expanded-steps-expanded-on-overview-page-when-returning-from-an-external-site