### PR TITLE
Only publish one image size for step by steps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").strip
 gem 'dalli'
 gem 'gds-api-adapters', '~> 59.4.0'
 gem 'govuk_ab_testing', '~> 2.4.1'
-gem 'govuk_app_config', '~> 1.16.1'
+gem 'govuk_app_config', '~> 1.16.3'
 gem 'govuk_frontend_toolkit', '~> 8.2.0'
 gem 'govuk_document_types'
 gem 'govuk_publishing_components', '~> 16.24.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       rubocop-rspec (~> 1.28)
       scss_lint
     govuk_ab_testing (2.4.1)
-    govuk_app_config (1.16.1)
+    govuk_app_config (1.16.3)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
@@ -367,7 +367,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_ab_testing (~> 2.4.1)
-  govuk_app_config (~> 1.16.1)
+  govuk_app_config (~> 1.16.3)
   govuk_document_types
   govuk_frontend_toolkit (~> 8.2.0)
   govuk_publishing_components (~> 16.24.0)

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -2,8 +2,6 @@
 
 <% step_image_urls = [
   image_url("govuk_publishing_components/govuk-schema-placeholder-1x1.png"),
-  image_url("govuk_publishing_components/govuk-schema-placeholder-4x3.png"),
-  image_url("govuk_publishing_components/govuk-schema-placeholder-16x9.png"),
 ] %>
 <script type="application/ld+json">
   <%= raw step_by_step.structured_data(step_image_urls).to_json %>


### PR DESCRIPTION
Google's showing assorted sizes when HowTo rich results are rendered.  This
looks a little weird.  An example of this is below 👇 

The image format in the rich result is square, so we won't bother showing
the rectangular ones as alternatives.

![Screenshot 2019-05-24 10 24 33](https://user-images.githubusercontent.com/773037/58476044-8f660600-8147-11e9-839d-333c3bd7446e.png)
