### PR TITLE
Update HowTo schema for step by steps

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -29,19 +29,17 @@ class StepNav
   end
 
   def structured_data
-    step_items = details["step_by_step_nav"]["steps"].map do |step|
-      contents = step["contents"].map do |content|
+    step_items = details["step_by_step_nav"]["steps"].map.with_index(1) do |step, step_index|
+      contents = step["contents"].map.with_index(1) do |content, item_index|
+        direction_index = item_index
+
         if content["type"] == "paragraph"
-          content["text"]
+          how_to_direction(content, direction_index)
         elsif content["type"] == "list"
           content["contents"].map do |c|
-            next unless c["href"]
-
-            {
-              "@type": "WebPage",
-              "@id": url_for_base_path_or_absolute_url(c["href"]),
-              "name": c["text"],
-            }
+            how_to_direction(c, direction_index).tap do
+              direction_index += 1
+            end
           end
         end
       end
@@ -49,6 +47,7 @@ class StepNav
       {
         "@type": "HowToStep",
         "name": step["title"],
+        "position": step_index,
         "itemListElement": contents.flatten.compact,
       }
     end
@@ -56,12 +55,26 @@ class StepNav
     {
       "@context": "http://schema.org",
       "@type": "HowTo",
+      "description": description,
       "name": title,
-      "steps": {
-        "@type": "ItemList",
-        "itemListElement": step_items,
-      }
+      "step": step_items,
     }
+  end
+
+  def how_to_direction(content, index)
+    {
+      "@type": "HowToDirection",
+      "text": content["text"],
+      "position": index,
+    }.merge(direction_url(content))
+  end
+
+  def direction_url(content)
+    if content["href"]
+      { "url": url_for_base_path_or_absolute_url(content["href"]) }
+    else
+      {}
+    end
   end
 
   def url_for_base_path_or_absolute_url(href)

--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -28,7 +28,7 @@ class StepNav
     new(content_item)
   end
 
-  def structured_data
+  def structured_data(image_urls)
     step_items = details["step_by_step_nav"]["steps"].map.with_index(1) do |step, step_index|
       contents = step["contents"].map.with_index(1) do |content, item_index|
         direction_index = item_index
@@ -46,6 +46,7 @@ class StepNav
 
       {
         "@type": "HowToStep",
+        "image": image_urls,
         "name": step["title"],
         "position": step_index,
         "itemListElement": contents.flatten.compact,
@@ -56,6 +57,7 @@ class StepNav
       "@context": "http://schema.org",
       "@type": "HowTo",
       "description": description,
+      "image": image_urls,
       "name": title,
       "step": step_items,
     }

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -1,7 +1,12 @@
 <% content_for :title, step_by_step.title %>
 
+<% step_image_urls = [
+  image_url("govuk_publishing_components/govuk-schema-placeholder-1x1.png"),
+  image_url("govuk_publishing_components/govuk-schema-placeholder-4x3.png"),
+  image_url("govuk_publishing_components/govuk-schema-placeholder-16x9.png"),
+] %>
 <script type="application/ld+json">
-  <%= raw step_by_step.structured_data.to_json %>
+  <%= raw step_by_step.structured_data(step_image_urls).to_json %>
 </script>
 
 <% content_for :meta_tags do %>

--- a/test/models/step_nav_test.rb
+++ b/test/models/step_nav_test.rb
@@ -11,165 +11,220 @@ describe StepNav do
       expected = {
         "@context": "http://schema.org",
         "@type": "HowTo",
+        "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
         "name": "Learn to drive a car: step by step",
-        "steps": {
-          "@type": "ItemList",
-          "itemListElement": [
-            {
-              "@type": "HowToStep",
-              "name": "Check you're allowed to drive",
-              "itemListElement": [
-                "Most people can start learning to drive when they’re 17.",
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/vehicles-can-drive",
-                  "name": "Check what age you can drive"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/legal-obligations-drivers-riders",
-                  "name": "Requirements for driving legally"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/driving-eyesight-rules",
-                  "name": "Driving eyesight rules"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "Get a provisional driving licence",
-              "itemListElement": [
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/apply-first-provisional-driving-licence",
-                  "name": "Apply for your first provisional driving licence"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "Driving lessons and practice",
-              "itemListElement": [
-                "You need a provisional driving licence to take lessons or practice.",
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/guidance/the-highway-code",
-                  "name": "The Highway Code"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/driving-lessons-learning-to-drive",
-                  "name": "Taking driving lessons"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/find-driving-schools-and-lessons",
-                  "name": "Find driving schools, lessons and instructors"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions",
-                  "name": "Practise vehicle safety questions"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "Prepare for your theory test",
-              "itemListElement": [
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/theory-test/revision-and-practice",
-                  "name": "Theory test revision and practice"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/take-practice-theory-test",
-                  "name": "Take a practice theory test"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app",
-                  "name": "Theory and hazard perception test app"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "Book and manage your theory test",
-              "itemListElement": [
-                "You need a provisional driving licence to book your theory test.",
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/book-theory-test",
-                  "name": "Book your theory test"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/theory-test/what-to-take",
-                  "name": "What to take to your test"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/change-theory-test",
-                  "name": "Change your theory test appointment"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/check-theory-test",
-                  "name": "Check your theory test appointment details"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/cancel-theory-test",
-                  "name": "Cancel your theory test"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "Book and manage your driving test",
-              "itemListElement": [
-                "You must pass your theory test before you can book your driving test.",
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/book-driving-test",
-                  "name": "Book your driving test"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/driving-test/what-to-take",
-                  "name": "What to take to your test"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/check-driving-test",
-                  "name": "Check your driving test appointment details"
-                },
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/cancel-driving-test",
-                  "name": "Cancel your driving test"
-                }
-              ]
-            },
-            {
-              "@type": "HowToStep",
-              "name": "When you pass",
-              "itemListElement": [
-                "You can start driving as soon as you pass your driving test.",
-                "You must have an insurance policy that allows you to drive without supervision.",
-                {
-                  "@type": "WebPage",
-                  "@id": "http://www.test.gov.uk/pass-plus",
-                  "name": "Find out about Pass Plus training courses"
-                }
-              ]
-            }
-          ]
-        }
+        "step": [
+          {
+            "@type": "HowToStep",
+            "name": "Check you're allowed to drive",
+            "position": 1,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "Most people can start learning to drive when they’re 17.",
+                "position": 1
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Check what age you can drive",
+                "position": 2,
+                "url": "http://www.test.gov.uk/vehicles-can-drive"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Requirements for driving legally",
+                "position": 3,
+                "url": "http://www.test.gov.uk/legal-obligations-drivers-riders"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Driving eyesight rules",
+                "position": 4,
+                "url": "http://www.test.gov.uk/driving-eyesight-rules"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Get a provisional driving licence",
+            "position": 2,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "Apply for your first provisional driving licence",
+                "position": 1,
+                "url": "http://www.test.gov.uk/apply-first-provisional-driving-licence"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Driving lessons and practice",
+            "position": 3,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "You need a provisional driving licence to take lessons or practice.",
+                "position": 1
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "The Highway Code",
+                "position": 2,
+                "url": "http://www.test.gov.uk/guidance/the-highway-code"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Taking driving lessons",
+                "position": 3,
+                "url": "http://www.test.gov.uk/driving-lessons-learning-to-drive"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Find driving schools, lessons and instructors",
+                "position": 4,
+                "url": "http://www.test.gov.uk/find-driving-schools-and-lessons"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Practise vehicle safety questions",
+                "position": 5,
+                "url": "http://www.test.gov.uk/government/publications/car-show-me-tell-me-vehicle-safety-questions"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Prepare for your theory test",
+            "position": 4,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "Theory test revision and practice",
+                "position": 1,
+                "url": "http://www.test.gov.uk/theory-test/revision-and-practice"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Take a practice theory test",
+                "position": 2,
+                "url": "http://www.test.gov.uk/take-practice-theory-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Theory and hazard perception test app",
+                "position": 3,
+                "url": "https://www.safedrivingforlife.info/shop/product/official-dvsa-theory-test-kit-app-app"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Book and manage your theory test",
+            "position": 5,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "You need a provisional driving licence to book your theory test.",
+                "position": 1
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Book your theory test",
+                "position": 2,
+                "url": "http://www.test.gov.uk/book-theory-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "What to take to your test",
+                "position": 3,
+                "url": "http://www.test.gov.uk/theory-test/what-to-take"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Change your theory test appointment",
+                "position": 4,
+                "url": "http://www.test.gov.uk/change-theory-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Check your theory test appointment details",
+                "position": 5,
+                "url": "http://www.test.gov.uk/check-theory-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Cancel your theory test",
+                "position": 6,
+                "url": "http://www.test.gov.uk/cancel-theory-test"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Book and manage your driving test",
+            "position": 6,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "You must pass your theory test before you can book your driving test.",
+                "position": 1
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Book your driving test",
+                "position": 2,
+                "url": "http://www.test.gov.uk/book-driving-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "What to take to your test",
+                "position": 3,
+                "url": "http://www.test.gov.uk/driving-test/what-to-take"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Change your driving test appointment",
+                "position": 4
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Check your driving test appointment details",
+                "position": 5,
+                "url": "http://www.test.gov.uk/check-driving-test"
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Cancel your driving test",
+                "position": 6,
+                "url": "http://www.test.gov.uk/cancel-driving-test"
+              }
+            ]
+          },
+          {
+            "@type": "HowToStep",
+            "name": "When you pass",
+            "position": 7,
+            "itemListElement": [
+              {
+                "@type": "HowToDirection",
+                "text": "You can start driving as soon as you pass your driving test.",
+                "position": 1
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "You must have an insurance policy that allows you to drive without supervision.",
+                "position": 2
+              },
+              {
+                "@type": "HowToDirection",
+                "text": "Find out about Pass Plus training courses",
+                "position": 3,
+                "url": "http://www.test.gov.uk/pass-plus"
+              }
+            ]
+          }
+        ]
       }
 
       assert_equal expected.deep_stringify_keys, step_by_step.structured_data.deep_stringify_keys

--- a/test/models/step_nav_test.rb
+++ b/test/models/step_nav_test.rb
@@ -5,6 +5,7 @@ describe StepNav do
     it 'generates structured data using the HowTo schema' do
       content_item = GovukSchemas::Example.find('step_by_step_nav', example_name: 'learn_to_drive_a_car')
       step_by_step = StepNav.new(ContentItem.new(content_item))
+      image_urls = %w(http://assets.gov.uk/image1.png http://assets.gov.uk/image2.png)
 
       # Generated with:
       # puts JSON.pretty_generate(step_by_step.structured_data)
@@ -12,10 +13,12 @@ describe StepNav do
         "@context": "http://schema.org",
         "@type": "HowTo",
         "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
+        "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
         "name": "Learn to drive a car: step by step",
         "step": [
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Check you're allowed to drive",
             "position": 1,
             "itemListElement": [
@@ -46,6 +49,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Get a provisional driving licence",
             "position": 2,
             "itemListElement": [
@@ -59,6 +63,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Driving lessons and practice",
             "position": 3,
             "itemListElement": [
@@ -95,6 +100,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Prepare for your theory test",
             "position": 4,
             "itemListElement": [
@@ -120,6 +126,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Book and manage your theory test",
             "position": 5,
             "itemListElement": [
@@ -162,6 +169,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Book and manage your driving test",
             "position": 6,
             "itemListElement": [
@@ -203,6 +211,7 @@ describe StepNav do
           },
           {
             "@type": "HowToStep",
+            "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "When you pass",
             "position": 7,
             "itemListElement": [
@@ -227,7 +236,7 @@ describe StepNav do
         ]
       }
 
-      assert_equal expected.deep_stringify_keys, step_by_step.structured_data.deep_stringify_keys
+      assert_equal expected.deep_stringify_keys, step_by_step.structured_data(image_urls).deep_stringify_keys
     end
   end
 end


### PR DESCRIPTION
The structured data report in Webmaster tools indicated that the `step` field was incorrectly formatted.  The [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/) indicated that everything was OK.

Trying step by steps in the [rich results tool](https://search.google.com/test/rich-results) indicated some places where we could improve.

The main reason for errors is because the [HowTo](https://schema.org/HowTo) `steps` field has been quietly [superseded](https://schema.org/step), so instead of needing an ItemList of steps, we have to do something a bit different.

We've replaced the previous `text` and `WebPage` elements with [`HowToDirection`](https://schema.org/HowToDirection) and added a position indicator because we care about the order in which the steps and sub-steps appear.

We've also added images to the HowTo and the steps. These images are the [same placeholders](https://github.com/alphagov/govuk_publishing_components/blob/739f207e42ff250dbae9e71e6b8c37810248e0b8/app/views/govuk_publishing_components/components/_machine_readable_metadata.html.erb#L2-L6) as used in the other schema.org components.  They're quite important for rendering the rich text result snippets for HowTo so we should include them.

You can check out the difference by submitting a step by step URL (eg `/get-tax-free-childcare`) from the review app to https://search.google.com/test/rich-results, but it's the difference between the following two screenshots.

## No image
![Screenshot 2019-05-24 10 24 48](https://user-images.githubusercontent.com/773037/58321498-2d8b6080-7e16-11e9-8623-e38169e2199d.png)

## Image
![Screenshot 2019-05-24 11 23 26](https://user-images.githubusercontent.com/773037/58321575-6a575780-7e16-11e9-8823-712c00dca842.png)

There are previews of the [rich search results](https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=jsonld&utm_source=how-to&id=8Oq8gSgIdniGNamRhS5Cbw&view=search-preview)
They should also also pass the [structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/)

