### PR TITLE
Update Brexit taxon page navigation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,11 +106,11 @@ en:
     in_page_nav_title: "On this page"
     in_page_sub_topic_title: "Sub-topics"
     brexit:
-      prepare_for_eu_exit: "Prepare for EU Exit"
-      business_preparations: "Prepare your business for the UK leaving the EU"
-      uk_resident_preparations: "Prepare for EU Exit if you live in the UK"
-      uk_nationals_in_eu_preparations: "Living in Europe after the UK leaves the EU"
-      eu_citizens_in_uk_preparations: "Continue to live in the UK after it leaves the EU"
+      prepare_for_eu_exit: "Prepare for Brexit"
+      business_preparations: "Prepare your business or organisation for Brexit"
+      uk_resident_preparations: "Prepare for Brexit if you live in the UK"
+      uk_nationals_in_eu_preparations: "Living in Europe after Brexit"
+      eu_citizens_in_uk_preparations: "Continue to live in the UK after Brexit"
   campaign:
     other_campaigns:
       title: "Other guidance"

--- a/test/integration/citizen_readiness_test.rb
+++ b/test/integration/citizen_readiness_test.rb
@@ -16,7 +16,7 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_can_see_the_correct_title
-    page.assert_selector "h1", text: "Prepare for EU exit"
+    page.assert_selector "h1", text: "Prepare for Brexit"
   end
 
   def and_the_page_has_metatags
@@ -43,7 +43,7 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
 
   def stub_citizen_readiness_page(base_path)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: 'special_route') do |payload|
-      payload.merge(title: "Prepare for EU exit", base_path: base_path, description: "Prepare yourself for Brexit")
+      payload.merge(title: "Prepare for Brexit", base_path: base_path, description: "Prepare yourself for Brexit")
     end
     content_store_has_item(base_path, content_item)
   end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -329,13 +329,13 @@ private
   end
 
   def then_i_can_see_navigation_to_brexit_pages
-    page.assert_selector("h2.gem-c-heading", text: "Prepare for EU Exit")
-    page.assert_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business for the UK leaving the EU")
+    page.assert_selector("h2.gem-c-heading", text: "Prepare for Brexit")
+    page.assert_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business or organisation for Brexit")
   end
 
   def and_no_navigation_to_brexit_pages
-    page.assert_no_selector("h2.gem-c-heading", text: "Prepare for EU Exit")
-    page.assert_no_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business for the UK leaving the EU")
+    page.assert_no_selector("h2.gem-c-heading", text: "Prepare for Brexit")
+    page.assert_no_selector("a[href='/business-uk-leaving-eu']")
   end
 
   def then_page_has_meta_robots


### PR DESCRIPTION
The styleguide says we should be using "Brexit".  Also tweaked some of the other wording to reflect the updated footer on (eg) https://www.gov.uk/universal-credit.