### PR TITLE
Hide person image if they are not currently in a role

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -98,6 +98,10 @@ class Person
     end
   end
 
+  def currently_in_a_role?
+    current_role_appointments.any?
+  end
+
 private
 
   def slug

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -4,11 +4,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= render "govuk_publishing_components/components/image_card", {
-      href: "#",
-      image_src: person.image_url,
-      image_alt: person.image_alt_text,
-    } %>
+    <% if person.currently_in_a_role? %>
+      <%= render "govuk_publishing_components/components/image_card", {
+        href: "#",
+        image_src: person.image_url,
+        image_alt: person.image_alt_text,
+      } %>
+    <% end %>
 
     <%= render "govuk_publishing_components/components/contents_list", {
       contents: [

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -56,6 +56,18 @@ describe Person do
     end
   end
 
+  describe "currently_in_a_role?" do
+    it "returns true if the person has a current role appointment" do
+      assert @person.currently_in_a_role?
+    end
+
+    it "returns false if the person doesn't have a current role appointment" do
+      @api_data["links"]["role_appointments"][0]["details"]["current"] = false
+      @api_data["links"]["role_appointments"][1]["details"]["current"] = false
+      refute @person.currently_in_a_role?
+    end
+  end
+
   describe "ordered previous appointments" do
     it "should have previous appointment text" do
       assert_equal "Secretary of State for Foreign and Commonwealth Affairs", @person.previous_roles_items.first[:link][:text]


### PR DESCRIPTION
This matches the same behaviour in Whitehall which hides the image if the person currently doesn't have a role.

https://github.com/alphagov/whitehall/pull/2058

[Trello Card](https://trello.com/c/EqAc64Vy/1572-hide)