### PR TITLE
Don't index the "latest" pages for topics

### DIFF
--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -8,6 +8,7 @@
 
 <% content_for :meta_section do %>
   <meta name="govuk:section" content="<%= meta_section %>">
+  <meta name="robots" content="noindex">
 <% end %>
 
 <% content_for :breadcrumbs do %>


### PR DESCRIPTION
The topics latest pages aren't an appropriate landing page for users. They'll be replaced by the taxonomy-based latest pages.

https://trello.com/c/bWTdUDbx