### PR TITLE
Facet taxon search for "other taxons"

### DIFF
--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -41,6 +41,10 @@ class RummagerSearch
     search_result["start"]
   end
 
+  def facets
+    search_result["facets"]
+  end
+
   def organisations
     @organisations ||= search_result.dig('aggregates', 'organisations', 'options').map do |option|
       organisation = option['value']

--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -1,4 +1,6 @@
 class BrexitTaxonsPresenter
+  CITIZEN_TAXON_CONTENT_ID = 'd7bdaee2-8ea5-460e-b00d-6e9382eb6b61'.freeze
+
   FEATURED_TAXONS = %w(
     /going-and-being-abroad
     /work
@@ -28,20 +30,27 @@ class BrexitTaxonsPresenter
       .linked_items('level_one_taxons')
       .reject { |content_item| FEATURED_TAXONS.include?(content_item.base_path) }
       .reject { |content_item| REJECTED_TAXONS.include?(content_item.base_path) }
-      .select { |content_item| search_response_including_brexit(content_item.content_id, document_types).total.positive? }
+      .select { |content_item| taxon_ids_with_citizen_tagged_content.include?(content_item.content_id) }
       .map { |content_item| BrexitTaxonPresenter.new(content_item) }
   end
 
 private
 
-  def search_response_including_brexit(content_id, filter_content_store_document_type)
-    params = {
-      count: 1,
-      fields: %w(title link),
-      filter_all_part_of_taxonomy_tree: [content_id, 'd7bdaee2-8ea5-460e-b00d-6e9382eb6b61'],
-      filter_content_store_document_type: filter_content_store_document_type
-    }
-    RummagerSearch.new(params)
+  def taxon_ids_with_citizen_tagged_content
+    @taxon_ids_with_citizen_tagged_content ||= begin
+      params = {
+        count: 0,
+        facet_part_of_taxonomy_tree: "1000,examples:0,scope:all_filters",
+        filter_taxons: CITIZEN_TAXON_CONTENT_ID,
+        filter_content_store_document_type: document_types
+      }
+
+      search_result = RummagerSearch.new(params)
+
+      search_result.facets["part_of_taxonomy_tree"]["options"].map do |item|
+        item.dig("value", "slug")
+      end
+    end
   end
 
   def document_types

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-bundle install
+bundle check || bundle install
 
 if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -4,12 +4,12 @@ describe BrexitTaxonsPresenter do
   include TaxonHelpers
 
   FEATURED_TAXONS = [
-    { "title" => "Going and being abroad", "base_path" => "/going-and-being-abroad" },
-    { "title" => "Work", "base_path" => "/work" },
-    { "title" => "Transport", "base_path" => "/transport" },
-    { "title" => "Environment", "base_path" => "/environment" },
-    { "title" => "Business and industry", "base_path" => "/business-and-industry" },
-    { "title" => "Education", "base_path" => "/education" }
+    { "title" => "Going and being abroad", "base_path" => "/going-and-being-abroad", "content_id" => "going-taxon-id" },
+    { "title" => "Work", "base_path" => "/work", "content_id" => "work-taxon-id" },
+    { "title" => "Transport", "base_path" => "/transport", "content_id" => "transport-taxon-id" },
+    { "title" => "Environment", "base_path" => "/environment", "content_id" => "environment-taxon-id" },
+    { "title" => "Business and industry", "base_path" => "/business-and-industry", "content_id" => "business-taxon-id" },
+    { "title" => "Education", "base_path" => "/education", "content_id" => "education-taxon-id" }
   ].freeze
 
   REJECTED_TAXONS = [{ "title" => "Government", "base_path" => "/government/all" }].freeze
@@ -67,14 +67,42 @@ describe BrexitTaxonsPresenter do
 
     it 'should return other level one taxons tagged to Brexit when these exist' do
       OTHER_TAXONS = [
-        { "title" => "Brexit guidance", "base_path" => "/brexit-guidance" }
+        { "title" => "Brexit guidance", "base_path" => "/brexit-guidance", "content_id" => "first-content-id" }
       ].freeze
 
       ContentItem.stubs(:find!)
         .with('/')
         .returns(ContentItem.new("links" => { "level_one_taxons" => [FEATURED_TAXONS, REJECTED_TAXONS, OTHER_TAXONS].flatten }))
 
-      Services.rummager.stubs(:search).times(OTHER_TAXONS.count).returns("total" => 1)
+      Services.rummager.stubs(:search).returns(
+        "results" => [],
+        "total" => 34,
+        "start" => 0,
+        "facets" => {
+          "part_of_taxonomy_tree" => {
+            "options" => [
+              {
+                "value" => {
+                  "slug" => "first-content-id"
+                },
+                "documents" => 12
+              },
+              {
+                "value" => {
+                  "slug" => "second-content-id"
+                },
+                "documents" => 10
+              },
+              {
+                "value" => {
+                  "slug" => "third-content-id"
+                },
+                "documents" => 5
+              }
+            ]
+          }
+        }
+      )
 
       other_taxons = presenter.other_taxons
 


### PR DESCRIPTION
This reduces the number of queries that we need to do to find relevant taxon
topics (that aren't featured or excluded) from 13 to 1.

It generates a query like this:
https://www.gov.uk/api/search.json?filter_taxons=d7bdaee2-8ea5-460e-b00d-6e9382eb6b61&fields=link&count=0&facet_part_of_taxonomy_tree=1000,examples:0,scope:all_filters
which gets the content ids of all taxons that have content that is also tagged
to the topic that is filtered by.

The response looks like this:
```
{
  "results": [],
  "total": 34,
  "start": 0,
  "facets": {
    "part_of_taxonomy_tree": {
      "options": [
        {
          "value": {
            "slug": "d7bdaee2-8ea5-460e-b00d-6e9382eb6b61"
          },
          "documents": 34
        },
        {
          "value": {
          "slug": "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
          },
          "documents": 34
        }
      ]
    }
  }
}
```

In testing, this query typically took 0.025 seconds on staging.

I've had to rejig the `select` process now, as we're matching on content_id,
but it should be a bit quicker, and more reliable because we're making fewer
network requests.
