### PR TITLE
Rescue 403 errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :restrict_request_formats
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
@@ -48,6 +49,8 @@ private
 
     format && self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
   end
+
+  def error_403; error 403; end
 
   def error_404; error 404; end
 

--- a/test/controllers/step_nav_controller_test.rb
+++ b/test/controllers/step_nav_controller_test.rb
@@ -9,4 +9,14 @@ describe StepNavController do
 
     assert_response 404
   end
+
+  it "returns a 403 when the user is not authorised" do
+    slug = SecureRandom.hex
+    url = content_store_endpoint + "/content/" + slug
+    stub_request(:get, url).to_return(status: 403, headers: {})
+
+    get :show, params: { slug: slug }
+
+    assert_response 403
+  end
 end

--- a/test/controllers/step_nav_controller_test.rb
+++ b/test/controllers/step_nav_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+describe StepNavController do
+  it "returns a 404 when the page doesn't exist" do
+    slug = SecureRandom.hex
+    stub_content_store_does_not_have_item("/#{slug}")
+
+    get :show, params: { slug: slug }
+
+    assert_response 404
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/DAqDo4oW
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed?
Adds error handling to handle 403 errors thrown by content-store

## Why?
Users should be redirect to a signon page if they are trying to access a content item on the draft stack and they are either not signed in, do not have a valid auth_bypass token, of the content item is restricted in some other way. They are instead being shown a "Problem has occurred" page because 403s are not being handled correctly.