### PR TITLE
Revert "Bump govuk_app_config from 1.16.1 to 1.16.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").strip
 gem 'dalli'
 gem 'gds-api-adapters', '~> 59.4.0'
 gem 'govuk_ab_testing', '~> 2.4.1'
-gem 'govuk_app_config', '~> 1.16.2'
+gem 'govuk_app_config', '~> 1.16.1'
 gem 'govuk_frontend_toolkit', '~> 8.2.0'
 gem 'govuk_document_types'
 gem 'govuk_publishing_components', '~> 16.24.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       rubocop-rspec (~> 1.28)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (1.16.2)
+    govuk_app_config (1.16.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -367,7 +367,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.4.1)
-  govuk_app_config (~> 1.16.2)
+  govuk_app_config (~> 1.16.1)
   govuk_document_types
   govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 16.24.0)


### PR DESCRIPTION
Reverts alphagov/collections#1123

https://github.com/alphagov/govuk_app_config/pull/93