### PR TITLE
Allow the URLs for organisation finders to be configured

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -99,8 +99,16 @@ module Organisations
           if documents[:items].length.positive?
             documents[:items].push(
               link: {
-                text: I18n.t(:see_all, scope: [:organisations, :document_types, document_type]),
-                path: "/government/#{document_type}?departments%5B%5D=#{@org.slug}"
+                text: I18n.t(
+                  :text,
+                  organisation: @org.slug,
+                  scope: [:organisations, :document_types, document_type, :see_all],
+                ),
+                path: I18n.t(
+                  :path,
+                  organisation: @org.slug,
+                  scope: [:organisations, :document_types, document_type, :see_all],
+                ),
               }
             )
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -15,16 +15,24 @@ cy:
       documents: "Dogfennau"
       announcements:
         title: "Cyhoeddiadau"
-        see_all: "Gweld ein holl cyhoeddiadau"
+        see_all:
+          text: "Gweld ein holl cyhoeddiadau"
+          path: "/government/announcements?departments[]=%{organisation}"
       consultations:
         title: "Ymgynghoriadau"
-        see_all: "Gweld ein holl ymgynghoriadau"
+        see_all:
+          text: "Gweld ein holl ymgynghoriadau"
+          path: "/government/consultations?departments[]=%{organisation}"
       publications:
         title: "Cyhoeddiadau"
-        see_all: "Gweld ein holl cyhoeddiadau"
+        see_all:
+          text: "Gweld ein holl cyhoeddiadau"
+          path: "/government/publications?departments[]=%{organisation}"
       statistics:
         title: "Hystadegau"
-        see_all: "Gweld ein holl hystadegau"
+        see_all:
+          text: "Gweld ein holl hystadegau"
+          path: "/government/statistics?departments[]=%{organisation}"
     featured: "Sylw"
     foi:
       make_an_foi_request: Gwneud cais DRhG

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,16 +13,24 @@ en:
       documents: "Documents"
       announcements:
         title: "Announcements"
-        see_all: "See all announcements"
+        see_all:
+          text: "See all announcements"
+          path: "/government/announcements?departments[]=%{organisation}"
       consultations:
         title: "Consultations"
-        see_all: "See all consultations"
+        see_all:
+          text: "See all consultations"
+          path: "/government/consultations?departments[]=%{organisation}"
       publications:
         title: "Publications"
-        see_all: "See all publications"
+        see_all:
+          text: "See all publications"
+          path: "/government/publications?departments[]=%{organisation}"
       statistics:
         title: "Statistics"
-        see_all: "See all statistics"
+        see_all:
+          text: "See all statistics"
+          path: "/government/statistics?departments[]=%{organisation}"
     featured: "Featured"
     foi:
       make_an_foi_request: Make an FOI request

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -117,7 +117,7 @@ describe Organisations::DocumentsPresenter do
               {
                 link: {
                   text: "See all announcements",
-                  path: "/government/announcements?departments%5B%5D=attorney-generals-office"
+                  path: "/government/announcements?departments[]=attorney-generals-office"
                 }
               }
             ],
@@ -147,7 +147,7 @@ describe Organisations::DocumentsPresenter do
               {
                 link: {
                   text: "See all consultations",
-                  path: "/government/consultations?departments%5B%5D=attorney-generals-office"
+                  path: "/government/consultations?departments[]=attorney-generals-office"
                 }
               }
             ],
@@ -177,7 +177,7 @@ describe Organisations::DocumentsPresenter do
               {
                 link: {
                   text: "See all publications",
-                  path: "/government/publications?departments%5B%5D=attorney-generals-office"
+                  path: "/government/publications?departments[]=attorney-generals-office"
                 }
               }
             ],


### PR DESCRIPTION
Moves the URL configuration into the locale files. This allows greater configuration and no longer forces the finder URL convention which is not compatible with the new finder URLs.

See https://trello.com/c/fZM6JhkU and https://trello.com/c/loZpQ8we
Review https://govuk-collections-pr-1004.herokuapp.com/government/organisations/cabinet-office