### PR TITLE
Display DFID document type in uppercase

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -142,7 +142,13 @@ module Organisations
         end
 
         if item["content_store_document_type"]
-          metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ").gsub("Foi ", "FOI ")
+          metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ")
+
+          # Handle document types with acronyms
+          document_acronyms = %w{Foi Dfid}
+          document_acronyms.each do |acronym|
+            metadata[:document_type].gsub!(acronym, acronym.upcase)
+          end
         end
 
         documents << {

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -145,7 +145,7 @@ module Organisations
           metadata[:document_type] = item["content_store_document_type"].capitalize.tr("_", " ")
 
           # Handle document types with acronyms
-          document_acronyms = %w{Foi Dfid}
+          document_acronyms = %w{Foi Dfid Aaib Cma Esi Hmrc Html Maib Raib Utaac}
           document_acronyms.each do |acronym|
             metadata[:document_type].gsub!(acronym, acronym.upcase)
           end

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -75,6 +75,16 @@ describe Organisations::DocumentsPresenter do
       assert_equal expected, @documents_presenter.latest_documents
     end
 
+    it "formats document types with acronyms correctly" do
+      # This only applies to types containing "FOI" and "DFID"
+      stub_rummager_latest_content_with_acronym("attorney-generals-office")
+
+      expected = "DFID research output"
+      actual = @documents_presenter.latest_documents[:items].first[:metadata][:document_type]
+
+      assert_equal expected, actual
+    end
+
     it 'returns true if latest documents by type exist for an organisation' do
       assert @documents_presenter.has_latest_documents_by_type?
     end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -36,6 +36,18 @@ module OrganisationHelpers
       ] }.to_json)
   end
 
+  def stub_rummager_latest_content_with_acronym(organisation_slug)
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other").
+      to_return(body: { results: [
+        {
+          title: "Rapist has sentence increased after Solicitor General’s referral",
+          link: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
+          content_store_document_type: "dfid_research_output",
+          public_timestamp: "2018-06-18T17:39:34.000+01:00"
+        }
+      ] }.to_json)
+  end
+
   def stub_rummager_latest_announcements_request(organisation_slug)
     stub_request(:get, Plek.new.find("search") + "/search.json?count=2&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_content_purpose_supergroup=news_and_communications&filter_organisations=#{organisation_slug}&order=-public_timestamp").
       to_return(body: { results: [
@@ -340,6 +352,33 @@ module OrganisationHelpers
             public_updated_at: "2017-06-04T11:30:03.000+01:00",
             document_type: "Policy paper"
           }
+        ]
+      }
+    }.with_indifferent_access
+  end
+
+  def latest_documents_with_acronyms
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        organisation_govuk_status: {
+          status: "live",
+        },
+        brand: "attorney-generals-office",
+        organisation_featuring_priority: "news",
+        ordered_featured_documents: [
+          {
+            title: "New head of the Serious Fraud Office announced",
+            href: "/government/news/new-head-of-the-serious-fraud-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+              alt_text: "Attorney General Jeremy Wright QC MP"
+            },
+            summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+            public_updated_at: "2018-06-04T11:30:03.000+01:00",
+            document_type: "Dfid_research_output"
+          },
         ]
       }
     }.with_indifferent_access


### PR DESCRIPTION
We want "Dfid research output" to display as "DFID research output"

## Before
<img width="525" alt="screen shot 2018-07-25 at 14 51 44" src="https://user-images.githubusercontent.com/29889908/43205026-4a215ba4-901a-11e8-82bd-a1a8dd0c2f92.png">

## After
<img width="447" alt="screen shot 2018-07-25 at 15 02 45" src="https://user-images.githubusercontent.com/29889908/43205677-cfb85758-901b-11e8-85d7-afdea533eddb.png">

Link: https://govuk-collections-pr-807.herokuapp.com/government/organisations/department-for-international-development