### PR TITLE
Fix bug for sub-topics section of the in page nav

### DIFF
--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -42,7 +42,7 @@
       <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
 
       <% if presented_taxon.show_subtopic_grid? %>
-        <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group">
+        <div id="sub-topics" class="taxon-page__section-group">
           <%= render "govuk_publishing_components/components/heading", {
             text: t('taxons.explore_sub_topics'),
             heading_level: 2,


### PR DESCRIPTION
- Having two ID's meant the link in the in page nav was not scrolling to the sub-topics section in the page