### PR TITLE
Fix bottom padding for Biography section on the person page

### DIFF
--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,10 +1,11 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Biography",
-  id: "biography",
-  margin_bottom: 2,
-} %>
+<section id="biography" class="govuk-!-padding-bottom-9">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Biography",
+    margin_bottom: 2,
+  } %>
 
-<%= render "govuk_publishing_components/components/govspeak", {
-} do %>
-  <%= person.biography.html_safe %>
-<% end %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <%= person.biography.html_safe %>
+  <% end %>
+</section>


### PR DESCRIPTION
Done to match whitehall.

Old collections spacing shown below:

![image](https://user-images.githubusercontent.com/24547183/69160282-3a48f280-0ae1-11ea-84e1-5e142a82e182.png)

Vs the current spacing on whitehall:

![image](https://user-images.githubusercontent.com/24547183/69160361-59e01b00-0ae1-11ea-97e4-883b983faaf5.png)



