### PR TITLE
Update person template header to include roles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -22,8 +22,13 @@ class Person
     @content_item.content_item_data["title"]
   end
 
-  def roles
-    links["ordered_current_appointments"].map { |ra| ra["title"] }.to_sentence
+  def current_roles
+    links.fetch("ordered_current_appointments", [])
+      .map { |appointment| appointment["links"]["role"].first }
+  end
+
+  def current_roles_title
+    current_roles.map { |role| role["title"] }.to_sentence
   end
 
   def image_url

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, person.title %>
 
 <%= render "govuk_publishing_components/components/title", {
-  context: person.roles,
+  context: person.current_roles_title,
   title: person.title
 } %>
 

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+describe Person do
+  setup do
+    @api_data = {
+      "links" => {
+        "ordered_current_appointments" => [
+          {
+            "links" => {
+              "role" => [{
+                "title" => "Prime Minister",
+              }],
+            },
+          },
+          {
+            "links" => {
+              "role" => [{
+                "title" => "First Lord of the Treasury",
+              }],
+            },
+          },
+        ],
+      },
+    }
+    @content_item = ContentItem.new(@api_data)
+    @person = Person.new(@content_item)
+  end
+
+  describe "current_roles_title" do
+    it "combines the titles into a sentence" do
+      assert_equal "Prime Minister and First Lord of the Treasury", @person.current_roles_title
+    end
+  end
+end


### PR DESCRIPTION
Update the header of a person template to include roles so it matches the design of the page we have in Whitehall.

[Trello](https://trello.com/c/iNSK7NVU/1506-3-update-person-template-header-to-include-roles)