### PR TITLE
Sort documents in the "services" and "guidance & regulation" supergroups by popularity descending

### DIFF
--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -1,10 +1,13 @@
 module Search
   class Supergroup
-    attr_reader :content_purpose_supergroup
+    attr_reader :content_purpose_supergroup, :sort_order
 
-    def initialize(organisation_slug:, content_purpose_supergroup:)
+    DEFAULT_SORT_ORDER = '-public_timestamp'.freeze
+
+    def initialize(organisation_slug:, content_purpose_supergroup:, sort_order: DEFAULT_SORT_ORDER)
       @organisation_slug = organisation_slug
       @content_purpose_supergroup = content_purpose_supergroup
+      @sort_order = sort_order
     end
 
     def has_documents?
@@ -29,7 +32,7 @@ module Search
     def default_rummager_params
       {
         count: 2,
-        order: "-public_timestamp",
+        order: @sort_order,
         fields: %w[title link content_store_document_type public_timestamp]
       }
     end

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -32,7 +32,7 @@ module Search
     def default_rummager_params
       {
         count: 2,
-        order: @sort_order,
+        order: sort_order,
         fields: %w[title link content_store_document_type public_timestamp]
       }
     end

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -9,7 +9,10 @@ module Search
       transparency
     ).freeze
 
-    SUPERGROUP_SORT_ORDER = {}.freeze
+    SUPERGROUP_SORT_ORDER = {
+      'services' => '-popularity',
+      'guidance_and_regulation' => '-popularity',
+    }.freeze
 
     def initialize(organisation:)
       @organisation = organisation

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -9,6 +9,8 @@ module Search
       transparency
     ).freeze
 
+    SUPERGROUP_SORT_ORDER = {}.freeze
+
     def initialize(organisation:)
       @organisation = organisation
     end
@@ -21,7 +23,8 @@ module Search
       @groups ||= SUPERGROUP_TYPES.map { |group|
         Supergroup.new(
           organisation_slug: (@organisation ? @organisation.slug : nil),
-          content_purpose_supergroup: group
+          content_purpose_supergroup: group,
+          sort_order: SUPERGROUP_SORT_ORDER.fetch(group, Supergroup::DEFAULT_SORT_ORDER),
         )
       }
     end

--- a/test/services/search/supergroups_test.rb
+++ b/test/services/search/supergroups_test.rb
@@ -37,6 +37,16 @@ describe Search::Supergroups do
     it 'returns an array of supergroups regardless of doc responses' do
       assert_equal @supergroups.groups.map(&:content_purpose_supergroup), @no_docs_supergroups.groups.map(&:content_purpose_supergroup)
     end
+
+    it 'sorts supergroup documents by the given sort order' do
+      @supergroups.groups.each do |group|
+        sort_order = Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(
+          group.content_purpose_supergroup,
+          Search::Supergroup::DEFAULT_SORT_ORDER,
+        )
+        assert_equal sort_order, group.sort_order
+      end
+    end
   end
 
   def raw_rummager_result
@@ -48,12 +58,13 @@ describe Search::Supergroups do
     }
   end
 
-  def stub_rummager_supergroup_request(supergroup, organisation, results)
+  def stub_rummager_supergroup_request(group, organisation, results)
     stub_supergroup_request(
       results: results,
       additional_params: {
-        filter_content_purpose_supergroup: supergroup,
+        filter_content_purpose_supergroup: group,
         filter_organisations: organisation.slug,
+        order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
       }
     )
   end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -13,6 +13,7 @@ module OrganisationHelpers
       url = build_rummager_query_url(
         filter_organisations: organisation_slug,
         filter_content_purpose_supergroup: group,
+        order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
       )
 
       stub_request(:get, url).to_return(body: build_result_body(group, empty).to_json)


### PR DESCRIPTION
[Trello card](https://trello.com/c/wTJRIpnh/672-change-sort-order-of-2-supergroup-lists-on-org-pages)