### PR TITLE
Add IDs to organisation headings in the organisation list

### DIFF
--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -5,7 +5,8 @@
       <% unless @presented_organisations.executive_office?(organisation_type) %>
         <%= render "govuk_publishing_components/components/heading", {
           text: organisation_type.to_s.humanize,
-          heading_level: 2
+          heading_level: 2,
+          id: organisation_type
         } %>
         <div class="organisations__department-count-wrapper">
           <p class="visuallyhidden">There are <span class="js-accessible-department-count"><%= organisations.count %></span> <%= organisation_type.to_s.humanize %></p>


### PR DESCRIPTION
The homepage section about government departments has two adjacent links that both link to the same page, but have different text.

**How does this affect users**
Confusing for screen readers and confusing for cognitive issues
WCAG 2.4.4 (A)

To mitigate against this, we should amend both links and the page they point to, so that links anchor to the relevant section.

To do this we first need to add a mechanism to link to relevant sections.

This work adds the `organisation_type` id to each section heading.

Once this is live then https://github.com/alphagov/frontend/pull/1852 needs to be deployed as well.