### PR TITLE
Fix the CI build

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
 
   # Configuration to stop Brexit landing page showing in production before campaign
   # goes live
-  if (ENV['BASIC_AUTH_USERNAME'] && ENV['BASIC_AUTH_PASSWORD'] && ENV['HEROKU_APP_NAME']) || ENV['JENKINS'] || ENV['PUBLISHING_E2E_TESTS_COMMAND']
+  if (ENV['BASIC_AUTH_USERNAME'] && ENV['BASIC_AUTH_PASSWORD'] && ENV['HEROKU_APP_NAME'])
     config.show_brexit_landing_page = true
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,9 @@ GovukAbTesting.configure do |config|
   config.acceptance_test_framework = :active_support
 end
 
+# Ensure the Brexit taxon page is visible for integration tests
+Rails.application.config.show_brexit_landing_page = true
+
 class ActiveSupport::TestCase
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::Rummager


### PR DESCRIPTION
The Brexit campaign landing page is not visible to the tests running in CI, therefore master is not building.

This sets the configuration to show the Brexit campaign landing page for all tests.

Trello card: https://trello.com/c/wTOfPyE5