### PR TITLE
Refactor citizen landing page to improve performance

### DIFF
--- a/app/presenters/brexit_taxon_presenter.rb
+++ b/app/presenters/brexit_taxon_presenter.rb
@@ -1,29 +1,29 @@
 class BrexitTaxonPresenter
-  attr_reader :taxon
+  attr_reader :taxon_content_item
   delegate(
     :title,
     :base_path,
-    to: :taxon
+    to: :taxon_content_item
   )
 
-  def initialize(taxon, index = nil)
-    @taxon = taxon
+  def initialize(taxon_content_item, index = nil)
+    @taxon_content_item = taxon_content_item
     @index = index
   end
 
   def description
-    I18n.t("campaign.taxon_descriptions.#{taxon.base_path.delete('/')}")
+    I18n.t("campaign.taxon_descriptions.#{taxon_content_item.base_path.delete('/')}")
   end
 
   def finder_link
-    "/prepare-eu-exit#{taxon.base_path}"
+    "/prepare-eu-exit#{taxon_content_item.base_path}"
   end
 
   def data_attributes
     {
       "track-category": "navGridContentClicked",
       "track-action": @index,
-      "track-label": taxon.title
+      "track-label": taxon_content_item.title
     }
   end
 end

--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -14,9 +14,13 @@ class BrexitTaxonsPresenter
 
   def featured_taxons
     @featured_taxons ||= FEATURED_TAXONS
-      .map { |base_path| ContentItem.find!(base_path) }
-      .each_with_index
-      .map { |content_item, index| BrexitTaxonPresenter.new(content_item, index) }
+      .to_enum
+      .with_index(1)
+      .map do |base_path, index|
+        content_item = ContentItem.find!(base_path)
+
+        BrexitTaxonPresenter.new(content_item, index)
+      end
   end
 
   def other_taxons

--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -10,9 +10,9 @@ class BrexitTaxonsPresenter
 
   def featured_taxons
     @featured_taxons ||= FEATURED_TAXONS
-      .map { |base_path| Taxon.find(base_path) }
-      .map
-      .with_index(1) { |taxon, index| BrexitTaxonPresenter.new(taxon, index) }
+      .map { |base_path| ContentItem.find!(base_path) }
+      .each_with_index
+      .map { |content_item, index| BrexitTaxonPresenter.new(content_item, index) }
   end
 
   def other_taxons
@@ -21,8 +21,7 @@ class BrexitTaxonsPresenter
       .reject { |content_item| FEATURED_TAXONS.include?(content_item.base_path) }
       .reject { |content_item| content_item.base_path == "/government/all" }
       .select { |content_item| search_response_including_brexit(content_item.content_id, document_types).total.positive? }
-      .map { |content_item| Taxon.find(content_item.base_path) }
-      .map { |taxon| BrexitTaxonPresenter.new(taxon) }
+      .map { |content_item| BrexitTaxonPresenter.new(content_item) }
   end
 
 private

--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -8,6 +8,10 @@ class BrexitTaxonsPresenter
     /education
   ).freeze
 
+  REJECTED_TAXONS = %w(
+    /government/all
+  ).freeze
+
   def featured_taxons
     @featured_taxons ||= FEATURED_TAXONS
       .map { |base_path| ContentItem.find!(base_path) }
@@ -19,7 +23,7 @@ class BrexitTaxonsPresenter
     @other_taxons ||= ContentItem.find!('/')
       .linked_items('level_one_taxons')
       .reject { |content_item| FEATURED_TAXONS.include?(content_item.base_path) }
-      .reject { |content_item| content_item.base_path == "/government/all" }
+      .reject { |content_item| REJECTED_TAXONS.include?(content_item.base_path) }
       .select { |content_item| search_response_including_brexit(content_item.content_id, document_types).total.positive? }
       .map { |content_item| BrexitTaxonPresenter.new(content_item) }
   end

--- a/test/presenters/brexit_taxon_presenter_test.rb
+++ b/test/presenters/brexit_taxon_presenter_test.rb
@@ -5,8 +5,7 @@ describe BrexitTaxonPresenter do
 
   let(:content_hash) { education_taxon }
   let(:content_item) { ContentItem.new(content_hash) }
-  let(:taxon) { Taxon.new(ContentItem.new(content_hash)) }
-  let(:presenter) { described_class.new(taxon) }
+  let(:presenter) { described_class.new(content_item) }
 
   describe '#finder_link' do
     it 'should return a link for the finder' do

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -12,7 +12,7 @@ describe BrexitTaxonsPresenter do
     { "title" => "Education", "base_path" => "/education" }
   ].freeze
 
-  REJECTED_TAXONS = [{"title" => "Government", "base_path" => "/government/all" }].freeze
+  REJECTED_TAXONS = [{ "title" => "Government", "base_path" => "/government/all" }].freeze
 
   let(:presenter) { described_class.new }
 

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -12,7 +12,7 @@ describe BrexitTaxonsPresenter do
     { "title" => "Education", "base_path" => "/education" }
   ].freeze
 
-  GOV_TAXONS = [{ "title" => "Government", "base_path" => "/government/all" }].freeze
+  REJECTED_TAXONS = [{"title" => "Government", "base_path" => "/government/all" }].freeze
 
   let(:presenter) { described_class.new }
 
@@ -35,12 +35,30 @@ describe BrexitTaxonsPresenter do
   end
 
   describe '#other_taxons' do
+    it 'should not process featured taxons when featured taxons are included in the content item' do
+      ContentItem.stubs(:find!)
+        .with('/')
+        .returns(ContentItem.new("links" => { "level_one_taxons" => FEATURED_TAXONS }))
+
+      Services.rummager.stubs(:search).never
+
+      presenter.other_taxons
+    end
+
+    it 'should not process rejected taxons when rejected taxons are included in the content item' do
+      ContentItem.stubs(:find!)
+        .with('/')
+        .returns(ContentItem.new("links" => { "level_one_taxons" => REJECTED_TAXONS }))
+
+      Services.rummager.stubs(:search).never
+
+      presenter.other_taxons
+    end
+
     it 'should return empty array when no other level one taxons have content tagged to Brexit' do
       ContentItem.stubs(:find!)
         .with('/')
-        .returns(ContentItem.new("links" => { "level_one_taxons" => [FEATURED_TAXONS, GOV_TAXONS].flatten }))
-
-      Services.rummager.stubs(:search).returns("total" => 0)
+        .returns(ContentItem.new("links" => { "level_one_taxons" => [FEATURED_TAXONS, REJECTED_TAXONS].flatten }))
 
       other_taxons = presenter.other_taxons
 
@@ -54,9 +72,9 @@ describe BrexitTaxonsPresenter do
 
       ContentItem.stubs(:find!)
         .with('/')
-        .returns(ContentItem.new("links" => { "level_one_taxons" => [FEATURED_TAXONS, GOV_TAXONS, OTHER_TAXONS].flatten }))
+        .returns(ContentItem.new("links" => { "level_one_taxons" => [FEATURED_TAXONS, REJECTED_TAXONS, OTHER_TAXONS].flatten }))
 
-      Services.rummager.stubs(:search).returns("total" => 1)
+      Services.rummager.stubs(:search).times(OTHER_TAXONS.count).returns("total" => 1)
 
       other_taxons = presenter.other_taxons
 

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -19,9 +19,9 @@ describe BrexitTaxonsPresenter do
   describe '#featured_taxons' do
     it 'should return the featured taxons presenters' do
       FEATURED_TAXONS.each do |taxon|
-        Taxon.stubs(:find)
+        ContentItem.stubs(:find!)
           .with(taxon.fetch('base_path'))
-          .returns(Taxon.new(ContentItem.new(generic_taxon(taxon.fetch('base_path')))))
+          .returns(ContentItem.new(generic_taxon(taxon.fetch('base_path'))))
       end
 
       featured_taxons = presenter.featured_taxons
@@ -51,12 +51,6 @@ describe BrexitTaxonsPresenter do
       OTHER_TAXONS = [
         { "title" => "Brexit guidance", "base_path" => "/brexit-guidance" }
       ].freeze
-
-      OTHER_TAXONS.each do |taxon|
-        Taxon.stubs(:find)
-          .with(taxon.fetch('base_path'))
-          .returns(Taxon.new(ContentItem.new(generic_taxon(taxon.fetch('base_path')))))
-      end
 
       ContentItem.stubs(:find!)
         .with('/')


### PR DESCRIPTION
This PR refactors the citizen landing page to remove the need to create new `Topic` instances, instead using `ContentItem` data. For `other_taxons` in `BrexitTaxonsPresenter`, the `ContentItem` of `/` can be used directly to create `ContentItem`s and remove the need for any additional calls to the Content Store.