### PR TITLE
Use component title for Courts headers

### DIFF
--- a/app/views/organisations/_courts_header.html.erb
+++ b/app/views/organisations/_courts_header.html.erb
@@ -1,0 +1,17 @@
+<div class="grid-row">
+  <div class="column-two-thirds organisation__margin-bottom">
+    <%= render "govuk_publishing_components/components/title", {
+      title: @header.org.title
+    } %>
+
+    <div class="organisation__parent-organisations brand--<%= @organisation.brand %>">
+      <%= t('organisations.administered_by') %>
+      <%= @show.parent_organisations %>
+    </div>
+  </div>
+
+  <div class="column-one-third">
+    <%= render "govuk_publishing_components/components/translation-nav", @header.translation_links %>
+    <%= render "components/topic-list", @header.ordered_featured_links %>
+  </div>
+</div>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -14,11 +14,6 @@
           <%= t('organisations.part_of') %>
           <%= @show.parent_organisations %>
         </div>
-      <% elsif @organisation.is_court_or_hmcts_tribunal? %>
-        <div class="organisation__parent-organisations brand--<%= @organisation.brand %>">
-          <%= t('organisations.administered_by') %>
-          <%= @show.parent_organisations %>
-        </div>
       <% end %>
     </div>
 

--- a/app/views/organisations/court.html.erb
+++ b/app/views/organisations/court.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
-<%= render partial: 'header' %>
+<%= render partial: 'courts_header' %>
 
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',
            schema: :organisation,

--- a/test/integration/courts_pages_test.rb
+++ b/test/integration/courts_pages_test.rb
@@ -7,7 +7,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
     when_i_visit_a_courts_page
     i_see_the_current_page_breadcrumb
     and_the_courts_breadcrumb
-    the_correct_title
+    the_courts_title
     and_featured_links
     and_the_what_we_do_section
     and_contacts
@@ -21,7 +21,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
     when_i_visit_an_hmcts_tribunal_page
     i_see_the_current_page_breadcrumb
     and_the_courts_breadcrumb
-    the_correct_title
+    the_courts_title
     and_featured_links
     and_the_what_we_do_section
     and_contacts

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -717,6 +717,11 @@ module OrganisationHelpers
     refute page.has_css?(".organisation__no10-banner")
   end
 
+  def the_courts_title
+    assert page.has_title?("#{@title} - GOV.UK")
+    assert page.has_css?(".gem-c-title__text", text: @title)
+  end
+
   def and_featured_links
     assert page.has_css?(".app-c-topic-list")
   end


### PR DESCRIPTION
The h1 for [other organisations](https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government) is small because we can be more reliant on other aspects of the page, such as the organisation logo, featured items and the "latest from <department>" sections to inform users where they are.

Courts and tribunals pages don't have these things, so it makes much more sense to have a more visually significant page header.  Fortunately we can use the title component to do this.

You can see a full list of courts and tribunals on the [index page](https://www.gov.uk/courts-tribunals) if you want to check a range of them.

[example tribunal in this review app](https://govuk-collections-pr-1152.herokuapp.com/courts-tribunals/employment-tribunal)
[current state in collections (to indicate the change here)](http://govuk-collections.herokuapp.com/courts-tribunals/employment-tribunal)
[live page (to see what we're eventually retiring)](https://www.gov.uk/courts-tribunals/employment-tribunal)

## After

### Mobile
<img src="https://user-images.githubusercontent.com/773037/59843233-06aa4680-9350-11e9-94d4-88a867e6c3be.png" width="400" />

### Desktop
<img src="https://user-images.githubusercontent.com/773037/59843243-0dd15480-9350-11e9-97b3-629d49a0801a.png" width="800" />

## Before (in this app)

### Mobile
<img src="https://user-images.githubusercontent.com/773037/59843289-29d4f600-9350-11e9-858a-df982b3bf697.png" width="400" />

### Desktop
<img src="https://user-images.githubusercontent.com/773037/59843287-293c5f80-9350-11e9-816c-839104e3e675.png" width="800" />

## Current live

### Mobile
<img src="https://user-images.githubusercontent.com/773037/59843203-f98d5780-934f-11e9-9474-14281d38b345.png" width="400" />

### Desktop
<img src="https://user-images.githubusercontent.com/773037/59843216-ff833880-934f-11e9-8cb5-903421d71b82.png" width="800" />


https://trello.com/c/Sct194Sn/822-fix-courts-and-tribunals-h1