### PR TITLE
Add Welsh translations for organisation documents

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -97,16 +97,17 @@ module Organisations
       all_documents.each do |document_group|
         document_group.each do |document_type, documents|
           if documents[:items].length.positive?
+            translated_document_type = I18n.t("organisations.document_types.#{document_type}")
             documents[:items].push(
               link: {
-                text: I18n.t('organisations.document_types.see_all_documents', type: document_type),
+                text: I18n.t('organisations.document_types.see_all_documents', type: translated_document_type),
                 path: "/government/#{document_type}?departments%5B%5D=#{@org.slug}"
               }
             )
 
             formatted_documents << {
               documents: documents,
-              title: I18n.t('organisations.document_types.' + document_type.to_s),
+              title: I18n.t("organisations.document_types.our_#{document_type}"),
             }
           end
         end

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,10 +13,14 @@ cy:
     corporate_information: "Gwybodaeth gorfforaethol"
     document_types:
       documents: "Dogfennau"
-      announcements: "Ein cyhoeddiadau"
-      consultations: "Ein ymgynghoriadau"
-      publications: "Ein cyhoeddiadau"
-      statistics: "Ein hystadegau"
+      announcements: "cyhoeddiadau"
+      consultations: "ymgynghoriadau"
+      publications: "cyhoeddiadau"
+      statistics: "hystadegau"
+      our_announcements: "Ein cyhoeddiadau"
+      our_consultations: "Ein ymgynghoriadau"
+      our_publications: "Ein cyhoeddiadau"
+      our_statistics: "Ein hystadegau"
       see_all_documents: "Gweld ein holl %{type}"
     foi:
       make_an_foi_request: Gwneud cais DRhG

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,10 +11,14 @@ en:
     corporate_information: "Corporate information"
     document_types:
       documents: "Documents"
-      announcements: "Our announcements"
-      consultations: "Our consultations"
-      publications: "Our publications"
-      statistics: "Our statistics"
+      announcements: "announcements"
+      consultations: "consultations"
+      publications: "publications"
+      statistics: "statistics"
+      our_announcements: "Our announcements"
+      our_consultations: "Our consultations"
+      our_publications: "Our publications"
+      our_statistics: "Our statistics"
       see_all_documents: "See all %{type}"
     featured_news: "What %{title} is doing"
     foi:


### PR DESCRIPTION
This commit adds the correct Welsh translations for the “see all” links on organisation home pages.

Before:

<img width="1440" alt="screen shot 2018-10-02 at 12 13 13" src="https://user-images.githubusercontent.com/444232/46346773-160e2600-c641-11e8-8dc3-c8857db8f71c.png">

After:

<img width="1440" alt="screen shot 2018-10-02 at 12 49 56" src="https://user-images.githubusercontent.com/444232/46346943-b401f080-c641-11e8-8bce-46e2bec82374.png">
