### PR TITLE
Add Brexit Landing Page

### DIFF
--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -1,0 +1,37 @@
+class BrexitLandingPageController < ApplicationController
+  def show
+    setup_content_item_and_navigation_helpers(taxon)
+
+    render locals: {
+      presented_taxon: presented_taxon,
+      presentable_section_items: presentable_section_items
+    }
+  end
+
+private
+
+  def taxon
+    @taxon ||= Taxon.find(request.path)
+  end
+
+  def presented_taxon
+    @presented_taxon ||= TaxonPresenter.new(taxon)
+  end
+
+  def presentable_section_items
+    @presentable_section_items = @presented_taxon.sections.select { |section| section[:show_section] }.map do |section|
+      {
+          href: "##{section[:id]}",
+          text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title])
+      }
+    end
+
+    @presentable_section_items << { href: "#organisations", text: t('taxons.organisations') }
+
+    if presented_taxon.show_subtopic_grid?
+      @presentable_section_items << { href: "#sub-topics", text: t('taxons.explore_sub_topics') }
+    end
+
+    @presentable_section_items
+  end
+end

--- a/app/views/brexit_landing_page/_brexit_preparation.html.erb
+++ b/app/views/brexit_landing_page/_brexit_preparation.html.erb
@@ -1,0 +1,25 @@
+<div class="taxon-page__section-group taxon-page__section-group--brexit">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("taxons.brexit.prepare_for_eu_exit"),
+        heading_level: 2,
+        margin_bottom: 3
+      } %>
+    </div>
+  </div>
+  <ul class="taxon-page__link-list">
+    <li class="taxon-page__link-list-item">
+      <a href="/business-uk-leaving-eu"><%= I18n.t("taxons.brexit.business_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/prepare-eu-exit"><%= I18n.t("taxons.brexit.uk_resident_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/uk-nationals-living-eu"><%= I18n.t("taxons.brexit.uk_nationals_in_eu_preparations") %></a>
+    </li>
+    <li class="taxon-page__link-list-item">
+      <a href="/staying-uk-eu-citizen"><%= I18n.t("taxons.brexit.eu_citizens_in_uk_preparations") %></a>
+    </li>
+  </ul>
+</div>

--- a/app/views/brexit_landing_page/_common.html.erb
+++ b/app/views/brexit_landing_page/_common.html.erb
@@ -1,0 +1,26 @@
+<% content_for :is_full_width_header, true %>
+<% content_for :title, presented_taxon.title %>
+<% content_for :meta_tags do %>
+  <meta name="robots" content="noindex">
+  <meta name="description" content="<%= presented_taxon.description %>">
+  <meta name="govuk:navigation-page-type" content="Taxon Page" />
+<% end %>
+
+<%= render partial: 'page_header', locals: { presented_taxon: presented_taxon } %>
+
+<% if taxon_is_live?(presented_taxon) %>
+  <div class="taxon-page__email-link-wrapper">
+    <div class="full-page-width-wrapper">
+        <%= render "components/email-link", {
+          text: "Sign up for updates to this topic page",
+          href: "/email-signup/?topic=#{presented_taxon.base_path}",
+          data: {
+            module: "track-click",
+            track_category: "emailAlertLinkClicked",
+            track_action: presented_taxon.base_path,
+            track_label: ""
+          }
+        } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/brexit_landing_page/_email_alerts.html.erb
+++ b/app/views/brexit_landing_page/_email_alerts.html.erb
@@ -1,0 +1,8 @@
+<% if taxon_is_live?(presented_taxon) %>
+  <div class='subscriptions'>
+    <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
+      Get email alerts for this topic
+      <span class='visuallyhidden'><%= presented_taxon.title %></span>
+    </a>
+  </div>
+<% end %>

--- a/app/views/brexit_landing_page/_organisation_logos_and_list.html.erb
+++ b/app/views/brexit_landing_page/_organisation_logos_and_list.html.erb
@@ -1,0 +1,21 @@
+<div class="taxon-page__organisations">
+  <ol>
+    <% organisations_with_logos.each do |promoted_organisation| %>
+      <li class="taxon-page__organisation">
+        <%= render 'govuk_publishing_components/components/organisation_logo', {
+            organisation: promoted_organisation
+          }
+        %>
+      </li>
+    <% end %>
+  </ol>
+</div>
+
+<% if organisations_without_logos.any? %>
+  <div <%= "data-module=track-click" if track_click?(organisations_without_logos) %>>
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: organisations_without_logos,
+      margin_bottom: true
+    %>
+  </div>
+<% end %>

--- a/app/views/brexit_landing_page/_organisations.html.erb
+++ b/app/views/brexit_landing_page/_organisations.html.erb
@@ -1,0 +1,35 @@
+<% if presented_organisations.show_organisations? %>
+  <div id="organisations" class="taxon-page__section-group taxon-page__section-group--organisation" data-module="toggle">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+              text: t('taxons.organisations'),
+              heading_level: 2,
+              margin_bottom: 3
+          } %>
+
+
+        <%= render partial: 'organisation_logos_and_list', locals: {
+              organisations_with_logos: presented_organisations.promoted_organisation_list[:promoted_with_logos],
+              organisations_without_logos: presented_organisations.promoted_organisation_list[:promoted_without_logos]
+        } %>
+
+        <% if presented_organisations.show_more_organisations? %>
+            <div class="taxon-page__show-more-toggle taxon-page__see-more">
+              <a href="#"
+              data-controls="more-organisations"
+              data-expanded="false"
+              data-toggled-text="Show fewer organisations">Show more organisations</a>
+            </div>
+
+          <div id="more-organisations" class="js-hidden">
+            <%= render partial: 'organisation_logos_and_list', locals: {
+                  organisations_with_logos: presented_organisations.show_more_organisation_list[:organisations_with_logos],
+                  organisations_without_logos: presented_organisations.show_more_organisation_list[:organisations_without_logos]
+            } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -1,0 +1,24 @@
+<%= render "govuk_publishing_components/components/inverse_header", { full_width: true } do %>
+  <div class="full-page-width-wrapper">
+    <%= render 'govuk_publishing_components/components/breadcrumbs',
+      breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
+      collapse_on_mobile: true,
+      inverse: true
+    %>
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <%= render "govuk_publishing_components/components/title", {
+          title: presented_taxon.title,
+          average_title_length: 'long',
+          inverse: true
+        } %>
+
+        <%= render 'govuk_publishing_components/components/lead_paragraph', {
+            text: presented_taxon.description,
+            inverse: true
+        } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/brexit_landing_page/sections/_guidance_and_regulation.html.erb
+++ b/app/views/brexit_landing_page/sections/_guidance_and_regulation.html.erb
@@ -1,0 +1,7 @@
+<%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents]
+%>
+
+<% if section[:see_more_link] %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>

--- a/app/views/brexit_landing_page/sections/_news_and_communications.html.erb
+++ b/app/views/brexit_landing_page/sections/_news_and_communications.html.erb
@@ -1,0 +1,37 @@
+<%
+  featured_item = section[:promoted_content].first
+  featured_item_layout_class = "taxon-page__featured-item--single" if section[:documents].empty?
+%>
+
+  <div class="taxon-page__featured-item <%= featured_item_layout_class %>">
+    <%= render "govuk_publishing_components/components/image_card", {
+        large: true,
+        href: featured_item[:link].fetch(:path),
+        image_src: featured_item[:image][:url],
+        heading_text: featured_item[:link].fetch(:text),
+        metadata: featured_item[:metadata][:organisations],
+        context: {
+          date: featured_item[:metadata][:public_updated_at],
+          text: featured_item[:metadata][:document_type]
+        },
+        href_data_attributes: {
+          track_category: featured_item[:link][:data_attributes][:track_category],
+          track_action: featured_item[:link][:data_attributes][:track_action],
+          track_label: featured_item[:link][:data_attributes][:track_label],
+          track_options: featured_item[:link][:data_attributes][:track_options]
+        }
+    } %>
+  </div>
+  <% if section[:documents].any? %>
+    <div>
+      <%= render 'govuk_publishing_components/components/document_list',
+        items: section[:documents],
+        margin_top: true,
+        margin_bottom: true
+      %>
+  <% else %>
+    <div class="taxon-page__featured-see-more">
+  <% end %>
+    <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+
+  </div>

--- a/app/views/brexit_landing_page/sections/_policy_and_engagement.html.erb
+++ b/app/views/brexit_landing_page/sections/_policy_and_engagement.html.erb
@@ -1,0 +1,8 @@
+<%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents]
+%>
+
+<% if section[:see_more_link] %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>
+

--- a/app/views/brexit_landing_page/sections/_research_and_statistics.html.erb
+++ b/app/views/brexit_landing_page/sections/_research_and_statistics.html.erb
@@ -1,0 +1,7 @@
+<%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents]
+%>
+
+<% if section[:see_more_link] %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>

--- a/app/views/brexit_landing_page/sections/_see_more_link.html.erb
+++ b/app/views/brexit_landing_page/sections/_see_more_link.html.erb
@@ -1,0 +1,6 @@
+<%= link_to(
+    section[:see_more_link][:text],
+    section[:see_more_link][:url],
+    data: section[:see_more_link][:data],
+    class: "taxon-page__see-more"
+)%>

--- a/app/views/brexit_landing_page/sections/_services.html.erb
+++ b/app/views/brexit_landing_page/sections/_services.html.erb
@@ -1,0 +1,7 @@
+<%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents]
+%>
+
+<% if section[:see_more_link] %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>

--- a/app/views/brexit_landing_page/sections/_transparency.html.erb
+++ b/app/views/brexit_landing_page/sections/_transparency.html.erb
@@ -1,0 +1,7 @@
+<%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents]
+%>
+
+<% if section[:see_more_link] %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_class, "taxon-page taxon-page--grid" %>
+<% content_for :brexit_taxon, presented_taxon.brexit? %>
+<%=
+  render(
+      partial: 'common',
+      locals: {
+          presented_taxon: presented_taxon
+      }
+  )
+%>
+
+<div class="full-page-width-wrapper">
+  <div class="grid-row">
+    <div class="column-one-third content-list__sticky">
+      <h2><%= t('taxons.in_page_nav_title') %></h2>
+      <%= render "govuk_publishing_components/components/contents_list", {
+          hide_title: true,
+          contents: @presentable_section_items
+      } %>
+    </div>
+    <div class="column-two-thirds">
+      <% if content_for(:brexit_taxon) %>
+        <%= render partial: 'brexit_preparation' %>
+      <% end %>
+      <% presented_taxon.sections.each do |section| %>
+        <% if section[:show_section] %>
+          <div id="<%= section[:id] %>" class="taxon-page__section-group">
+            <div class="grid-row">
+              <div class="column-two-thirds">
+                <%= render "govuk_publishing_components/components/heading", {
+                    text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+                    heading_level: 2,
+                    margin_bottom: 3
+                } %>
+              </div>
+            </div>
+            <%= render(
+                    partial: section[:partial_template],
+                    locals: { section: section }
+                )
+            %>
+          </div>
+        <% end %>
+      <% end %>
+
+      <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
+
+      <% if presented_taxon.show_subtopic_grid? %>
+        <div id="sub-topics" class="taxon-page__section-group">
+          <%= render "govuk_publishing_components/components/heading", {
+              text: t('taxons.explore_sub_topics'),
+              heading_level: 2,
+              margin_bottom: 3
+          } %>
+
+          <%= render 'govuk_publishing_components/components/document_list',
+                     items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| { link: { text: child_taxon.title, path: child_taxon.base_path, data_attributes: presented_taxon.options_for_child_taxon(index: index) }} },
+                     margin_bottom: true
+          %>
+
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,5 +73,6 @@ Rails.application.routes.draw do
   end
 
   get '/world/*taxon_base_path', to: 'world_wide_taxons#show'
+  get '/government/brexit', to: 'brexit_landing_page#show'
   get '*taxon_base_path', to: 'taxons#show'
 end

--- a/test/controllers/brexit_landing_page_controller_test.rb
+++ b/test/controllers/brexit_landing_page_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+describe BrexitLandingPageController do
+  include RummagerHelpers
+  include GovukAbTesting::MinitestHelpers
+  include TaxonHelpers
+
+  describe "GET show" do
+    before do
+      brexit_taxon = taxon
+      brexit_taxon['base_path'] = '/government/brexit'
+      content_store_has_item(brexit_taxon["base_path"], brexit_taxon)
+      stub_content_for_taxon(brexit_taxon["content_id"], [brexit_taxon])
+      stub_content_for_taxon(brexit_taxon["content_id"], generate_search_results(5))
+      stub_document_types_for_supergroup('guidance_and_regulation')
+      stub_most_popular_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_guidance_and_regulation, filter_content_store_document_type: 'guidance_and_regulation')
+      stub_document_types_for_supergroup('services')
+      stub_most_popular_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_services, filter_content_store_document_type: 'services')
+      stub_document_types_for_supergroup('news_and_communications')
+      stub_most_recent_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_news_and_communications, filter_content_store_document_type: 'news_and_communications')
+      stub_document_types_for_supergroup('policy_and_engagement')
+      stub_most_recent_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_policy_and_engagement, filter_content_store_document_type: 'policy_and_engagement')
+      stub_document_types_for_supergroup('transparency')
+      stub_most_recent_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_transparency, filter_content_store_document_type: 'transparency')
+      stub_document_types_for_supergroup('research_and_statistics')
+      stub_most_recent_content_for_taxon(brexit_taxon["content_id"], tagged_content_for_research_and_statistics, filter_content_store_document_type: 'research_and_statistics')
+      stub_organisations_for_taxon(brexit_taxon["content_id"], tagged_organisations)
+    end
+
+    it "renders the page" do
+      get :show
+
+      assert_response :success
+    end
+  end
+end

--- a/test/integration/brexit_landing_page_test.rb
+++ b/test/integration/brexit_landing_page_test.rb
@@ -1,0 +1,33 @@
+require 'integration_test_helper'
+require_relative '../support/brexit_landing_page_steps'
+
+class BrexitLandingPageTest < ActionDispatch::IntegrationTest
+  include BrexitLandingPageSteps
+
+  it 'renders the brexit page' do
+    given_there_is_a_brexit_taxon
+    when_i_visit_the_brexit_landing_page
+    then_i_can_see_the_title_section
+    then_i_can_see_navigation_to_brexit_pages
+    and_i_can_see_the_email_signup_link
+    and_i_can_see_the_services_section
+    and_i_can_see_the_guidance_and_regulation_section
+    and_i_can_see_the_news_and_communications_section
+    and_i_can_see_the_policy_papers_and_consulations_section
+    and_i_can_see_the_transparency_and_foi_releases_section
+    and_i_can_see_the_research_and_statistics_section
+    and_i_can_see_the_organisations_section
+  end
+
+  it 'renders an in-page nav' do
+    given_there_is_a_brexit_taxon
+    when_i_visit_the_brexit_landing_page
+    and_i_can_see_the_in_page_nav
+  end
+
+  it "has tracking on all links" do
+    given_there_is_a_brexit_taxon
+    when_i_visit_the_brexit_landing_page
+    then_all_links_have_tracking_data
+  end
+end

--- a/test/support/brexit_landing_page_steps.rb
+++ b/test/support/brexit_landing_page_steps.rb
@@ -1,0 +1,287 @@
+require 'gds_api/test_helpers/content_item_helpers'
+
+module BrexitLandingPageSteps
+  include GdsApi::TestHelpers::ContentItemHelpers
+  include RummagerHelpers
+
+  def given_there_is_a_brexit_taxon
+    content_store_has_item(brexit_taxon_path, content_item)
+    and_the_taxon_has_tagged_content
+  end
+
+  def brexit_taxon_path
+    "/government/brexit"
+  end
+
+  def content_id
+    "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+  end
+
+  def content_item
+    @content_item ||= begin
+      GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
+        item.merge(
+          "base_path" => brexit_taxon_path,
+          "content_id" => content_id,
+          "title" => "Brexit",
+          "phase" => "live",
+          "links" => {},
+        )
+      end
+    end
+  end
+
+  def when_i_visit_the_brexit_landing_page
+    visit brexit_taxon_path
+  end
+
+  def and_the_taxon_has_tagged_content
+    # We still need to stub tagged content because it is used by the sub-topic grid
+    stub_content_for_taxon(content_id, tagged_content)
+    stub_document_types_for_supergroup('guidance_and_regulation')
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: 'guidance_and_regulation')
+    stub_document_types_for_supergroup('services')
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: 'services')
+    stub_document_types_for_supergroup('news_and_communications')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: 'news_and_communications')
+    stub_document_types_for_supergroup('policy_and_engagement')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: 'policy_and_engagement')
+    stub_document_types_for_supergroup('transparency')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: 'transparency')
+    stub_document_types_for_supergroup('research_and_statistics')
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: 'research_and_statistics')
+    stub_organisations_for_taxon(content_id, tagged_organisations)
+  end
+
+  def then_i_can_see_the_title_section
+    assert page.has_selector?('title', text: content_item['title'], visible: false)
+
+    within '.gem-c-breadcrumbs' do
+      assert page.has_link?('Home', href: '/')
+    end
+  end
+
+  def and_i_can_see_the_email_signup_link
+    assert page.has_link?(
+      'Sign up for updates to this topic page',
+      href: "/email-signup/?topic=#{current_path}"
+    )
+    assert page.has_css?("a[data-track-category='emailAlertLinkClicked']", text: "Sign up for updates to this topic page")
+    assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: "Sign up for updates to this topic page")
+    assert page.has_css?("a[data-track-label=\"\"]", text: "Sign up for updates to this topic page")
+  end
+
+  def and_i_can_see_the_guidance_and_regulation_section
+    assert page.has_selector?('.gem-c-heading', text: "Guidance")
+
+    tagged_content_for_guidance_and_regulation.each do |item|
+      if item['content_store_document_type'] == 'guide'
+        mainstream_content_list_item_test(item)
+      else
+        all_other_sections_list_item_test(item)
+      end
+    end
+
+    expected_link = {
+      text: "See more guidance and regulation in this topic",
+      url: "/search/guidance-and-regulation?" + finder_query_string
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_services_section
+    assert page.has_selector?('.gem-c-heading', text: "Services")
+    tagged_content_for_services.each do |item|
+      mainstream_content_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See more services in this topic",
+      url: "/search/services?" + finder_query_string
+    }
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_news_and_communications_section
+    assert page.has_selector?('.gem-c-heading', text: "News")
+    assert page.has_selector?('.taxon-page__featured-item')
+
+    tagged_content_for_news_and_communications.each do |item|
+      all_other_sections_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See more news and communications in this topic",
+      url: "/search/news-and-communications?" + finder_query_string
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_policy_papers_and_consulations_section
+    assert page.has_selector?('.gem-c-heading', text: "Policy")
+
+    tagged_content_for_policy_and_engagement.each do |item|
+      all_other_sections_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See more policy papers and consultations in this topic",
+      url: "/search/policy-papers-and-consultations?" + finder_query_string
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_transparency_and_foi_releases_section
+    assert page.has_selector?('.gem-c-heading', text: "Transparency")
+
+    tagged_content_for_transparency.each do |item|
+      all_other_sections_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See more transparency and freedom of information releases in this topic",
+      url: "/search/transparency-and-freedom-of-information-releases?" + finder_query_string
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def and_i_can_see_the_research_and_statistics_section
+    assert page.has_selector?('.gem-c-heading', text: "Research")
+
+    tagged_content_for_research_and_statistics.each do |item|
+      all_other_sections_list_item_test(item)
+    end
+
+    expected_link = {
+      text: "See more research and statistics in this topic",
+      url: "/search/research-and-statistics?" + finder_query_string
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def mainstream_content_list_item_test(item)
+    assert page.has_selector?('.gem-c-document-list__item-title[href="' + item["link"] + '"]', text: item["title"])
+    assert page.has_selector?('.gem-c-document-list__item-description', text: item["description"])
+    assert page.has_no_content?(expected_organisations(item))
+  end
+
+  def all_other_sections_list_item_test(item)
+    assert page.has_selector?('.gem-c-document-list__item-title[href="' + item["link"] + '"]', text: item["title"])
+    assert page.has_selector?('.gem-c-document-list__attribute time', text: item["public_updated_at"])
+    assert page.has_selector?('.gem-c-document-list__attribute', text: item["content_store_document_type"].humanize)
+    assert page.has_content?(expected_organisations(item))
+  end
+
+  def and_i_can_see_the_organisations_section
+    assert page.has_content?('Organisations')
+
+    tagged_org_with_logo = tagged_organisation_with_logo['value']['link']
+    assert page.has_css?(".gem-c-organisation-logo a[href='#{tagged_org_with_logo}']")
+
+    assert page.has_link?(tagged_organisation['value']['title'],
+                          href: tagged_organisation['value']['link'])
+  end
+
+  def and_i_can_see_the_in_page_nav
+    assert page.has_selector?('.gem-c-contents-list__list')
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Services")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Guidance and regulation")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "News and communications")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Research and statistics")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Policy papers and consultations")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Transparency and freedom of information releases")
+    assert page.has_selector?('.gem-c-contents-list__link', text: "Organisations")
+  end
+
+  def then_i_can_see_navigation_to_brexit_pages
+    page.assert_selector("h2.gem-c-heading", text: "Prepare for Brexit")
+    page.assert_selector("a[href='/business-uk-leaving-eu']", text: "Prepare your business or organisation for Brexit")
+  end
+
+  def then_all_links_have_tracking_data
+    [
+      'services', 'guidance and regulation', 'news and communications',
+      'research and statistics', 'policy papers and consultations',
+      'transparency and freedom of information releases'
+    ].each do |section|
+      assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: "See more #{section} in this topic")
+      assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: "See more #{section} in this topic")
+    end
+  end
+
+  def tagged_content
+    generate_search_results(5)
+  end
+
+  def tagged_content_for_services
+    @tagged_content_for_services ||= generate_search_results(2, "services")
+  end
+
+  def tagged_content_for_guidance_and_regulation
+    @tagged_content_for_guidance_and_regulation ||= generate_search_results(2, 'guidance_and_regulation')
+  end
+
+  def tagged_content_for_news_and_communications
+    @tagged_content_for_news_and_communications ||= generate_search_results(2, "news_and_communications")
+  end
+
+  def tagged_content_for_policy_and_engagement
+    @tagged_content_for_policy_and_engagement ||= generate_search_results(2, "policy_and_engagement")
+  end
+
+  def tagged_content_for_transparency
+    @tagged_content_for_transparency ||= generate_search_results(2, "transparency")
+  end
+
+  def tagged_content_for_research_and_statistics
+    @tagged_content_for_research_and_statistics ||= generate_search_results(2, "research_and_statistics")
+  end
+
+  def tagged_organisations
+    [
+        tagged_organisation,
+        tagged_organisation_with_logo
+    ]
+  end
+
+  def tagged_organisation
+    {
+        'value' => {
+            'title' => 'Organisation without logo',
+            'link' => '/government/organisations/organisation-without-logo',
+            'organisation_state' => 'live'
+        }
+    }
+  end
+
+  def tagged_organisation_with_logo
+    {
+        'value' => {
+            'title' => 'Organisation with logo',
+            'link' => '/government/organisations/organisation-with-logo',
+            'organisation_state' => 'live',
+            'organisation_brand' => 'org-brand',
+            'organisation_crest' => 'single-identity',
+            'logo_formatted_title' => "organisation-with-logo"
+        }
+    }
+  end
+
+  def finder_query_string
+    {
+      parent: content_item['base_path'],
+      topic: content_item['content_id'],
+    }.to_query
+  end
+
+  def expected_organisations(content)
+    content['organisations']
+      .map { |org| org['title'] }
+      .to_sentence
+  end
+end


### PR DESCRIPTION
This is a preparatory refactor of the brexit taxon page.

Now `/government/brexit` will be rendered by a new controller with new views under brexit_landing_page, rather than the taxon controller.

The new code behind /government/brexit is almost exactly the same as it was before.

End users should not see a change as a result of this.

This will enable us to make changes to the brexit taxon page without impacting other taxon pages.