### PR TITLE
Content tweaks for campaign page

### DIFF
--- a/app/controllers/brexit_campaign_controller.rb
+++ b/app/controllers/brexit_campaign_controller.rb
@@ -22,7 +22,7 @@ private
       contents_list_links: [
         { text: "running a business", href: "https://euexitbusiness.campaign.gov.uk" },
         { text: "a UK national living in the EU", href: "/uk-nationals-living-eu" },
-        { text: "an EU national living in the UK", href: "/staying-uk-eu-citizen" },
+        { text: "an EU national and you want to continue living in the UK", href: "/staying-uk-eu-citizen" },
       ]
     }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,7 +83,7 @@ en:
     in_page_nav_title: "On this page"
     in_page_sub_topic_title: "Sub-topics"
   campaign:
-    email_signup: "Sign up for updates about Brexit on all GOV.UK pages"
+    email_signup: "Sign up for updates about EU Exit on all GOV.UK pages"
     see_more: "See more"
     see_more_in_taxon: "See more in %{topic}"
     other_topics: "Other EU Exit topics"


### PR DESCRIPTION
Changes:

- Change "Brexit' in email signup link to "EU Exit"
- Change other campaign text from "an EU national living in the UK" to "an EU national and you want to continue living in the UK"