### PR TITLE
Add organisations to role pages

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -26,6 +26,10 @@ class Role
     details["body"]
   end
 
+  def organisations
+    links["ordered_parent_organisations"]
+  end
+
 private
 
   def links

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,0 +1,6 @@
+<% if role.organisations %>
+  <div class="organisations-list">
+    Organisations:
+    <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
+  </div>
+<% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -2,6 +2,8 @@
 
 <%= render partial: "header", locals: { role: role } %>
 
+<%= render partial: "organisations", locals: { role: role } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,47 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
+      "fingerprint": "09675c8c0a58117c047450d03a97d966185563d1772d22ac99487d7de702dfc7",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/roles/_organisations.html.erb",
+      "line": 4,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").organisations.map do\n link_to(organisation[\"title\"], organisation[\"base_path\"])\n end.to_sentence",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "RolesController",
+          "method": "show",
+          "line": 6,
+          "file": "app/controllers/roles_controller.rb",
+          "rendered": {
+            "name": "roles/show",
+            "file": "app/views/roles/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "roles/show",
+          "line": 5,
+          "file": "app/views/roles/show.html.erb",
+          "rendered": {
+            "name": "roles/_organisations",
+            "file": "app/views/roles/_organisations.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "roles/_organisations"
+      },
+      "user_input": "Role.find!(\"/government/ministers/#{params[:role_name]}\").organisations",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
       "fingerprint": "69993c7fdb955862f1f0fb0afe804b3dd1ef40b9fd43273c285bd13ba23f6199",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -48,7 +89,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/people/_biography.html.erb",
-      "line": 10,
+      "line": 9,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Person.find!(\"/government/people/#{params[:name]}\").biography",
       "render_path": [
@@ -66,7 +107,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 28,
+          "line": 32,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_biography",
@@ -89,7 +130,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/roles/show.html.erb",
-      "line": 17,
+      "line": 16,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").responsibilities",
       "render_path": [
@@ -114,6 +155,6 @@
       "note": "The resposibilities of a role comes from the Content Store which is trusted and provides us with rendered HTML."
     }
   ],
-  "updated": "2019-11-15 14:10:19 +0000",
+  "updated": "2019-11-25 09:53:01 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+describe Role do
+  setup do
+    @api_data = {
+      "base_path" => "/government/ministers/prime-minister",
+      "links" => {
+        "ordered_parent_organisations" => [
+          {
+            "base_path" => "/government/organisations/cabinet-office",
+            "title" => "Cabinet Office",
+          },
+          {
+            "base_path" => "/government/organisations/prime-ministers-office-10-downing-street",
+            "title" => "Prime Minister's Office, 10 Downing Street",
+          },
+        ],
+      },
+    }
+    @content_item = ContentItem.new(@api_data)
+    @role = Role.new(@content_item)
+  end
+
+  describe "organisations" do
+    it "should have organisations title and base_path" do
+      expected = [
+        {
+          "title" => "Cabinet Office",
+          "base_path" => "/government/organisations/cabinet-office",
+        },
+        {
+          "title" => "Prime Minister's Office, 10 Downing Street",
+          "base_path" => "/government/organisations/prime-ministers-office-10-downing-street",
+        },
+      ]
+      assert_equal expected, @role.organisations
+    end
+  end
+end


### PR DESCRIPTION
The organisations data is retrieved from the content store and displayed into a link, as there can be more than one organisation present, the to_sentence ruby function is used for readability.

Screenshot:
![Screen Shot 2019-11-21 at 16 46 13](https://user-images.githubusercontent.com/6651749/69358214-69e13180-0c7e-11ea-951a-17aa08039ee0.png)

Trello: https://trello.com/c/IyNL6Q2F/1557-2-add-mini-organisations-to-role-pages