### PR TITLE
Render meta description on brexit page

### DIFF
--- a/app/views/brexit_campaign/show.html.erb
+++ b/app/views/brexit_campaign/show.html.erb
@@ -1,5 +1,9 @@
 <%= content_for :title, 'Prepare for the UK leaving the EU' %>
 
+<% content_for :meta_tags do %>
+  <%= tag("meta", name: "description", content: @campaign.description) if @campaign.description %>
+<% end %>
+
 <%= render partial: 'header' %>
 
 <div class="taxon-page__email-link-wrapper">

--- a/test/integration/citizen_readiness_test.rb
+++ b/test/integration/citizen_readiness_test.rb
@@ -4,6 +4,7 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
   it "renders links to citizen relevant content correctly" do
     when_i_visit_the_citizen_readiness_page
     then_i_can_see_the_correct_title
+    and_the_page_has_metatags
     and_i_can_see_email_signup_with_tracking
     and_i_can_see_featured_links_with_tracking
     and_i_can_see_featured_taxons_with_tracking
@@ -24,6 +25,10 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
 
   def then_i_can_see_the_correct_title
     page.assert_selector "h1", text: "Prepare for EU exit"
+  end
+
+  def and_the_page_has_metatags
+    page.assert_selector("meta[name='description'][content='Prepare yourself for Brexit']", visible: false)
   end
 
   def and_i_can_see_email_signup_with_tracking
@@ -57,7 +62,7 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
 
   def stub_citizen_readiness_page(base_path)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: 'special_route') do |payload|
-      payload.merge(title: "Prepare for EU exit", base_path: base_path)
+      payload.merge(title: "Prepare for EU exit", base_path: base_path, description: "Prepare yourself for Brexit")
     end
     content_store_has_item(base_path, content_item)
   end


### PR DESCRIPTION
We're about to republish the content item with a description.  We should use it in metatags if it's there.

https://govuk-collections-pr-1056.herokuapp.com/prepare-eu-exit (won't have a meta description until the content item in 👇 is published)

Related to https://github.com/alphagov/collections-publisher/pull/581

https://trello.com/c/5GLtZUxs/152-get-prepare-eu-exit-in-search