### PR TITLE
Fix duplicate tracking events for See All News

### DIFF
--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -19,7 +19,7 @@ module Supergroups
       {
         text: see_all_link_text,
         url: "/search/advanced?#{query_string}",
-        data: see_all_link_data_attributes(base_path)
+        data: see_all_link_data_attributes(base_path, name)
       }
     end
 
@@ -53,12 +53,12 @@ module Supergroups
       I18n.t(:see_all_in_topic, scope: :taxons, type: group_title.downcase)
     end
 
-    def see_all_link_data_attributes(base_path)
+    def see_all_link_data_attributes(base_path, name)
       {
         track_category: "SeeAllLinkClicked",
         track_action: base_path,
         track_label: name,
-        module: "track-click"
+        module: ("track-click" unless name.eql?('news_and_communications'))
       }
     end
 


### PR DESCRIPTION
Duplicate tracking events were being sent when a user clicked on See All News and Communications in this topic.
This is because the link was wrapped by a parent with `data-module=track-click` while it also had that attribute itself.

This is a work-around. Ideally we should modify the document list component so it adds the track click module itself rather than having to wrap the component when we include it. This is a lot more work as the additional `data-module=track-click` has to be removed from each app where it is being used to wrap the document list component. [A card](https://trello.com/c/Sdhh6x3w/152-document-list-component-should-add-data-module-track-click-itself) has been added for this work.