### PR TITLE
Catch incorrect organisation api requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
     get "/organisations/:organisation_name",
       to: "organisations_api#show",
       as: :api_organisation
+
+    get "/organisations/*other_route", to: proc { [404, { }, ["404 error"]] }
   end
 
   get "/courts-tribunals/:organisation_name(.:locale)",

--- a/test/integration/organisations_api_route_test.rb
+++ b/test/integration/organisations_api_route_test.rb
@@ -1,0 +1,10 @@
+require 'integration_test_helper'
+
+class OrganisationApiRouteTest < ActionDispatch::IntegrationTest
+  it "should respond with '404 for a bad route'" do
+    get "/api/organisations/bad/route", as: :json
+
+    assert_equal 404, response.status
+    assert_equal "404 error", response.body
+  end
+end


### PR DESCRIPTION
`/api/organisations` is a prefix route so can get some odd things sent to it which at present fall through to the taxons catch all at the bottom of routes.rb resulting in a `500` error.

The largest cause of errors in collections over the last week has been this issue:
<img width="568" alt="screenshot 2019-01-28 09 44 34" src="https://user-images.githubusercontent.com/773037/51827449-55900a80-22e1-11e9-8bcf-4f2c87fe4174.png">

It's best if we can avoid 500s for incorrect user requests, so let's catch them where we can.  This is a naive attempt which rejects things that are under the api namespace, but haven't matched the simple route of `/api/organisations/<org-name>`.
