### PR TITLE
Add buying from europe link

### DIFF
--- a/app/presenters/citizen_readiness/links_presenter.rb
+++ b/app/presenters/citizen_readiness/links_presenter.rb
@@ -4,6 +4,7 @@ module CitizenReadiness
 
     FEATURED_LINKS = %w(
       /visit-europe-brexit
+      /buying-europe-brexit
     ).freeze
 
     FEATURED_TAXONS = %w(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,6 +107,9 @@ en:
     see_more_in_taxon: "See more in %{topic}"
     other_topics: "Other EU Exit topics"
     links:
+      buying-europe-brexit:
+        title: "Buying things from Europe after Brexit"
+        description: "Includes consumer rights, making payments and package holidays"
       visit-europe-brexit:
         title: "Visit Europe after Brexit"
         description: "Includes passports, driving and travel, EHIC cards, pets and mobile roaming fees"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,7 +114,7 @@ en:
         title: "Visit Europe after Brexit"
         description: "Includes passports, driving and travel, EHIC cards, pets and mobile roaming fees"
     taxon_descriptions:
-      business-and-industry: "Includes consumer rights, banking and selling online"
+      business-and-industry: "Includes imports, banking and selling online"
       education: "Includes studying abroad and Erasmus+"
       environment: "Includes environmental standards and food labels"
       going-and-being-abroad: "Includes passports, foreign travel advice, pet travel and mobile roaming fees"

--- a/test/integration/citizen_readiness_test.rb
+++ b/test/integration/citizen_readiness_test.rb
@@ -44,10 +44,10 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
   end
 
   def and_i_can_see_featured_taxons_with_tracking
-    page.assert_selector ".campaign__taxon a[data-track-category][data-track-action][data-track-label]", count: 5
-    page.assert_selector ".campaign__taxon a[data-track-action=1]",
+    page.assert_selector ".campaign__taxon a[data-track-category][data-track-action][data-track-label]", count: 6
+    page.assert_selector ".campaign__taxon a[data-track-action=2]",
       text: "Work and things"
-    page.assert_selector ".campaign__taxon a[data-track-action=4]",
+    page.assert_selector ".campaign__taxon a[data-track-action=5]",
       text: "Education, training and skills"
   end
 

--- a/test/presenters/citizen_readiness/links_presenter_test.rb
+++ b/test/presenters/citizen_readiness/links_presenter_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 describe CitizenReadiness::LinksPresenter do
   include TaxonHelpers
 
-  FEATURED_LINKS = [{ "base_path" => "/visit-europe-brexit" }].freeze
+  FEATURED_LINKS = [
+    { "base_path" => "/visit-europe-brexit" },
+    { "base_path" => "/buying-europe-brexit" },
+  ].freeze
 
   FEATURED_TAXONS = [
     { "title" => "Work", "base_path" => "/work", "content_id" => "work-taxon-id" },


### PR DESCRIPTION
The title/description have been confirmed with content.  We're not removing any links as part of this update.

https://govuk-collections-pr-1061.herokuapp.com/prepare-eu-exit

https://trello.com/c/d7T9ng4w/147-add-buying-things-from-europe-to-landing-page