### PR TITLE
Render people in a layout similar to Whitehall

### DIFF
--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,8 +1,35 @@
 <% content_for :title, person.title %>
 
-<p class="type"><%= person.roles %></p>
-<h1><%= person.title %></h1>
+<%= render "govuk_publishing_components/components/title", {
+  context: person.roles,
+  title: person.title
+} %>
 
-<p><img src="<%= person.image_url %>" alt="<%= person.image_alt_text %>"></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/image_card", {
+      href: "#",
+      image_src: person.image_url,
+      image_alt: person.image_alt_text,
+      description: "Contents",
+      extra_links: [
+        {
+          text: "Biography",
+          href: "#biography"
+        }
+      ]
+    } %>
+  </div>
 
-<p><%= person.biography %></p>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Biography",
+      id: "biography",
+    } %>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <p><%= person.biography %></p>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
We're currently looking into whether we could migrate people and roles out of Whitehall.

While investigating, I discovered that we already have the document type set up in collections, and we already have quite a lot of the information required in the Content Store.

I've never done any frontend work before, but I wanted to have a go so this changes the layout of the page in collections to match the current layout in Whitehall.

## Old

<img width="996" alt="Screenshot 2019-10-22 at 14 28 00" src="https://user-images.githubusercontent.com/510498/67290558-2e651300-f4d8-11e9-813b-7790ddd5b22c.png">

## New

<img width="996" alt="Screenshot 2019-10-22 at 14 27 46" src="https://user-images.githubusercontent.com/510498/67290591-39b83e80-f4d8-11e9-9358-ad70ae8ac45b.png">

## Whitehall

<img width="949" alt="Screenshot 2019-10-22 at 14 27 49" src="https://user-images.githubusercontent.com/510498/67290603-42a91000-f4d8-11e9-8607-be954827abf4.png">
