### PR TITLE
Use new role_appointments link

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -103,13 +103,28 @@ private
     )["results"]
   end
 
+  def role_appointments(current:)
+    links
+      .fetch("role_appointments", [])
+      .filter { |role_appointment| role_appointment["details"]["current"] == current }
+      .sort_by { |role_appointment| role_appointment["details"]["person_appointment_order"] }
+  end
+
+  def current_role_appointments
+    @current_role_appointments ||= role_appointments(current: true)
+  end
+
+  def previous_role_appointments
+    @previous_role_appointments ||= role_appointments(current: false)
+  end
+
   def current_roles
-    links.fetch("ordered_current_appointments", [])
+    current_role_appointments
       .map { |appointment| appointment["links"]["role"].first }
   end
 
   def previous_roles
-    links.fetch("ordered_previous_appointments", []).map do |previous_appointment|
+    previous_role_appointments.map do |previous_appointment|
       previous_appointment["links"]["role"].first.tap do |role|
         role["start_year"] = Time.parse(previous_appointment["details"]["started_on"]).strftime("%Y")
         role["end_year"] = Time.parse(previous_appointment["details"]["ended_on"]).strftime("%Y")

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -5,12 +5,16 @@ describe Person do
     @api_data = {
       "base_path" => "/government/people/boris-johnson",
       "links" => {
-        "ordered_current_appointments" => [
+        "role_appointments" => [
           {
             "links" => {
               "role" => [{
                 "title" => "Prime Minister",
               }],
+            },
+            "details" => {
+              "current" => true,
+              "person_appointment_order" => 1,
             },
           },
           {
@@ -19,20 +23,24 @@ describe Person do
                 "title" => "First Lord of the Treasury",
               }],
             },
-          },
-        ],
-        "ordered_previous_appointments" => [
-          {
             "details" => {
-              "started_on" => "2016-07-13T00:00:00+01:00",
-              "ended_on" => "2018-07-09T00:00:00+01:00",
+              "current" => true,
+              "person_appointment_order" => 2,
             },
+          },
+          {
             "links" => {
               "role" => [
                 {
                   "title" => "Secretary of State for Foreign and Commonwealth Affairs",
                 },
               ],
+            },
+            "details" => {
+              "current" => false,
+              "person_appointment_order" => 3,
+              "started_on" => "2016-07-13T00:00:00+01:00",
+              "ended_on" => "2018-07-09T00:00:00+01:00",
             },
           },
         ],


### PR DESCRIPTION
This is a new reverse link (`role_appointments`) automatically added by the Publishing API. See https://github.com/alphagov/publishing-api/pull/1645 for more details.

The old (`ordered_current_appointments` and `ordered_previous_appointments`) links will be removed by https://github.com/alphagov/whitehall/pull/5161 so this will mean the pages keep working when they are removed.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)