### PR TITLE
Bugfix: Show correct about page links on Welsh organisation pages

### DIFF
--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -18,7 +18,7 @@
 
           <% unless @organisation.is_court_or_hmcts_tribunal? %>
           <p>
-            <a href="<%= @organisation.base_path %>/about" class="brand__color">
+            <a href="<%= t('organisations.about_page_path', organisation: @organisation.slug) %>" class="brand__color">
               <%= t('organisations.read_more') %>
             </a>
           </p>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -4,6 +4,7 @@ cy:
   view_all: gwelir holl
   view_less: gwelir llai
   organisations:
+    about_page_path: "/government/organisations/%{organisation}/about.cy"
     administered_by: "Gweinyddir gan"
     contact:
       contact_details: "Contact details"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   view_all: "view all"
   view_less: "view less"
   organisations:
+    about_page_path: "/government/organisations/%{organisation}/about"
     administered_by: "Administered by"
     contact:
       contact_details: "Contact details"

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -687,6 +687,14 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-image-card .gem-c-image-card__title-link", text: "Sir Jeremy Heywood")
   end
 
+  it "show a link to the correct about page on Welsh and English pages" do
+    visit "/government/organisations/attorney-generals-office"
+    assert page.has_css?("a[href='/government/organisations/attorney-generals-office/about']", text: "Read more about what we do")
+
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    assert page.has_css?("a[href='/government/organisations/office-of-the-secretary-of-state-for-wales/about.cy']", text: "Darllen mwy am yr hyn rydyn ni'n ei wneud")
+  end
+
   it "shows translated text on welsh pages" do
     visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
     assert page.has_css?(".gem-c-heading", text: "Ein huwch swyddogion milwrol")


### PR DESCRIPTION
Currently the about page link is incorrect on the org page when the page is translated.

The provided path is: /government/organisations/land-registry.cy/about.
The correct path is: /government/organisations/land-registry/about.cy.

This fixes that issue and adds a test to check for it.