### PR TITLE
Add AB test setup for Brexit landing page

### DIFF
--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -1,4 +1,9 @@
 class BrexitLandingPageController < ApplicationController
+  # 68 was chosen to uniquely identify BrexitLandingPageTest in GA
+  CUSTOM_DIMENSION = 68
+
+  helper_method :page_variant
+
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
@@ -7,9 +12,24 @@ class BrexitLandingPageController < ApplicationController
       presentable_section_items: presentable_section_items,
       show_dynamic_list: show_dynamic_list?,
     }
+
+    page_variant.configure_response(response)
   end
 
 private
+
+  def page_variant
+    @page_variant ||= begin
+                        ab_test = GovukAbTesting::AbTest.new(
+                          "BrexitLandingPageTest",
+                          dimension: CUSTOM_DIMENSION,
+                          allowed_variants: %w(A B),
+                          control_variant: "A",
+                        )
+
+                        ab_test.requested_variant(request.headers)
+                      end
+  end
 
   def taxon
     Taxon.find(request.path)
@@ -22,8 +42,8 @@ private
   def presentable_section_items
     presented_taxon.supergroup_sections.select { |section| section[:show_section] }.map do |section|
       {
-          href: "##{section[:id]}",
-          text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
+        href: "##{section[:id]}",
+        text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
       }
     end
   end

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :extra_headers do %>
-  <link rel="preload" as="image" href="<%= asset_path 'chevron-extend-hover.svg' %>">
+<% content_for :meta_tags do %>
+  <%= page_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <%=
   render(
       partial: 'page_header',
       locals: {
-          presented_taxon: presented_taxon,
-          show_dynamic_list: show_dynamic_list
+        presented_taxon: presented_taxon,
+        show_dynamic_list: show_dynamic_list
       }
   )
 %>

--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -2,7 +2,7 @@
 <%= render 'shared/tag_meta', tag: subtopic, description: "Subscribe to get an email each time content is published or updated in the '#{subtopic.combined_title}' topic." %>
 <% content_for :page_class, "email-signup-new" %>
 
-<% content_for :meta_section do %>
+<% content_for :meta_tags do %>
   <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
 

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -6,7 +6,7 @@
       } %>
 <% end %>
 
-<% content_for :meta_section do %>
+<% content_for :meta_tags do %>
   <meta name="govuk:section" content="<%= meta_section %>">
   <meta name="robots" content="noindex">
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= yield :meta_section %>
-  <%= yield :extra_headers %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
 </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
-  <%= yield :meta_section %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
 </head>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -2,12 +2,9 @@
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <meta name='govuk:navigation-page-type' content='Second Level Browse'>
-<% end %>
-<% content_for :page_class, "browse" %>
-
-<% content_for :meta_section do %>
   <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
+<% content_for :page_class, "browse" %>
 
 <h1 class="visuallyhidden"><%= t("browse.title") %></h1>
 

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -2,6 +2,7 @@
 <%= render 'shared/tag_meta', tag: subtopic %>
 <% content_for :meta_tags do %>
   <meta name='govuk:navigation-page-type' content='Second Level Topic'>
+  <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
 <% content_for :page_title do %>
   <%
@@ -14,10 +15,6 @@
     end
   %>
   <%= render "govuk_publishing_components/components/title", title_params %>
-<% end %>
-
-<% content_for :meta_section do %>
-  <meta name="govuk:section" content="<%= meta_section %>">
 <% end %>
 
 <%= render(

--- a/test/controllers/brexit_landing_page_controller_test.rb
+++ b/test/controllers/brexit_landing_page_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 describe BrexitLandingPageController do
   include TaxonHelpers
+  include GovukAbTesting::MinitestHelpers
 
   describe "GET show" do
     before do
@@ -14,6 +15,34 @@ describe BrexitLandingPageController do
       get :show
 
       assert_response :success
+    end
+
+    context "Brexit landing page AB tests" do
+      it "renders A variant" do
+        with_variant BrexitLandingPageTest: "A" do
+          get :show
+
+          assert_response :success
+          assert_equal("GOVUK-ABTest-BrexitLandingPageTest", response.headers["Vary"])
+          assert_includes(
+            response.body,
+            "<meta name=\"govuk:ab-test\" content=\"BrexitLandingPageTest:A\" data-analytics-dimension=\"68\" data-allowed-variants=\"A,B\">",
+          )
+        end
+      end
+
+      it "renders B variant" do
+        with_variant BrexitLandingPageTest: "B" do
+          get :show
+
+          assert_response :success
+          assert_equal("GOVUK-ABTest-BrexitLandingPageTest", response.headers["Vary"])
+          assert_includes(
+            response.body,
+            "<meta name=\"govuk:ab-test\" content=\"BrexitLandingPageTest:B\" data-analytics-dimension=\"68\" data-allowed-variants=\"A,B\">",
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR sets up two variants of the landing page, A and you guessed it... B. These variants are currently the same but B will be updated with the new landing page designs in a later PR.

Further information in following commits: ->

Co-authored: @vanitabarrett @1pretz1 

Trello:
https://trello.com/c/Az3SiQxJ/265-add-a-b-test-logic-to-the-landing-page

Also thanks to @kevindew for bashing his head against a problem due for my (@1pretz1) gross negligence of the rules of html! 😆😭   