### PR TITLE
Add dimension 29 to topic pages

### DIFF
--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -30,7 +30,7 @@ module Supergroups
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
+            data_attributes: data_attributes(document.base_path, document.title, index)
           },
           metadata: {
             document_type: document.content_store_document_type.humanize

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -73,7 +73,7 @@ module Supergroups
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
+            data_attributes: data_attributes(document.base_path, document.title, index)
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -25,7 +25,7 @@ module Supergroups
             text: document.title,
             path: document.base_path,
             description: document.description,
-            data_attributes: data_attributes(document.base_path, index)
+            data_attributes: data_attributes(document.base_path, document.title, index)
           }
         }
 

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -52,11 +52,14 @@ module Supergroups
 
   private
 
-    def data_attributes(base_path, index)
+    def data_attributes(base_path, link_text, index)
       {
         track_category: data_module_label + "DocumentListClicked",
         track_action: index,
-        track_label: base_path
+        track_label: base_path,
+        track_options: {
+          dimension29: link_text
+        }
       }
     end
 
@@ -70,7 +73,7 @@ module Supergroups
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, index)
+            data_attributes: data_attributes(document.base_path, document.title, index)
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -46,7 +46,7 @@ private
           url: org.link,
           brand: org.brand,
           crest: org.crest,
-          data_attributes: data_attributes(org.link, index + 1)
+          data_attributes: data_attributes(org.link, org.title, index + 1)
       }
     end
   end
@@ -61,17 +61,20 @@ private
         link: {
           text: organisation.title,
           path: organisation.link,
-          data_attributes: data_attributes(organisation.link, tracking_number + index)
+          data_attributes: data_attributes(organisation.link, organisation.title, tracking_number + index)
         }
       }
     end
   end
 
-  def data_attributes(base_path, index)
+  def data_attributes(base_path, link_text, index)
     {
       track_category: "organisationsDocumentListClicked",
       track_action: index,
-      track_label: base_path
+      track_label: base_path,
+      track_options: {
+        dimension29: link_text
+      }
     }
   end
 end

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -20,7 +20,10 @@ describe Supergroups::GuidanceAndRegulation do
             data_attributes: {
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           },
           metadata: {
@@ -48,7 +51,11 @@ describe Supergroups::GuidanceAndRegulation do
             data_attributes: {
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
+
             }
           },
           metadata: {
@@ -78,7 +85,10 @@ describe Supergroups::GuidanceAndRegulation do
             data_attributes: {
               track_category: "guidanceAndRegulationHighlightBoxClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           },
           metadata: {

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -22,7 +22,10 @@ describe Supergroups::NewsAndCommunications do
             data_attributes: {
               track_category: "newsAndCommunicationsDocumentListClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           },
           metadata: {
@@ -76,7 +79,10 @@ describe Supergroups::NewsAndCommunications do
             data_attributes: {
               track_category: "newsAndCommunicationsFeaturedLinkClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           },
           metadata: {

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -126,7 +126,10 @@ describe Supergroups::PolicyAndEngagement do
                 data_attributes: {
                   track_category: "policyAndEngagementDocumentListClicked",
                   track_action: 1,
-                  track_label: '/government/tagged/content-1'
+                  track_label: '/government/tagged/content-1',
+                  track_options: {
+                    dimension29: 'Tagged Content Title'
+                  }
                 }
               },
               metadata: {
@@ -207,7 +210,10 @@ private
         data_attributes: {
           track_category: "policyAndEngagementDocumentListClicked",
           track_action: index + 1,
-          track_label: '/government/tagged/content'
+          track_label: '/government/tagged/content',
+          track_options: {
+            dimension29: 'Tagged Content Title'
+          }
         }
       },
       metadata: {

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -21,7 +21,10 @@ describe Supergroups::Services do
             data_attributes: {
               track_category: "servicesDocumentListClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           }
         }
@@ -44,7 +47,10 @@ describe Supergroups::Services do
             data_attributes: {
               track_category: "servicesHighlightBoxClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: 'Tagged Content Title'
+              }
             }
           }
         }

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -20,7 +20,10 @@ describe Supergroups::Transparency do
             data_attributes: {
               track_category: "transparencyDocumentListClicked",
               track_action: 1,
-              track_label: '/government/tagged/content'
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: "Tagged Content Title"
+              }
             }
           },
           metadata: {

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -39,7 +39,10 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
-              track_label: '/government/organisations/department-for-education'
+              track_label: '/government/organisations/department-for-education',
+              track_options: {
+                dimension29: 'Department for Education'
+              }
             }
           }
         }
@@ -67,7 +70,10 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             track_category: "organisationsDocumentListClicked",
             track_action: 1,
-            track_label: '/government/organisations/department-for-education'
+            track_label: '/government/organisations/department-for-education',
+            track_options: {
+              dimension29: 'Department for Education'
+            }
           }
         }
       ]
@@ -93,7 +99,10 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
-              track_label: '/government/organisations/department-for-education'
+              track_label: '/government/organisations/department-for-education',
+              track_options: {
+                dimension29: 'Department for Education'
+              }
             }
           }
         }
@@ -123,7 +132,10 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
-            track_label: '/government/organisations/department-for-education'
+            track_label: '/government/organisations/department-for-education',
+            track_options: {
+              dimension29: 'Department for Education'
+            }
           }
         )
       end
@@ -151,7 +163,10 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               track_category: "organisationsDocumentListClicked",
               track_action: index + 1,
-              track_label: '/government/organisations/department-for-education'
+              track_label: '/government/organisations/department-for-education',
+              track_options: {
+                dimension29: 'Department for Education'
+              }
             }
           }
         )
@@ -183,7 +198,10 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
-            track_label: '/government/organisations/department-for-education'
+            track_label: '/government/organisations/department-for-education',
+            track_options: {
+              dimension29: 'Department for Education'
+            }
           }
         )
       end
@@ -196,7 +214,10 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               track_category: "organisationsDocumentListClicked",
               track_action: 4,
-              track_label: '/government/organisations/department-for-education'
+              track_label: '/government/organisations/department-for-education',
+              track_options: {
+                dimension29: 'Department for Education'
+              }
             }
           }
         }
@@ -228,7 +249,10 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             track_category: "organisationsDocumentListClicked",
             track_action: 6,
-            track_label: '/government/organisations/department-for-education'
+            track_label: '/government/organisations/department-for-education',
+            track_options: {
+              dimension29: 'Department for Education'
+            }
           }
         }
       ]
@@ -256,7 +280,10 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               track_category: "organisationsDocumentListClicked",
               track_action: 6,
-              track_label: '/government/organisations/department-for-education'
+              track_label: '/government/organisations/department-for-education',
+              track_options: {
+                dimension29: 'Department for Education'
+              }
             }
           }
         }


### PR DESCRIPTION
Trello: https://trello.com/c/zyPBgFFc/71-implement-event-tracking-navigation-link-text-custom-dimension-29-to-topic-pages

Add the link text as dimension 29 for google analytics tracking on topic pages.

Screenshot showing dimension29 is now present and set to the value of the link text:
<img width="385" alt="screen shot 2018-07-20 at 14 43 58" src="https://user-images.githubusercontent.com/29889908/43005639-66bc6ddc-8c2b-11e8-9739-43a1bdc8551c.png">

Heroku link: https://govuk-collections-pr-800.herokuapp.com/education