### PR TITLE
Modify See All Link on Topic Pages

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -58,6 +58,11 @@
   clear: both;
 }
 
+.taxon-page__see-more {
+  display: block;
+  margin-top: $gutter;
+}
+
 .taxon-page__show-more-toggle {
   display: none;
 

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -3,7 +3,10 @@ class TaxonsController < ApplicationController
 
   def show
     setup_content_item_and_navigation_helpers(taxon)
-    render "show_#{taxon_page_variant.variant_name.downcase}", locals: {
+
+    variant = taxon_page_variant.variant_name.downcase
+
+    render "show_#{variant}", locals: {
       presented_taxon: presented_taxon
     }
   end

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -50,7 +50,7 @@ module Supergroups
     def see_all_link_text
       group_title = I18n.t(name, scope: :content_purpose_supergroup, default: title)
 
-      I18n.t(:see_all_of_type, scope: :taxons, type: group_title.downcase)
+      I18n.t(:see_all_in_topic, scope: :taxons, type: group_title.downcase)
     end
 
     def see_all_link_data_attributes(base_path)

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -18,7 +18,8 @@ module Supergroups
 
       {
         text: see_all_link_text,
-        url: "/search/advanced?#{query_string}"
+        url: "/search/advanced?#{query_string}",
+        data: see_all_link_data_attributes(base_path)
       }
     end
 
@@ -50,6 +51,15 @@ module Supergroups
       group_title = I18n.t(name, scope: :content_purpose_supergroup, default: title)
 
       I18n.t(:see_all_of_type, scope: :taxons, type: group_title.downcase)
+    end
+
+    def see_all_link_data_attributes(base_path)
+      {
+        track_category: "SeeAllLinkClicked",
+        track_action: base_path,
+        track_label: name,
+        module: "track-click"
+      }
     end
 
     def data_attributes(base_path, link_text, index)

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -15,7 +15,7 @@
         } %>
 
         <% if presented_organisations.show_more_organisations? %>
-            <div class="taxon-page__show-more-toggle">
+            <div class="taxon-page__show-more-toggle taxon-page__see-more">
               <a href="#"
               data-controls="more-organisations"
               data-expanded="false"

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -5,8 +5,5 @@
 %>
 
 <% if section[:see_more_link] %>
-  <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url]
-  )%>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 <% end %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -26,9 +26,7 @@
   <% else %>
     <div class="taxon-page__featured-see-more">
   <% end %>
-    <%= link_to(
-      section[:see_more_link][:text],
-      section[:see_more_link][:url]
-    )%>
+    <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+
   </div>
 </div>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -5,8 +5,6 @@
 %>
 
 <% if section[:see_more_link] %>
-  <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url]
-  )%>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 <% end %>
+

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -5,8 +5,5 @@
 %>
 
 <% if section[:see_more_link] %>
-  <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url]
-  )%>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 <% end %>

--- a/app/views/taxons/sections/_see_more_link.html.erb
+++ b/app/views/taxons/sections/_see_more_link.html.erb
@@ -1,0 +1,5 @@
+<%= link_to(
+    section[:see_more_link][:text],
+    section[:see_more_link][:url],
+    data: section[:see_more_link][:data]
+)%>

--- a/app/views/taxons/sections/_see_more_link.html.erb
+++ b/app/views/taxons/sections/_see_more_link.html.erb
@@ -1,5 +1,6 @@
 <%= link_to(
     section[:see_more_link][:text],
     section[:see_more_link][:url],
-    data: section[:see_more_link][:data]
+    data: section[:see_more_link][:data],
+    class: "taxon-page__see-more"
 )%>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -5,8 +5,5 @@
 %>
 
 <% if section[:see_more_link] %>
-  <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url]
-  )%>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 <% end %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -5,8 +5,5 @@
 %>
 
 <% if section[:see_more_link] %>
-  <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url]
-  )%>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 <% end %>

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -24,7 +24,7 @@
       </div>
       <%= render(
         partial: section[:partial_template],
-        locals: { section: section }
+        locals: { presented_taxon: presented_taxon, section: section }
       )
      %>
     </div>

--- a/app/views/taxons/show_b.html.erb
+++ b/app/views/taxons/show_b.html.erb
@@ -3,3 +3,4 @@
     presented_taxon: presented_taxon
   }
 %>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
   taxons:
     organisations: "Organisations"
     sub_topics: "Explore these sub-topics"
-    see_all_of_type: "See all %{type}"
+    see_all_in_topic: "See more %{type} in this topic"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -15,8 +15,8 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_services_section
     and_i_can_see_the_guidance_and_regulation_section
     and_i_can_see_the_news_and_communications_section
-    and_i_can_see_the_policy_and_engagement_section
-    and_i_can_see_the_transparency_section
+    and_i_can_see_the_policy_papers_and_consulations_section
+    and_i_can_see_the_transparency_and_foi_releases_section
     and_i_can_see_the_research_and_statistics_section
     and_i_can_see_the_organisations_section
     and_i_can_see_the_sub_topics_grid
@@ -168,7 +168,7 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more guidance and regulation in this topic",
       url: "/search/advanced?" + finder_query_string("guidance_and_regulation")
     }
 
@@ -182,7 +182,7 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more services in this topic",
       url: "/search/advanced?" + finder_query_string('services')
     }
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -197,14 +197,14 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more news and communications in this topic",
       url: "/search/advanced?" + finder_query_string("news_and_communications")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
-  def and_i_can_see_the_policy_and_engagement_section
+  def and_i_can_see_the_policy_papers_and_consulations_section
     assert page.has_selector?('.gem-c-heading', text: "Policy")
 
     tagged_content_for_policy_and_engagement.each do |item|
@@ -212,14 +212,14 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more policy papers and consultations in this topic",
       url: "/search/advanced?" + finder_query_string("policy_and_engagement")
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
 
-  def and_i_can_see_the_transparency_section
+  def and_i_can_see_the_transparency_and_foi_releases_section
     assert page.has_selector?('.gem-c-heading', text: "Transparency")
 
     tagged_content_for_transparency.each do |item|
@@ -227,7 +227,7 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more transparency and freedom of information releases in this topic",
       url: "/search/advanced?" + finder_query_string("transparency")
     }
 
@@ -242,7 +242,7 @@ private
     end
 
     expected_link = {
-      text: "See all",
+      text: "See more research and statistics in this topic",
       url: "/search/advanced?" + finder_query_string("research_and_statistics")
     }
 
@@ -294,11 +294,13 @@ private
   end
 
   def see_all_links_have_tracking_data
-    ['services', 'guidance and regulation', 'news and communications',
-     'research and statistics', 'policy papers and consultations',
-     'transparency and freedom of information releases'].each do |section|
-      assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: "See all #{section}")
-      assert page.has_css?("a[data-track-action=\"/foo\"]", text: "See all #{section}")
+    [
+      'services', 'guidance and regulation', 'news and communications',
+      'research and statistics', 'policy papers and consultations',
+      'transparency and freedom of information releases'
+    ].each do |section|
+      assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: "See more #{section} in this topic")
+      assert page.has_css?("a[data-track-action=\"/foo\"]", text: "See more #{section} in this topic")
     end
   end
 

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -21,6 +21,14 @@ describe Supergroups::Supergroup do
 
       assert expected_details, supergroup.finder_link(base_path)
     end
+
+    it 'returns correct data' do
+      base_path = '/base/path'
+      finder_link_data = supergroup.finder_link(base_path)[:data]
+      assert_equal "SeeAllLinkClicked", finder_link_data[:track_category]
+      assert_equal base_path, finder_link_data[:track_action]
+      assert_equal "supergroup_name", finder_link_data[:track_label]
+    end
   end
 
   describe '#partial_template' do


### PR DESCRIPTION
Trello:
- https://trello.com/c/s2hhuGMD/46-%F0%9F%8D%90-implement-new-design-of-see-all-links
- https://trello.com/c/cKJBaFw5/12-add-event-tracking-to-topic-pages-see-all-links-all-supergroups

## Before
<img width="972" alt="screen shot 2018-10-30 at 13 44 27" src="https://user-images.githubusercontent.com/29889908/47722286-f8d17500-dc49-11e8-8cf7-899956c86a97.png">


## After
<img width="985" alt="screen shot 2018-10-30 at 13 44 31" src="https://user-images.githubusercontent.com/29889908/47722332-1b638e00-dc4a-11e8-9570-bf0374c1da91.png">