### PR TITLE
Remove blue boxes on topic pages

### DIFF
--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -10,12 +10,6 @@ module Supergroups
       @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
-    def promoted_content(taxon_id)
-      items = tagged_content(taxon_id).shift(promoted_content_count)
-
-      format_document_data(items, "HighlightBoxClicked")
-    end
-
   private
 
     def guide?(document)

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -10,6 +10,12 @@ module Supergroups
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
+    def document_list(taxon_id)
+      items = tagged_content(taxon_id).drop(promoted_content_count)
+
+      format_document_data(items)
+    end
+
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
       format_document_data(items, "FeaturedLinkClicked", true)

--- a/app/presenters/supergroups/research_and_statistics.rb
+++ b/app/presenters/supergroups/research_and_statistics.rb
@@ -9,9 +9,5 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
-
-    def promoted_content_count
-      0
-    end
   end
 end

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -10,12 +10,6 @@ module Supergroups
       @content = MostPopularContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
-    def promoted_content(taxon_id)
-      items = tagged_content(taxon_id).shift(promoted_content_count)
-
-      format_document_data(items, "HighlightBoxClicked")
-    end
-
   private
 
     def format_document_data(documents, data_category = "")

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -35,13 +35,9 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      items = tagged_content(taxon_id).drop(promoted_content_count)
+      items = tagged_content(taxon_id)
 
       format_document_data(items)
-    end
-
-    def promoted_content(*)
-      []
     end
 
     def data_module_label
@@ -65,10 +61,6 @@ module Supergroups
           dimension29: link_text
         }
       }
-    end
-
-    def promoted_content_count(*)
-      3
     end
 
     def format_document_data(documents, data_category = "", with_image_url = false)

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -9,9 +9,5 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
-
-    def promoted_content_count
-      0
-    end
   end
 end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -28,7 +28,7 @@ module SupergroupSections
         {
           id: supergroup.name,
           title: supergroup.title,
-          promoted_content: supergroup.promoted_content(taxon_id),
+          promoted_content: (supergroup.promoted_content(taxon_id) if supergroup.methods.include? :promoted_content),
           documents: supergroup.document_list(taxon_id),
           partial_template: supergroup.partial_template,
           see_more_link: supergroup.finder_link(base_path),

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,7 +1,4 @@
 <%= render 'govuk_publishing_components/components/taxonomy_list',
-  highlight_box: {
-    items: section[:promoted_content]
-  },
   document_list: {
     items: section[:documents]
   }

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,9 +1,6 @@
 <%= render 'govuk_publishing_components/components/taxonomy_list',
-  highlight_box: {
-    items: section[:promoted_content]
-  },
   document_list: {
-    items: section[:documents]
+    items: section[:promoted_content] + section[:documents]
   }
 %>
 

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,8 +1,4 @@
 <%= render 'govuk_publishing_components/components/taxonomy_list',
-  highlight_box: {
-    items: section[:promoted_content],
-    inverse: true
-  },
   document_list: {
     items: section[:documents]
   }

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -10,7 +10,7 @@ describe Supergroups::GuidanceAndRegulation do
     it 'returns a document list for the guidance and regulation supergroup' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('guidance', 4))
+        .returns(section_tagged_content_list('guidance', 1))
 
       expected = [
         {
@@ -40,7 +40,7 @@ describe Supergroups::GuidanceAndRegulation do
     it 'return a document list for guides' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('guide', 4))
+        .returns(section_tagged_content_list('guide', 1))
 
       expected = [
         {
@@ -68,38 +68,6 @@ describe Supergroups::GuidanceAndRegulation do
 
       assert_equal expected, actual
       assert_equal 1, actual.count
-    end
-  end
-
-  describe '#promoted_content' do
-    it 'returns promoted content for the guidance and regulation supergroup' do
-      MostPopularContent.any_instance
-        .stubs(:fetch)
-        .returns(section_tagged_content_list('guidance'))
-
-      expected = [
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            data_attributes: {
-              track_category: "guidanceAndRegulationHighlightBoxClicked",
-              track_action: 1,
-              track_label: '/government/tagged/content',
-              track_options: {
-                dimension29: 'Tagged Content Title'
-              }
-            }
-          },
-          metadata: {
-            public_updated_at: '2018-02-28T08:01:00.000+00:00',
-            organisations: 'Tagged Content Organisation',
-            document_type: 'Guidance'
-          }
-        }
-      ]
-
-      assert_equal expected, guidance_and_regulation_supergroup.promoted_content(taxon_id)
     end
   end
 

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -10,7 +10,7 @@ describe Supergroups::Services do
     it 'returns a document list for the services supergroup' do
       MostPopularContent.any_instance
         .stubs(:fetch)
-        .returns(section_tagged_content_list('form', 4))
+        .returns(section_tagged_content_list('form', 1))
 
       expected = [
         {
@@ -31,32 +31,6 @@ describe Supergroups::Services do
       ]
 
       assert_equal expected, service_supergroup.document_list(taxon_id)
-    end
-
-    it 'returns a promoted content list for the services supergroup' do
-      MostPopularContent.any_instance
-        .stubs(:fetch)
-        .returns(section_tagged_content_list('form'))
-
-      expected = [
-        {
-          link: {
-            text: 'Tagged Content Title',
-            path: '/government/tagged/content',
-            description: 'Description of tagged content',
-            data_attributes: {
-              track_category: "servicesHighlightBoxClicked",
-              track_action: 1,
-              track_label: '/government/tagged/content',
-              track_options: {
-                dimension29: 'Tagged Content Title'
-              }
-            }
-          }
-        }
-      ]
-
-      assert_equal expected, service_supergroup.promoted_content(taxon_id)
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/RuewWEyV/92-make-topic-page-lists-consistent

This removes highlight boxes from topic pages. Instead, everything is displayed in a document list.

Exceptions:
  news_and_communications: this still displays the most recent item as an image card
  policy_papers_and_consultations: this still displays consultations first, but they are now no visually different

## Before:
<img width="988" alt="screen shot 2018-10-25 at 13 04 52" src="https://user-images.githubusercontent.com/29889908/47498941-9b5ab400-d856-11e8-9fbb-c3218006ec04.png">

## After:
<img width="985" alt="screen shot 2018-10-25 at 13 04 41" src="https://user-images.githubusercontent.com/29889908/47498960-a7467600-d856-11e8-80a4-8e15bf8226d4.png">