### PR TITLE
Migrate from govuk-lint to rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,3 @@
-AllCops:
-  TargetRubyVersion: 2.3
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ end
 group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'govuk-lint'
   gem 'jasmine-rails'
   gem 'pry-byebug'
+  gem 'rubocop-govuk'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,11 +126,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_ab_testing (2.4.1)
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
@@ -212,7 +207,7 @@ GEM
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
     null_logger (0.0.1)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
@@ -282,10 +277,14 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
@@ -313,8 +312,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -383,7 +380,6 @@ DEPENDENCIES
   gds-api-adapters (~> 61.0.0)
   govspeak (~> 6.5.1)
   govuk-content-schema-test-helpers
-  govuk-lint
   govuk_ab_testing (~> 2.4.1)
   govuk_app_config (~> 2.0.1)
   govuk_document_types
@@ -398,6 +394,7 @@ DEPENDENCIES
   rails (= 5.2.3)
   rails-controller-testing
   rinku
+  rubocop-govuk
   sass-rails (~> 5.0.3)
   simplecov
   simplecov-rcov

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
   unless ENV["JENKINS"]
-    sh "bundle exec govuk-lint-ruby --parallel --format clang app spec lib"
+    sh "bundle exec rubocop --parallel --format clang app spec lib"
   end
 end


### PR DESCRIPTION
Docs: https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html