### PR TITLE
Get consultation closing dates from rummager

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,6 +8,7 @@ class Document
     :description,
     :base_path,
     :public_updated_at,
+    :end_date,
     :change_note,
     :format,
     :content_store_document_type,

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -17,6 +17,7 @@ class RummagerSearch
         description: result["description"],
         base_path: result["link"],
         public_updated_at: timestamp,
+        end_date: result["end_date"],
         change_note: result["latest_change_note"],
         format: result["format"],
         content_store_document_type: result['content_store_document_type'],

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -24,13 +24,8 @@ module Supergroups
       )
     end
 
-    def consultation_closing_date(base_path)
-      @consultation = ::Services.content_store.content_item(base_path)
-
-      # Don't continue if the Content Store returned something unexpected
-      return if @consultation["base_path"] != base_path
-
-      date = Date.parse(@consultation["details"]["closing_date"])
+    def consultation_closing_date(consultation)
+      date = Date.parse(consultation.end_date)
 
       if date < Time.zone.today
         return date.strftime("Date closed %d %B %Y")
@@ -67,7 +62,7 @@ module Supergroups
         }
 
         if consultation?(document.content_store_document_type)
-          data[:metadata][:closing_date] = consultation_closing_date(document.base_path)
+          data[:metadata][:closing_date] = consultation_closing_date(document)
         end
 
         if data_category.present?

--- a/app/services/rummager_fields.rb
+++ b/app/services/rummager_fields.rb
@@ -4,6 +4,7 @@ module RummagerFields
                            description
                            content_store_document_type
                            public_timestamp
+                           end_date
                            organisations
                            image_url).freeze
 

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -17,17 +17,6 @@ describe Supergroups::PolicyAndEngagement do
     end
 
     describe 'consultations' do
-      before do
-        content = content_item_for_base_path('/government/tagged/content').merge(
-          "details": {
-            "body": "",
-            "closing_date": "2017-07-10T23:45:00.000+00:00"
-          }
-        )
-
-        content_store_has_item('/government/tagged/content', content)
-      end
-
       it 'prioritises consultations over other content' do
         tagged_document_list = %w(
           open_consultation
@@ -67,6 +56,7 @@ describe Supergroups::PolicyAndEngagement do
             title: 'Tagged Content Title',
             description: 'Description of tagged content',
             public_updated_at: '2018-02-28T08:01:00.000+00:00',
+            end_date: '2018-07-10T23:45:00.000+00:00',
             base_path: '/government/tagged/content-1',
             content_store_document_type: 'open_consultation',
             organisations: 'Tagged Content Organisation'
@@ -75,15 +65,6 @@ describe Supergroups::PolicyAndEngagement do
           MostRecentContent.any_instance
             .stubs(:fetch)
             .returns([document])
-
-          content = content_item_for_base_path('/government/tagged/content-1').merge(
-            "details": {
-              "body": "",
-              "closing_date": "2018-07-10T23:45:00.000+00:00"
-            }
-          )
-
-          content_store_has_item('/government/tagged/content-1', content)
 
           expected = [
             {
@@ -158,7 +139,7 @@ private
     }
 
     if consultation?(document_type)
-      result[:metadata][:closing_date] = 'Date closed 10 July 2017'
+      result[:metadata][:closing_date] = 'Date closed 28 August 2018'
     end
 
     [result]

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -255,17 +255,23 @@ module RummagerHelpers
   def section_tagged_content_list(doc_type, count = 1)
     content_list = []
 
+    params = {
+      title: 'Tagged Content Title',
+      description: 'Description of tagged content',
+      public_updated_at: '2018-02-28T08:01:00.000+00:00',
+      base_path: '/government/tagged/content',
+      content_store_document_type: doc_type,
+      organisations: 'Tagged Content Organisation',
+      image_url: 'an/image/path'
+    }
+
+    if doc_type.include?("consultation")
+      params[:end_date] = '2018-08-28T08:01:00.000+01:00'
+    end
+
     count.times do
       content_list.push(
-        Document.new(
-          title: 'Tagged Content Title',
-          description: 'Description of tagged content',
-          public_updated_at: '2018-02-28T08:01:00.000+00:00',
-          base_path: '/government/tagged/content',
-          content_store_document_type: doc_type,
-          organisations: 'Tagged Content Organisation',
-          image_url: 'an/image/path'
-        )
+        Document.new(params)
       )
     end
 


### PR DESCRIPTION
Topic pages currently look up consultation closing date information from content store, which means up to 5 extra api requests are required to render a page.  By bundling this information in the initial rummager request we can skip all of this.

This should speed up page rendering (particularly when content store is slow), as well as making the render process more robust as we need to make fewer api requests.

Consultation closing dates are shown in the "Policy papers and consultations" sections on pages such as https://www.gov.uk/education and https://gov.uk/transport/road-infrastructure.  

This was added to Whitehall in https://github.com/alphagov/whitehall/pull/4611 (and all consultations have been reindexed) so all the information should be present in rummager.

Example pages (should look identical to current live versions): 
- https://govuk-collections-pr-1016.herokuapp.com/education
- https://govuk-collections-pr-1016.herokuapp.com/transport/road-infrastructure

I deployed this to staging for 10 minutes or so (16:30ish to 16:40ish) and the percentiles for page duration show an immediate improvement:

![screenshot 2019-01-25 16 50 02](https://user-images.githubusercontent.com/773037/51759974-6104eb00-20c1-11e9-8c58-9da19b7fe637.png)
