### PR TITLE
Use heading component on topic pages

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -2,15 +2,6 @@
   background-color: $grey-4;
 }
 
-.taxon-page__section-heading {
-  @include bold-27;
-  margin-bottom: $gutter-half;
-}
-
-.taxon-page__grid-heading {
-  margin-bottom: $gutter-half;
-}
-
 .taxon-page__email-link-wrapper {
   background-color: $grey-4;
   margin-top: -$gutter;
@@ -106,6 +97,8 @@
 
   .taxon-page__grid-heading {
     @include bold-19;
+    margin-bottom: $gutter-half;
+
     @include media (tablet) {
       padding-bottom: $gutter-one-third;
     }

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -2,7 +2,11 @@
   <div class="taxon-page__section-group taxon-page__section-group--organisation" data-module="toggle">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <h2 class="taxon-page__section-heading">Organisations</h2>
+        <%= render "govuk_publishing_components/components/heading", {
+            text: t('taxons.organisations'),
+            heading_level: 2,
+            margin_bottom: 2
+          } %>
 
 
         <%= render partial: 'organisation_logos_and_list', locals: {

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -15,7 +15,11 @@
     <div class="taxon-page__section-group">
       <div class="grid-row">
         <div class="column-two-thirds">
-          <h2 class="taxon-page__section-heading"><%= section[:title] %></h2>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: section[:title],
+            heading_level: 2,
+            margin_bottom: 2
+          } %>
         </div>
       </div>
       <%= render(
@@ -33,7 +37,12 @@
 <% if content_for(:is_taxon_with_subtopics) %>
   <nav role="navigation" class="taxon-page__grid">
     <div class="full-page-width-wrapper">
-      <h2 class="taxon-page__section-heading taxon-page__grid-heading">Explore these sub-topics</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('taxons.sub_topics'),
+        heading_level: 2,
+        font_size: 19,
+        margin_bottom: 2
+      } %>
       <ol class="taxon-page__grid-wrapper">
         <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
           <li class="taxon-page__grid-item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,9 @@ en:
       tribunal_ndpb: "Tribunal non-departmental public body"
       other: "Other"
     what_we_do: "What %{title} does"
+  taxons:
+    organisations: "Organisations"
+    sub_topics: "Explore these sub-topics"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -134,7 +134,7 @@ private
   end
 
   def and_i_can_see_the_guidance_and_regulation_section
-    assert page.has_content?('Guidance and regulation')
+    assert page.has_selector?('.gem-c-heading', text: "Guidance and regulation")
 
     tagged_content_for_guidance_and_regulation.each do |item|
       if item['content_store_document_type'] == 'guide'
@@ -153,7 +153,7 @@ private
   end
 
   def and_i_can_see_the_services_section
-    assert page.has_content?('Services')
+    assert page.has_selector?('.gem-c-heading', text: "Services")
     tagged_content_for_services.each do |item|
       services_section_list_item_test(item)
     end
@@ -166,7 +166,7 @@ private
   end
 
   def and_i_can_see_the_news_and_communications_section
-    assert page.has_content?("News and communications")
+    assert page.has_selector?('.gem-c-heading', text: "News and communications")
     assert page.has_selector?('.taxon-page__featured-item')
 
     tagged_content_for_news_and_communications.each do |item|
@@ -182,7 +182,7 @@ private
   end
 
   def and_i_can_see_the_policy_and_engagement_section
-    assert page.has_content?("Policy and engagement")
+    assert page.has_selector?('.gem-c-heading', text: "Policy and engagement")
 
     tagged_content_for_policy_and_engagement.each do |item|
       all_other_sections_list_item_test(item)
@@ -197,7 +197,7 @@ private
   end
 
   def and_i_can_see_the_transparency_section
-    assert page.has_content?("Transparency")
+    assert page.has_selector?('.gem-c-heading', text: "Transparency")
 
     tagged_content_for_transparency.each do |item|
       all_other_sections_list_item_test(item)
@@ -212,7 +212,7 @@ private
   end
 
   def and_i_can_see_the_research_and_statistics_section
-    assert page.has_content?("Research and statistics")
+    assert page.has_selector?('.gem-c-heading', text: "Research and statistics")
 
     tagged_content_for_research_and_statistics.each do |item|
       all_other_sections_list_item_test(item)


### PR DESCRIPTION
This shouldn't change how the title of each section looks to the user.

## Before:
<img width="983" alt="screen shot 2018-09-18 at 10 34 24" src="https://user-images.githubusercontent.com/29889908/45678516-7b84f180-bb2e-11e8-9a4b-bde8a406e93d.png">

## After:
<img width="997" alt="screen shot 2018-09-18 at 10 34 03" src="https://user-images.githubusercontent.com/29889908/45678483-614b1380-bb2e-11e8-9de9-473016ffe551.png">

Review App: https://govuk-collections-pr-865.herokuapp.com/government/europe