### PR TITLE
Fix tracking of mainstream browse pages

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -96,6 +96,8 @@
       return out.resolve();
     },
     showSection: function(state){
+      this.setContentIDMetaTag(state.sectionData.content_id);
+      this.setNavigationPageTypeMetaTag(state.sectionData.navigation_page_type);
       state.title = this.getTitle(state.slug);
       this.setTitle(state.title);
       this.$section.html(state.sectionData.html)
@@ -167,8 +169,9 @@
       return out.resolve();
     },
     showSubsection: function(state){
+      this.setContentIDMetaTag(state.sectionData.content_id);
+      this.setNavigationPageTypeMetaTag(state.sectionData.navigation_page_type);
       state.title = this.getTitle(state.slug);
-
       this.setTitle(state.title);
       this.$subsection.html(state.sectionData.html);
       this.highlightSection('section', state.path);
@@ -232,7 +235,13 @@
       }
     },
     setTitle: function(title){
-      $('title').text(title);
+      $('title').text(title + ' - GOV.UK');
+    },
+    setContentIDMetaTag: function(content_id){
+      $('meta[name="govuk:content-id"]').attr('content', content_id);
+    },
+    setNavigationPageTypeMetaTag: function(navigation_page_type){
+      $('meta[name="govuk:navigation-page-type"]').attr('content', navigation_page_type);
     },
     addLoading: function($el){
       this.$el.attr('aria-busy', 'true');

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -21,6 +21,8 @@ class BrowseController < ApplicationController
       end
       f.json do
         render json: {
+          content_id: page.content_id,
+          navigation_page_type: "First Level Browse",
           breadcrumbs: breadcrumb_content,
           html: second_level_browse_pages_partial(page)
         }

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -11,6 +11,8 @@ class SecondLevelBrowsePageController < ApplicationController
       end
       f.json do
         render json: {
+          content_id: page.content_id,
+          navigation_page_type: "Second Level Browse",
           breadcrumbs: breadcrumb_content,
           html: render_partial('_links', page: page)
         }

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,6 +1,7 @@
 class MainstreamBrowsePage
   attr_reader :content_item
   delegate(
+    :content_id,
     :base_path,
     :title,
     :description,

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -16,10 +16,10 @@ describe('browse-columns.js', function() {
     expect(bc.sectionCache('prefix', 'object-name')).toBe('cache-thing');
   });
 
-  it("should set page title", function() {
+  it("should set page title with the GOV.UK suffix", function() {
     GOVUK.BrowseColumns.prototype.setTitle('new-title');
 
-    expect($('title').text()).toBe('new-title');
+    expect($('title').text()).toBe('new-title - GOV.UK');
   });
 
   it("should get section data and cache it", function() {

--- a/test/models/mainstream_browse_page_test.rb
+++ b/test/models/mainstream_browse_page_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe MainstreamBrowsePage do
   setup do
     @api_data = {
+      "content_id" => "f818b54c-01c7-43e9-8165-cec12e4053ff",
       "base_path" => "/browse/benefits/child",
       "title" => "Child Benefit",
       "description" => "Information about eligibility, claiming and when Child Benefit stops",
@@ -16,6 +17,10 @@ describe MainstreamBrowsePage do
   end
 
   describe "basic properties" do
+    it "returns the browse page content_id" do
+      assert_equal "f818b54c-01c7-43e9-8165-cec12e4053ff", @page.content_id
+    end
+
     it "returns the browse page base_path" do
       assert_equal "/browse/benefits/child", @page.base_path
     end


### PR DESCRIPTION
This commit fixes a number of issues that affect the accurate tracking of mainstream browse page interactions due to the use of Ajax:

* Adds the ‘- GOV.UK’ suffix to page title when the page changes
* Amends the govuk:content-id meta tag when the page changes
* Amends the govuk:navigation-page-type meta tag when the page changes

Trello: https://trello.com/c/Eh4RPIKi/374-google-analytics-custom-dimensions-not-reported-correctly-for-mainstream-browse-pages