### PR TITLE
Add in page nav

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,3 +1,13 @@
+.content-list__sticky {
+  @include media (tablet) {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+  }
+}
+
+
+
 .taxon-feedback-wrapper {
   background-color: $grey-4;
 }

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -7,7 +7,8 @@ class TaxonsController < ApplicationController
     variant = taxon_page_variant.variant_name.downcase
 
     render "show_#{variant}", locals: {
-      presented_taxon: presented_taxon
+      presented_taxon: presented_taxon,
+      presentable_section_items: presentable_section_items
     }
   end
 
@@ -19,5 +20,22 @@ private
 
   def presented_taxon
     @presented_taxon ||= TaxonPresenter.new(taxon)
+  end
+
+  def presentable_section_items
+    @presentable_section_items = @presented_taxon.sections.select { |section| section[:show_section] }.map do |section|
+      {
+          href: "##{section[:id]}",
+          text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title])
+      }
+    end
+
+    @presentable_section_items << { href: "#organisations", text: t('taxons.organisations') }
+
+    if presented_taxon.show_subtopic_grid?
+      @presentable_section_items << { href: "#sub-topics", text: t('taxons.sub_topics') }
+    end
+
+    @presentable_section_items
   end
 end

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -5,7 +5,8 @@
         <%= render "govuk_publishing_components/components/heading", {
             text: t('taxons.organisations'),
             heading_level: 2,
-            margin_bottom: 2
+            margin_bottom: 2,
+            id: "organisations"
           } %>
 
 

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -1,18 +1,17 @@
 <% if presented_organisations.show_organisations? %>
-  <div class="taxon-page__section-group taxon-page__section-group--organisation" data-module="toggle">
+  <div id="organisations" class="taxon-page__section-group taxon-page__section-group--organisation" data-module="toggle">
     <div class="grid-row">
       <div class="column-two-thirds">
         <%= render "govuk_publishing_components/components/heading", {
-            text: t('taxons.organisations'),
-            heading_level: 2,
-            margin_bottom: 2,
-            id: "organisations"
+              text: t('taxons.organisations'),
+              heading_level: 2,
+              margin_bottom: 2
           } %>
 
 
         <%= render partial: 'organisation_logos_and_list', locals: {
-          organisations_with_logos: presented_organisations.promoted_organisation_list[:promoted_with_logos],
-          organisations_without_logos: presented_organisations.promoted_organisation_list[:promoted_without_logos]
+              organisations_with_logos: presented_organisations.promoted_organisation_list[:promoted_with_logos],
+              organisations_without_logos: presented_organisations.promoted_organisation_list[:promoted_without_logos]
         } %>
 
         <% if presented_organisations.show_more_organisations? %>
@@ -25,8 +24,8 @@
 
           <div id="more-organisations" class="js-hidden">
             <%= render partial: 'organisation_logos_and_list', locals: {
-              organisations_with_logos: presented_organisations.show_more_organisation_list[:organisations_with_logos],
-              organisations_without_logos: presented_organisations.show_more_organisation_list[:organisations_without_logos]
+                  organisations_with_logos: presented_organisations.show_more_organisation_list[:organisations_with_logos],
+                  organisations_without_logos: presented_organisations.show_more_organisation_list[:organisations_without_logos]
             } %>
           </div>
         <% end %>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,7 +1,5 @@
-<%= render 'govuk_publishing_components/components/taxonomy_list',
-  document_list: {
+<%= render 'govuk_publishing_components/components/document_list',
     items: section[:documents]
-  }
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -3,9 +3,9 @@
   featured_item_layout_class = "taxon-page__featured-item--single" if section[:documents].empty?
 %>
 
-<div class="grid-row">
-  <div class="taxon-page__featured-item column-one-third <%= featured_item_layout_class %>" <%= "data-module=track-click" if track_click?(section[:promoted_content]) %>>
+  <div class="taxon-page__featured-item <%= featured_item_layout_class %>" <%= "data-module=track-click" if track_click?(section[:promoted_content]) %>>
     <%= render "govuk_publishing_components/components/image_card", {
+        large: true,
         href: featured_item[:link].fetch(:path),
         image_src: featured_item[:image][:url],
         heading_text: featured_item[:link].fetch(:text),
@@ -17,7 +17,7 @@
     } %>
   </div>
   <% if section[:documents].any? %>
-    <div class="column-two-thirds" <%= "data-module=track-click" if track_click?(section[:documents]) %>>
+    <div <%= "data-module=track-click" if track_click?(section[:documents]) %>>
       <%= render 'govuk_publishing_components/components/document_list',
         items: section[:documents],
         margin_top: true,
@@ -29,4 +29,3 @@
     <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
 
   </div>
-</div>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,7 +1,5 @@
-<%= render 'govuk_publishing_components/components/taxonomy_list',
-  document_list: {
+<%= render 'govuk_publishing_components/components/document_list',
     items: section[:promoted_content] + section[:documents]
-  }
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -1,7 +1,5 @@
-<%= render 'govuk_publishing_components/components/taxonomy_list',
-  document_list: {
+<%= render 'govuk_publishing_components/components/document_list',
     items: section[:documents]
-  }
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,7 +1,5 @@
-<%= render 'govuk_publishing_components/components/taxonomy_list',
-  document_list: {
+<%= render 'govuk_publishing_components/components/document_list',
     items: section[:documents]
-  }
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,7 +1,5 @@
-<%= render 'govuk_publishing_components/components/taxonomy_list',
-  document_list: {
+<%= render 'govuk_publishing_components/components/document_list',
     items: section[:documents]
-  }
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -2,10 +2,10 @@
 <% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
 <%=
   render(
-      partial: 'common',
-      locals: {
-          presented_taxon: presented_taxon
-      }
+    partial: 'common',
+    locals: {
+      presented_taxon: presented_taxon
+    }
   )
 %>
 
@@ -16,16 +16,16 @@
         <div class="grid-row">
           <div class="column-two-thirds">
             <%= render "govuk_publishing_components/components/heading", {
-                text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
-                heading_level: 2,
-                margin_bottom: 2
+              text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+              heading_level: 2,
+              margin_bottom: 2
             } %>
           </div>
         </div>
         <%= render(
-                partial: section[:partial_template],
-                locals: { presented_taxon: presented_taxon, section: section }
-            )
+          partial: section[:partial_template],
+          locals: { presented_taxon: presented_taxon, section: section }
+        )
         %>
       </div>
     <% end %>
@@ -38,20 +38,20 @@
   <nav role="navigation" class="taxon-page__grid">
     <div class="full-page-width-wrapper">
       <%= render "govuk_publishing_components/components/heading", {
-          text: t('taxons.sub_topics'),
-          heading_level: 2,
-          font_size: 19,
-          margin_bottom: 2
+        text: t('taxons.sub_topics'),
+        heading_level: 2,
+        font_size: 19,
+        margin_bottom: 2
       } %>
       <ol class="taxon-page__grid-wrapper">
         <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
           <li class="taxon-page__grid-item">
             <h3 class="taxon-page__grid-heading">
               <%= link_to(
-                      child_taxon.title,
-                      child_taxon.base_path,
-                      data: presented_taxon.options_for_child_taxon(index: index)
-                  )%>
+                child_taxon.title,
+                child_taxon.base_path,
+                data: presented_taxon.options_for_child_taxon(index: index)
+              )%>
             </h3>
             <p class="taxon-page__grid-item-description"><%= child_taxon.description %></p>
           </li>

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -2,32 +2,32 @@
 <% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
 <%=
   render(
-    partial: 'common',
-    locals: {
-      presented_taxon: presented_taxon
-    }
+      partial: 'common',
+      locals: {
+          presented_taxon: presented_taxon
+      }
   )
 %>
 
 <div class="full-page-width-wrapper">
   <% presented_taxon.sections.each do |section| %>
     <% if section[:show_section] %>
-    <div class="taxon-page__section-group">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
-            heading_level: 2,
-            margin_bottom: 2
-          } %>
+      <div class="taxon-page__section-group">
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <%= render "govuk_publishing_components/components/heading", {
+                text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+                heading_level: 2,
+                margin_bottom: 2
+            } %>
+          </div>
         </div>
+        <%= render(
+                partial: section[:partial_template],
+                locals: { presented_taxon: presented_taxon, section: section }
+            )
+        %>
       </div>
-      <%= render(
-        partial: section[:partial_template],
-        locals: { presented_taxon: presented_taxon, section: section }
-      )
-     %>
-    </div>
     <% end %>
   <% end %>
 
@@ -38,20 +38,20 @@
   <nav role="navigation" class="taxon-page__grid">
     <div class="full-page-width-wrapper">
       <%= render "govuk_publishing_components/components/heading", {
-        text: t('taxons.sub_topics'),
-        heading_level: 2,
-        font_size: 19,
-        margin_bottom: 2
+          text: t('taxons.sub_topics'),
+          heading_level: 2,
+          font_size: 19,
+          margin_bottom: 2
       } %>
       <ol class="taxon-page__grid-wrapper">
         <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
           <li class="taxon-page__grid-item">
             <h3 class="taxon-page__grid-heading">
               <%= link_to(
-                child_taxon.title,
-                child_taxon.base_path,
-                data: presented_taxon.options_for_child_taxon(index: index)
-              )%>
+                      child_taxon.title,
+                      child_taxon.base_path,
+                      data: presented_taxon.options_for_child_taxon(index: index)
+                  )%>
             </h3>
             <p class="taxon-page__grid-item-description"><%= child_taxon.description %></p>
           </li>

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -1,5 +1,69 @@
-<%= render template: "taxons/show_a",
-  locals: {
-    presented_taxon: presented_taxon
-  }
+<% content_for :page_class, "taxon-page taxon-page--grid" %>
+<% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
+<%=
+  render(
+      partial: 'common',
+      locals: {
+          presented_taxon: presented_taxon
+      }
+  )
 %>
+
+<div class="full-page-width-wrapper">
+  <div class="grid-row">
+    <div class="column-one-third">
+      <%= render "govuk_publishing_components/components/contents_list", {
+          hide_title: true,
+          contents: [
+              {
+                  text: "On this page:",
+                  active: true,
+                  items: @presentable_section_items
+              }
+          ]
+      } %>
+    </div>
+    <div class="column-two-thirds">
+      <% presented_taxon.sections.each do |section| %>
+        <% if section[:show_section] %>
+          <div class="taxon-page__section-group">
+            <div class="grid-row">
+              <div class="column-two-thirds">
+                <%= render "govuk_publishing_components/components/heading", {
+                    text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+                    heading_level: 2,
+                    margin_bottom: 2,
+                    id: section[:id]
+                } %>
+              </div>
+            </div>
+            <%= render(
+                    partial: section[:partial_template],
+                    locals: {section: section}
+                )
+            %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= render partial: 'organisations', locals: {presented_organisations: presented_taxon.organisations_section} %>
+
+      <% if content_for(:is_taxon_with_subtopics) %>
+        <div id="taxon-sub-topics" class="taxon-page__section-group">
+          <%= render "govuk_publishing_components/components/heading", {
+              text: t('taxons.sub_topics'),
+              heading_level: 2,
+              margin_bottom: 2,
+              id: "sub-topics"
+          } %>
+
+          <%= render 'govuk_publishing_components/components/document_list',
+                     items: presented_taxon.child_taxons.map{ |child_taxon| { link: { text: child_taxon.title, path: child_taxon.base_path }} },
+                     margin_bottom: true
+          %>
+
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -1,65 +1,57 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
 <%=
   render(
-      partial: 'common',
-      locals: {
-          presented_taxon: presented_taxon
-      }
+    partial: 'common',
+    locals: {
+      presented_taxon: presented_taxon
+    }
   )
 %>
 
 <div class="full-page-width-wrapper">
   <div class="grid-row">
-    <div class="column-one-third">
+    <div class="column-one-third content-list__sticky">
+      <h2><%= t('taxons.in_page_nav_title') %></h2>
       <%= render "govuk_publishing_components/components/contents_list", {
-          hide_title: true,
-          contents: [
-              {
-                  text: "On this page:",
-                  active: true,
-                  items: @presentable_section_items
-              }
-          ]
+        hide_title: true,
+        contents: @presentable_section_items
       } %>
     </div>
     <div class="column-two-thirds">
       <% presented_taxon.sections.each do |section| %>
         <% if section[:show_section] %>
-          <div class="taxon-page__section-group">
+          <div id="<%= section[:id] %>" class="taxon-page__section-group">
             <div class="grid-row">
               <div class="column-two-thirds">
                 <%= render "govuk_publishing_components/components/heading", {
-                    text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
-                    heading_level: 2,
-                    margin_bottom: 2,
-                    id: section[:id]
+                  text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+                  heading_level: 2,
+                  margin_bottom: 2
                 } %>
               </div>
             </div>
             <%= render(
-                    partial: section[:partial_template],
-                    locals: {section: section}
-                )
+              partial: section[:partial_template],
+              locals: { section: section }
+              )
             %>
           </div>
         <% end %>
       <% end %>
 
-      <%= render partial: 'organisations', locals: {presented_organisations: presented_taxon.organisations_section} %>
+      <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
 
-      <% if content_for(:is_taxon_with_subtopics) %>
-        <div id="taxon-sub-topics" class="taxon-page__section-group">
+      <% if presented_taxon.show_subtopic_grid? %>
+        <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group">
           <%= render "govuk_publishing_components/components/heading", {
-              text: t('taxons.sub_topics'),
-              heading_level: 2,
-              margin_bottom: 2,
-              id: "sub-topics"
+            text: t('taxons.sub_topics'),
+            heading_level: 2,
+            margin_bottom: 2
           } %>
 
           <%= render 'govuk_publishing_components/components/document_list',
-                     items: presented_taxon.child_taxons.map{ |child_taxon| { link: { text: child_taxon.title, path: child_taxon.base_path }} },
-                     margin_bottom: true
+            items: presented_taxon.child_taxons.map{ |child_taxon| { link: { text: child_taxon.title, path: child_taxon.base_path }} },
+            margin_bottom: true
           %>
 
         </div>
@@ -67,3 +59,4 @@
     </div>
   </div>
 </div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
     organisations: "Organisations"
     sub_topics: "Explore these sub-topics"
     see_all_in_topic: "See more %{type} in this topic"
+    in_page_nav_title: "On this page"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -21,6 +21,13 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_research_and_statistics_section
     and_i_can_see_the_organisations_section
     and_i_can_see_the_sub_topics_grid
+  end
+
+  it 'renders an in-page nav in variant C' do
+    given_there_is_a_taxon_with_children
+    and_the_taxon_is_live
+    and_the_taxon_has_tagged_content
+    when_i_visit_that_taxon_with_variant("C")
     and_i_can_see_the_in_page_nav
   end
 
@@ -286,17 +293,15 @@ private
   end
 
   def and_i_can_see_the_in_page_nav
-    GovukAbTesting::RequestedVariant.any_instance.stubs(:variant_name).returns("C")
-    visit base_path
-
-    assert page.has_selector?('#taxon-sub-topics')
-
-    child_taxons = @content_item["links"]["child_taxons"]
-
-    child_taxons.each do |child_taxon|
-      assert page.has_css?(".gem-c-document-list__item-title", text: child_taxon['title'])
-      assert page.has_link?(child_taxon['title'], href: child_taxon['base_path'])
-    end
+    assert page.has_selector?('.gem-c-contents-list__list')
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Services")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Guidance and regulation")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "News and communications")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Research and statistics")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Policy papers and consultations")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Transparency and freedom of information releases")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Organisations")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Explore these sub-topics")
   end
 
   def then_page_has_meta_robots

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -4,6 +4,7 @@ require_relative '../support/taxon_helpers'
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
   include RummagerHelpers
   include TaxonHelpers
+  include GovukAbTesting::MinitestHelpers
 
   it 'renders a taxon page for a live taxon' do
     given_there_is_a_taxon_with_children
@@ -20,6 +21,7 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_research_and_statistics_section
     and_i_can_see_the_organisations_section
     and_i_can_see_the_sub_topics_grid
+    and_i_can_see_the_in_page_nav
   end
 
   it 'renders a taxon page for a draft taxon' do
@@ -279,6 +281,20 @@ private
 
     child_taxons.each do |child_taxon|
       assert page.has_css?("h3.taxon-page__grid-heading", text: child_taxon['title'])
+      assert page.has_link?(child_taxon['title'], href: child_taxon['base_path'])
+    end
+  end
+
+  def and_i_can_see_the_in_page_nav
+    GovukAbTesting::RequestedVariant.any_instance.stubs(:variant_name).returns("C")
+    visit base_path
+
+    assert page.has_selector?('#taxon-sub-topics')
+
+    child_taxons = @content_item["links"]["child_taxons"]
+
+    child_taxons.each do |child_taxon|
+      assert page.has_css?(".gem-c-document-list__item-title", text: child_taxon['title'])
       assert page.has_link?(child_taxon['title'], href: child_taxon['base_path'])
     end
   end


### PR DESCRIPTION
This change adds an in page navigation to topic pages. This change is part of an A/B Test, which will be present in Variant C.

Trello card: https://trello.com/c/5hFNt9yn

**Before**
![screen shot 2018-11-02 at 10 07 03](https://user-images.githubusercontent.com/6651749/47909199-18a1ac80-de87-11e8-940e-4a1cc23ad37f.png)

This PR adds a in page nav to the left. This will allow users to navigate through content in each supergroup linked to the topic.

**After**
![screen shot 2018-11-02 at 09 54 07](https://user-images.githubusercontent.com/6651749/47908791-ecd1f700-de85-11e8-8b84-e0a322074ba5.png)
