### PR TITLE
Fix spacing on campaign page

### DIFF
--- a/app/views/brexit_campaign/_all_taxons.html.erb
+++ b/app/views/brexit_campaign/_all_taxons.html.erb
@@ -24,8 +24,6 @@
       </div>
     </div>
   <% else %>
-    <div class="grid-row">
-      <%= render partial: 'featured_taxons' %>
-    </div>
+    <%= render partial: 'featured_taxons' %>
   <% end %>
 </section>


### PR DESCRIPTION
The taxon grid was wider than the featured links at the bottom of the page. This PR fixes that.

## Before 
<img width="1017" alt="screen shot 2018-12-11 at 12 41 44" src="https://user-images.githubusercontent.com/29889908/49801465-2c6fe680-fd42-11e8-8765-fa67ec4b550f.png">

## After
<img width="981" alt="screen shot 2018-12-11 at 12 42 43" src="https://user-images.githubusercontent.com/29889908/49801500-44476a80-fd42-11e8-8048-6b52b46b69fa.png">