### PR TITLE
Fix topical event bug

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -100,7 +100,7 @@ module Organisations
           image_alt: news["image"]["alt_text"],
           context: {
             date: date,
-            text: I18n.t("content_item.schema_name.#{news['document_type'].parameterize(separator: '_')}", count: 1, default: news["document_type"]),
+            text: I18n.t("content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
           },
           heading_text: news["title"],
           description: news["summary"].html_safe,


### PR DESCRIPTION
For some reason whitehall sends a null for the document type of a
topical event when it's featured for an organisation to the
publishing-api. This was causing the app to crash when the organisation
in collections was rendered featuring a topical event.

Zendesk tickets:
https://govuk.zendesk.com/agent/tickets/3839462
https://govuk.zendesk.com/agent/tickets/3841854