### PR TITLE
Add URLs to steps in HowTo schema

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -48,6 +48,7 @@ class StepNav
         "@type": "HowToStep",
         "image": image_urls,
         "name": step["title"],
+        "url": step_url(step["title"].parameterize),
         "position": step_index,
         "itemListElement": contents.flatten.compact,
       }
@@ -85,5 +86,9 @@ class StepNav
     else
       Plek.new.website_root + href
     end
+  end
+
+  def step_url(step_slug)
+    Plek.new.website_root + base_path + "#" + step_slug
   end
 end

--- a/test/models/step_nav_test.rb
+++ b/test/models/step_nav_test.rb
@@ -20,6 +20,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Check you're allowed to drive",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#check-you-re-allowed-to-drive",
             "position": 1,
             "itemListElement": [
               {
@@ -51,6 +52,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Get a provisional driving licence",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#get-a-provisional-driving-licence",
             "position": 2,
             "itemListElement": [
               {
@@ -65,6 +67,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Driving lessons and practice",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#driving-lessons-and-practice",
             "position": 3,
             "itemListElement": [
               {
@@ -102,6 +105,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Prepare for your theory test",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#prepare-for-your-theory-test",
             "position": 4,
             "itemListElement": [
               {
@@ -128,6 +132,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Book and manage your theory test",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#book-and-manage-your-theory-test",
             "position": 5,
             "itemListElement": [
               {
@@ -171,6 +176,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "Book and manage your driving test",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#book-and-manage-your-driving-test",
             "position": 6,
             "itemListElement": [
               {
@@ -213,6 +219,7 @@ describe StepNav do
             "@type": "HowToStep",
             "image": ["http://assets.gov.uk/image1.png", "http://assets.gov.uk/image2.png"],
             "name": "When you pass",
+            "url": "http://www.test.gov.uk/learn-to-drive-a-car#when-you-pass",
             "position": 7,
             "itemListElement": [
               {


### PR DESCRIPTION
The absence of URLs are currently showing as [warnings in the structured data testing tool](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgov.uk%2Flearn-to-drive-a-car). We can resolve this one quickly as steps already have a deterministic ID based on the title.

I've updated the component to use the [same method to generate IDs](https://github.com/alphagov/govuk_publishing_components/pull/1152). It's nearly the same already, just it doesn't collapse multiple dashes.