### PR TITLE
Fix intermittent test failures

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,10 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::Rummager
 
+  setup do
+    I18n.locale = :en
+  end
+
   after do
     WebMock.reset!
   end


### PR DESCRIPTION
Sometimes tests get in a slightly funny state and inherit the wrong locale from the previous test.  Given that the default locale is :en and is only changed if the request path has a ".cy" on the end it seems fine to ensure that this is the case in tests.

This is a similar approach to that taken in [calendars](https://github.com/alphagov/calendars/blob/2350910bb6d29bf023b89d1dbfd4e734e5539d81/test/test_helper.rb#L27)

[An example of a test that has got stuck in the wrong language](https://ci.integration.publishing.service.gov.uk/job/collections/job/master/797/console)