### PR TITLE
Reduce duplicate content store requests

### DIFF
--- a/app/controllers/latest_changes_controller.rb
+++ b/app/controllers/latest_changes_controller.rb
@@ -28,7 +28,7 @@ private
   end
 
   def subtopic
-    Topic.find(subtopic_base_path, pagination_params)
+    @subtopic ||= Topic.find(subtopic_base_path, pagination_params)
   end
 
   # Breadcrumbs for this page are hardcoded because it doesn't have a

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -33,7 +33,7 @@ private
   end
 
   def page
-    MainstreamBrowsePage.find(
+    @page ||= MainstreamBrowsePage.find(
       "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}"
     )
   end

--- a/app/controllers/services_and_information_controller.rb
+++ b/app/controllers/services_and_information_controller.rb
@@ -15,7 +15,7 @@ private
   end
 
   def service_and_information
-    ServiceAndInformation.find!(base_path)
+    @service_and_information ||= ServiceAndInformation.find!(base_path)
   end
 
   def grouped_links


### PR DESCRIPTION
A few of the controllers aren't memoizing the content item when it's returned.  This results in the same request being resent multiple times.

This should save in the region of 70,000 content store requests per day, perhaps more if there are some 500s and they're automatically retried by a load balancer.