### PR TITLE
Add variant D for multivariate test

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -140,3 +140,9 @@
     padding-bottom: $gutter-half;
   }
 }
+
+.taxon-page__sub-topic-sidebar a {
+  display: block;
+  text-decoration: none;
+  padding-top: $gutter-one-third;
+}

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -33,7 +33,7 @@ private
     @presentable_section_items << { href: "#organisations", text: t('taxons.organisations') }
 
     if presented_taxon.show_subtopic_grid?
-      @presentable_section_items << { href: "#sub-topics", text: t('taxons.sub_topics') }
+      @presentable_section_items << { href: "#sub-topics", text: t('taxons.explore_sub_topics') }
     end
 
     @presentable_section_items

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -38,7 +38,7 @@
   <nav role="navigation" class="taxon-page__grid">
     <div class="full-page-width-wrapper">
       <%= render "govuk_publishing_components/components/heading", {
-        text: t('taxons.sub_topics'),
+        text: t('taxons.explore_sub_topics'),
         heading_level: 2,
         font_size: 19,
         margin_bottom: 2

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -44,7 +44,7 @@
       <% if presented_taxon.show_subtopic_grid? %>
         <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group">
           <%= render "govuk_publishing_components/components/heading", {
-            text: t('taxons.sub_topics'),
+            text: t('taxons.explore_sub_topics'),
             heading_level: 2,
             margin_bottom: 2
           } %>

--- a/app/views/taxons/show_d.html.erb
+++ b/app/views/taxons/show_d.html.erb
@@ -1,5 +1,56 @@
-<%= render template: "taxons/show_a",
-  locals: {
-    presented_taxon: presented_taxon
-  }
+<% content_for :page_class, "taxon-page taxon-page--grid" %>
+<%=
+  render(
+      partial: 'common',
+      locals: {
+          presented_taxon: presented_taxon
+      }
+  )
 %>
+
+<div class="full-page-width-wrapper">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <% presented_taxon.sections.each do |section| %>
+        <% if section[:show_section] %>
+          <div id="<%= section[:id] %>" class="taxon-page__section-group">
+            <div class="grid-row">
+              <div class="column-two-thirds">
+                <%= render "govuk_publishing_components/components/heading", {
+                    text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+                    heading_level: 2,
+                    margin_bottom: 2
+                } %>
+              </div>
+            </div>
+            <%= render(
+              partial: section[:partial_template],
+              locals: { section: section }
+              )
+            %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
+
+    </div>
+    <div class="column-one-third">
+      <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group taxon-page__sub-topic-sidebar" data-module="track-click">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: (presented_taxon.show_subtopic_grid? ? t('taxons.in_page_sub_topic_title') : t('taxons.in_page_sub_topic_title_no_sub_topics')),
+            margin_bottom: 2
+        } %>
+        <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
+          <%= link_to child_taxon.title, child_taxon.base_path, data: {
+            track_category: "navGridContentClicked",
+            track_action: index + 1,
+            track_label: child_taxon.base_path,
+            track_options: {}
+          } %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,9 +78,12 @@ en:
     what_we_do: "What %{title} does"
   taxons:
     organisations: "Organisations"
-    sub_topics: "Explore these sub-topics"
+    explore_sub_topics: "Explore these sub-topics"
     see_all_in_topic: "See more %{type} in this topic"
     in_page_nav_title: "On this page"
+    in_page_sub_topic_title: "Sub-topics"
+    in_page_sub_topic_title_no_sub_topics: "No sub-topics"
+
   language_names:
     en: English
     cy: Cymraeg


### PR DESCRIPTION
Add the D variant for the taxon pages multivariate test. This variant shows sub-topics in the right hand side of the page

Trello: https://trello.com/c/duufSV8t/45-build-top-of-page-subtopic-navigation

![screenshot-localhost-3070-2018 11 05-16-27-53](https://user-images.githubusercontent.com/41049800/48011586-fecac880-e117-11e8-902d-0c33ccf309a9.png)
