### PR TITLE
Drop unnecessary content store requests

### DIFF
--- a/app/presenters/brexit_taxons_presenter.rb
+++ b/app/presenters/brexit_taxons_presenter.rb
@@ -15,19 +15,14 @@ class BrexitTaxonsPresenter
   ).freeze
 
   def featured_taxons
-    @featured_taxons ||= FEATURED_TAXONS
-      .to_enum
-      .with_index(1)
-      .map do |base_path, index|
-        content_item = ContentItem.find!(base_path)
-
-        BrexitTaxonPresenter.new(content_item, index)
-      end
+    @featured_taxons ||= FEATURED_TAXONS.map.with_index do |base_path, index|
+      featured_taxon = level_one_taxons.detect { |taxon| taxon.base_path == base_path }
+      BrexitTaxonPresenter.new(featured_taxon, index)
+    end
   end
 
   def other_taxons
-    @other_taxons ||= ContentItem.find!('/')
-      .linked_items('level_one_taxons')
+    @other_taxons ||= level_one_taxons
       .reject { |content_item| FEATURED_TAXONS.include?(content_item.base_path) }
       .reject { |content_item| REJECTED_TAXONS.include?(content_item.base_path) }
       .select { |content_item| taxon_ids_with_citizen_tagged_content.include?(content_item.content_id) }
@@ -35,6 +30,10 @@ class BrexitTaxonsPresenter
   end
 
 private
+
+  def level_one_taxons
+    @level_one_taxons ||= ContentItem.find!('/').linked_items('level_one_taxons')
+  end
 
   def taxon_ids_with_citizen_tagged_content
     @taxon_ids_with_citizen_tagged_content ||= begin

--- a/test/presenters/brexit_taxons_presenter_test.rb
+++ b/test/presenters/brexit_taxons_presenter_test.rb
@@ -18,11 +18,9 @@ describe BrexitTaxonsPresenter do
 
   describe '#featured_taxons' do
     it 'should return the featured taxons presenters' do
-      FEATURED_TAXONS.each do |taxon|
-        ContentItem.stubs(:find!)
-          .with(taxon.fetch('base_path'))
-          .returns(ContentItem.new(generic_taxon(taxon.fetch('base_path'))))
-      end
+      ContentItem.stubs(:find!)
+        .with('/')
+        .returns(ContentItem.new("links" => { "level_one_taxons" => FEATURED_TAXONS }))
 
       featured_taxons = presenter.featured_taxons
 


### PR DESCRIPTION
This PR is for improving the process for getting the data to render the /prepare-eu-exit page which is serving a few 500s because of content store timeouts

The information we need is in the links hash of the home page which we already request.  We don't need to request each content item, as we're only interested in the title and base path.

I think we originally did this because we thought we might need some other fields which weren't included in the links from the home page.

https://govuk-collections-pr-1024.herokuapp.com/prepare-eu-exit
(should look identical to: https://www.gov.uk/prepare-eu-exit )