### PR TITLE
Hide the govuk-accordion controls

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -103,3 +103,8 @@
 .app-c-accordion__controls {
   @extend %contain-floats;
 }
+
+
+.govuk-accordion__controls {
+  display: none;
+}


### PR DESCRIPTION
After the new accordion (based on `govuk-frontend`) was introduced in the `govuk_publishing_components` gem it started to clash (they are using the same `data-module` value for initialisation) with the accordion component defined in this repository.

Long term fix is to replace this component with the one in the in `govuk_publishing_components`, however the local component contains a lot of logic including tracking with Google Analytics that we need to make sure are preserved before doing the switch. Meanwhile the...

Short term fix is to hide the controls exposed by the script coming from `govuk_publishing_components` and leave the local controls do their job.

### Before
![screenshot-www gov uk-2019 02 21-17-32-23](https://user-images.githubusercontent.com/788096/53189205-dd2a1a00-35fe-11e9-805f-18cd19f25fab.png)

### After
![screenshot-www gov uk-2019 02 21-17-32-39](https://user-images.githubusercontent.com/788096/53189208-e0250a80-35fe-11e9-94a2-c16e26bd94ac.png)
