### PR TITLE
Change collections accordion namespace

### DIFF
--- a/app/assets/javascripts/components/accordion.js
+++ b/app/assets/javascripts/components/accordion.js
@@ -5,7 +5,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   "use strict";
 
-  Modules.Accordion = function () {
+  Modules.CollectionsAccordion = function () {
 
     var bulkActions = {
       openAll: {

--- a/app/views/components/_accordion.html.erb
+++ b/app/views/components/_accordion.html.erb
@@ -2,7 +2,7 @@
   sections ||= false
 %>
 <% if sections %>
-  <div data-module="accordion" class="app-c-accordion js-hidden">
+  <div data-module="collections-accordion" class="app-c-accordion js-hidden">
     <% sections.each_with_index do |section, index| %>
       <%
         id = section[:id] || section[:title].downcase.tr(" ","-")

--- a/spec/javascripts/components/accordion_spec.js
+++ b/spec/javascripts/components/accordion_spec.js
@@ -36,7 +36,7 @@ describe('An accordion module', function () {
   var expectedAccordionContentCount = 1;
 
   beforeEach(function () {
-    accordion = new GOVUK.Modules.Accordion();
+    accordion = new GOVUK.Modules.CollectionsAccordion();
     $element = $(html);
     accordion.start($element);
   });


### PR DESCRIPTION
Change the collections accordion component from having the JS module name `accordion` to `collections-accordion`, in order to prevent a namespace conflict, where both components JS was initialising at the same time, causing two 'open/close all' links to be added to accordions - see https://www.gov.uk/world/afghanistan.
