### PR TITLE
Use Email Alert Frontend for Organisation Email Alerts

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -14,7 +14,7 @@ module Organisations
 
     def subscription_links
       {
-        email_signup_link: "/government/email-signup/new?email_signup[feed]=#{@org.web_url}.atom",
+        email_signup_link: "/email-signup?link=#{@org.base_path}",
         feed_link_box_value: "#{@org.web_url}.atom",
         brand: @org.brand
       }

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -625,7 +625,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows subscription links" do
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".gem-c-subscription-links__link[href='/government/email-signup/new?email_signup%5Bfeed%5D=http://www.test.gov.uk/government/organisations/attorney-generals-office.atom']", text: "Get email alerts")
+    assert page.has_css?(".gem-c-subscription-links__link[href='/email-signup?link=/government/organisations/attorney-generals-office']", text: "Get email alerts")
     assert page.has_css?(".gem-c-subscription-links__link[href='#']", text: "Subscribe to feed")
   end
 


### PR DESCRIPTION
This will enable users to subscribe to organisation email alerts
via the EmailAlertFrontend user interface.

**Note:** Should be merged after https://github.com/alphagov/email-alert-frontend/pull/451

Trello: https://trello.com/c/NSJuSR4z/587.