### PR TITLE
Update browse page to fix heading structure

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -90,7 +90,7 @@
     showRoot: function(){
       this.$section.html('');
       this.displayState = 'root';
-      this.$root.find('h1').focus();
+      this.$root.find('.js-heading').focus();
 
       var out = new $.Deferred()
       return out.resolve();
@@ -117,7 +117,7 @@
         animationDone.resolve();
       }
       return animationDone.then(function(){
-        this.$section.find('h1').focus();
+        this.$section.find('.js-heading').focus();
       }.bind(this));
     },
     animateSubsectionToSectionDesktop: function(){
@@ -187,7 +187,7 @@
         animationDone.resolve();
       }
       return animationDone.then(function(){
-        this.$subsection.find('h1').focus();
+        this.$subsection.find('.js-heading').focus();
       }.bind(this));
     },
     animateSectionToSubsectionDesktop: function(){

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,5 +1,5 @@
 <div id="root" class="pane root-pane">
-  <h1 class="visuallyhidden" tabindex="-1">All categories</h1>
+  <h2 class="visuallyhidden" tabindex="-1">All categories</h2>
   <ul>
     <% top_level_browse_pages.each_with_index do |page, index| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -4,6 +4,8 @@
   <meta name='govuk:navigation-page-type' content='Browse Index'>
 <% end %>
 
+<h1 class="visuallyhidden"><%= t("browse.title") %></h1>
+
 <div class="browse-panes root" data-module="track-click">
   <%= render 'top_level_browse_pages',
     top_level_browse_pages: page.top_level_browse_pages %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -5,6 +5,8 @@
 <% end %>
 <% content_for :page_class, "browse" %>
 
+<h1 class="visuallyhidden"><%= t("browse.title") %></h1>
+
 <div class="browse-panes section" data-state="section" data-module="track-click">
   <div id="section" class="section-pane pane with-sort">
     <%= render 'second_level_browse_page/second_level_browse_pages',

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,9 +1,9 @@
 <div class="pane-inner <%= page.lists.curated? ? 'curated-list' : 'a-to-z' %>">
-  <h1 tabindex="-1"><%= page.title %></h1>
+  <h2 tabindex="-1" class="js-heading"><%= page.title %></h2>
 
   <% page.lists.each_with_index do |list, section_index| %>
     <% if page.lists.curated? %>
-      <h2 class='list-header'><%= list.title %></h2>
+      <h3 class='list-header'><%= list.title %></h3>
     <% else %>
       <p class="sort-order"><%= hairspace list.title %></p>
     <% end %>

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -1,5 +1,5 @@
 <div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
-  <h1 tabindex="-1"><%= title %></h1>
+  <h2 tabindex="-1" class="js-heading"><%= title %></h2>
   <% unless curated_order %>
     <p class="sort-order"><%= hairspace 'A to Z' %></p>
   <% end %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -9,6 +9,8 @@
   <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
 
+<h1 class="visuallyhidden"><%= t("browse.title") %></h1>
+
 <div class="browse-panes subsection" data-state="subsection" data-module="track-click">
   <div id="subsection" class="subsection-pane pane with-sort">
     <%= render 'links', page: page %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,8 @@ en:
         title: "a UK national living in the EU"
       staying-uk-eu-citizen:
         title: "an EU national and you want to continue living in the UK"
+  browse:
+    title: "Browse GOV.UK"
   language_names:
     en: English
     cy: Cymraeg

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -74,7 +74,7 @@ When(/^I click on a second level browse page$/) do
 end
 
 Then(/^I should see the second level browse page$/) do
-  assert page.has_selector?('h1', text: 'Judges')
+  assert page.has_selector?('h2', text: 'Judges')
 end
 
 Then(/^the A to Z label should be present$/) do


### PR DESCRIPTION
The heading structure on the browse pages could be improved. It has multiple `H1` tags and `H3`s following a `H1`.

![browse1](https://user-images.githubusercontent.com/861310/58624607-881a3600-82c8-11e9-9a40-9a375e44c424.jpg)

This PR:

- demotes multiple `H1` tags to `H2`s
- adds a visually hidden `H1` 'Browse GOV.UK'
- updates the Javascript to ensure screen reader users still get focus on a newly opened column's heading

Result:

![browse2](https://user-images.githubusercontent.com/861310/58624716-d0395880-82c8-11e9-872b-4f162de0b95d.jpg)

Old heading structure:

<img width="349" alt="Screen Shot 2019-05-30 at 10 52 05" src="https://user-images.githubusercontent.com/861310/58624832-0bd42280-82c9-11e9-96d5-6d2e1c2e4cb4.png">

New heading structure:

<img width="345" alt="Screen Shot 2019-05-30 at 10 52 18" src="https://user-images.githubusercontent.com/861310/58624847-12629a00-82c9-11e9-9a46-36e8aabd7ba0.png">



Trello card: https://trello.com/c/3z9ocB2B/776-fix-headings-on-browse
