### PR TITLE
Change 'See more...' links on topic pages to point to supergroup finders

### DIFF
--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -36,6 +36,10 @@ module Supergroups
 
   private
 
+    def finder_path
+      "/search/policy-papers-and-consultations"
+    end
+
     def reorder_tagged_documents_to_prioritise_consultations
       consultations = @content.select do |content_item|
         consultation?(content_item.content_store_document_type)

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -10,15 +10,10 @@ module Supergroups
       name.humanize
     end
 
-    def finder_link(base_path)
-      query_string = {
-        topic: base_path,
-        group: name
-      }.to_query
-
+    def finder_link(base_path, taxon_id)
       {
         text: see_all_link_text,
-        url: "/search/advanced?#{query_string}",
+        url: finder_url(base_path, taxon_id),
         data: see_all_link_data_attributes(base_path, name)
       }
     end
@@ -46,6 +41,15 @@ module Supergroups
     end
 
   private
+
+    def finder_path
+      "/search/#{name.dasherize}"
+    end
+
+    def finder_url(base_path, taxon_id)
+      query_string = { parent: base_path, topic: taxon_id }.to_query
+      [finder_path, query_string].join('?')
+    end
 
     def see_all_link_text
       group_title = I18n.t(name, scope: :content_purpose_supergroup, default: title)

--- a/app/presenters/supergroups/transparency.rb
+++ b/app/presenters/supergroups/transparency.rb
@@ -9,5 +9,11 @@ module Supergroups
     def tagged_content(taxon_id)
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
+
+  private
+
+    def finder_path
+      "/search/transparency-and-freedom-of-information-releases"
+    end
   end
 end

--- a/app/services/supergroup_sections.rb
+++ b/app/services/supergroup_sections.rb
@@ -31,7 +31,7 @@ module SupergroupSections
           promoted_content: (supergroup.promoted_content(taxon_id) if supergroup.methods.include? :promoted_content),
           documents: supergroup.document_list(taxon_id),
           partial_template: supergroup.partial_template,
-          see_more_link: supergroup.finder_link(base_path),
+          see_more_link: supergroup.finder_link(base_path, taxon_id),
           show_section: supergroup.show_section?(taxon_id)
         }
       end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -196,7 +196,7 @@ private
 
     expected_link = {
       text: "See more guidance and regulation in this topic",
-      url: "/search/advanced?" + finder_query_string("guidance_and_regulation")
+      url: "/search/guidance-and-regulation?" + finder_query_string
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -210,7 +210,7 @@ private
 
     expected_link = {
       text: "See more services in this topic",
-      url: "/search/advanced?" + finder_query_string('services')
+      url: "/search/services?" + finder_query_string
     }
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
   end
@@ -225,7 +225,7 @@ private
 
     expected_link = {
       text: "See more news and communications in this topic",
-      url: "/search/advanced?" + finder_query_string("news_and_communications")
+      url: "/search/news-and-communications?" + finder_query_string
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -240,7 +240,7 @@ private
 
     expected_link = {
       text: "See more policy papers and consultations in this topic",
-      url: "/search/advanced?" + finder_query_string("policy_and_engagement")
+      url: "/search/policy-papers-and-consultations?" + finder_query_string
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -255,7 +255,7 @@ private
 
     expected_link = {
       text: "See more transparency and freedom of information releases in this topic",
-      url: "/search/advanced?" + finder_query_string("transparency")
+      url: "/search/transparency-and-freedom-of-information-releases?" + finder_query_string
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -270,7 +270,7 @@ private
 
     expected_link = {
       text: "See more research and statistics in this topic",
-      url: "/search/advanced?" + finder_query_string("research_and_statistics")
+      url: "/search/research-and-statistics?" + finder_query_string
     }
 
     assert page.has_link?(expected_link[:text], href: expected_link[:url])
@@ -443,10 +443,10 @@ private
     }
   end
 
-  def finder_query_string(supergroup)
+  def finder_query_string
     {
-      topic: @content_item['base_path'],
-      group: supergroup
+      parent: @content_item['base_path'],
+      topic: @content_item['content_id'],
     }.to_query
   end
 

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -4,8 +4,10 @@ describe Supergroups::Supergroup do
   include RummagerHelpers
 
   let(:taxon_id) { '12345' }
-  let(:supergroup_name) { 'supergroup_name' }
+  let(:supergroup_name) { 'news_and_communications' }
   let(:supergroup) { Supergroups::Supergroup.new(supergroup_name) }
+  let(:base_path) { '/education/skills' }
+  let(:taxon_id) { 'taxon_id' }
 
   describe '#title' do
     it 'returns human readable title' do
@@ -15,25 +17,22 @@ describe Supergroups::Supergroup do
 
   describe '#finder_link' do
     it 'returns finder link details' do
-      base_path = '/base/path'
+      expected_details = '/news-and-communications?parent=%2Feducation%2Fskills&topic=taxon_id'
 
-      expected_details = 'search/advanced?group=supergroup_name&topic=%2Fbase%2Fpath'
-
-      assert expected_details, supergroup.finder_link(base_path)
+      assert expected_details, supergroup.finder_link(base_path, taxon_id)
     end
 
     it 'returns correct data' do
-      base_path = '/base/path'
-      finder_link_data = supergroup.finder_link(base_path)[:data]
+      finder_link_data = supergroup.finder_link(base_path, taxon_id)[:data]
       assert_equal "SeeAllLinkClicked", finder_link_data[:track_category]
       assert_equal base_path, finder_link_data[:track_action]
-      assert_equal "supergroup_name", finder_link_data[:track_label]
+      assert_equal "news_and_communications", finder_link_data[:track_label]
     end
   end
 
   describe '#partial_template' do
     it 'returns the path to the section view' do
-      assert 'taxons/sections/supergroup_name', supergroup.partial_template
+      assert 'taxons/sections/news_and_communications', supergroup.partial_template
     end
   end
 


### PR DESCRIPTION
As part of our work to retire topic page finders (/search/advanced), we need to change the 'See more...' links on topic pages to point to appropriate supergroup finders.

'See more...' links should point to the right supergroup finder, filtered by the taxon.

Should be merged in after https://github.com/alphagov/finder-frontend/pull/1188 is deployed.

https://trello.com/c/qhxNedVR/766-change-see-more-links-on-topic-pages-to-point-to-supergroup-finders-s