### PR TITLE
[PROTOTYPE][DO NOT MERGE] Prototype browse popular content

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "views/email-signups";
 @import "views/organisations";
 @import "views/organisation";
+@import "views/browse-prototype";
 
 @import "modules/full-page-width";
 

--- a/app/assets/stylesheets/views/_browse-prototype.scss
+++ b/app/assets/stylesheets/views/_browse-prototype.scss
@@ -1,0 +1,16 @@
+.browse-list {
+  list-style: none;
+  margin-bottom: $gutter * 1.5;
+}
+
+.browse-list__row {
+  clear: both;
+}
+
+.browse-heading {
+  @include bold-19;
+}
+
+.browse-document {
+  margin: 5px 0;
+}

--- a/app/assets/stylesheets/views/_browse-prototype.scss
+++ b/app/assets/stylesheets/views/_browse-prototype.scss
@@ -2,6 +2,10 @@
   float: right;
 }
 
+.browse__margin-bottom {
+  margin-bottom: $gutter;
+}
+
 .browse-colour-key {
   margin-bottom: $gutter;
 }
@@ -28,6 +32,10 @@
 
 .browse-document {
   margin-top: 10px;
+}
+
+.browse-document__taxons {
+  font-size: 14px;
 }
 
 .browse-document__metadata {

--- a/app/assets/stylesheets/views/_browse-prototype.scss
+++ b/app/assets/stylesheets/views/_browse-prototype.scss
@@ -1,3 +1,18 @@
+.browse-toggle-labels {
+  float: right;
+}
+
+.browse-colour-key {
+  margin-bottom: $gutter;
+}
+
+.browse-colour-key li {
+  margin: 5px;
+  padding: 3px;
+  list-style: none;
+  display: inline-block;
+}
+
 .browse-list {
   list-style: none;
   margin-bottom: $gutter * 1.5;
@@ -12,5 +27,38 @@
 }
 
 .browse-document {
-  margin: 5px 0;
+  margin-top: 10px;
+}
+
+.browse-document__metadata {
+  padding: 3px;
+  font-size: 12px;
+
+  &--services {
+    background-color: rgba($turquoise, 0.75);
+  }
+
+  &--guidance_and_regulation {
+    background-color: rgba($mellow-red, 0.5);
+  }
+
+  &--news_and_communications {
+    background-color: rgba($yellow, 0.75);
+  }
+
+  &--policy_and_engagement {
+    background-color: rgba($fuschia, 0.5);
+  }
+
+  &--transparency {
+    background-color: rgba($light-blue, 0.75);
+  }
+
+  &--research_and_statistics {
+    background-color: rgba($pink, 0.5);
+  }
+
+  &--other {
+    background-color: $grey-2;
+  }
 }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -4,6 +4,7 @@ class BrowseController < ApplicationController
   def index
     page = MainstreamBrowsePage.find("/browse")
     setup_content_item_and_navigation_helpers(page)
+    @browse = BrowsePresenter.new
 
     render :index, locals: {
       page: page

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,6 +11,8 @@ class Document
     :change_note,
     :format,
     :content_store_document_type,
+    :content_purpose_supergroup,
+    :content_purpose_subgroup,
     :organisations
   )
 end

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -19,6 +19,8 @@ class RummagerSearch
         public_updated_at: timestamp,
         change_note: result["latest_change_note"],
         format: result["format"],
+        content_purpose_supergroup: result["content_purpose_supergroup"],
+        content_purpose_subgroup: result["content_purpose_subgroup"],
         content_store_document_type: result['content_store_document_type'],
         organisations: organisations
       )

--- a/app/presenters/browse_presenter.rb
+++ b/app/presenters/browse_presenter.rb
@@ -1,4 +1,6 @@
 class BrowsePresenter
+  include ActionView::Helpers::UrlHelper
+
   def top_level_taxons
     # Retrieve the root taxon (GOV.UK homepage)
     top_level_taxons = Services.content_store.content_item('/').dig('links', 'level_one_taxons').map do |top_level_taxon|
@@ -14,6 +16,30 @@ class BrowsePresenter
 
   def all_supergroups
     %w(services guidance_and_regulation news_and_communications policy_and_engagement research_and_statistics transparency other)
+  end
+
+  def associated_taxons(base_path, parent_taxon_path)
+    associated_taxons = Services.content_store.content_item(base_path).dig('links', 'taxons')
+
+    associated_taxons.each do |taxon|
+      if parent_taxon_path.eql?("/business-and-industry")
+        associated_taxons.delete_if {|taxon| !taxon["base_path"].include?(parent_taxon_path) && !taxon["base_path"].include?("/business") }
+      elsif parent_taxon_path.eql?("/defence-and-armed-forces")
+        associated_taxons.delete_if {|taxon| !taxon["base_path"].include?(parent_taxon_path) && !taxon["base_path"].include?("/defence") }
+      elsif parent_taxon_path.eql?("/government/all")
+        associated_taxons.delete_if {|taxon| !taxon["base_path"].include?(parent_taxon_path) && !taxon["base_path"].include?("/government") }
+      elsif parent_taxon_path.eql?("/work")
+        associated_taxons.delete_if {|taxon| !taxon["base_path"].include?(parent_taxon_path) && !taxon["base_path"].include?("/employment") }
+      else
+        associated_taxons.delete_if {|taxon| !taxon["base_path"].include?(parent_taxon_path) && !taxon["base_path"].include?("/business") }
+      end
+    end
+
+    taxon_links = associated_taxons.map do |taxon|
+      link_to taxon["title"], taxon["base_path"]
+    end
+
+    taxon_links.to_sentence.html_safe
   end
 
 private

--- a/app/presenters/browse_presenter.rb
+++ b/app/presenters/browse_presenter.rb
@@ -1,0 +1,20 @@
+class BrowsePresenter
+  def top_level_taxons
+    # Retrieve the root taxon (GOV.UK homepage)
+    top_level_taxons = Services.content_store.content_item('/').dig('links', 'level_one_taxons').map do |top_level_taxon|
+      {
+        title: top_level_taxon["title"],
+        base_path: top_level_taxon["base_path"],
+        popular_content: most_popular_content(top_level_taxon["content_id"])
+      }
+    end
+
+    top_level_taxons.sort_by {|taxon_hash| taxon_hash[:title]}
+  end
+
+private
+
+  def most_popular_content(taxon_id)
+    MostPopularContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: false)
+  end
+end

--- a/app/presenters/browse_presenter.rb
+++ b/app/presenters/browse_presenter.rb
@@ -12,6 +12,10 @@ class BrowsePresenter
     top_level_taxons.sort_by {|taxon_hash| taxon_hash[:title]}
   end
 
+  def all_supergroups
+    %w(services guidance_and_regulation news_and_communications policy_and_engagement research_and_statistics transparency other)
+  end
+
 private
 
   def most_popular_content(taxon_id)

--- a/app/services/rummager_fields.rb
+++ b/app/services/rummager_fields.rb
@@ -4,6 +4,8 @@ module RummagerFields
                            description
                            content_store_document_type
                            public_timestamp
+                           content_purpose_supergroup
+                           content_purpose_subgroup
                            organisations).freeze
 
   FEED_SEARCH_FIELDS = %w(title

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,10 +1,14 @@
-<% content_for :title, "All categories" %>
-<% content_for :page_class, "browse" %>
-<% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='Browse Index'>
-<% end %>
+<% content_for :title, "Prototype: Mainstream Browse" %>
 
-<div class="browse-panes root" data-module="track-click">
-  <%= render 'top_level_browse_pages',
-    top_level_browse_pages: page.top_level_browse_pages %>
-</div>
+<ul class="grid-row">
+  <% @browse.top_level_taxons.each_with_index do |top_level_taxon, index| %>
+    <li class="browse-list column-one-third <%= "browse-list__row" if index % 3 == 0 %>">
+      <h2 class="browse-heading"><%= top_level_taxon[:title] %></h2>
+      <ul>
+        <% top_level_taxon[:popular_content].each do |document| %>
+          <li class="browse-document"><%= link_to(document.title, document.base_path) %></li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -15,6 +15,9 @@
   <% end %>
 </ul>
 
+<h2 class="browse-heading">Tagging Information</h2>
+<p class="browse__margin-bottom">The taxons listed below each content page are the taxons that content is tagged to within that specific top-level taxon <em>only</em>. It is possible that the content page is tagged to other taxons outside that branch.
+
 <ul class="grid-row">
   <% @browse.top_level_taxons.each_with_index do |top_level_taxon, index| %>
     <li class="browse-list column-one-third <%= "browse-list__row" if index % 3 == 0 %>">
@@ -22,6 +25,7 @@
       <ul>
         <% top_level_taxon[:popular_content].each do |document| %>
           <li class="browse-document"><%= link_to(document.title, document.base_path) %></li>
+          <p class="browse-document__taxons">Tagged to <%= @browse.associated_taxons(document.base_path, top_level_taxon[:base_path]) %></p>
           <span class="browse-document__metadata browse-document__metadata--<%= document.content_purpose_supergroup %>"><%= document.content_purpose_supergroup %></span>
           <span class="browse-document__metadata browse-document__metadata--<%= document.content_purpose_supergroup %>"><%= document.content_purpose_subgroup %></span>
         <% end %>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,5 +1,20 @@
 <% content_for :title, "Prototype: Mainstream Browse" %>
 
+<script>
+  function toggleLabels() {
+    $('.browse-document__metadata').toggleClass("js-hidden")
+  }
+</script>
+
+<button class="browse-toggle-labels" onClick="toggleLabels()">Toggle labels</button>
+
+<h2 class="browse-heading">Supergroup Colour Key</h2>
+<ul class="browse-colour-key">
+  <% @browse.all_supergroups.each do |supergroup| %>
+    <li class="browse-document__metadata--<%= supergroup %>"><%= supergroup %></li>
+  <% end %>
+</ul>
+
 <ul class="grid-row">
   <% @browse.top_level_taxons.each_with_index do |top_level_taxon, index| %>
     <li class="browse-list column-one-third <%= "browse-list__row" if index % 3 == 0 %>">
@@ -7,6 +22,8 @@
       <ul>
         <% top_level_taxon[:popular_content].each do |document| %>
           <li class="browse-document"><%= link_to(document.title, document.base_path) %></li>
+          <span class="browse-document__metadata browse-document__metadata--<%= document.content_purpose_supergroup %>"><%= document.content_purpose_supergroup %></span>
+          <span class="browse-document__metadata browse-document__metadata--<%= document.content_purpose_supergroup %>"><%= document.content_purpose_subgroup %></span>
         <% end %>
       </ul>
     </li>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -4,9 +4,14 @@
   function toggleLabels() {
     $('.browse-document__metadata').toggleClass("js-hidden")
   }
+
+  function toggleTaxons() {
+    $('.browse-document__taxons').toggleClass("js-hidden")
+  }
 </script>
 
 <button class="browse-toggle-labels" onClick="toggleLabels()">Toggle labels</button>
+<button class="browse-toggle-labels" onClick="toggleTaxons()">Toggle taxons</button>
 
 <h2 class="browse-heading">Supergroup Colour Key</h2>
 <ul class="browse-colour-key">


### PR DESCRIPTION
This is a prototype to demonstrate the top 5 popular content items for each top-level taxon. It show the taxon that each piece of content is tagged to and the supergroup and subgroup it belongs to. We will use this prototype to think about possible [next steps for mainstream browse](https://docs.google.com/document/d/1S_Bb7Ehd40Cb5gu8Gf-4znVnc6CLXWvq8MKH3tcfQhU/edit?ts=5b88121f#heading=h.vyxf0fbhnv7x) and surfacing popular content to users earlier on in their journeys.

Link to prototype: https://govuk-collections-pr-850.herokuapp.com/browse

**NOTE: DO NOT MERGE. This prototype replaces the /browse route (this isn't something we want to do, I just didn't want to spend time creating new routes for a prototype). This is also why the tests are failing.**

<img width="997" alt="screen shot 2018-09-07 at 13 05 19" src="https://user-images.githubusercontent.com/29889908/45218212-b1101c00-b29e-11e8-9897-a8f16f96ae6a.png">

<img width="993" alt="screen shot 2018-09-07 at 13 05 12" src="https://user-images.githubusercontent.com/29889908/45218223-c127fb80-b29e-11e8-9372-1b7f7e1e161c.png">
