### PR TITLE
Fix schema.org breadcrumbs on org pages

### DIFF
--- a/app/views/organisations/_breadcrumb.html.erb
+++ b/app/views/organisations/_breadcrumb.html.erb
@@ -7,10 +7,11 @@
       },
       {
         title: "Organisations",
-        url: "/government/organisations/"
+        url: "/government/organisations"
       },
       {
-        title: @header.org.title
+        title: @header.org.title,
+        is_current_page: true
       }
     ]
   } %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -504,13 +504,19 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "displays breadcrumbs" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
-    assert page.has_css?(".gem-c-breadcrumbs", text: "Prime Minister's Office, 10 Downing Street")
+
+    within ".gem-c-breadcrumbs" do
+      assert page.has_link?("Home", href: "/")
+      assert page.has_link?("Organisations", href: "/government/organisations")
+
+      assert page.has_css?(".gem-c-breadcrumbs--current", text: "Prime Minister's Office, 10 Downing Street")
+    end
 
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".gem-c-breadcrumbs", text: "Attorney General's Office")
+    assert page.has_css?(".gem-c-breadcrumbs--current", text: "Attorney General's Office")
 
     visit "/government/organisations/charity-commission"
-    assert page.has_css?(".gem-c-breadcrumbs", text: "The Charity Commission")
+    assert page.has_css?(".gem-c-breadcrumbs--current", text: "The Charity Commission")
   end
 
   it "sets the page title" do


### PR DESCRIPTION
## Before
![screen shot 2018-09-10 at 15 54 31](https://user-images.githubusercontent.com/773037/45347043-f2584280-b5a2-11e8-8c88-7c2aaf79d192.png)

## After
![screen shot 2018-09-10 at 15 54 14](https://user-images.githubusercontent.com/773037/45347044-f2584280-b5a2-11e8-9b92-63349aff26c8.png)

The [breadcrumb component uses the `:is_current_page` property](https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs/highlight_current_page) to set extra attributes on the current page (such as `aria-current`) and helps determine the url to set on any links.

We haven't been setting these on org pages which means that the schema implementation is invalid on pages which include the current page in the breadcrumb.

An example page is:

- https://www.gov.uk/government/organisations/department-for-work-pensions

Which fails schema validation on the breadcrumb because the `@id` is mandatory:

- https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Forganisations%2Fdepartment-for-work-pensions

Setting the `is_current_page` property:

- makes the link clickable (it links to the #content section on the same page)
- sets the `aria-current` property to the current page which helps with accessibility
- enables click tracking on the link, so we can see whether our breadcrumbs are
confusing.
- and also fixes the schema.org thing which was the basis for this ticket anyway

https://trello.com/c/GOPIPoAm/159-error-in-schema-breadcrumblist-for-certain-pages