### PR TITLE
Serve /goverment/feed

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,5 +1,5 @@
 class FeedsController < ApplicationController
-  enable_request_formats organisation: :atom
+  enable_request_formats organisation: :atom, all: :atom
 
   before_action do
     # Allows ajax requests as per https://govuk.zendesk.com/agent/tickets/1935680
@@ -13,7 +13,9 @@ class FeedsController < ApplicationController
     @organisation = Organisation.find!(path)
 
     results = FeedContent.new(filter_organisations: organisation_name).results
-    @items = results.map { |result| FeedEntryPresenter.new(result) }
+    items = results.map { |result| FeedEntryPresenter.new(result) }
+
+    render :feed, locals: { items: items, root_url: @organisation.web_url, title: "#{@organisation.title} - Activity on GOV.UK" }
   end
 
 private

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -18,6 +18,13 @@ class FeedsController < ApplicationController
     render :feed, locals: { items: items, root_url: @organisation.web_url, title: "#{@organisation.title} - Activity on GOV.UK" }
   end
 
+  def all
+    results = FeedContent.new({}).results
+    items = results.map { |result| FeedEntryPresenter.new(result) }
+
+    render :feed, locals: { items: items, root_url: Plek.new.website_root, title: "Activity on GOV.UK" }
+  end
+
 private
 
   def organisation_name

--- a/app/views/feeds/feed.atom.builder
+++ b/app/views/feeds/feed.atom.builder
@@ -1,11 +1,13 @@
-atom_feed(language: 'en-GB', root_url: @organisation.web_url) do |feed|
-  feed.title("#{@organisation.title} - Activity on GOV.UK")
+atom_feed(language: 'en-GB', root_url: root_url) do |feed|
+  feed.title(title)
+
   feed.author do |author|
     author.name('HM Government')
   end
-  feed.updated(@items.first.updated) if @items.any?
 
-  @items.each do |item|
+  feed.updated(items.first.updated) if items.any?
+
+  items.each do |item|
     feed.entry(item, id: item.id, url: item.url, updated: item.updated) do |entry|
       entry.title(item.title)
       if item.display_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   post "/topic/:topic_slug/:subtopic_slug/email-signup",
     to: "email_signups#create"
 
+  get "/government/feed" => "feeds#all", defaults: { format: "atom" }
+
   get "/government/organisations",
     to: "organisations#index",
     as: :organisations


### PR DESCRIPTION
This is an Atom feed currently served by Whitehall. It is generated using the same method as the organisations feed. When we [migrated that feed][1] we identified two functional changes that will also apply here:

- The `id` of the feed will change from `tag:www.gov.uk,2005:DocumentCollection/231443` to a URL.
- We can no longer provide long form feed content as Rummager doesn't let us obtain that. We fall back to providing a title and a summary.

In addition, we will be serving more content in the feed, not just things published by Whitehall (AAIB reports for example). We've not heard any complaints about that, according to @sihugh. 

[1]: https://github.com/alphagov/collections/pull/682

https://trello.com/c/wGkUiiGq

