### PR TITLE
Cache search queries by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby File.read(".ruby-version").strip
 
+gem 'dalli'
 gem 'gds-api-adapters', '~> 59.0.0'
 gem 'govuk_ab_testing', '~> 2.4.1'
 gem 'govuk_app_config', '~> 1.13.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       railties (>= 4, < 6)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    dalli (2.7.10)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
@@ -375,6 +376,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   cucumber-rails
+  dalli
   gds-api-adapters (~> 59.0.0)
   govuk-content-schema-test-helpers
   govuk-lint
@@ -405,4 +407,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/app/controllers/organisations_api_controller.rb
+++ b/app/controllers/organisations_api_controller.rb
@@ -28,7 +28,7 @@ private
   RESULTS_PER_PAGE = 20
 
   def presented_organisations(start:)
-    organisations = get_organisations(count: RESULTS_PER_PAGE, start: start)
+    organisations = organisations_from_search(count: RESULTS_PER_PAGE, start: start)
     OrganisationsApiPresenter.new(
       organisations["results"],
       current_page: current_page,
@@ -39,7 +39,7 @@ private
   end
 
   def presented_organisation(slug:)
-    organisation = get_organisation(slug: slug)
+    organisation = organisation_from_search(slug: slug)
 
     raise OrganisationNotFound if organisation["total"].zero?
 
@@ -53,22 +53,26 @@ private
     ).present
   end
 
-  def get_organisations(count:, start:)
-    Services.rummager.search(
+  def organisations_from_search(count:, start:)
+    params = {
       filter_format: "organisation",
       order: "title",
       count: count,
       start: start
-    )
+    }
+
+    @organisations_from_search ||= Services.cached_search(params, metric_key: 'organisations_api.search.request_time')
   end
 
-  def get_organisation(slug:)
-    Services.rummager.search(
+  def organisation_from_search(slug:)
+    params = {
       filter_format: "organisation",
       filter_slug: slug,
       count: 1,
       start: 0
-    )
+    }
+
+    @organisation_from_search ||= Services.cached_search(params, metric_key: 'organisation_api.search.request_time')
   end
 
   def set_link_header(links:)

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -17,12 +17,13 @@ private
   helper_method :organisations
 
   def subtopic_organisations(subtopic_content_id)
-    OrganisationsFacetPresenter.new(
-      Services.rummager.search(
-        count: "0",
-        filter_topic_content_ids: [subtopic_content_id],
-        facet_organisations: "1000",
-      )["facets"]["organisations"]
-    )
+    params = {
+      count: "0",
+      filter_topic_content_ids: [subtopic_content_id],
+      facet_organisations: "1000"
+    }
+    results = Services.cached_search(params)
+
+    OrganisationsFacetPresenter.new(results["facets"]["organisations"])
   end
 end

--- a/app/lib/services_and_information_links_grouper.rb
+++ b/app/lib/services_and_information_links_grouper.rb
@@ -12,10 +12,13 @@ class ServicesAndInformationLinksGrouper
 private
 
   def grouped_links_from_rummager
-    Services.rummager.search(
-      count: "0",
-      filter_organisations: @organisation_id,
-      facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
-    ).to_hash["facets"]["specialist_sectors"]["options"]
+    @grouped_links_from_rummager ||= begin
+      params = {
+        count: "0",
+        filter_organisations: @organisation_id,
+        facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title"
+      }
+      Services.cached_search(params)["facets"]["specialist_sectors"]["options"]
+    end
   end
 end

--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -67,6 +67,6 @@ class RummagerSearch
 private
 
   def search_result
-    @search_result ||= Services.rummager.search(@search_params)
+    @search_result ||= Services.cached_search(@search_params)
   end
 end

--- a/app/services/feed_content.rb
+++ b/app/services/feed_content.rb
@@ -20,6 +20,6 @@ private
       order: '-public_timestamp',
     )
 
-    Services.rummager.search(params)
+    @search_response ||= Services.cached_search(params, metric_key: 'feeds.search.request_time')
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store, nil, { namespace: :collections, compress: true } unless ENV['HEROKU_APP_NAME']
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  config.cache_store = :null_store
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -14,6 +14,14 @@ module Services
     @content_store ||= GdsApi::ContentStore.new(Plek.new.find('content-store'))
   end
 
+  def self.cached_search(params, metric_key: "search.request_time")
+    Rails.cache.fetch(params, expires_in: 5.minutes) do
+      GovukStatsd.time(metric_key) do
+        self.rummager.search(params).to_h
+      end
+    end
+  end
+
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.new.find("search"))
   end


### PR DESCRIPTION
_Adds `cached_search` to `Services` which caches calls to search for a default of 5 minutes, and records times to graphite_

The search parameters in this app are generally fixed which makes the calls to rummager fairly cacheable.  We don't mind if the results are a little stale as we'll otherwise fall back to the mirrors on a 5xx error which can be up to 24 hours old.

In practice these won't get hit repeatedly over a short period except when Fastly doesn't have a cached response (for example requests with query strings) or if repeated errors occur.

Some of these pages make multiple requests to render a single page, so caching successful requests should add some resilience to the process.  That is, if a page needs to make four requests to search and the third one fails, then the first two should already be cached so will not need to be made again.

We also add graphite metrics to the requests to search, so we can track what makes a page slow a bit easier.

Test URLs:
- https://govuk-collections-pr-1075.herokuapp.com/education
- https://govuk-collections-pr-1075.herokuapp.com/government/organisations/ministry-of-defence
- https://govuk-collections-pr-1075.herokuapp.com/prepare-eu-exit
- https://govuk-collections-pr-1075.herokuapp.com/browse/justice/reporting-crimes-compensation
- https://govuk-collections-pr-1075.herokuapp.com/topic/business-tax/aggregates-levy