### PR TITLE
Add Organisation schema to org pages

### DIFF
--- a/app/views/organisations/_show_organisation.html.erb
+++ b/app/views/organisations/_show_organisation.html.erb
@@ -1,6 +1,10 @@
 <%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
 
+<%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  schema: :organisation,
+  content_item: @organisation.content_item.content_item_data %>
+
 <% if @documents.has_featured_news? %>
   <%= render partial: 'featured_news' %>
 <% end %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -783,4 +783,14 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/attorney-generals-office"
     refute page.has_content?(/Greater transparency across government is at the heart of our commitment to let you hold politicians and public bodies to account./i)
   end
+
+  it "has GovernmentOrganization schema.org information" do
+    visit "/government/organisations/prime-ministers-office-10-downing-street"
+
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    org_schema = schemas.detect { |schema| schema["@type"] == "GovernmentOrganization" }
+    assert_equal org_schema["name"], "Prime Minister's Office, 10 Downing Street"
+  end
 end


### PR DESCRIPTION
Tijmen added the schema to govuk_publishing_components, so let's use it.

I'm unsure how to best test this as it's mostly encapsulated within the gem.  I think a minimal check that something reasonable is rendered is OK as this ensures that we're passing the right thing in.

I've tested this on https://search.google.com/structured-data/testing-tool/u/0/?authuser=0 and it renders appropriately:

![screen shot 2018-08-06 at 11 55 40](https://user-images.githubusercontent.com/773037/43712909-bbe7f2b2-996f-11e8-92a7-8574c7b31270.png)

https://trello.com/c/1lRjxlD6/109-add-organisation-schema-to-org-pages