### PR TITLE
Fix broken tracking click data

### DIFF
--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -7,15 +7,9 @@ module Supergroups
     end
 
     def document_list(taxon_id)
-      items = tagged_content(taxon_id).drop(promoted_content_count(taxon_id))
+      items = tagged_content(taxon_id)
 
       format_document_data(items)
-    end
-
-    def promoted_content(taxon_id)
-      items = tagged_content(taxon_id).shift(promoted_content_count(taxon_id))
-
-      format_document_data(items, "HighlightBoxClicked")
     end
 
     def tagged_content(taxon_id)
@@ -46,16 +40,6 @@ module Supergroups
     end
 
   private
-
-    def promoted_content_count(taxon_id)
-      consultation_count = tagged_content(taxon_id).count do |content_item|
-        consultation?(content_item.content_store_document_type)
-      end
-
-      return 3 if consultation_count > 3
-
-      consultation_count
-    end
 
     def reorder_tagged_documents_to_prioritise_consultations
       consultations = @content.select do |content_item|

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -64,6 +64,7 @@ module Supergroups
 
     def data_attributes(base_path, link_text, index)
       {
+        module: "track-click",
         track_category: data_module_label + "DocumentListClicked",
         track_action: index,
         track_label: base_path,

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -58,7 +58,7 @@ module Supergroups
         track_category: "SeeAllLinkClicked",
         track_action: base_path,
         track_label: name,
-        module: ("track-click" unless name.eql?('news_and_communications'))
+        module: "track-click"
       }
     end
 

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -3,7 +3,7 @@
   featured_item_layout_class = "taxon-page__featured-item--single" if section[:documents].empty?
 %>
 
-  <div class="taxon-page__featured-item <%= featured_item_layout_class %>" <%= "data-module=track-click" if track_click?(section[:promoted_content]) %>>
+  <div class="taxon-page__featured-item <%= featured_item_layout_class %>">
     <%= render "govuk_publishing_components/components/image_card", {
         large: true,
         href: featured_item[:link].fetch(:path),
@@ -14,11 +14,16 @@
           date: featured_item[:metadata][:public_updated_at],
           text: featured_item[:metadata][:document_type]
         },
-        href_data_attributes: featured_item[:link][:data_attributes]
+        href_data_attributes: {
+          track_category: featured_item[:link][:data_attributes][:track_category],
+          track_action: featured_item[:link][:data_attributes][:track_action],
+          track_label: featured_item[:link][:data_attributes][:track_label],
+          track_options: featured_item[:link][:data_attributes][:track_options]
+        }
     } %>
   </div>
   <% if section[:documents].any? %>
-    <div <%= "data-module=track-click" if track_click?(section[:documents]) %>>
+    <div>
       <%= render 'govuk_publishing_components/components/document_list',
         items: section[:documents],
         margin_top: true,

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -13,7 +13,8 @@
         context: {
           date: featured_item[:metadata][:public_updated_at],
           text: featured_item[:metadata][:document_type]
-        }
+        },
+        href_data_attributes: featured_item[:link][:data_attributes]
     } %>
   </div>
   <% if section[:documents].any? %>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,5 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:promoted_content] + section[:documents]
+    items: section[:documents]
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -50,7 +50,7 @@
           } %>
 
           <%= render 'govuk_publishing_components/components/document_list',
-            items: presented_taxon.child_taxons.map{ |child_taxon| { link: { text: child_taxon.title, path: child_taxon.base_path }} },
+            items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| { link: { text: child_taxon.title, path: child_taxon.base_path, data_attributes: presented_taxon.options_for_child_taxon(index: index) }} },
             margin_bottom: true
           %>
 

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -18,6 +18,7 @@ describe Supergroups::GuidanceAndRegulation do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             data_attributes: {
+              module: "track-click",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',
@@ -49,6 +50,7 @@ describe Supergroups::GuidanceAndRegulation do
             path: '/government/tagged/content',
             description: 'Description of tagged content',
             data_attributes: {
+              module: "track-click",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -20,6 +20,7 @@ describe Supergroups::NewsAndCommunications do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             data_attributes: {
+              module: "track-click",
               track_category: "newsAndCommunicationsDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',
@@ -76,6 +77,7 @@ describe Supergroups::NewsAndCommunications do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             data_attributes: {
+              module: "track-click",
               track_category: "newsAndCommunicationsFeaturedLinkClicked",
               track_action: 1,
               track_label: '/government/tagged/content',

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -124,6 +124,7 @@ describe Supergroups::PolicyAndEngagement do
                 text: 'Tagged Content Title',
                 path: '/government/tagged/content-1',
                 data_attributes: {
+                  module: "track-click",
                   track_category: "policyAndEngagementDocumentListClicked",
                   track_action: 1,
                   track_label: '/government/tagged/content-1',
@@ -216,6 +217,7 @@ private
         text: 'Tagged Content Title',
         path: '/government/tagged/content',
         data_attributes: {
+          module: "track-click",
           track_category: "policyAndEngagementDocumentListClicked",
           track_action: index + 1,
           track_label: '/government/tagged/content',

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -18,6 +18,7 @@ describe Supergroups::ResearchAndStatistics do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             data_attributes: {
+              module: "track-click",
               track_category: "researchAndStatisticsDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -19,6 +19,7 @@ describe Supergroups::Services do
             path: '/government/tagged/content',
             description: 'Description of tagged content',
             data_attributes: {
+              module: "track-click",
               track_category: "servicesDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -18,6 +18,7 @@ describe Supergroups::Transparency do
             text: 'Tagged Content Title',
             path: '/government/tagged/content',
             data_attributes: {
+              module: "track-click",
               track_category: "transparencyDocumentListClicked",
               track_action: 1,
               track_label: '/government/tagged/content',


### PR DESCRIPTION
Fixes various problems with tracking data either being incomplete or not triggering a Google analytics event for links on taxon pages