### PR TITLE
Add current role holder and biography

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -38,6 +38,14 @@ class Role
       .first
   end
 
+  def current_holder_biography
+    current_holder["details"]["body"]
+  end
+
+  def link_to_person
+    current_holder["base_path"]
+  end
+
 private
 
   def content_item_data

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -1,0 +1,25 @@
+<% if role.current_holder %>
+  <%= render "govuk_publishing_components/components/heading", {
+      text: "Current role holder:",
+      id: "current-role-holder-title",
+  } %>
+
+  <div>
+    <%= render "govuk_publishing_components/components/heading", {
+        text: role.current_holder["title"],
+        id: "current-role-holder-title",
+    } %>
+  </div>
+
+  <div>
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <%= role.current_holder_biography.html_safe %>
+    <% end %>
+  </div>
+
+  <div class="read-more">
+    <%= link_to "More about this person", role.link_to_person, class: "govuk-link" %>
+  </div>
+<% end %>
+

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -17,5 +17,7 @@
     } do %>
       <%= role.responsibilities.html_safe %>
     <% end %>
+
+    <%= render partial: "current_role_holder_with_biography", locals: { role: role } %>
   </div>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -44,6 +44,47 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
+      "fingerprint": "41d918e3e7218ab94e6f8beaa0caaebeefc28aad188b68fe83ed122dc936e6d5",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").biography",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "RolesController",
+          "method": "show",
+          "line": 6,
+          "file": "app/controllers/roles_controller.rb",
+          "rendered": {
+            "name": "roles/show",
+            "file": "app/views/roles/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "roles/show",
+          "line": 21,
+          "file": "app/views/roles/show.html.erb",
+          "rendered": {
+            "name": "roles/_current_role_holder_with_biography",
+            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "roles/_current_role_holder_with_biography"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
       "fingerprint": "69993c7fdb955862f1f0fb0afe804b3dd1ef40b9fd43273c285bd13ba23f6199",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -148,7 +189,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 32,
+          "line": 34,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_biography",
@@ -163,6 +204,47 @@
       "user_input": null,
       "confidence": "Medium",
       "note": "This comes from the content store"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 84,
+      "fingerprint": "a0f6b1ae902ff6177c16772111a8c507679a1f2dacca44586105f07e02417433",
+      "check_name": "RenderInline",
+      "message": "Unescaped model attribute rendered inline",
+      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
+      "code": "render(text => Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder[\"title\"], { :id => \"current-role-holder-title\" })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "RolesController",
+          "method": "show",
+          "line": 6,
+          "file": "app/controllers/roles_controller.rb",
+          "rendered": {
+            "name": "roles/show",
+            "file": "app/views/roles/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "roles/show",
+          "line": 21,
+          "file": "app/views/roles/show.html.erb",
+          "rendered": {
+            "name": "roles/_current_role_holder_with_biography",
+            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "roles/_current_role_holder_with_biography"
+      },
+      "user_input": "Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder[\"title\"]",
+      "confidence": "Medium",
+      "note": ""
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -194,8 +276,49 @@
       "user_input": null,
       "confidence": "Medium",
       "note": "The resposibilities of a role comes from the Content Store which is trusted and provides us with rendered HTML."
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "e8bcb16e0944f7a9c9ed74a19117e472937e4855539e5a0b762ceafc879ad2f2",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder_biography",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "RolesController",
+          "method": "show",
+          "line": 6,
+          "file": "app/controllers/roles_controller.rb",
+          "rendered": {
+            "name": "roles/show",
+            "file": "app/views/roles/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "roles/show",
+          "line": 21,
+          "file": "app/views/roles/show.html.erb",
+          "rendered": {
+            "name": "roles/_current_role_holder_with_biography",
+            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "roles/_current_role_holder_with_biography"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2019-11-25 13:40:26 +0000",
+  "updated": "2019-11-26 13:47:27 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -38,6 +38,9 @@ describe Role do
                 {
                   "title" => "The Rt Hon Boris Johnson",
                   "base_path" => "/government/people/boris-johnson",
+                  "details" => {
+                    "body" => "<p>Boris Johnson became Prime Minister on 24 July 2019. He was previously Foreign Secretary from 13 July 2016 to 9 July 2018. He was elected Conservative MP for Uxbridge and South Ruislip in May 2015. Previously he was the MP for Henley from June 2001 to June 2008.</p> ",
+                  },
                 },
               ],
             },
@@ -66,13 +69,26 @@ describe Role do
   end
 
   describe "current_holder" do
-    it "should have title and base_path" do
-      expected = {
+    setup do
+      @expected = {
         "title" => "The Rt Hon Boris Johnson",
         "base_path" => "/government/people/boris-johnson",
+        "details" => {
+          "body" => "<p>Boris Johnson became Prime Minister on 24 July 2019. He was previously Foreign Secretary from 13 July 2016 to 9 July 2018. He was elected Conservative MP for Uxbridge and South Ruislip in May 2015. Previously he was the MP for Henley from June 2001 to June 2008.</p> ",
+        },
       }
+    end
 
-      assert_equal expected, @role.current_holder
+    it "should have title and base_path" do
+      assert_equal @expected, @role.current_holder
+    end
+
+    it "should have body with biography" do
+      assert_equal @expected["details"]["body"], @role.current_holder_biography
+    end
+
+    it "should have link to person" do
+      assert_equal @expected["base_path"], @role.link_to_person
     end
   end
 end


### PR DESCRIPTION
This PR adds current role, biography and a link to the person, which is retrieved from the content store. 

Screenshot:
![Screen Shot 2019-11-26 at 11 15 18](https://user-images.githubusercontent.com/6651749/69628500-a24c8b00-1043-11ea-832a-1795683808d7.png)

Trello: https://trello.com/c/02C3OKnk/1559-2-add-current-role-holder-to-role-pages
