### PR TITLE
Add schemas to exempt Org pages

### DIFF
--- a/app/views/organisations/_separate_website.html.erb
+++ b/app/views/organisations/_separate_website.html.erb
@@ -1,6 +1,10 @@
 <%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
 
+<%= render 'govuk_publishing_components/components/machine_readable_metadata',
+  schema: :organisation,
+  content_item: organisation.content_item.content_item_data %>
+
 <%= render "govuk_publishing_components/components/notice", {
   title: @not_live.non_live_organisation_notice
 } %>


### PR DESCRIPTION
Pages like [the Student Loans Company](https://www.gov.uk/government/organisations/student-loans-company) use a different base page to [non-exempt orgs](https://github.com/alphagov/collections/blob/e774db44dd73fee76c2fe2bf9f022130d8d5bda5/app/views/organisations/_show_organisation.html.erb#L4-L6) and were missing schema information.

https://trello.com/c/aoP7LQGh/180-add-parent-and-child-orgs-to-the-governmentorganization-schema
