### PR TITLE
Fix contact layout on org pages

### DIFF
--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -94,14 +94,19 @@ module Organisations
     end
 
     def contact_address(post)
-      data = ""
-      data << contact_line(post["title"])
-      data << contact_line(post["street_address"].gsub("\r\n", "<br/>"))
-      data << contact_line(post["locality"])
-      data << contact_line(post["region"])
-      data << contact_line(post["postal_code"])
-      data << contact_line(post["world_location"])
-      data = data.gsub("<br/><br/>", "<br/>")
+      compacted_addresses = post.delete_if { |_key, address_line| address_line.blank? }
+
+      if compacted_addresses
+        data = ""
+        data << contact_line(post["title"])
+        data << contact_line(post["street_address"]&.gsub("\r\n", "<br/>"))
+        data << contact_line(post["locality"])
+        data << contact_line(post["region"])
+        data << contact_line(post["postal_code"])
+        data << contact_line(post["world_location"])
+        data = data.gsub("<br/><br/>", "<br/>")
+      end
+
       data if data.length.positive?
     end
 

--- a/test/presenters/organisations/contacts_presenter_test.rb
+++ b/test/presenters/organisations/contacts_presenter_test.rb
@@ -89,5 +89,24 @@ describe Organisations::ContactsPresenter do
 
       assert_equal expected, @contacts_presenter.contacts
     end
+
+    it 'does not return empty address information' do
+      content_item = ContentItem.new(organisation_with_empty_contact_details)
+      organisation = Organisation.new(content_item)
+      @empty_contacts_presenter = Organisations::ContactsPresenter.new(organisation)
+
+      expected = [
+        {
+          title: "Department for International Trade",
+          post_addresses: [nil],
+          phone_numbers: [],
+          email_addresses: [],
+          links: [],
+          description: nil
+        }
+      ]
+
+      assert_equal expected, @empty_contacts_presenter.contacts
+    end
   end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -537,6 +537,33 @@ module OrganisationHelpers
     }.with_indifferent_access
   end
 
+  def organisation_with_empty_contact_details
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        brand: "attorney-generals-office"
+      },
+      links: {
+        ordered_contacts: [
+          {
+            title: "Department for International Trade",
+            details: {
+              title: "Department for International Trade",
+              post_addresses: [{
+                title: "",
+                street_address: " ",
+                postal_code: " ",
+                world_location: "",
+                locality: ""
+              }]
+            }
+          }
+        ]
+      }
+    }.with_indifferent_access
+  end
+
   def organisation_with_corporate_information
     {
       title: "Attorney General's Office",


### PR DESCRIPTION
Trello: https://trello.com/c/yyYujbEo/182-phe-contact-details-are-right-aligned

Previously, addresses with a blank space were not being filtered out by our checks, so we were ending up with the following in the HTML: `<address><br /></address>`. This was causing the other contact details to be right-aligned as they should be if there is a street address.

This adds a check in the contact presenter which removes all white space first.

## Before:
<img width="640" alt="screen shot 2018-09-24 at 13 37 10" src="https://user-images.githubusercontent.com/29889908/45952509-2f8aee80-bfff-11e8-906e-61050082e57a.png">

## After:
<img width="649" alt="screen shot 2018-09-24 at 13 37 17" src="https://user-images.githubusercontent.com/29889908/45952517-36196600-bfff-11e8-864c-b328604dc17c.png">


