### PR TITLE
Fixes duplicate rummager requests

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -17,7 +17,7 @@ class TaxonPresenter
   end
 
   def sections
-    SupergroupSections.supergroup_sections(taxon.content_id, taxon.base_path)
+    @sections ||= SupergroupSections.supergroup_sections(taxon.content_id, taxon.base_path)
   end
 
   def organisations_section


### PR DESCRIPTION
PR #915 inadvertently resulted in [duplicate Rummager requests](https://github.com/alphagov/collections/blob/7ca8a199e7993628f7b0f05425395f6b0089569f/app/controllers/taxons_controller.rb#L25) which caused an increase in 90th percentile rendering times, only spotted after deploy

![screenshot-grafana publishing service gov uk-2018 11 06-14-55-55](https://user-images.githubusercontent.com/41049800/48072321-267f6680-e1d4-11e8-87e1-8de30f54ae7f.png)

This adds memoization to remove the problem, which showed a decrease in rendering times on integration

![screenshot-grafana integration publishing service gov uk-2018 11 06-14-57-27](https://user-images.githubusercontent.com/41049800/48072394-4f9ff700-e1d4-11e8-842f-54332ff6daa7.png)
