### PR TITLE
Update person template to include previous appointments

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,6 +38,20 @@ class Person
     details["body"]
   end
 
+  def previous_appointments
+    ordered_previous_appointments.map do |role|
+      {
+        link: {
+          text: role["title"],
+          path: role["base_path"],
+        },
+        metadata: {
+          appointment_duration: "#{role['start_year']} to #{role['end_year']}",
+        },
+      }
+    end
+  end
+
 private
 
   def current_roles
@@ -51,5 +65,14 @@ private
 
   def details
     @content_item.content_item_data["details"]
+  end
+
+  def ordered_previous_appointments
+    links["ordered_previous_appointments"].map do |previous_appointment|
+      role = previous_appointment["links"]["role"].first
+      role["start_year"] = Time.parse(previous_appointment["details"]["started_on"]).strftime("%Y")
+      role["end_year"] = Time.parse(previous_appointment["details"]["ended_on"]).strftime("%Y")
+      role
+    end
   end
 end

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Previous roles in government",
+      id: "previous-roles",
+  } %>
+  <%= render "govuk_publishing_components/components/document_list", {
+      items: person.previous_appointments
+  } %>
+</div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -32,4 +32,8 @@
       <%= person.biography %>
     <% end %>
   </div>
+
+  <%= render partial: 'previous_roles', locals: {
+      person: person
+  } %>
 </div>

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -20,6 +20,21 @@ describe Person do
             },
           },
         ],
+        "ordered_previous_appointments" => [
+          {
+            "details" => {
+              "started_on" => "2016-07-13T00:00:00+01:00",
+              "ended_on" => "2018-07-09T00:00:00+01:00",
+            },
+            "links" => {
+              "role" => [
+                {
+                  "title" => "Secretary of State for Foreign and Commonwealth Affairs",
+                },
+              ],
+            },
+          },
+        ],
       },
     }
     @content_item = ContentItem.new(@api_data)
@@ -29,6 +44,15 @@ describe Person do
   describe "current_roles_title" do
     it "combines the titles into a sentence" do
       assert_equal "Prime Minister and First Lord of the Treasury", @person.current_roles_title
+    end
+  end
+
+  describe "ordered previous appointments" do
+    it "should have previous appointment text" do
+      assert_equal "Secretary of State for Foreign and Commonwealth Affairs", @person.previous_appointments.first[:link][:text]
+    end
+    it "should have previous appointment duration text" do
+      assert_equal "2016 to 2018", @person.previous_appointments.first[:metadata][:appointment_duration]
     end
   end
 end


### PR DESCRIPTION
This PR allows previous roles on people pages to be displayed:
![Screen Shot 2019-11-13 at 13 25 25](https://user-images.githubusercontent.com/6651749/68767718-15eca200-0619-11ea-923c-853c56ebde3d.png)

This data is retrieved from the content store.

Trello: 
https://trello.com/c/cI4gRrdt/1508-3-update-person-template-to-include-previous-roles