### PR TITLE
Add Prepare for EU Exit section to Brexit topic

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -146,3 +146,16 @@
   text-decoration: none;
   padding-top: $gutter-one-third;
 }
+
+.taxon-page__link-list {
+  list-style-type: none;
+}
+
+.taxon-page__link-list-item {
+  @include core-19;
+  margin-bottom: 10px;
+
+  @include media(tablet) {
+    margin-bottom: 5px;
+  }
+}

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -153,7 +153,7 @@
 
 .taxon-page__link-list-item {
   @include core-19;
-  margin-bottom: 10px;
+  margin-bottom: $gutter-one-third;
 
   @include media(tablet) {
     margin-bottom: 5px;

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -37,4 +37,8 @@ class TaxonPresenter
       track_options: {},
     }
   end
+
+  def is_brexit?
+    content_id == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+  end
 end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -38,7 +38,7 @@ class TaxonPresenter
     }
   end
 
-  def is_brexit?
+  def brexit?
     content_id == "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
   end
 end

--- a/app/views/taxons/_brexit_preparation.html.erb
+++ b/app/views/taxons/_brexit_preparation.html.erb
@@ -1,0 +1,25 @@
+<div class="taxon-page__section-group taxon-page__section-group--brexit">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("taxons.brexit.prepare_for_eu_exit"),
+        heading_level: 2,
+        margin_bottom: 2
+      } %>
+    </div>
+  </div>
+  <ul class="taxon-page__link-list">
+    <li class="taxon-page__link-list-item">
+      <a href="/business-uk-leaving-eu"><%= I18n.t("taxons.brexit.business_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/prepare-eu-exit"><%= I18n.t("taxons.brexit.uk_resident_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/uk-nationals-living-eu"><%= I18n.t("taxons.brexit.uk_nationals_in_eu_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/staying-uk-eu-citizen"><%= I18n.t("taxons.brexit.eu_citizens_in_uk_preparations") %></a>
+    </li>
+  </ul>
+</div>

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
 <% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
-<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
+<% content_for :brexit_taxon, presented_taxon.brexit? %>
 <%=
   render(
     partial: 'common',

--- a/app/views/taxons/show_a.html.erb
+++ b/app/views/taxons/show_a.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
 <% content_for :is_taxon_with_subtopics, presented_taxon.show_subtopic_grid? %>
+<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
 <%=
   render(
     partial: 'common',
@@ -10,6 +11,10 @@
 %>
 
 <div class="full-page-width-wrapper">
+  <% if content_for(:brexit_taxon) %>
+    <%= render partial: 'brexit_preparation' %>
+  <% end %>
+
   <% presented_taxon.sections.each do |section| %>
     <% if section[:show_section] %>
       <div class="taxon-page__section-group">

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
+<% content_for :brexit_taxon, presented_taxon.brexit? %>
 <%=
   render(
     partial: 'common',

--- a/app/views/taxons/show_c.html.erb
+++ b/app/views/taxons/show_c.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
+<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
 <%=
   render(
     partial: 'common',
@@ -18,6 +19,9 @@
       } %>
     </div>
     <div class="column-two-thirds">
+      <% if content_for(:brexit_taxon) %>
+        <%= render partial: 'brexit_preparation' %>
+      <% end %>
       <% presented_taxon.sections.each do |section| %>
         <% if section[:show_section] %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
@@ -59,4 +63,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/taxons/show_d.html.erb
+++ b/app/views/taxons/show_d.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
+<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
 <%=
   render(
       partial: 'common',
@@ -11,6 +12,9 @@
 <div class="full-page-width-wrapper">
   <div class="grid-row">
     <div class="column-two-thirds">
+      <% if content_for(:brexit_taxon) %>
+        <%= render partial: 'brexit_preparation' %>
+      <% end %>
       <% presented_taxon.sections.each do |section| %>
         <% if section[:show_section] %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
@@ -56,4 +60,3 @@
     <% end %>
   </div>
 </div>
-

--- a/app/views/taxons/show_d.html.erb
+++ b/app/views/taxons/show_d.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :brexit_taxon, presented_taxon.is_brexit? %>
+<% content_for :brexit_taxon, presented_taxon.brexit? %>
 <%=
   render(
       partial: 'common',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,6 @@ en:
       health-and-social-care: "Includes healthcare in the EU, medicine and health insurance"
       transport: "Includes driving licences, vehicle insurance and flying to the EU"
       work: "Includes workplace rights and working in the EU"
-
   language_names:
     en: English
     cy: Cymraeg

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,12 @@ en:
     see_all_in_topic: "See more %{type} in this topic"
     in_page_nav_title: "On this page"
     in_page_sub_topic_title: "Sub-topics"
+    brexit:
+      prepare_for_eu_exit: "Prepare for EU Exit"
+      business_preparations: "Prepare your business for the UK leaving the EU"
+      uk_resident_preparations: "Prepare for EU Exit if you live in the UK"
+      uk_nationals_in_eu_preparations: "Living in Europe after the UK leaves the EU"
+      eu_citizens_in_uk_preparations: "Continue to live in the UK after it leaves the EU"
   campaign:
     email_signup: "Sign up for updates about EU Exit on all GOV.UK pages"
     see_more: "See more"
@@ -98,6 +104,7 @@ en:
       health-and-social-care: "Includes healthcare in the EU, medicine and health insurance"
       transport: "Includes driving licences, vehicle insurance and flying to the EU"
       work: "Includes workplace rights and working in the EU"
+
   language_names:
     en: English
     cy: Cymraeg

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -133,22 +133,22 @@ private
     content_store_has_item(base_path, @content_item)
   end
 
-  def and_the_taxon_has_tagged_content
+  def and_the_taxon_has_tagged_content(taxon_content_id = content_id)
     # We still need to stub tagged content because it is used by the sub-topic grid
-    stub_content_for_taxon(content_id, tagged_content)
+    stub_content_for_taxon(taxon_content_id, tagged_content)
     stub_document_types_for_supergroup('guidance_and_regulation')
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: 'guidance_and_regulation')
+    stub_most_popular_content_for_taxon(taxon_content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: 'guidance_and_regulation')
     stub_document_types_for_supergroup('services')
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: 'services')
+    stub_most_popular_content_for_taxon(taxon_content_id, tagged_content_for_services, filter_content_store_document_type: 'services')
     stub_document_types_for_supergroup('news_and_communications')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: 'news_and_communications')
+    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: 'news_and_communications')
     stub_document_types_for_supergroup('policy_and_engagement')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: 'policy_and_engagement')
+    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: 'policy_and_engagement')
     stub_document_types_for_supergroup('transparency')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: 'transparency')
+    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_transparency, filter_content_store_document_type: 'transparency')
     stub_document_types_for_supergroup('research_and_statistics')
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: 'research_and_statistics')
-    stub_organisations_for_taxon(content_id, tagged_organisations)
+    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: 'research_and_statistics')
+    stub_organisations_for_taxon(taxon_content_id, tagged_organisations)
   end
 
   def when_i_visit_that_taxon

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -61,7 +61,13 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
       and_the_taxon_has_tagged_content
       when_i_visit_that_taxon_with_variant(variant)
       see_all_links_have_tracking_data
+      and_no_navigation_to_brexit_pages
     end
+  end
+
+  it "shows Brexit navigation" do
+    given_there_is_a_brexit_taxon_which_i_visit
+    then_i_can_see_navigation_to_brexit_pages
   end
 
 private
@@ -121,6 +127,19 @@ private
 
   def given_there_is_a_taxon_without_children
     @content_item = content_item_without_children(base_path, content_id)
+  end
+
+  def given_there_is_a_brexit_taxon_which_i_visit
+    brexit_content_id = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+    brexit_taxon_path = "/a-brexit-path"
+
+    @content_item = content_item_without_children(brexit_taxon_path, brexit_content_id)
+    @content_item["phase"] = "live"
+    content_store_has_item(brexit_taxon_path, @content_item)
+
+    and_the_taxon_has_tagged_content(brexit_content_id)
+
+    visit brexit_taxon_path
   end
 
   def and_the_taxon_is_live
@@ -334,6 +353,16 @@ private
         assert_equal "{}", element["data-track-options"]
       end
     end
+  end
+
+  def then_i_can_see_navigation_to_brexit_pages
+    page.assert_selector("h2.gem-c-heading", text: "Prepare for EU Exit")
+    page.assert_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business for the UK leaving the EU")
+  end
+
+  def and_no_navigation_to_brexit_pages
+    page.assert_no_selector("h2.gem-c-heading", text: "Prepare for EU Exit")
+    page.assert_no_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business for the UK leaving the EU")
   end
 
   def then_page_has_meta_robots


### PR DESCRIPTION
This adds links to the preparation pages.

The links are now correct

https://govuk-collections-pr-964.herokuapp.com/government/brexit 
(should have the links)

https://govuk-collections-pr-964.herokuapp.com/transport
(shouldn't have the links)

![govuk-collections-pr-964 herokuapp com_government_brexit](https://user-images.githubusercontent.com/773037/50294668-49a56300-046e-11e9-9b07-41caa878da3d.png)

