### PR TITLE
Update headings on organisation pages

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -97,17 +97,16 @@ module Organisations
       all_documents.each do |document_group|
         document_group.each do |document_type, documents|
           if documents[:items].length.positive?
-            translated_document_type = I18n.t("organisations.document_types.#{document_type}")
             documents[:items].push(
               link: {
-                text: I18n.t('organisations.document_types.see_all_documents', type: translated_document_type),
+                text: I18n.t(:see_all, scope: [:organisations, :document_types, document_type]),
                 path: "/government/#{document_type}?departments%5B%5D=#{@org.slug}"
               }
             )
 
             formatted_documents << {
               documents: documents,
-              title: I18n.t("organisations.document_types.our_#{document_type}"),
+              title: I18n.t(:title, scope: [:organisations, :document_types, document_type]),
             }
           end
         end

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -7,10 +7,6 @@ module Organisations
       @org = organisation
     end
 
-    def featured_news_title
-      I18n.t('organisations.featured_news', title: prefixed_title)
-    end
-
     def prefixed_title
       prefix = needs_definite_article?(@org.title) ? "the " : ""
       (prefix + @org.title)

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -1,5 +1,14 @@
-<section class="organisation__section-wrap organisation__margin-bottom" id="featured-documents">
-  <h2 class="visually-hidden"><%= @show.featured_news_title %></h2>
+<section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom" id="featured-documents">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+          text: I18n.t('organisations.featured'),
+          padding: true,
+          margin_bottom: 2
+      } %>
+    </div>
+  </div>
+
   <% if @organisation.is_news_organisation? %>
     <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>
   <% end %>

--- a/app/views/organisations/_latest_documents_by_type.html.erb
+++ b/app/views/organisations/_latest_documents_by_type.html.erb
@@ -1,11 +1,9 @@
 <section class="<%= "brand--#{@organisation.brand} brand__border-color" if @organisation.is_live? %> organisation__brand-border-top organisation__margin-bottom">
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
+  <div class="visually-hidden">
+    <%= render "govuk_publishing_components/components/heading", {
         text: t('organisations.document_types.documents'),
         padding: true
-      } %>
-    </div>
+    } %>
   </div>
 
   <% @documents.latest_documents_by_type.in_groups_of(2, false) do |documents_group| %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -22,6 +22,7 @@ cy:
       our_publications: "Ein cyhoeddiadau"
       our_statistics: "Ein hystadegau"
       see_all_documents: "Gweld ein holl %{type}"
+    featured: "Sylw"
     foi:
       make_an_foi_request: Gwneud cais DRhG
       freedom_of_information_act: Freedom of Information (FOI) Act

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -13,15 +13,18 @@ cy:
     corporate_information: "Gwybodaeth gorfforaethol"
     document_types:
       documents: "Dogfennau"
-      announcements: "cyhoeddiadau"
-      consultations: "ymgynghoriadau"
-      publications: "cyhoeddiadau"
-      statistics: "hystadegau"
-      our_announcements: "Ein cyhoeddiadau"
-      our_consultations: "Ein ymgynghoriadau"
-      our_publications: "Ein cyhoeddiadau"
-      our_statistics: "Ein hystadegau"
-      see_all_documents: "Gweld ein holl %{type}"
+      announcements:
+        title: "Cyhoeddiadau"
+        see_all: "Gweld ein holl cyhoeddiadau"
+      consultations:
+        title: "Ymgynghoriadau"
+        see_all: "Gweld ein holl ymgynghoriadau"
+      publications:
+        title: "Cyhoeddiadau"
+        see_all: "Gweld ein holl cyhoeddiadau"
+      statistics:
+        title: "Hystadegau"
+        see_all: "Gweld ein holl hystadegau"
     featured: "Sylw"
     foi:
       make_an_foi_request: Gwneud cais DRhG

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,7 +20,7 @@ en:
       our_publications: "Our publications"
       our_statistics: "Our statistics"
       see_all_documents: "See all %{type}"
-    featured_news: "What %{title} is doing"
+    featured: "Featured"
     foi:
       make_an_foi_request: Make an FOI request
       freedom_of_information_act: Freedom of Information (FOI) Act

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,15 +11,18 @@ en:
     corporate_information: "Corporate information"
     document_types:
       documents: "Documents"
-      announcements: "announcements"
-      consultations: "consultations"
-      publications: "publications"
-      statistics: "statistics"
-      our_announcements: "Our announcements"
-      our_consultations: "Our consultations"
-      our_publications: "Our publications"
-      our_statistics: "Our statistics"
-      see_all_documents: "See all %{type}"
+      announcements:
+        title: "Announcements"
+        see_all: "See all announcements"
+      consultations:
+        title: "Consultations"
+        see_all: "See all consultations"
+      publications:
+        title: "Publications"
+        see_all: "See all publications"
+      statistics:
+        title: "Statistics"
+        see_all: "See all statistics"
     featured: "Featured"
     foi:
       make_an_foi_request: Make an FOI request

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -321,15 +321,15 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
   it "shows latest documents by type on separate website page" do
     visit "/government/organisations/fire-service-college"
     assert page.has_css?(".gem-c-heading", text: "Documents")
-    assert page.has_css?(".gem-c-heading", text: "Our announcements")
+    assert page.has_css?(".gem-c-heading", text: "Announcements")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/first-events-announced-for-national-democracy-week']", text: "First events announced for National Democracy Week")
 
-    assert page.has_css?(".gem-c-heading", text: "Our consultations")
+    assert page.has_css?(".gem-c-heading", text: "Consultations")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/consultations/consultation-on-revised-code-of-data-matching-practice']", text: "Consultation on revised Code of Data Matching Practice")
 
-    assert page.has_css?(".gem-c-heading", text: "Our publications")
+    assert page.has_css?(".gem-c-heading", text: "Publications")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/publications/national-democracy-week-partner-pack']", text: "National Democracy Week: partner pack")
 
-    refute page.has_css?(".gem-c-heading", text: "Our statistics")
+    refute page.has_css?(".gem-c-heading", text: "Statistics")
   end
 end

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -640,16 +640,16 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/attorney-generals-office"
     assert page.has_css?(".gem-c-heading", text: "Documents")
 
-    assert page.has_css?(".gem-c-heading", text: "Our announcements")
+    assert page.has_css?(".gem-c-heading", text: "Announcements")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/first-events-announced-for-national-democracy-week']", text: "First events announced for National Democracy Week")
 
-    assert page.has_css?(".gem-c-heading", text: "Our consultations")
+    assert page.has_css?(".gem-c-heading", text: "Consultations")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/consultations/consultation-on-revised-code-of-data-matching-practice']", text: "Consultation on revised Code of Data Matching Practice")
 
-    assert page.has_css?(".gem-c-heading", text: "Our publications")
+    assert page.has_css?(".gem-c-heading", text: "Publications")
     assert page.has_css?(".gem-c-document-list__item-title[href='/government/publications/national-democracy-week-partner-pack']", text: "National Democracy Week: partner pack")
 
-    refute page.has_css?(".gem-c-heading", text: "Our statistics")
+    refute page.has_css?(".gem-c-heading", text: "Statistics")
   end
 
   it "does not show the latest documents by type section if there are none" do

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -123,7 +123,7 @@ describe Organisations::DocumentsPresenter do
             ],
             brand: "attorney-generals-office"
           },
-          title: "Our announcements"
+          title: "Announcements"
         }
 
       assert_equal expected, @documents_presenter.latest_documents_by_type[0]
@@ -153,7 +153,7 @@ describe Organisations::DocumentsPresenter do
             ],
             brand: "attorney-generals-office"
           },
-          title: "Our consultations"
+          title: "Consultations"
         }
 
       assert_equal expected, @documents_presenter.latest_documents_by_type[1]
@@ -183,7 +183,7 @@ describe Organisations::DocumentsPresenter do
             ],
             brand: "attorney-generals-office"
           },
-          title: "Our publications"
+          title: "Publications"
         }
 
       assert_equal expected, @documents_presenter.latest_documents_by_type[2]


### PR DESCRIPTION
- Adds a "Featured" heading to the featured section
- Removes "Our" prefix from document type lists, this will make it easier to swap these lists for supergroup based lists.

#### Before:

![department for education - gov uk 2018-12-20 10-44-17](https://user-images.githubusercontent.com/2715/50280395-46957d00-0444-11e9-8784-e157788b0f84.png)

#### After:

![department for education - gov uk 2018-12-20 10-43-59](https://user-images.githubusercontent.com/2715/50280403-4bf2c780-0444-11e9-9584-d3edd312f2a7.png)

Part of https://trello.com/c/fZM6JhkU & https://trello.com/c/qlWbwW4q