### PR TITLE
Cache common usages of search for a short period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
 
+gem 'dalli'
 gem 'gds-api-adapters', '~> 59.0.0'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 1.13.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       railties (>= 4, < 6)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    dalli (2.7.10)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
@@ -375,6 +376,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cucumber-rails
+  dalli
   gds-api-adapters (~> 59.0.0)
   govuk-content-schema-test-helpers
   govuk-lint
@@ -405,4 +407,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -67,6 +67,8 @@ class RummagerSearch
 private
 
   def search_result
-    @search_result ||= Services.rummager.search(@search_params)
+    @search_result ||= Rails.cache.fetch(@search_params, expires_in: 5.minutes) do
+      Services.rummager.search(@search_params).to_h
+    end
   end
 end

--- a/app/services/feed_content.rb
+++ b/app/services/feed_content.rb
@@ -20,6 +20,8 @@ private
       order: '-public_timestamp',
     )
 
-    Services.rummager.search(params)
+    @search_response ||= Rails.cache.fetch(params, expires_in: 10.minutes) do
+      Services.rummager.search(params)
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store, nil, { namespace: :collections, compress: true } unless ENV['HEROKU_APP_NAME']
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
These code paths are commonly used, and the parameters are generally fixed which makes the calls to rummager fairly cacheable (as opposed to finders which have lots of combinations).  We don't mind if the results are a little stale as we'll otherwise fall back to the mirrors on a 5xx error which can be up to 24 hours old.

Memcache is already set up on frontend machines