### PR TITLE
Fix link to all announcements

### DIFF
--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -17,7 +17,7 @@
     } %>
 
     <div class="read-more">
-      <%= link_to "View all announcements", person.redirect_to_news_and_communications, class: "govuk-link" %>
+      <%= link_to "View all announcements", person.link_to_news_and_communications, class: "govuk-link" %>
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
The method is called `link_to_news_and_communications` rather than `redirect_to_news_and_communications`.