### PR TITLE
Landing page design tweaks

### DIFF
--- a/app/assets/stylesheets/helpers/_overwrites.scss
+++ b/app/assets/stylesheets/helpers/_overwrites.scss
@@ -1,4 +1,6 @@
 .gem-c-chevron-banner__link-container {
+  padding: govuk-spacing(2);
+
   @include govuk-media-query(desktop) {
     padding: govuk-spacing(3);
   }

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -12,7 +12,7 @@ $red: #E61E32;
 }
 
 .landing-page__header {
-  padding-bottom: govuk-spacing(9);
+  padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(3);
   background-color: $dark-blue;
   color: govuk-colour("white");
@@ -20,8 +20,17 @@ $red: #E61E32;
 
 // scss-lint:disable QualifyingElement
 p.landing-page__header-text {
-  @include govuk-font(24);
+  font-size: 16px;
+  line-height: 1.25;
   color: govuk-colour("white");
+
+  @include govuk-media-query($from: mobile) {
+    @include govuk-font(24, $line-height: 1.25);
+  }
+
+  &:last-child {
+    margin-bottom: govuk-spacing(6);
+  }
 }
 
 hr.landing-page__divider {

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -52,7 +52,7 @@ hr.landing-page__divider {
 }
 
 .landing-page__section-list-wrapper {
-  margin-bottom: govuk-spacing(6);
+  margin: 0 0 govuk-spacing(6) 0;
   border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
   padding-top: govuk-spacing(4);
 }

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -11,11 +11,11 @@
 
   <% buckets.each do |bucket| %>
     <div class="grid-row landing-page__section-list-wrapper">
-      <div class="govuk-grid-column-one-third">
+      <div class="govuk-grid-column-one-third govuk-!-padding-left-0 govuk-!-padding-right-0">
         <% if bucket["row_title"] %><h3 class="govuk-heading-s"><%= bucket["row_title"] %></h3><% end %>
       </div>
 
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0 govuk-!-padding-right-0">
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
           <%= bucket["list_block"] %>


### PR DESCRIPTION
Trello: https://trello.com/c/4vLsIEbP/143-frontend-tweaks-for-brexit-landing-page

## What
Fixes the following issues:

- Brings the grey border lines in-line with the red borders
- Fixes cropped chevron issue on smaller screen (expands a temporary override - we should eventually move this into the gem if possible)
- Makes header text and spacing more consistent

## Before and After
### Grey borders
<img width="1019" alt="Screen Shot 2019-10-21 at 13 51 58" src="https://user-images.githubusercontent.com/29889908/67206640-f98a8a80-f409-11e9-939a-62feaf9ed14e.png">
<img width="984" alt="Screen Shot 2019-10-21 at 13 51 47" src="https://user-images.githubusercontent.com/29889908/67206639-f98a8a80-f409-11e9-963e-006a17e70c3d.png">

### Chevron
<img width="337" alt="Screen Shot 2019-10-21 at 13 52 51" src="https://user-images.githubusercontent.com/29889908/67206720-22ab1b00-f40a-11e9-8b3e-6f4f81badf6c.png">
<img width="319" alt="Screen Shot 2019-10-21 at 13 53 04" src="https://user-images.githubusercontent.com/29889908/67206725-250d7500-f40a-11e9-9a5b-7129f5933b71.png">

### Font size/spacing
<img width="333" alt="Screen Shot 2019-10-21 at 13 53 33" src="https://user-images.githubusercontent.com/29889908/67206765-3b1b3580-f40a-11e9-9ca3-23ca855e62dc.png">

<img width="337" alt="Screen Shot 2019-10-21 at 13 53 43" src="https://user-images.githubusercontent.com/29889908/67206757-36ef1800-f40a-11e9-89c8-11bb77007a4a.png">

https://govuk-collections-pr-1333.herokuapp.com/brexit