### PR TITLE
Remove no sub-topics heading when no sub-topics present

### DIFF
--- a/app/views/taxons/show_d.html.erb
+++ b/app/views/taxons/show_d.html.erb
@@ -35,22 +35,25 @@
       <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
 
     </div>
-    <div class="column-one-third">
-      <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group taxon-page__sub-topic-sidebar" data-module="track-click">
-        <%= render "govuk_publishing_components/components/heading", {
-            text: (presented_taxon.show_subtopic_grid? ? t('taxons.in_page_sub_topic_title') : t('taxons.in_page_sub_topic_title_no_sub_topics')),
-            margin_bottom: 2
-        } %>
-        <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
-          <%= link_to child_taxon.title, child_taxon.base_path, data: {
-            track_category: "navGridContentClicked",
-            track_action: index + 1,
-            track_label: child_taxon.base_path,
-            track_options: {}
-          } %>
-        <% end %>
+
+    <% if presented_taxon.show_subtopic_grid? %>
+      <div class="column-one-third">
+          <div id="taxon-sub-topics sub-topics" class="taxon-page__section-group taxon-page__sub-topic-sidebar" data-module="track-click">
+            <%= render "govuk_publishing_components/components/heading", {
+                text: t('taxons.in_page_sub_topic_title'),
+                margin_bottom: 2
+            } %>
+            <% presented_taxon.child_taxons.each_with_index do |child_taxon, index| %>
+              <%= link_to child_taxon.title, child_taxon.base_path, data: {
+                track_category: "navGridContentClicked",
+                track_action: index + 1,
+                track_label: child_taxon.base_path,
+                track_options: {}
+              } %>
+            <% end %>
+          </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,7 +82,6 @@ en:
     see_all_in_topic: "See more %{type} in this topic"
     in_page_nav_title: "On this page"
     in_page_sub_topic_title: "Sub-topics"
-    in_page_sub_topic_title_no_sub_topics: "No sub-topics"
 
   language_names:
     en: English

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -39,14 +39,6 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     and_i_can_see_the_sub_topic_side_nav
   end
 
-  it 'renders an in-page sub-topic side nav with notice if there are no sub-topics in variant D' do
-    given_there_is_a_taxon_without_children
-    and_the_taxon_is_live
-    and_the_taxon_has_tagged_content
-    when_i_visit_that_taxon_with_variant("D")
-    and_i_can_see_the_sub_topic_side_nav_with_no_sub_topics_notice
-  end
-
   it 'renders a taxon page for a draft taxon' do
     given_there_is_a_taxon_with_children
     and_the_taxon_is_not_live
@@ -341,13 +333,6 @@ private
         assert_equal child_taxon['base_path'], element["data-track-label"]
         assert_equal "{}", element["data-track-options"]
       end
-    end
-  end
-
-  def and_i_can_see_the_sub_topic_side_nav_with_no_sub_topics_notice
-    assert page.has_selector?('.taxon-page__sub-topic-sidebar')
-    within('.taxon-page__sub-topic-sidebar') do
-      assert page.has_selector?('h2', text: "No sub-topics")
     end
   end
 


### PR DESCRIPTION
We no longer require a heading displaying 'No sub-topics' when sub-topics are not present.

**Before**
![screen shot 2018-11-12 at 09 48 09](https://user-images.githubusercontent.com/6651749/48339500-498c9900-e660-11e8-95f2-9c4097fa4247.png)

**After**
![screen shot 2018-11-12 at 09 49 11](https://user-images.githubusercontent.com/6651749/48339516-50b3a700-e660-11e8-84fe-485a87b42206.png)
