### PR TITLE
Remove all services link from Charity Commission

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -115,7 +115,6 @@ module Organisations
 
     def has_services_and_information_link?
       orgs_with_services_and_information_link = %w{
-        charity-commission
         department-for-education
         department-for-environment-food-rural-affairs
         driver-and-vehicle-standards-agency


### PR DESCRIPTION
The Charity Commission want to remove the "All Charity Commission services and information" from their organisation page as it duplicates information that is available elsewhere.

Zendesk ticket here: https://govuk.zendesk.com/agent/tickets/3799607 

## Before
<img width="452" alt="Screen Shot 2019-09-12 at 15 22 59" src="https://user-images.githubusercontent.com/29889908/64792372-3ba1f000-d571-11e9-8e08-7df3659f1b92.png">

## After
<img width="323" alt="Screen Shot 2019-09-12 at 15 22 53" src="https://user-images.githubusercontent.com/29889908/64792382-3f357700-d571-11e9-92ec-f5fe99806acc.png">
