### PR TITLE
Fix non-typographic apostrophe

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -13,7 +13,7 @@
 </div>
 
 <form class="filter-organisations-list__form" data-filter="form">
-  <label class="filter-organisations-list__label" for="filter-organisations-list">What's the latest<br />from</label>
+  <label class="filter-organisations-list__label" for="filter-organisations-list">What’s the latest<br />from</label>
   <input class="filter-organisations-list__input" type="text" id="filter-organisations-list" placeholder="For example, Home Office">
   <span class="filter-organisations-list__label" aria-hidden="true">?</span>
 </form>

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -24,7 +24,7 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
 
   it "renders organisation filter" do
     assert page.has_css?('.filter-organisations-list__form')
-    assert page.has_css?('.filter-organisations-list__label', text: "What's the latestfrom")
+    assert page.has_css?('.filter-organisations-list__label', text: "What’s the latestfrom")
     assert page.has_css?('.filter-organisations-list__input')
   end
 


### PR DESCRIPTION
Original change by @quis. I just added the test fix.

> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard

– http://smartquotesforsmartpeople.com

;)