### PR TITLE
Add people feed

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,5 +1,5 @@
 class FeedsController < ApplicationController
-  enable_request_formats organisation: :atom, all: :atom
+  enable_request_formats organisation: :atom, all: :atom, person: :atom
 
   before_action do
     # Allows ajax requests as per https://govuk.zendesk.com/agent/tickets/1935680
@@ -16,6 +16,16 @@ class FeedsController < ApplicationController
     items = results.map { |result| FeedEntryPresenter.new(result) }
 
     render :feed, locals: { items: items, root_url: @organisation.web_url, title: "#{@organisation.title} - Activity on GOV.UK" }
+  end
+
+  def person
+    path = "/government/people/#{params[:slug]}"
+    @person = Person.find!(path)
+
+    results = FeedContent.new(filter_people: params[:slug]).results
+    items = results.map { |result| FeedEntryPresenter.new(result) }
+
+    render :feed, locals: { items: items, root_url: @person.web_url, title: "#{@person.title} - Activity on GOV.UK" }
   end
 
   def all

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,6 +38,10 @@ class Person
     details["body"]
   end
 
+  def web_url
+    Plek.current.website_root + base_path
+  end
+
 private
 
   def links

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     as: :services_and_information
 
   get "/government/people/:name", to: "people#show"
+  get "/government/people/:slug.atom" => "feeds#person"
   get "/government/ministers/:role_name", to: "roles#show"
 
   scope :api, defaults: { format: :json } do


### PR DESCRIPTION
We're moving the atom feeds to collections from Whitehall, so that content from all applications shows up there. This adds a atom feed for people, in the same way as we serve the organisations feed and global feed (https://github.com/alphagov/collections/pull/792).

https://trello.com/c/vYdbh3TQ