### PR TITLE
Add mini current role holder to role pages

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,11 +15,11 @@ class Role
   end
 
   def base_path
-    @content_item.content_item_data["base_path"]
+    content_item_data["base_path"]
   end
 
   def title
-    @content_item.content_item_data["title"]
+    content_item_data["title"]
   end
 
   def responsibilities
@@ -32,11 +32,15 @@ class Role
 
 private
 
+  def content_item_data
+    content_item.content_item_data
+  end
+
   def links
-    @content_item.content_item_data["links"]
+    content_item_data["links"]
   end
 
   def details
-    @content_item.content_item_data["details"]
+    content_item_data["details"]
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -30,6 +30,14 @@ class Role
     links["ordered_parent_organisations"]
   end
 
+  def current_holder
+    links
+      .fetch("role_appointments", [])
+      .find { |ra| ra.dig("details", "current") }
+      .dig("links", "person")
+      .first
+  end
+
 private
 
   def content_item_data

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,0 +1,6 @@
+<% if role.current_holder %>
+  <div>
+      Current role holder:
+      <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
+  </div>
+<% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -4,6 +4,8 @@
 
 <%= render partial: "organisations", locals: { role: role } %>
 
+<%= render partial: "current_holder", locals: { role: role } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -15,6 +15,34 @@ describe Role do
             "title" => "Prime Minister's Office, 10 Downing Street",
           },
         ],
+        "role_appointments" => [
+          {
+            "details" => {
+              "current" => false,
+            },
+            "links" => {
+              "person" => [
+                {
+                  "title" => "The Rt Hon Theresa May",
+                  "base_path" => "/government/people/theresa-may",
+                },
+              ],
+            },
+          },
+          {
+            "details" => {
+              "current" => true,
+            },
+            "links" => {
+              "person" => [
+                {
+                  "title" => "The Rt Hon Boris Johnson",
+                  "base_path" => "/government/people/boris-johnson",
+                },
+              ],
+            },
+          },
+        ],
       },
     }
     @content_item = ContentItem.new(@api_data)
@@ -34,6 +62,17 @@ describe Role do
         },
       ]
       assert_equal expected, @role.organisations
+    end
+  end
+
+  describe "current_holder" do
+    it "should have title and base_path" do
+      expected = {
+        "title" => "The Rt Hon Boris Johnson",
+        "base_path" => "/government/people/boris-johnson",
+      }
+
+      assert_equal expected, @role.current_holder
     end
   end
 end


### PR DESCRIPTION
The current role holder data is retrieved from the content store and
displayed into a link.

[Trello card](https://trello.com/c/jRxT5RZc/1558-1-add-mini-current-role-holder-to-role-pages)