### PR TITLE
Add foreign travel advice index page to results

### DIFF
--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -45,6 +45,6 @@ private
   end
 
   def document_types
-    GovukDocumentTypes.supergroup_document_types('guidance_and_regulation', 'services')
+    %w(travel_advice_index) + GovukDocumentTypes.supergroup_document_types('guidance_and_regulation', 'services')
   end
 end


### PR DESCRIPTION
We want this to appear when it is appropriately tagged.

https://trello.com/c/UDfCG0jA/184-add-foreign-travel-advice-index-to-going-abroad-finder