### PR TITLE
Fix links to supergroup finders on org pages

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -44,7 +44,7 @@ cy:
         title: "Canllawiau a rheoleiddio"
         see_all:
           text: "Gweld yr holl ganllawiau a rheoleiddio"
-          path: "/guidance-and-regulation?organisations[]=%{organisation}&parent=%{organisation}"
+          path: "/search/guidance-and-regulation?organisations[]=%{organisation}&parent=%{organisation}"
       research_and_statistics:
         title: "Ymchwil ac ystadegau"
         see_all:
@@ -54,7 +54,7 @@ cy:
         title: "Papurau polisi ac ymgynghoriadau"
         see_all:
           text: "Gweld yr holl bapurau polisi ac ymgynghoriadau"
-          path: "/search/policy-and-engagement?organisations[]=%{organisation}&parent=%{organisation}"
+          path: "/search/policy-papers-and-consultations?organisations[]=%{organisation}&parent=%{organisation}"
       transparency:
         title: "Datganiadau tryloywder a rhyddid gwybodaeth"
         see_all:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
         title: "Guidance and regulation"
         see_all:
           text: "See all guidance and regulation"
-          path: "/guidance-and-regulation?organisations[]=%{organisation}&parent=%{organisation}"
+          path: "/search/guidance-and-regulation?organisations[]=%{organisation}&parent=%{organisation}"
       research_and_statistics:
         title: "Research and statistics"
         see_all:
@@ -37,7 +37,7 @@ en:
         title: "Policy and engagement"
         see_all:
           text: "See all policy and engagement"
-          path: "/search/policy-and-engagement?organisations[]=%{organisation}&parent=%{organisation}"
+          path: "/search/policy-papers-and-consultations?organisations[]=%{organisation}&parent=%{organisation}"
       transparency:
         title: "Transparency"
         see_all:

--- a/test/presenters/organisations/supergroups_presenter_test.rb
+++ b/test/presenters/organisations/supergroups_presenter_test.rb
@@ -78,7 +78,7 @@ describe Organisations::SupergroupsPresenter do
       assert_equal Date.parse(1.hour.ago.iso8601), document[:metadata][:public_updated_at]
       assert_equal "Guide", document[:metadata][:document_type]
 
-      assert_equal '/guidance-and-regulation?organisations[]=attorney-generals-office&parent=attorney-generals-office', supergroup[:finder_link][:path]
+      assert_equal '/search/guidance-and-regulation?organisations[]=attorney-generals-office&parent=attorney-generals-office', supergroup[:finder_link][:path]
       assert_equal 'See all guidance and regulation', supergroup[:finder_link][:text]
     end
 


### PR DESCRIPTION
The URLs of these finders have changed, so we need to change the links too.