### PR TITLE
Add Welsh translations for document types and dates

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -100,7 +100,7 @@ module Organisations
           image_alt: news["image"]["alt_text"],
           context: {
             date: date,
-            text: news["document_type"],
+            text: I18n.t("content_item.schema_name.#{news['document_type'].parameterize(separator: '_')}", count: 1, default: news["document_type"]),
           },
           heading_text: news["title"],
           description: news["summary"].html_safe,

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -123,3 +123,374 @@ cy:
   language_names:
     en: English
     cy: Cymraeg
+  content_item:
+    schema_name:
+      announcement:
+        zero:
+        one: Cyhoeddiad
+        two:
+        few:
+        many:
+        other: Cyhoeddiadau
+      authored_article:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      case_study:
+        zero:
+        one: Astudiaeth achos
+        two:
+        few:
+        many:
+        other: Astudiaethau achos
+      closed_consultation:
+        zero:
+        one: Ymgynghoriad ar gau
+        two:
+        few:
+        many:
+        other: Ymgynghoriadau ar gau
+      consultation:
+        zero:
+        one: Ymgynghoriad
+        two:
+        few:
+        many:
+        other: Ymgynghoriadau
+      consultation_outcome:
+        zero:
+        one: Canlyniad ymgynghoriad
+        two:
+        few:
+        many:
+        other: Canlyniadau ymgynghoriadau
+      corporate_report:
+        zero:
+        one: Adroddiad corfforaethol
+        two:
+        few:
+        many:
+        other: Adroddiadau corfforaethol
+      correspondence:
+        zero:
+        one: Gohebiaeth
+        two:
+        few:
+        many:
+        other: Gohebiaeth
+      decision:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      detailed_guide:
+        zero:
+        one: Cyfarwyddyd manwl
+        two:
+        few:
+        many:
+        other: Cyfarwyddyd manwl
+      document_collection:
+        zero:
+        one: Cyfres
+        two:
+        few:
+        many:
+        other:
+      draft_text:
+        zero:
+        one: Testun drafft
+        two:
+        few:
+        many:
+        other: Testun drafft
+      fatality_notice:
+        zero:
+        one: Hysbysiad marwolaeth
+        two:
+        few:
+        many:
+        other: Hysbysiadau marwolaeth
+      foi_release:
+        zero:
+        one: Datganiad Rhyddid Gwybodaeth
+        two:
+        few:
+        many:
+        other: Datganiadau Rhyddid Gwybodaeth
+      form:
+        zero:
+        one: Ffurflen
+        two:
+        few:
+        many:
+        other: Ffurflenni
+      government_response:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      guidance:
+        zero:
+        one: Cyfarwyddyd
+        two:
+        few:
+        many:
+        other: Cyfarwyddyd
+      impact_assessment:
+        zero:
+        one: Asesiad o'r effaith
+        two:
+        few:
+        many:
+        other: Asesiadau o'r effaith
+      imported:
+        zero:
+        one: wedi mewngludo - yn disgwyl math
+        two:
+        few:
+        many:
+        other: wedi mewngludo - yn disgwyl math
+      independent_report:
+        zero:
+        one: Adroddiad annibynnol
+        two:
+        few:
+        many:
+        other: Adroddiadau annibynnol
+      international_treaty:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      map:
+        zero:
+        one: Map
+        two:
+        few:
+        many:
+        other: Mapiau
+      national_statistics:
+        zero:
+        one: Ystadegau - ystadegau gwladol
+        two:
+        few:
+        many:
+        other: Ystadegau - ystadegau gwladol
+      news_article:
+        zero:
+        one: Erthygl newyddion
+        two:
+        few:
+        many:
+        other: Erthyglau newyddion
+      news_story:
+        zero:
+        one: Stori newyddion
+        two:
+        few:
+        many:
+        other: Straeon newyddion
+      notice:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      open_consultation:
+        zero:
+        one: Ymgynghoriad ar agor
+        two:
+        few:
+        many:
+        other: Ymgynghoriadau ar agor
+      oral_statement:
+        zero:
+        one: Datganiad llafar i'r senedd
+        two:
+        few:
+        many:
+        other: Datganiadau llafar i'r senedd
+      policy:
+        zero:
+        one: Polisi
+        two:
+        few:
+        many:
+        other: Polisïau
+      policy_paper:
+        zero:
+        one: Papur polisi
+        two:
+        few:
+        many:
+        other: Papurau polisi
+      press_release:
+        zero:
+        one: Datganiad i'r wasg
+        two:
+        few:
+        many:
+        other: Datganiadau i'r wasg
+      promotional:
+        zero:
+        one: Deunydd hyrwyddo
+        two:
+        few:
+        many:
+        other: Deunydd hyrwyddo
+      publication:
+        zero:
+        one: Cyhoeddiad
+        two:
+        few:
+        many:
+        other: Cyhoeddiadau
+      regulation:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      research:
+        zero:
+        one: Ymchwil a dadansoddiad
+        two:
+        few:
+        many:
+        other: Ymchwil a dadansoddiad
+      speaking_notes:
+        zero:
+        one: Nodiadau siarad
+        two:
+        few:
+        many:
+        other: Nodiadau siarad
+      service_sign_in:
+        one: Gwasanaeth Mewngofnodi
+        other: Gwasanaeth Mewngofnodi
+      speech:
+        zero:
+        one: Araith
+        two:
+        few:
+        many:
+        other: Areithiau
+      statement_to_parliament:
+        zero:
+        one: Datganiad i'r senedd
+        two:
+        few:
+        many:
+        other: Datganiadau i'r senedd
+      statistical_data_set:
+        zero:
+        one: Set data ystadegol
+        two:
+        few:
+        many:
+        other: Setiau data ystadegol
+      official_statistics:
+        zero:
+        one: Ystadegau
+        two:
+        few:
+        many:
+        other: Ystadegau
+      statutory_guidance:
+        zero:
+        one:
+        two:
+        few:
+        many:
+        other:
+      transcript:
+        zero:
+        one: Trawsgrifiad
+        two:
+        few:
+        many:
+        other: Trawsgrifiadau
+      transparency:
+        zero:
+        one: Data tryloywder
+        two:
+        few:
+        many:
+        other: Data tryloywder
+      world_location_news_article:
+        zero:
+        one: Erthygl newyddion
+        two:
+        few:
+        many:
+        other: Erthyglau newyddion
+      written_statement:
+        zero:
+        one: Datganiad ysgrifenedig i'r Senedd
+        two:
+        few:
+        many:
+        other: Datganiadau ysgrifenedig i'r Senedd
+  date:
+    formats:
+      default: "%d %M %Y"
+    abbr_day_names:
+    - Sul
+    - Llun
+    - Maw
+    - Mer
+    - Iau
+    - Gwe
+    - Sad
+    abbr_month_names:
+    -
+    - Ion
+    - Chw
+    - Maw
+    - Ebr
+    - Mai
+    - Meh
+    - Gor
+    - Awst
+    - Med
+    - Hyd
+    - Tach
+    - Rha
+    day_names:
+    - Dydd Sul
+    - Dydd Llun
+    - Dydd Mawrth
+    - Dydd Mercher
+    - Dydd Iau
+    - Dydd Gwener
+    - Dydd Sadwrn
+    month_names:
+    -
+    - Ionawr
+    - Chwefror
+    - Mawrth
+    - Ebrill
+    - Mai
+    - Mehefin
+    - Gorffennaf
+    - Awst
+    - Medi
+    - Hydref
+    - Tachwedd
+    - Rhagfyr
+    order:
+    - :year
+    - :month
+    - :day

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,3 +156,218 @@ en:
   language_names:
     en: English
     cy: Cymraeg
+  content_item:
+    schema_name:
+      aaib_report:
+        one: Air Accidents Investigation Branch report
+        other: Air Accidents Investigation Branch reports
+      announcement:
+        one: Announcement
+        other: Announcements
+      asylum_support_decision:
+        one: Asylum support tribunal decision
+        other: Asylum support tribunal decisions
+      business_finance_support_scheme:
+        one: Business finance support scheme
+        other: Business finance support schemes
+      case_study:
+        one: Case study
+        other: Case studies
+      closed_consultation:
+        one: Closed consultation
+        other: Closed consultations
+      cma_case:
+        one: Competition and Markets Authority case
+        other: Competition and Markets Authority cases
+      coming_soon:
+        one: Coming Soon
+        other: Coming Soon
+      consultation:
+        one: Consultation
+        other: Consultations
+      consultation_outcome:
+        one: Consultation outcome
+        other: Consultation outcomes
+      corporate_information_page:
+        one: Information page
+        other: Information pages
+      corporate_report:
+        one: Corporate report
+        other: Corporate reports
+      correspondence:
+        one: Correspondence
+        other: Correspondences
+      countryside_stewardship_grant:
+        one: Countryside Stewardship grant
+        other: Countryside Stewardship grants
+      detailed_guide:
+        one: Guidance
+        other: Guidance
+      dfid_research_output:
+        one: Research for Development Output
+        other: Research for Development Outputs
+      document_collection:
+        one: Collection
+        other: Collections
+      draft_text:
+        one: Draft text
+        other: Draft texts
+      drug_safety_update:
+        one: Drug Safety Update
+        other: Drug Safety Updates
+      employment_appeal_tribunal_decision:
+        one: Employment appeal tribunal decision
+        other: Employment appeal tribunal decisions
+      employment_tribunal_decision:
+        one: Employment tribunal decision
+        other: Employment tribunal decisions
+      esi_fund:
+        one: European Structural and Investment Fund (ESIF)
+        other: European Structural and Investment Funds (ESIF)
+      fatality_notice:
+        one: Fatality notice
+        other: Fatality notices
+      foi_release:
+        one: FOI release
+        other: FOI releases
+      form:
+        one: Form
+        other: Forms
+      guidance:
+        one: Guidance
+        other: Guidance
+      statutory_guidance:
+        one: Statutory guidance
+        other: Statutory guidance
+      impact_assessment:
+        one: Impact assessment
+        other: Impact assessments
+      imported:
+        one: imported - awaiting type
+        other: imported - awaiting type
+      independent_report:
+        one: Independent report
+        other: Independent reports
+      international_development_fund:
+        one: International development funding
+        other: International development funding
+      international_treaty:
+        one: International treaty
+        other: International treaties
+      map:
+        one: Map
+        other: Maps
+      maib_report:
+        one: Marine Accident Investigation Branch report
+        other: Marine Accident Investigation Branch reports
+      medical_safety_alert:
+        one: Alerts and recalls for drugs and medical devices
+        other: Alerts and recalls for drugs and medical devices
+      notice:
+        one: Notice
+        other: Notices
+      decision:
+        one: Decision
+        other: Decisions
+      national_statistics:
+        one: National Statistics
+        other: National Statistics
+      national_statistics_announcement:
+        one: National statistics announcement
+        other: National statistics announcements
+      news_article:
+        one: News article
+        other: News articles
+      news_story:
+        one: News story
+        other: News stories
+      open_consultation:
+        one: Open consultation
+        other: Open consultations
+      oral_statement:
+        one: Oral statement to Parliament
+        other: Oral statements to Parliament
+      policy:
+        one: Policy
+        other: Policies
+      policy_paper:
+        one: Policy paper
+        other: Policy papers
+      press_release:
+        one: Press release
+        other: Press releases
+      promotional:
+        one: Promotional material
+        other: Promotional material
+      publication:
+        one: Publication
+        other: Publications
+      government_response:
+        one: Government response
+        other: Government responses
+      raib_report:
+        one: Rail Accident Investigation Branch report
+        other: Rail Accident Investigation Branch reports
+      regulation:
+        one: Regulation
+        other: Regulations
+      research:
+        one: Research and analysis
+        other: Research and analysis
+      residential_property_tribunal_decision:
+        one: Residential property tribunal decision
+        other: Residential property tribunal decisions
+      service_sign_in:
+        one: Service sign in
+        other: Service sign in
+      service_standard_report:
+        one: Service Standard Report
+        other: Service Standard Reports
+      speaking_notes:
+        one: Speaking notes
+        other: Speaking notes
+      speech:
+        one: Speech
+        other: Speeches
+      statement_to_parliament:
+        one: Statement to Parliament
+        other: Statements to Parliament
+      statistical_data_set:
+        one: Statistical data set
+        other: Statistical data sets
+      statistics_announcement:
+        one: Statistics release announcement
+        other: Statistics release announcements
+      official_statistics:
+        one: Official Statistics
+        other: Official Statistics
+      official_statistics_announcement:
+        one: Official statistics announcement
+        other: Official statistics announcements
+      take_part:
+        one: Take part
+        other: Take part
+      tax_tribunal_decision:
+        one: Tax and Chancery tribunal decision
+        other: Tax and Chancery tribunal decisions
+      transcript:
+        one: Transcript
+        other: Transcripts
+      transparency:
+        one: Transparency data
+        other: Transparency data
+      utaac_decision:
+        one: Administrative appeals tribunal decision
+        other: Administrative appeals tribunal decisions
+      world_location_news_article:
+        one: News article
+        other: News articles
+      world_news_story:
+        one: World news story
+        other: World news stories
+      written_statement:
+        one: Written statement to Parliament
+        other: Written statements to Parliament
+      authored_article:
+        one: Authored article
+        other: Authored articles


### PR DESCRIPTION
## What

Document types for the featured news stories on government department pages are now translated into Welsh. Date information is now localised wherever a date is used.

Translation for the document types was taken from [government-frontend](https://github.com/alphagov/government-frontend/blob/53fac709b9bd95f83e7eb5dd2b35200c470afd31/config/locales/cy.yml), and translation for the months was taken from [rails-i18n](https://github.com/svenfuchs/rails-i18n/blob/b40a4006e5ed1bd21e756c3b894cf47f3d0c4986/rails/locale/cy.yml) internationalisation files.

Seen on:
 - https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales.cy
 - https://www.gov.uk/government/organisations/department-for-work-pensions.cy
 - https://www.gov.uk/government/organisations/companies-house.cy

Trello card: https://trello.com/c/uA7mDUvI/76-mixed-languages-on-news-stories

## Why
Featured new stories on translated organisation pages don't have a localised date and translated document type. This means that screenreaders and other assistive technology are parsing the page contents incorrectly.

## Visual differences

Before:
<img width="325" alt="Screen Shot 2019-10-01 at 15 01 33" src="https://user-images.githubusercontent.com/1732331/65969326-815d2480-e45c-11e9-9446-a299b1f103ba.png">

After:
<img width="320" alt="Screen Shot 2019-10-01 at 15 01 42" src="https://user-images.githubusercontent.com/1732331/65969347-88843280-e45c-11e9-82a7-82e94dbd6d35.png">
