### PR TITLE
Various improvements to person page

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -40,6 +40,10 @@ class Person
     end
   end
 
+  def has_previous_roles?
+    previous_roles.present?
+  end
+
   def image_url
     details.dig("image", "url")
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -26,20 +26,8 @@ class Person
     current_roles.map { |role| role["title"] }.to_sentence
   end
 
-  def image_url
-    details.dig("image", "url")
-  end
-
-  def image_alt_text
-    details.dig("image", "alt_text")
-  end
-
-  def biography
-    details["body"]
-  end
-
-  def previous_appointments
-    ordered_previous_appointments.map do |role|
+  def previous_roles_items
+    previous_roles.map do |role|
       {
         link: {
           text: role["title"],
@@ -52,11 +40,32 @@ class Person
     end
   end
 
+  def image_url
+    details.dig("image", "url")
+  end
+
+  def image_alt_text
+    details.dig("image", "alt_text")
+  end
+
+  def biography
+    details["body"]
+  end
+
 private
 
   def current_roles
     links.fetch("ordered_current_appointments", [])
       .map { |appointment| appointment["links"]["role"].first }
+  end
+
+  def previous_roles
+    links.fetch("ordered_previous_appointments", []).map do |previous_appointment|
+      previous_appointment["links"]["role"].first.tap do |role|
+        role["start_year"] = Time.parse(previous_appointment["details"]["started_on"]).strftime("%Y")
+        role["end_year"] = Time.parse(previous_appointment["details"]["ended_on"]).strftime("%Y")
+      end
+    end
   end
 
   def links
@@ -65,14 +74,5 @@ private
 
   def details
     @content_item.content_item_data["details"]
-  end
-
-  def ordered_previous_appointments
-    links["ordered_previous_appointments"].map do |previous_appointment|
-      role = previous_appointment["links"]["role"].first
-      role["start_year"] = Time.parse(previous_appointment["details"]["started_on"]).strftime("%Y")
-      role["end_year"] = Time.parse(previous_appointment["details"]["ended_on"]).strftime("%Y")
-      role
-    end
   end
 end

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -2,6 +2,7 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: "Biography",
     id: "biography",
+    margin_bottom: 2,
   } %>
 
   <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Biography",
+    id: "biography",
+  } %>
+
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <%= person.biography.html_safe %>
+  <% end %>
+</div>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -1,0 +1,8 @@
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      context: person.current_roles_title,
+      title: person.title
+    } %>
+  </div>
+</header>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -2,6 +2,7 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: "Previous roles in government",
     id: "previous-roles",
+    margin_bottom: 2,
   } %>
 
   <%= render "govuk_publishing_components/components/document_list", {

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,11 +1,13 @@
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Previous roles in government",
-    id: "previous-roles",
-    margin_bottom: 2,
-  } %>
+<% if person.has_previous_roles? %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Previous roles in government",
+      id: "previous-roles",
+      margin_bottom: 2,
+    } %>
 
-  <%= render "govuk_publishing_components/components/document_list", {
-    items: person.previous_roles_items
-  } %>
-</div>
+    <%= render "govuk_publishing_components/components/document_list", {
+      items: person.previous_roles_items
+    } %>
+  </div>
+<% end %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -5,6 +5,6 @@
   } %>
 
   <%= render "govuk_publishing_components/components/document_list", {
-    items: person.previous_appointments
+    items: person.previous_roles_items
   } %>
 </div>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,9 +1,10 @@
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/heading", {
-      text: "Previous roles in government",
-      id: "previous-roles",
+    text: "Previous roles in government",
+    id: "previous-roles",
   } %>
+
   <%= render "govuk_publishing_components/components/document_list", {
-      items: person.previous_appointments
+    items: person.previous_appointments
   } %>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -14,11 +14,11 @@
           text: "Biography",
           href: "#biography"
         },
-        {
+        person.has_previous_roles? ? {
           text: "Previous roles",
           href: "#previous-roles"
-        },
-      ]
+        } : nil,
+      ].compact
     } %>
   </div>
 

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,9 +1,6 @@
 <% content_for :title, person.title %>
 
-<%= render "govuk_publishing_components/components/title", {
-  context: person.current_roles_title,
-  title: person.title
-} %>
+<%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -8,8 +8,10 @@
       href: "#",
       image_src: person.image_url,
       image_alt: person.image_alt_text,
-      description: "Contents",
-      extra_links: [
+    } %>
+
+    <%= render "govuk_publishing_components/components/contents_list", {
+      contents: [
         {
           text: "Biography",
           href: "#biography"

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -21,17 +21,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Biography",
-      id: "biography",
-    } %>
-
-    <%= render "govuk_publishing_components/components/govspeak", {
-    } do %>
-      <%= person.biography.html_safe %>
-    <% end %>
-  </div>
+  <%= render partial: "biography", locals: { person: person } %>
 
   <%= render partial: 'previous_roles', locals: {
       person: person

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -23,7 +23,5 @@
 
   <%= render partial: "biography", locals: { person: person } %>
 
-  <%= render partial: 'previous_roles', locals: {
-      person: person
-  } %>
+  <%= render partial: "previous_roles", locals: { person: person } %>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -16,7 +16,11 @@
         {
           text: "Biography",
           href: "#biography"
-        }
+        },
+        {
+          text: "Previous roles",
+          href: "#previous-roles"
+        },
       ]
     } %>
   </div>

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,0 +1,8 @@
+<header class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "Ministerial role",
+      title: role.title
+    } %>
+  </div>
+</header>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -1,9 +1,6 @@
 <% content_for :title, role.title %>
 
-<%= render "govuk_publishing_components/components/title", {
-  context: "Ministerial role",
-  title: role.title
-} %>
+<%= render partial: "header", locals: { role: role } %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -44,6 +44,47 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
+      "fingerprint": "6d00e707632cb298c5b6b44edcf141569cc3c81f0c09a99b91ab41ac8cc10602",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/people/_biography.html.erb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Person.find!(\"/government/people/#{params[:name]}\").biography",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "PeopleController",
+          "method": "show",
+          "line": 5,
+          "file": "app/controllers/people_controller.rb",
+          "rendered": {
+            "name": "people/show",
+            "file": "app/views/people/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "people/show",
+          "line": 28,
+          "file": "app/views/people/show.html.erb",
+          "rendered": {
+            "name": "people/_biography",
+            "file": "app/views/people/_biography.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "people/_biography"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "The biography of a person comes from the Content Store which is trusted and provides us with rendered HTML."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
       "fingerprint": "a31c67ced459f8f8fed487bace51003d694decf9b9295bfcb19227bcd687cdbc",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -71,39 +112,8 @@
       "user_input": null,
       "confidence": "Medium",
       "note": "The resposibilities of a role comes from the Content Store which is trusted and provides us with rendered HTML."
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "f6346b68e4ff615b38d84bfac2e512879402f408449cf504389b56515d453379",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/people/show.html.erb",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Person.find!(\"/government/people/#{params[:name]}\").biography",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PeopleController",
-          "method": "show",
-          "line": 5,
-          "file": "app/controllers/people_controller.rb",
-          "rendered": {
-            "name": "people/show",
-            "file": "app/views/people/show.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "people/show"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": "The biography of a person comes from the Content Store which is trusted and provides us with rendered HTML."
     }
   ],
-  "updated": "2019-11-13 14:39:16 +0000",
+  "updated": "2019-11-15 14:10:19 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -49,10 +49,11 @@ describe Person do
 
   describe "ordered previous appointments" do
     it "should have previous appointment text" do
-      assert_equal "Secretary of State for Foreign and Commonwealth Affairs", @person.previous_appointments.first[:link][:text]
+      assert_equal "Secretary of State for Foreign and Commonwealth Affairs", @person.previous_roles_items.first[:link][:text]
     end
+
     it "should have previous appointment duration text" do
-      assert_equal "2016 to 2018", @person.previous_appointments.first[:metadata][:appointment_duration]
+      assert_equal "2016 to 2018", @person.previous_roles_items.first[:metadata][:appointment_duration]
     end
   end
 end


### PR DESCRIPTION
This includes various improvements to the people page, notably adding margins to the bottom of headings and supporting people without any ordered previous appointments.

See commits for individual details.

<img width="1036" alt="Screenshot 2019-11-15 at 14 27 40" src="https://user-images.githubusercontent.com/510498/68950453-1a998d80-07b4-11ea-9faa-ee73b669f237.png">