### PR TITLE
Fix subtopic grid heading hierarchy

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -37,13 +37,13 @@
       <ol class="taxon-page__grid-wrapper">
         <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
           <li class="taxon-page__grid-item">
-            <h2 class="taxon-page__grid-heading">
+            <h3 class="taxon-page__grid-heading">
               <%= link_to(
                 child_taxon.title,
                 child_taxon.base_path,
                 data: presented_taxon.options_for_child_taxon(index: index)
               )%>
-            </h2>
+            </h3>
             <p class="taxon-page__grid-item-description"><%= child_taxon.description %></p>
           </li>
         <% end %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -245,6 +245,7 @@ private
     child_taxons = @content_item["links"]["child_taxons"]
 
     child_taxons.each do |child_taxon|
+      assert page.has_css?("h3.taxon-page__grid-heading", text: child_taxon['title'])
       assert page.has_link?(child_taxon['title'], href: child_taxon['base_path'])
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/kB08YBs1/74-fix-sub-topic-heading-hierarchy

On [topic pages](https://www.gov.uk/education), at the bottom of the page there is a heading (H2) "Explore these sub-topics". Underneath is a grid of sub-topics. This changes those headings from an incorrect H2 to a correct H3.

Heroku link: https://govuk-collections-pr-801.herokuapp.com/education