### PR TITLE
Update featured taxons on the Citizen landing page

### DIFF
--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -1,7 +1,7 @@
 class BrexitTaxonsPresenter
   FEATURED_TAXONS = %w(
     /going-and-being-abroad
-    /crime-justice-and-law
+    /work
     /transport
     /environment
     /business-and-industry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,12 +89,12 @@ en:
     other_topics: "Other EU Exit topics"
     taxon_descriptions:
       business-and-industry: "Includes consumer rights, banking and selling online"
-      crime-justice-and-law: "Includes data protection and legal services"
       education: "Includes studying abroad and Erasmus+"
       environment: "Includes environmental standards and food labels"
       going-and-being-abroad: "Includes passports, pet travel and mobile roaming fees"
       health-and-social-care: "Includes healthcare in the EU, medicine and health insurance"
       transport: "Includes driving licenses, vehicle insurance and flying to the EU"
+      work: "Includes workplace rights and working in the EU"
   language_names:
     en: English
     cy: Cymraeg

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -5,7 +5,7 @@ describe BrexitTaxonsPresenter do
 
   FEATURED_TAXONS = [
     { "title" => "Going and being abroad", "base_path" => "/going-and-being-abroad" },
-    { "title" => "Crime, justice and law", "base_path" => "/crime-justice-and-law" },
+    { "title" => "Work", "base_path" => "/work" },
     { "title" => "Transport", "base_path" => "/transport" },
     { "title" => "Environment", "base_path" => "/environment" },
     { "title" => "Business and industry", "base_path" => "/business-and-industry" },


### PR DESCRIPTION
This commit swaps out the `Crime, justice and law` taxon with the `Work` taxon, which has associated content.

Solo: @karlbaker02