### PR TITLE
Add ability to put Heroku preview app behind basic auth

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,14 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
-    }
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true"
   },
   "image": "heroku/ruby",
   "buildpacks": [

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,13 @@ class ApplicationController < ActionController::Base
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
 
+  if ENV["BASIC_AUTH_USERNAME"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
+
   # Allows additional request formats to be enabled.
   #
   # By default, PublicFacingController actions will only respond to HTML requests. To enable


### PR DESCRIPTION
The username and password are set using environment variables which are configured through the Heroku UI (https://dashboard.heroku.com/apps/govuk-collections/settings).

Trello card: https://trello.com/c/82ak276v