### PR TITLE
Remove IE8 exclusion

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <title><%= yield :title %> - GOV.UK</title>
   <%= javascript_include_tag "application" %>
-  <!--[if gt IE 8]><!--><%= stylesheet_link_tag "application" %><!--<![endif]-->
+  <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= yield :meta_section %>


### PR DESCRIPTION
I recently [removed the IE8 specific stylesheets](https://github.com/alphagov/collections/pull/1201) but failed to notice that the application layout template didn't include IE8 when including the styles from collections, which meant that any page in collections would have the general GOV.UK styles but not any collections specific styles.

This PR fixes that.