### PR TITLE
Fix the columns on the people page

### DIFF
--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,12 +1,10 @@
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Biography",
-    id: "biography",
-    margin_bottom: 2,
-  } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Biography",
+  id: "biography",
+  margin_bottom: 2,
+} %>
 
-  <%= render "govuk_publishing_components/components/govspeak", {
-  } do %>
-    <%= person.biography.html_safe %>
-  <% end %>
-</div>
+<%= render "govuk_publishing_components/components/govspeak", {
+} do %>
+  <%= person.biography.html_safe %>
+<% end %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,13 +1,11 @@
 <% if person.has_previous_roles? %>
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Previous roles in government",
-      id: "previous-roles",
-      margin_bottom: 2,
-    } %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Previous roles in government",
+    id: "previous-roles",
+    margin_bottom: 2,
+  } %>
 
-    <%= render "govuk_publishing_components/components/document_list", {
-      items: person.previous_roles_items
-    } %>
-  </div>
+  <%= render "govuk_publishing_components/components/document_list", {
+    items: person.previous_roles_items
+  } %>
 <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -24,7 +24,9 @@
     } %>
   </div>
 
-  <%= render partial: "biography", locals: { person: person } %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "biography", locals: { person: person } %>
 
-  <%= render partial: "previous_roles", locals: { person: person } %>
+    <%= render partial: "previous_roles", locals: { person: person } %>
+  </div>
 </div>


### PR DESCRIPTION
Both the biography and the previous roles need to be in the same
column div, at least to match the markup from Whitehall, so move the
column div in to the show.html.erb file.