### PR TITLE
Add research and statistics section to topic pages

### DIFF
--- a/app/presenters/supergroups/research_and_statistics.rb
+++ b/app/presenters/supergroups/research_and_statistics.rb
@@ -1,0 +1,17 @@
+module Supergroups
+  class ResearchAndStatistics < Supergroup
+    attr_reader :content
+
+    def initialize
+      super('research_and_statistics')
+    end
+
+    def tagged_content(taxon_id)
+      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+    end
+
+    def promoted_content_count
+      0
+    end
+  end
+end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -5,8 +5,9 @@ module SupergroupSections
     Supergroups::Services.new,
     Supergroups::GuidanceAndRegulation.new,
     Supergroups::NewsAndCommunications.new,
+    Supergroups::ResearchAndStatistics.new,
     Supergroups::PolicyAndEngagement.new,
-    Supergroups::Transparency.new
+    Supergroups::Transparency.new,
   ].freeze
 
   def self.supergroup_sections(taxon_id, base_path)

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -1,0 +1,12 @@
+<%= render 'govuk_publishing_components/components/taxonomy_list',
+  document_list: {
+    items: section[:documents]
+  }
+%>
+
+<% if section[:see_more_link] %>
+  <%= link_to(
+    section[:see_more_link][:text],
+    section[:see_more_link][:url]
+  )%>
+<% end %>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -15,6 +15,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_news_and_communications_section
     and_i_can_see_the_policy_and_engagement_section
     and_i_can_see_the_transparency_section
+    and_i_can_see_the_research_and_statistics_section
     and_i_can_see_the_organisations_section
     and_i_can_see_the_sub_topics_grid
   end
@@ -102,6 +103,7 @@ private
     stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_purpose_supergroup: 'news_and_communications')
     stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_purpose_supergroup: 'policy_and_engagement')
     stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_purpose_supergroup: 'transparency')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_purpose_supergroup: 'research_and_statistics')
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
@@ -204,6 +206,21 @@ private
     expected_link = {
       text: "See all transparency",
       url: "/search/advanced?" + finder_query_string("transparency")
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_research_and_statistics_section
+    assert page.has_content?("Research and statistics")
+
+    tagged_content_for_research_and_statistics.each do |item|
+      all_other_sections_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See all research and statistics",
+      url: "/search/advanced?" + finder_query_string("research_and_statistics")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -332,6 +349,10 @@ private
 
   def tagged_content_for_transparency
     @tagged_content_for_transparency ||= generate_search_results(2, "transparency")
+  end
+
+  def tagged_content_for_research_and_statistics
+    @tagged_content_for_research_and_statistics ||= generate_search_results(2, "research_and_statistics")
   end
 
   def finder_query_string(supergroup)

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+describe Supergroups::ResearchAndStatistics do
+  include RummagerHelpers
+
+  let(:taxon_id) { '12345' }
+  let(:research_and_statistics_supergroup) { Supergroups::ResearchAndStatistics.new }
+
+  describe '#document_list' do
+    it 'returns a document list for the research_and_statistics supergroup' do
+      MostRecentContent.any_instance
+        .stubs(:fetch)
+        .returns(section_tagged_content_list('statistics'))
+
+      expected = [
+        {
+          link: {
+            text: 'Tagged Content Title',
+            path: '/government/tagged/content',
+            data_attributes: {
+              track_category: "researchAndStatisticsDocumentListClicked",
+              track_action: 1,
+              track_label: '/government/tagged/content',
+              track_options: {
+                dimension29: "Tagged Content Title"
+              }
+            }
+          },
+          metadata: {
+            public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            organisations: 'Tagged Content Organisation',
+            document_type: 'Statistics'
+          }
+        }
+      ]
+
+      assert_equal expected, research_and_statistics_supergroup.document_list(taxon_id)
+    end
+  end
+end

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -15,6 +15,7 @@ describe SupergroupSections::Sections do
       Supergroups::GuidanceAndRegulation.any_instance.stubs(:tagged_content).with(taxon_id).returns(section_tagged_content_list('guide'))
       Supergroups::NewsAndCommunications.any_instance.stubs(:tagged_content).with(taxon_id).returns([])
       Supergroups::Transparency.any_instance.stubs(:tagged_content).with(taxon_id).returns([])
+      Supergroups::ResearchAndStatistics.any_instance.stubs(:tagged_content).with(taxon_id).returns([])
       @sections = supergroup_sections.sections
     end
 
@@ -43,7 +44,8 @@ describe SupergroupSections::Sections do
         'Guidance and regulation',
         'News and communications',
         'Policy and engagement',
-        'Transparency'
+        'Transparency',
+        'Research and statistics'
       ]
 
       section_titles = @sections.map { |section| section[:title] }

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -97,6 +97,8 @@ module RummagerHelpers
       when "policy_and_engagement"
         rummager_document_for_supergroup_section("content-item-#{number}", "policy_paper")
       when "transparency"
+        rummager_document_for_supergroup_section("content-item-#{number}", "transparency")
+      when "research_and_statistics"
         rummager_document_for_supergroup_section("content-item-#{number}", "research")
       else
         rummager_document_for_slug("content-item-#{number}")


### PR DESCRIPTION
Trello: https://trello.com/c/QM3T8bSa/141-rollout-supergroups-iteration-v22-document-types

We have added a new `research_and_statistics` `content_purpose_supergroup`. We therefore want to add this as a new supergroup section on topic pages.

<img width="986" alt="screen shot 2018-09-06 at 14 11 41" src="https://user-images.githubusercontent.com/29889908/45167287-bca50980-b1f0-11e8-96a8-3a1619d6bdda.png">

Example link: https://govuk-collections-pr-849.herokuapp.com/education
