### PR TITLE
Exclude metadata for the services supergroup on org pages

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -34,10 +34,12 @@ module OrganisationHelper
     image_url_array.join("/")
   end
 
-  def search_results_to_documents(search_results, organisation)
+  def search_results_to_documents(search_results, organisation, include_metadata: true)
     {
       brand: (organisation.brand if organisation.is_live?),
-      items: search_results.map { |result| Organisations::DocumentPresenter.new(result).present }
+      items: search_results.map { |result|
+        Organisations::DocumentPresenter.new(result, include_metadata: include_metadata).present
+      }
     }
   end
 end

--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -4,8 +4,11 @@ module Organisations
   #
   # See https://govuk-publishing-components.herokuapp.com/component-guide/document_list
   class DocumentPresenter
-    def initialize(rummager_result)
+    attr_accessor :include_metadata
+
+    def initialize(rummager_result, include_metadata: true)
       @raw_document = rummager_result
+      @include_metadata = include_metadata
     end
 
     def present
@@ -14,12 +17,22 @@ module Organisations
           text: @raw_document["title"],
           path: @raw_document["link"]
         },
-        metadata: {
-          public_updated_at: public_updated_at,
-          document_type: document_type
-        }
-      }
+      }.merge(present_metadata)
     end
+
+    def present_metadata
+      if include_metadata
+        {
+          metadata: {
+            public_updated_at: public_updated_at,
+            document_type: document_type
+          }
+        }
+      else
+        {}
+      end
+    end
+
 
   private
 

--- a/app/presenters/organisations/supergroups_presenter.rb
+++ b/app/presenters/organisations/supergroups_presenter.rb
@@ -3,8 +3,13 @@ module Organisations
     include OrganisationHelper
     attr_reader :org
 
-    def initialize(organisation)
+    DEFAULT_EXCLUDE_METADATA_FOR = %w(services).freeze
+
+    attr_accessor :exclude_metadata_for
+
+    def initialize(organisation, exclude_metadata_for: DEFAULT_EXCLUDE_METADATA_FOR)
       @org = organisation
+      @exclude_metadata_for = exclude_metadata_for
     end
 
     def has_groups?
@@ -15,8 +20,10 @@ module Organisations
       supergroups_collection.groups.map { |supergroup|
         next unless supergroup.has_documents?
 
+        exclude_metadata = exclude_metadata_for.include? supergroup.content_purpose_supergroup
+
         {
-          documents: search_results_to_documents(supergroup.documents, @org),
+          documents: search_results_to_documents(supergroup.documents, @org, include_metadata: !exclude_metadata),
           title: I18n.t(:title, scope: [:organisations, :document_types, supergroup.content_purpose_supergroup]),
           finder_link: finder_link(supergroup)
         }

--- a/test/presenters/organisations/document_presenter_test.rb
+++ b/test/presenters/organisations/document_presenter_test.rb
@@ -26,7 +26,20 @@ describe Organisations::DocumentPresenter do
     end
   end
 
-  def presenter(options = {})
+  context 'metadata is excluded' do
+    it 'excludes the metadata' do
+      expected = {
+        link: {
+          text: "Quiddich World Cup 2022 begins",
+          path: "/government/news/its-coming-home",
+        }
+      }
+
+      assert_equal expected, presenter(include_metadata: false).present
+    end
+  end
+
+  def presenter(options = {}, include_metadata: true)
     params = {
       "title" => "Quiddich World Cup 2022 begins",
       "link" => "/government/news/its-coming-home",
@@ -34,6 +47,6 @@ describe Organisations::DocumentPresenter do
       "public_timestamp" => "2022-11-21T12:00:00.000+01:00"
     }.merge(options)
 
-    described_class.new(params)
+    described_class.new(params, include_metadata: include_metadata)
   end
 end

--- a/test/presenters/organisations/supergroups_presenter_test.rb
+++ b/test/presenters/organisations/supergroups_presenter_test.rb
@@ -7,7 +7,7 @@ describe Organisations::SupergroupsPresenter do
   before :each do
     content_item = ContentItem.new(organisation_with_featured_documents)
     organisation = Organisation.new(content_item)
-    @supergroups_presenter = described_class.new(organisation)
+    @supergroups_presenter = described_class.new(organisation, exclude_metadata_for: %w(news_and_communications))
 
     content_item = ContentItem.new(organisation_with_no_documents)
     organisation = Organisation.new(content_item)
@@ -43,8 +43,7 @@ describe Organisations::SupergroupsPresenter do
 
       assert_equal 'Content item 1', document[:link][:text]
       assert_equal '/content-item-1', document[:link][:path]
-      assert_equal Date.parse(1.hour.ago.iso8601), document[:metadata][:public_updated_at]
-      assert_equal "News story", document[:metadata][:document_type]
+      assert_nil document[:metadata]
 
       assert_equal '/search/news-and-communications?organisations[]=attorney-generals-office&parent=attorney-generals-office', supergroup[:finder_link][:path]
       assert_equal 'See all news and communications', supergroup[:finder_link][:text]


### PR DESCRIPTION
On integration:

<img width="1060" alt="Screen Shot 2019-04-25 at 15 55 17" src="https://user-images.githubusercontent.com/75235/56745618-9da0bb00-6772-11e9-9db1-21dac618d734.png">

---

[Trello card](https://trello.com/c/b0FALEM6/678-exclude-date-and-doc-type-metadata-from-services-list-on-org-pages)