### PR TITLE
Refactor search parameter handling & exclude some subgroups from news&comms

### DIFF
--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -15,12 +15,14 @@ module Search
     end
 
     def documents
-      @documents ||= search_rummager(
-        {
-          filter_organisations: @organisation_slug,
-          filter_content_purpose_supergroup: @content_purpose_supergroup,
-        }.merge(additional_search_params)
-      )
+      @documents ||= search_rummager(documents_query)
+    end
+
+    def documents_query
+      {
+        filter_organisations: @organisation_slug,
+        filter_content_purpose_supergroup: @content_purpose_supergroup,
+      }.merge(additional_search_params)
     end
 
   private

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -1,13 +1,14 @@
 module Search
   class Supergroup
-    attr_reader :content_purpose_supergroup, :sort_order
+    attr_reader :content_purpose_supergroup, :sort_order, :additional_search_params
 
     DEFAULT_SORT_ORDER = '-public_timestamp'.freeze
 
-    def initialize(organisation_slug:, content_purpose_supergroup:, sort_order: DEFAULT_SORT_ORDER)
+    def initialize(organisation_slug:, content_purpose_supergroup:, sort_order: DEFAULT_SORT_ORDER, additional_search_params: {})
       @organisation_slug = organisation_slug
       @content_purpose_supergroup = content_purpose_supergroup
       @sort_order = sort_order
+      @additional_search_params = additional_search_params
     end
 
     def has_documents?
@@ -16,8 +17,10 @@ module Search
 
     def documents
       @documents ||= search_rummager(
-        filter_organisations: @organisation_slug,
-        filter_content_purpose_supergroup: @content_purpose_supergroup,
+        {
+          filter_organisations: @organisation_slug,
+          filter_content_purpose_supergroup: @content_purpose_supergroup,
+        }.merge(additional_search_params)
       )
     end
 

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -1,13 +1,12 @@
 module Search
   class Supergroup
-    attr_reader :content_purpose_supergroup, :sort_order, :additional_search_params
+    attr_reader :content_purpose_supergroup, :additional_search_params
 
     DEFAULT_SORT_ORDER = '-public_timestamp'.freeze
 
-    def initialize(organisation_slug:, content_purpose_supergroup:, sort_order: DEFAULT_SORT_ORDER, additional_search_params: {})
+    def initialize(organisation_slug:, content_purpose_supergroup:, additional_search_params: {})
       @organisation_slug = organisation_slug
       @content_purpose_supergroup = content_purpose_supergroup
-      @sort_order = sort_order
       @additional_search_params = additional_search_params
     end
 
@@ -35,7 +34,7 @@ module Search
     def default_rummager_params
       {
         count: 2,
-        order: sort_order,
+        order: DEFAULT_SORT_ORDER,
         fields: %w[title link content_store_document_type public_timestamp]
       }
     end

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -14,6 +14,12 @@ module Search
       'guidance_and_regulation' => '-popularity',
     }.freeze
 
+    SUPERGROUP_ADDITIONAL_SEARCH_PARAMS = {
+      'news_and_communications' => {
+        reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+      },
+    }.freeze
+
     def initialize(organisation:)
       @organisation = organisation
     end
@@ -28,6 +34,7 @@ module Search
           organisation_slug: (@organisation ? @organisation.slug : nil),
           content_purpose_supergroup: group,
           sort_order: SUPERGROUP_SORT_ORDER.fetch(group, Supergroup::DEFAULT_SORT_ORDER),
+          additional_search_params: SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}),
         )
       }
     end

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -9,14 +9,15 @@ module Search
       transparency
     ).freeze
 
-    SUPERGROUP_SORT_ORDER = {
-      'services' => '-popularity',
-      'guidance_and_regulation' => '-popularity',
-    }.freeze
-
     SUPERGROUP_ADDITIONAL_SEARCH_PARAMS = {
+      'guidance_and_regulation' => {
+        order: '-popularity',
+      },
       'news_and_communications' => {
         reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+      },
+      'services' => {
+        order: '-popularity',
       },
     }.freeze
 
@@ -33,7 +34,6 @@ module Search
         Supergroup.new(
           organisation_slug: (@organisation ? @organisation.slug : nil),
           content_purpose_supergroup: group,
-          sort_order: SUPERGROUP_SORT_ORDER.fetch(group, Supergroup::DEFAULT_SORT_ORDER),
           additional_search_params: SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}),
         )
       }

--- a/test/services/search/supergroups_test.rb
+++ b/test/services/search/supergroups_test.rb
@@ -47,6 +47,16 @@ describe Search::Supergroups do
         assert_equal sort_order, group.sort_order
       end
     end
+
+    it 'applies the given additional search parameters' do
+      @supergroups.groups.each do |group|
+        params = Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(
+          group.content_purpose_supergroup,
+          {},
+        )
+        assert_equal params, group.additional_search_params
+      end
+    end
   end
 
   def raw_rummager_result
@@ -65,7 +75,7 @@ describe Search::Supergroups do
         filter_content_purpose_supergroup: group,
         filter_organisations: organisation.slug,
         order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
-      }
+      }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}))
     )
   end
 end

--- a/test/services/search/supergroups_test.rb
+++ b/test/services/search/supergroups_test.rb
@@ -38,16 +38,6 @@ describe Search::Supergroups do
       assert_equal @supergroups.groups.map(&:content_purpose_supergroup), @no_docs_supergroups.groups.map(&:content_purpose_supergroup)
     end
 
-    it 'sorts supergroup documents by the given sort order' do
-      @supergroups.groups.each do |group|
-        sort_order = Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(
-          group.content_purpose_supergroup,
-          Search::Supergroup::DEFAULT_SORT_ORDER,
-        )
-        assert_equal sort_order, group.sort_order
-      end
-    end
-
     it 'applies the given additional search parameters' do
       @supergroups.groups.each do |group|
         params = Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(
@@ -74,7 +64,7 @@ describe Search::Supergroups do
       additional_params: {
         filter_content_purpose_supergroup: group,
         filter_organisations: organisation.slug,
-        order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
+        order: Search::Supergroup::DEFAULT_SORT_ORDER,
       }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}))
     )
   end

--- a/test/services/search/supergroups_test.rb
+++ b/test/services/search/supergroups_test.rb
@@ -44,7 +44,8 @@ describe Search::Supergroups do
           group.content_purpose_supergroup,
           {},
         )
-        assert_equal params, group.additional_search_params
+        query = group.documents_query
+        assert_equal query.merge(params), query
       end
     end
   end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -10,10 +10,11 @@ module OrganisationHelpers
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty = false)
     Search::Supergroups::SUPERGROUP_TYPES.each { |group|
-      url = build_rummager_query_url({
-        filter_organisations: organisation_slug,
-        filter_content_purpose_supergroup: group,
-        order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
+      url = build_rummager_query_url(
+        {
+          filter_organisations: organisation_slug,
+          filter_content_purpose_supergroup: group,
+          order: Search::Supergroup::DEFAULT_SORT_ORDER,
         }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}))
       )
 

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -10,10 +10,11 @@ module OrganisationHelpers
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty = false)
     Search::Supergroups::SUPERGROUP_TYPES.each { |group|
-      url = build_rummager_query_url(
+      url = build_rummager_query_url({
         filter_organisations: organisation_slug,
         filter_content_purpose_supergroup: group,
         order: Search::Supergroups::SUPERGROUP_SORT_ORDER.fetch(group, Search::Supergroup::DEFAULT_SORT_ORDER),
+        }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}))
       )
 
       stub_request(:get, url).to_return(body: build_result_body(group, empty).to_json)
@@ -42,7 +43,7 @@ module OrganisationHelpers
   end
 
   def build_rummager_query_url(params = {})
-    query = Rack::Utils.build_query default_params.merge(params)
+    query = Rack::Utils.build_nested_query default_params.merge(params)
     "#{Plek.new.find('search')}/search.json?#{query}"
   end
 


### PR DESCRIPTION
This is mostly just a generalisation of https://github.com/alphagov/collections/pull/1095

---

[Trello card](https://trello.com/c/k9JVBO1Z/711-exclude-safety-alerts-and-decisions-subgroups-from-news-and-communications-list-on-org-pages-m)