### PR TITLE
 Render govspeak HTML directly

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -22,11 +22,6 @@ class Person
     @content_item.content_item_data["title"]
   end
 
-  def current_roles
-    links.fetch("ordered_current_appointments", [])
-      .map { |appointment| appointment["links"]["role"].first }
-  end
-
   def current_roles_title
     current_roles.map { |role| role["title"] }.to_sentence
   end
@@ -44,6 +39,11 @@ class Person
   end
 
 private
+
+  def current_roles
+    links.fetch("ordered_current_appointments", [])
+      .map { |appointment| appointment["links"]["role"].first }
+  end
 
   def links
     @content_item.content_item_data["links"]

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -29,7 +29,7 @@
 
     <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
-      <p><%= person.biography %></p>
+      <%= person.biography %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Since [we have the Publishing API rendering the govspeak](https://github.com/alphagov/whitehall/pull/5134), it contains all the HTML formatting so we don't need to wrap it in a paragraph.

I've also made a method private which didn't need to be public.