### PR TITLE
 Translate content purpose into document types

### DIFF
--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -7,7 +7,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
     def promoted_content(taxon_id)

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -7,7 +7,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
     def promoted_content(taxon_id)

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -19,7 +19,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
 
       reorder_tagged_documents_to_prioritise_consultations
     end

--- a/app/presenters/supergroups/research_and_statistics.rb
+++ b/app/presenters/supergroups/research_and_statistics.rb
@@ -7,7 +7,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
     def promoted_content_count

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -7,7 +7,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
     def promoted_content(taxon_id)

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -101,5 +101,9 @@ module Supergroups
     def default_news_image_url
       "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
     end
+
+    def document_types
+      GovukDocumentTypes.supergroup_document_types(name)
+    end
   end
 end

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -7,7 +7,7 @@ module Supergroups
     end
 
     def tagged_content(taxon_id)
-      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_purpose_supergroup: @name)
+      @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
     def promoted_content_count

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,16 +1,16 @@
 class MostPopularContent
   include RummagerFields
 
-  attr_reader :content_id, :filter_content_purpose_supergroup, :number_of_links
+  attr_reader :content_id, :filter_content_store_document_type, :number_of_links
 
-  def initialize(content_id:, filter_content_purpose_supergroup:, number_of_links: 5)
+  def initialize(content_id:, filter_content_store_document_type:, number_of_links: 5)
     @content_id = content_id
-    @filter_content_purpose_supergroup = filter_content_purpose_supergroup
+    @filter_content_store_document_type = filter_content_store_document_type
     @number_of_links = number_of_links
   end
 
-  def self.fetch(content_id:, filter_content_purpose_supergroup:)
-    new(content_id: content_id, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
+  def self.fetch(content_id:, filter_content_store_document_type:)
+    new(content_id: content_id, filter_content_store_document_type: filter_content_store_document_type).fetch
   end
 
   def fetch
@@ -27,8 +27,8 @@ private
       fields: RummagerFields::TAXON_SEARCH_FIELDS,
       filter_part_of_taxonomy_tree: Array(content_id),
       order: '-popularity',
+      filter_content_store_document_type: filter_content_store_document_type,
     }
-    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     RummagerSearch.new(params)
   end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,16 +1,16 @@
 class MostRecentContent
   include RummagerFields
 
-  attr_reader :content_id, :filter_content_purpose_supergroup, :number_of_links
+  attr_reader :content_id, :filter_content_store_document_type, :number_of_links
 
-  def initialize(content_id:, filter_content_purpose_supergroup:, number_of_links: 5)
+  def initialize(content_id:, filter_content_store_document_type:, number_of_links: 5)
     @content_id = content_id
-    @filter_content_purpose_supergroup = filter_content_purpose_supergroup
+    @filter_content_store_document_type = filter_content_store_document_type
     @number_of_links = number_of_links
   end
 
-  def self.fetch(content_id:, filter_content_purpose_supergroup:)
-    new(content_id: content_id, filter_content_purpose_supergroup: filter_content_purpose_supergroup).fetch
+  def self.fetch(content_id:, filter_content_store_document_type:)
+    new(content_id: content_id, filter_content_store_document_type: filter_content_store_document_type).fetch
   end
 
   def fetch
@@ -26,8 +26,8 @@ private
       fields: RummagerFields::TAXON_SEARCH_FIELDS,
       filter_part_of_taxonomy_tree: [content_id],
       order: '-public_timestamp',
+      filter_content_store_document_type: filter_content_store_document_type,
     }
-    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     RummagerSearch.new(params)
   end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -98,12 +98,18 @@ private
   def and_the_taxon_has_tagged_content
     # We still need to stub tagged content because it is used by the sub-topic grid
     stub_content_for_taxon(content_id, tagged_content)
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_purpose_supergroup: 'guidance_and_regulation')
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_purpose_supergroup: 'services')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_purpose_supergroup: 'news_and_communications')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_purpose_supergroup: 'policy_and_engagement')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_purpose_supergroup: 'transparency')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_purpose_supergroup: 'research_and_statistics')
+    stub_document_types_for_supergroup('guidance_and_regulation')
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: 'guidance_and_regulation')
+    stub_document_types_for_supergroup('services')
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: 'services')
+    stub_document_types_for_supergroup('news_and_communications')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: 'news_and_communications')
+    stub_document_types_for_supergroup('policy_and_engagement')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: 'policy_and_engagement')
+    stub_document_types_for_supergroup('transparency')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: 'transparency')
+    stub_document_types_for_supergroup('research_and_statistics')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: 'research_and_statistics')
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -17,7 +17,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     @taxon = WorldWideTaxon.find(@base_path)
     stub_content_for_taxon(@taxon.content_id, search_results) # For the "general information" taxon
     stub_content_for_taxon(@taxon.content_id, search_results)
-    stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_content_purpose_supergroup: nil)
+    stub_most_popular_content_for_taxon(@taxon.content_id, search_results, filter_content_store_document_type: nil)
 
     @child_taxon = WorldWideTaxon.find(@child_taxon_base_path)
     stub_content_for_taxon(@child_taxon.content_id, search_results)

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -102,4 +102,12 @@ describe Supergroups::GuidanceAndRegulation do
       assert_equal expected, guidance_and_regulation_supergroup.promoted_content(taxon_id)
     end
   end
+
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("guidance_and_regulation")
+
+      assert_includes document_types, "guidance"
+    end
+  end
 end

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -121,4 +121,12 @@ describe Supergroups::NewsAndCommunications do
       assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
     end
   end
+
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("news_and_communications")
+
+      assert_includes document_types, "speech"
+    end
+  end
 end

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -192,6 +192,14 @@ describe Supergroups::PolicyAndEngagement do
     end
   end
 
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("policy_and_engagement")
+
+      assert_includes document_types, "open_consultation"
+    end
+  end
+
 private
 
   def expected_results(document_types, promoted_content: false)

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -37,4 +37,13 @@ describe Supergroups::ResearchAndStatistics do
       assert_equal expected, research_and_statistics_supergroup.document_list(taxon_id)
     end
   end
+
+
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("research_and_statistics")
+
+      assert_includes document_types, "statistics"
+    end
+  end
 end

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -59,4 +59,12 @@ describe Supergroups::Services do
       assert_equal expected, service_supergroup.promoted_content(taxon_id)
     end
   end
+
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("services")
+
+      assert_includes document_types, "transaction"
+    end
+  end
 end

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -37,4 +37,12 @@ describe Supergroups::Transparency do
       assert_equal expected, transparency_supergroup.document_list(taxon_id)
     end
   end
+
+  describe "document types" do
+    it "returns appropriate things" do
+      document_types = GovukDocumentTypes.supergroup_document_types("transparency")
+
+      assert_includes document_types, "transparency"
+    end
+  end
 end

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -7,7 +7,7 @@ describe MostPopularContent do
   def most_popular_content
     @most_popular_content ||= MostPopularContent.new(
       content_id: taxon_content_id,
-      filter_content_purpose_supergroup: 'guidance_and_regulation'
+      filter_content_store_document_type: %w(detailed_guide guidance),
     )
   end
 
@@ -62,8 +62,8 @@ describe MostPopularContent do
       end
     end
 
-    it 'filters content by the requested filter_content_purpose_supergroup only' do
-      assert_includes_params(filter_content_purpose_supergroup: 'guidance_and_regulation') do
+    it 'filters content by the requested document types only' do
+      assert_includes_params(filter_content_store_document_type: %w(detailed_guide guidance)) do
         most_popular_content.fetch
       end
     end

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -6,7 +6,7 @@ describe MostRecentContent do
   def most_recent_content
     @most_recent_content ||= MostRecentContent.new(
       content_id: taxon_content_id,
-      filter_content_purpose_supergroup: "news_and_communications",
+      filter_content_store_document_type: %w(authored_article correspondence),
     )
   end
 
@@ -65,8 +65,8 @@ describe MostRecentContent do
     end
   end
 
-  it "filters content by the requested filter_content_purpose_supergroup only" do
-    assert_includes_params(filter_content_purpose_supergroup: "news_and_communications") do
+  it "filters content by the requested document types only" do
+    assert_includes_params(filter_content_store_document_type: %w(authored_article correspondence)) do
       most_recent_content.fetch
     end
   end

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -19,7 +19,14 @@ module RummagerHelpers
       )
   end
 
-  def stub_most_popular_content_for_taxon(content_id, results, filter_content_purpose_supergroup: 'guidance_and_regulation')
+  def stub_document_types_for_supergroup(supergroup)
+    GovukDocumentTypes.stubs(:supergroup_document_types)
+      .with(supergroup)
+      .returns(supergroup)
+  end
+
+  def stub_most_popular_content_for_taxon(content_id, results,
+      filter_content_store_document_type: %w(detailed_guide manual))
     fields = RummagerFields::TAXON_SEARCH_FIELDS
 
     params = {
@@ -28,8 +35,8 @@ module RummagerHelpers
       fields: fields,
       filter_part_of_taxonomy_tree: Array(content_id),
       order: '-popularity',
+      filter_content_store_document_type: filter_content_store_document_type,
     }
-    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     Services.rummager.stubs(:search)
     .with(params)
@@ -40,7 +47,8 @@ module RummagerHelpers
     )
   end
 
-  def stub_most_recent_content_for_taxon(content_id, results, filter_content_purpose_supergroup: 'news_and_communication')
+  def stub_most_recent_content_for_taxon(content_id, results,
+      filter_content_store_document_type: %w(detailed_guide guidance))
     fields = RummagerFields::TAXON_SEARCH_FIELDS
 
     params = {
@@ -49,8 +57,8 @@ module RummagerHelpers
       fields: fields,
       filter_part_of_taxonomy_tree: [content_id],
       order: '-public_timestamp',
+      filter_content_store_document_type: filter_content_store_document_type,
     }
-    params[:filter_content_purpose_supergroup] = filter_content_purpose_supergroup if filter_content_purpose_supergroup.present?
 
     Services.rummager.stubs(:search)
     .with(params)


### PR DESCRIPTION
Iterating which document types belong to which supertype is very slow if it means republishing content and getting it all reindexed by rummager.  We are circumventing this by ignoring the `content_purpose_supergroup` properties of content items and rummager results, and instead translating them prior to performing queries.

We use the [govuk_document_types](https://github.com/alphagov/govuk_document_types) gem to help us with this. In the tests which exercise this path where we use the gem, we've stubbed the response to ensure that we reduce the brittleness of the tests as much as possible.

So that we can retain confidence that the gem returns reasonable responses for each of the groups (and that the groups still exist in the gem), we've added a few tests to assert how we expect the gem to behave.

These changes have already been done in [finder frontend](alphagov/finder-frontend#619), and this PR is to ensure that collections is in line with those changes.

https://trello.com/c/Q88UJzp5/177-update-collections-to-use-the-govukdocumenttypes-gem