### PR TITLE
Correct rummager env var in dummy mode

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -14,7 +14,7 @@ elif [[ $1 == "--dummy" ]] ; then
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://govuk-content-store-examples.herokuapp.com/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3070
 else
   bundle exec rails s -p 3070


### PR DESCRIPTION
PLEK_SERVICE_SEARCH_URI is the correct environment variable, as
Plek looks for _search_ rather than _rummager_. The --live mode
is already correct.