### PR TITLE
Make page headers same across both variants

### DIFF
--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -35,11 +35,7 @@
         } %>
 
         <% if show_dynamic_list %>
-          <% if page_variant.variant?("B") %>
-            <p class="landing-page__ready-intro">Find out how you or your business need to prepare by answering a few simple questions.</p>
-          <% else %>
-            <p class="landing-page__ready-intro"><%= I18n.t("brexit_landing_page.call_to_action_intro") %></p>
-          <% end %>
+          <p class="landing-page__ready-intro"><%= I18n.t("brexit_landing_page.call_to_action_intro") %></p>
 
           <%= render "govuk_publishing_components/components/chevron_banner", {
             href: "/get-ready-brexit-check",


### PR DESCRIPTION
The page header text should remain the same on the Brexit Landing Page, regardless of which variant a person is in.

The original change was a mistake - the text should have remained the same.