### PR TITLE
Include organisation description meta tags

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,6 +18,10 @@ class Organisation
     @content_item.content_item_data["title"]
   end
 
+  def description
+    @content_item.content_item_data["description"]
+  end
+
   def acronym
     details["acronym"]
   end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, organisation.title %>
 
 <% content_for :meta_tags do %>
+  <%= tag("meta", name: "description", content: organisation.description) if organisation.description %>
   <%= auto_discovery_link_tag(:json, api_organisation_url(organisation.slug), title: organisation.title) %>
   <%= auto_discovery_link_tag(:atom, feed_organisation_url(organisation.slug, format: :atom), title: organisation.title) %>
 <% end %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -8,6 +8,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     @content_item_no10 = {
       title: "Prime Minister's Office, 10 Downing Street",
+      description: "10 Downing Street is the official residence of the British Prime Minister.",
       base_path: "/government/organisations/prime-ministers-office-10-downing-street",
       details: {
         body: "10 Downing Street is the official residence and the office of the British Prime Minister.",
@@ -510,8 +511,10 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".content")
   end
 
-  it "has autodiscovery links to the RSS feed and the API" do
+  it "includes description and autodiscovery meta tags" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
+
+    page.assert_selector("meta[name='description'][content='10 Downing Street is the official residence of the British Prime Minister.']", visible: false)
     assert page.has_css?("link[rel='alternate'][type='application/json'][href$='/api/organisations/prime-ministers-office-10-downing-street']", visible: false)
     assert page.has_css?("link[rel='alternate'][type='application/atom+xml'][href$='/government/organisations/prime-ministers-office-10-downing-street.atom']", visible: false)
   end


### PR DESCRIPTION
We don't currently include these.  Related to, but not reliant upon https://github.com/alphagov/whitehall/pull/4569