### PR TITLE
Include announcements

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -79,6 +79,14 @@ class Person
     "/search/news-and-communications?people=#{slug}"
   end
 
+  def email_signup
+    "/email-signup?link=/government/people/#{slug}"
+  end
+
+  def subscribe_to_feed
+    "https://www.gov.uk/government/people/#{slug}.atom"
+  end
+
 private
 
   def slug

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -56,7 +56,40 @@ class Person
     details["body"]
   end
 
+  def announcement_items
+    announcements.map do |announcenment|
+      {
+        link: {
+          text: announcenment["title"],
+          path: announcenment["link"],
+        },
+        metadata: {
+          public_timestamp: Date.parse(announcenment["public_timestamp"]).strftime("%d %B %Y"),
+          content_store_document_type: announcenment["content_store_document_type"].humanize,
+        },
+      }
+    end
+  end
+
+  def has_announcements?
+    announcements.present?
+  end
+
 private
+
+  def announcements
+    @announcements ||= Services.cached_search(
+      count: 10,
+      order: "-public_timestamp",
+      filter_people: slug,
+      reject_content_purpose_supergroup: "other",
+      fields: %w[title link content_store_document_type public_timestamp],
+    )["results"]
+  end
+
+  def slug
+    base_path.split("/").last
+  end
 
   def current_roles
     links.fetch("ordered_current_appointments", [])

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -75,7 +75,15 @@ class Person
     announcements.present?
   end
 
+  def link_to_news_and_communications
+    "/search/news-and-communications?people=#{slug}"
+  end
+
 private
+
+  def slug
+    base_path.split("/").last
+  end
 
   def announcements
     @announcements ||= Services.cached_search(
@@ -85,10 +93,6 @@ private
       reject_content_purpose_supergroup: "other",
       fields: %w[title link content_store_document_type public_timestamp],
     )["results"]
-  end
-
-  def slug
-    base_path.split("/").last
   end
 
   def current_roles

--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -1,0 +1,13 @@
+<% if person.has_announcements? %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Announcements",
+        id: "announcements",
+        margin_bottom: 2,
+    } %>
+
+    <%= render "govuk_publishing_components/components/document_list", {
+        items: person.announcement_items
+    } %>
+  </div>
+<% end %>

--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -6,6 +6,12 @@
         margin_bottom: 5,
     } %>
 
+    <%= render "govuk_publishing_components/components/subscription-links", {
+        email_signup_link: person.email_signup,
+        feed_link: person.subscribe_to_feed,
+        margin_bottom: 5,
+    } %>
+
     <%= render "govuk_publishing_components/components/document_list", {
         items: person.announcement_items
     } %>

--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -1,9 +1,9 @@
 <% if person.has_announcements? %>
-  <div class="govuk-grid-column-two-thirds">
+  <section id="announcements">
     <%= render "govuk_publishing_components/components/heading", {
         text: "Announcements",
         id: "announcements",
-        margin_bottom: 2,
+        margin_bottom: 5,
     } %>
 
     <%= render "govuk_publishing_components/components/document_list", {
@@ -13,5 +13,5 @@
     <div class="read-more">
       <%= link_to "View all announcements", person.redirect_to_news_and_communications, class: "govuk-link" %>
     </div>
-  </div>
+  </section>
 <% end %>

--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -9,5 +9,9 @@
     <%= render "govuk_publishing_components/components/document_list", {
         items: person.announcement_items
     } %>
+
+    <div class="read-more">
+      <%= link_to "View all announcements", person.redirect_to_news_and_communications, class: "govuk-link" %>
+    </div>
   </div>
 <% end %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,4 +1,5 @@
 <% if person.has_previous_roles? %>
+  <section class="previous-roles govuk-!-padding-bottom-9">
   <%= render "govuk_publishing_components/components/heading", {
     text: "Previous roles in government",
     id: "previous-roles",
@@ -8,4 +9,5 @@
   <%= render "govuk_publishing_components/components/document_list", {
     items: person.previous_roles_items
   } %>
+  </section>
 <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -19,7 +19,11 @@
         person.has_previous_roles? ? {
           text: "Previous roles",
           href: "#previous-roles"
-        } : nil,
+        }: nil,
+        person.has_announcements? ? {
+            text: "Announcements",
+            href: "#announcements"
+        }: nil,
       ].compact
     } %>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -28,5 +28,6 @@
     <%= render partial: "biography", locals: { person: person } %>
 
     <%= render partial: "previous_roles", locals: { person: person } %>
-  </div>
+
+    <%= render partial: "announcements", locals: { person: person } %>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -30,4 +30,5 @@
     <%= render partial: "previous_roles", locals: { person: person } %>
 
     <%= render partial: "announcements", locals: { person: person } %>
+  </div>
 </div>

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe Person do
   setup do
     @api_data = {
+      "base_path" => "/government/people/boris-johnson",
       "links" => {
         "ordered_current_appointments" => [
           {
@@ -54,6 +55,28 @@ describe Person do
 
     it "should have previous appointment duration text" do
       assert_equal "2016 to 2018", @person.previous_roles_items.first[:metadata][:appointment_duration]
+    end
+  end
+
+  describe "announcements" do
+    it "should have annoucements" do
+      results = [
+        { "title" => "Government announces further support for those affected by flooding",
+          "link" => "/government/news/government-announces-further-support-for-those-affected-by-flooding",
+          "content_store_document_type" => "press_release",
+          "public_timestamp" => "2019-11-12T21:07:00.000+00:00",
+          "index" => "government",
+          "es_score" => nil,
+          "_id" => "/government/news/government-announces-further-support-for-those-affected-by-flooding",
+          "elasticsearch_type" => "edition",
+          "document_type" => "edition" },
+      ]
+
+      Services.rummager.stubs(:search).returns("results" => results,
+        "start" => 0,
+        "total" => 1)
+
+      assert_equal "Government announces further support for those affected by flooding", @person.announcement_items.first[:link][:text]
     end
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -77,12 +77,20 @@ describe Person do
                                                "total" => 1)
     end
 
-    it "should have annoucements" do
+    it "should have announcements" do
       assert_equal "Government announces further support for those affected by flooding", @person.announcement_items.first[:link][:text]
     end
 
     it "should have link to news and communications finder" do
       assert_equal "/search/news-and-communications?people=boris-johnson", @person.link_to_news_and_communications
+    end
+
+    it "should have link to email signup" do
+      assert_equal "/email-signup?link=/government/people/boris-johnson", @person.email_signup
+    end
+
+    it "should have link to subscription atom feed" do
+      assert_equal "https://www.gov.uk/government/people/boris-johnson.atom", @person.subscribe_to_feed
     end
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -59,8 +59,8 @@ describe Person do
   end
 
   describe "announcements" do
-    it "should have annoucements" do
-      results = [
+    setup do
+      @results = [
         { "title" => "Government announces further support for those affected by flooding",
           "link" => "/government/news/government-announces-further-support-for-those-affected-by-flooding",
           "content_store_document_type" => "press_release",
@@ -72,11 +72,17 @@ describe Person do
           "document_type" => "edition" },
       ]
 
-      Services.rummager.stubs(:search).returns("results" => results,
-        "start" => 0,
-        "total" => 1)
+      Services.rummager.stubs(:search).returns("results" => @results,
+                                               "start" => 0,
+                                               "total" => 1)
+    end
 
+    it "should have annoucements" do
       assert_equal "Government announces further support for those affected by flooding", @person.announcement_items.first[:link][:text]
+    end
+
+    it "should have link to news and communications finder" do
+      assert_equal "/search/news-and-communications?people=boris-johnson", @person.link_to_news_and_communications
     end
   end
 end


### PR DESCRIPTION
This PR updates the people template to include announcements, which are retrieved from search api. These results are presented by the document list component, which includes the title, public_timestamp and content_store_document_type.

At the bottom of the announcements, a link has been added to view all announcements, this is because the number of announcements displayed is 10 for each person. In order to view all announcements, the link redirects the user to the news and communications finder, filtered by person (the person they are viewing).

![Screen Shot 2019-11-19 at 14 18 36](https://user-images.githubusercontent.com/6651749/69154205-7a0adc80-0ad7-11ea-9251-4dfd1df7559e.png)

This PR also adds a link to announcements to sidebar.
![Screen Shot 2019-11-19 at 14 51 36](https://user-images.githubusercontent.com/6651749/69156903-0f0fd480-0adc-11ea-99f5-eb089b081586.png)

Trello: https://trello.com/c/YSTcpIwP/1509-5-update-person-template-to-include-announcements
