### PR TITLE
[DO NOT MERGE] Update test for breadcrumb component

### DIFF
--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -504,13 +504,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "displays breadcrumbs" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
-    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "Prime Minister's Office, 10 Downing Street")
+    assert page.has_css?(".gem-c-breadcrumbs", text: "Prime Minister's Office, 10 Downing Street")
 
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "Attorney General's Office")
+    assert page.has_css?(".gem-c-breadcrumbs", text: "Attorney General's Office")
 
     visit "/government/organisations/charity-commission"
-    assert page.has_css?(".gem-c-breadcrumbs .gem-c-breadcrumbs--item", text: "The Charity Commission")
+    assert page.has_css?(".gem-c-breadcrumbs", text: "The Charity Commission")
   end
 
   it "sets the page title" do


### PR DESCRIPTION
This updates collections ahead of a change to the breadcrumb component in [this PR](https://github.com/alphagov/govuk_publishing_components/pull/435). 

Do not merge this PR until a new version of the components gem is created and added to this PR (until then tests will fail anyway).