### PR TITLE
Get news image url from Rummager

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -49,29 +49,6 @@
       width: 100%;
     }
   }
-
-  .taxon-page__featured-text {
-    display: inline-block;
-    width: (2 / 3) * 100%;
-
-    @include media(tablet) {
-      width: 100%;
-    }
-  }
-
-  .taxon-page__featured-link {
-    @include bold-19;
-  }
-
-  .taxon-page__featured-metadata-wrapper {
-    @include core-16;
-    margin-top: $gutter-one-third / 2;
-
-    .taxon-page__featured-metadata {
-      display: inline-block;
-      margin-right: $gutter-two-thirds;
-    }
-  }
 }
 
 .taxon-page__featured-see-more {

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,6 +11,7 @@ class Document
     :change_note,
     :format,
     :content_store_document_type,
-    :organisations
+    :organisations,
+    :image_url
   )
 end

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -20,7 +20,8 @@ class RummagerSearch
         change_note: result["latest_change_note"],
         format: result["format"],
         content_store_document_type: result['content_store_document_type'],
-        organisations: organisations
+        organisations: organisations,
+        image_url: result["image_url"]
       )
     end
   end

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -12,29 +12,7 @@ module Supergroups
 
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
-
-      documents = format_document_data(items, "FeaturedLinkClicked")
-
-      documents.map do |document|
-        document_image = news_item_photo(document[:link][:path])
-        document[:image] = {
-          url: document_image["url"],
-          alt: document_image["alt_text"]
-        }
-      end
-
-      documents
-    end
-
-    def news_item_photo(base_path)
-      default_news_image = {
-        "url": "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg",
-        "alt_text": ""
-      }.with_indifferent_access
-
-      news_item = ::Services.content_store.content_item(base_path)
-
-      news_item["details"]["image"] || default_news_image
+      format_document_data(items, "FeaturedLinkClicked", true)
     end
 
   private

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -67,7 +67,7 @@ module Supergroups
       3
     end
 
-    def format_document_data(documents, data_category = "")
+    def format_document_data(documents, data_category = "", with_image_url = false)
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
@@ -86,8 +86,16 @@ module Supergroups
           data[:link][:data_attributes][:track_category] = data_module_label + data_category
         end
 
+        if with_image_url
+          data[:image] = { url: (document.image_url || default_news_image_url) }
+        end
+
         data
       end
+    end
+
+    def default_news_image_url
+      "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
     end
   end
 end

--- a/app/services/rummager_fields.rb
+++ b/app/services/rummager_fields.rb
@@ -4,7 +4,8 @@ module RummagerFields
                            description
                            content_store_document_type
                            public_timestamp
-                           organisations).freeze
+                           organisations
+                           image_url).freeze
 
   FEED_SEARCH_FIELDS = %w(title
                           link

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -5,36 +5,28 @@
 
 <div class="grid-row">
   <div class="taxon-page__featured-item column-one-third <%= featured_item_layout_class %>" <%= "data-module=track-click" if track_click?(section[:promoted_content]) %>>
-    <img class="taxon-page__featured-image" src="<%= featured_item[:image][:url] %>" alt="<%= featured_item[:image][:alt] %>">
-    <div class="taxon-page__featured-text">
-      <%= link_to(
-        featured_item[:link].fetch(:text),
-        featured_item[:link].fetch(:path),
-        class: "taxon-page__featured-link",
-        data: featured_item[:link][:data_attributes]
-        )
-      %>
-      <div class="taxon-page__featured-metadata-wrapper">
-        <% featured_item[:metadata].each do |metadata_key, metadata_value| %>
-          <% if metadata_key.to_s.eql?("public_updated_at") %>
-            <time class="taxon-page__featured-metadata" datetime="<%= metadata_value.iso8601 %>">
-              <%= l(metadata_value, format: '%e %B %Y') %>
-            </time>
-          <% else %>
-            <p class="taxon-page__featured-metadata"><%= metadata_value %></p>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+    <% metadata = featured_item[:metadata].map do |metadata_key, metadata_value|
+        if metadata_key.to_s.eql?("public_updated_at")
+          l(metadata_value, format: '%e %B %Y')
+        else
+          metadata_value
+        end
+      end
+    %>
+    <%= render "govuk_publishing_components/components/image_card", {
+        href: featured_item[:link].fetch(:path),
+        image_src: featured_item[:image][:url],
+        heading_text: featured_item[:link].fetch(:text),
+        metadata: metadata.delete_if { |metadatum| metadatum.blank? }.join(" - ")
+    } %>
   </div>
-
   <% if section[:documents].any? %>
     <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(section[:documents]) %>>
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents],
-      margin_top: true,
-      margin_bottom: true
-    %>
+      <%= render 'govuk_publishing_components/components/document_list',
+        items: section[:documents],
+        margin_top: true,
+        margin_bottom: true
+      %>
   <% else %>
     <div class="taxon-page__featured-see-more">
   <% end %>

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -57,8 +57,7 @@ describe Supergroups::NewsAndCommunications do
       content = content_item_for_base_path('/government/tagged/content').merge(
         "details": {
           "image": {
-            "url": "an/image/path",
-            "alt_text": "some alt text"
+            "url": "an/image/path"
           }
         }
       )
@@ -91,8 +90,7 @@ describe Supergroups::NewsAndCommunications do
             document_type: 'News story'
           },
           image: {
-            url: 'an/image/path',
-            alt: 'some alt text'
+            url: 'an/image/path'
           }
         }
       ]
@@ -114,34 +112,13 @@ describe Supergroups::NewsAndCommunications do
     end
 
     it 'returns the default whitehall image if no image is present' do
-      content = content_item_for_base_path('/government/tagged/content').merge(
-        "details": {}
-      )
-
-      content_store_has_item('/government/tagged/content', content)
-
+      content_list = section_tagged_content_list('news_story')
+      content_list.each { |content| content.image_url = nil }
       MostRecentContent.any_instance
       .stubs(:fetch)
-      .returns(section_tagged_content_list('news_story'))
+      .returns(content_list)
 
       assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
-    end
-
-    it 'uses empty alt text if using the default whitehall image' do
-      # The default whitehall image does not give more context/information to the user about the news item they are viewing.
-      # We therefore want to hide the image from screenreaders by setting alt_text to a blank value
-
-      content = content_item_for_base_path('/government/tagged/content').merge(
-        "details": {}
-      )
-
-      content_store_has_item('/government/tagged/content', content)
-
-      MostRecentContent.any_instance
-      .stubs(:fetch)
-      .returns(section_tagged_content_list('news_story'))
-
-      assert_equal "", news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:alt]
     end
   end
 end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -255,7 +255,8 @@ module RummagerHelpers
           public_updated_at: '2018-02-28T08:01:00.000+00:00',
           base_path: '/government/tagged/content',
           content_store_document_type: doc_type,
-          organisations: 'Tagged Content Organisation'
+          organisations: 'Tagged Content Organisation',
+          image_url: 'an/image/path'
         )
       )
     end


### PR DESCRIPTION
News and communications on taxon pages have an image, the url was gathered from Content Store, we can do now this from the Rummager request. This removes the unnecessary extra call, speeding up page load times.

Rummager doesn't return the alt text but by using an image_card instead of an image, then we don't need alt text as the link text overrides it for accessibility purposes (the whole image is part of the link).

Trello: https://trello.com/c/9Ckuzwca/178-taxon-pages-get-the-news-imageurl-from-rummager