### PR TITLE
Allow the Brexit landing page to be switched on by environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,10 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Configuration to stop Brexit landing page showing in production before campaign
+  # goes live
+  config.show_brexit_landing_page = true
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,12 @@ Rails.application.configure do
     ENV['GOVUK_ASSET_ROOT'] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
   end
 
+  # Configuration to stop Brexit landing page showing in production before campaign
+  # goes live
+  if (ENV['BASIC_AUTH_USERNAME'] && ENV['BASIC_AUTH_PASSWORD'] && ENV['HEROKU_APP_NAME']) || ENV['JENKINS'] || ENV['PUBLISHING_E2E_TESTS_COMMAND']
+    config.show_brexit_landing_page = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,10 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Configuration to stop Brexit landing page showing in production before campaign
+  # goes live
+  config.show_brexit_landing_page = true
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,6 @@ Rails.application.routes.draw do
   end
 
   get '/world/*taxon_base_path', to: 'world_wide_taxons#show'
-  get '/government/brexit', to: 'brexit_landing_page#show'
+  get '/government/brexit', to: 'brexit_landing_page#show' if Rails.application.config.respond_to?(:show_brexit_landing_page) && Rails.application.config.show_brexit_landing_page
   get '*taxon_base_path', to: 'taxons#show'
 end


### PR DESCRIPTION
Added a configuration flag so the Brexit landing page can be switched on/off in specific environments.  This allows us to ensure it is not shown to users in production until the campaign goes live.

This configuration will switch it on in the following environments: test, CI, development and all Heroku previews that have basic auth defined.

My preference would have been to do this by setting environment variables through Puppet, but then we'd end up putting some of this work in public repos.

This PR is to be reverted when the campaign goes live next week. 

Trello card: https://trello.com/c/wTOfPyE5