### PR TITLE
Reduce duplicate rummager requests

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -38,11 +38,11 @@ class Topic
   end
 
   def lists
-    ListSet.new("specialist_sector", content_item.content_id, details["groups"])
+    @lists ||= ListSet.new("specialist_sector", content_item.content_id, details["groups"])
   end
 
   def changed_documents
-    ChangedDocuments.new(content_item.content_id, @pagination_options)
+    @changed_documents ||= ChangedDocuments.new(content_item.content_id, @pagination_options)
   end
 
   def slug


### PR DESCRIPTION
Each of these models makes a request to rummager.  There's no need for these to be evaluated multiple times on each page request.

The results of the search is memoized internally, but that doesn't help much if you instantiate a new object.

`lists` is used on https://www.gov.uk/topic/transport/motorways-major-roads (for example)
`changed_documents` on https://www.gov.uk/topic/transport/motorways-major-roads/latest (for example)