### PR TITLE
Update see all latest link

### DIFF
--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -15,7 +15,7 @@
       <%= render "govuk_publishing_components/components/document_list", @documents.latest_documents %>
 
       <p class="organisation__margin-bottom brand--<%= @organisation.brand %>">
-        <a href="<%= "/government/organisations/latest?organisations[]=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all_latest_documents') %></a>
+        <a href="<%= "/search/all?organisations[]=#{@organisation.slug}&order=updated-newest&parent=#{@organisation.slug}" %>" class="brand__color"><%= t('organisations.see_all_latest_documents') %></a>
       </p>
 
       <%= render "govuk_publishing_components/components/subscription-links", @show.subscription_links %>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -620,7 +620,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows a see all link in the latest documents section" do
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?("a[href='/government/organisations/latest?organisations%5B%5D=attorney-generals-office']", text: "See all")
+    assert page.has_css?("a[href='/search/all?organisations%5B%5D=attorney-generals-office&order=updated-newest&parent=attorney-generals-office']", text: "See all")
   end
 
   it "shows subscription links" do


### PR DESCRIPTION
The current link is already being redirected to the /search/all page, but
doesn't have the correct `order` param, nor does it have the `parent` param
which sets the breadcrumb.

Example URL: https://govuk-collections-pr-1073.herokuapp.com/government/organisations/department-for-education

https://trello.com/c/OAfILA3R/376-replace-links-on-org-pages-with-all-content-links-s