### PR TITLE
Add route for roles with locales

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,7 +3,7 @@ class PeopleController < ApplicationController
     @person = Person.find!(request.path)
     setup_content_item_and_navigation_helpers(@person)
     render :show, locals: {
-        person: @person,
+      person: @person,
     }
   end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,10 +1,9 @@
 class RolesController < ApplicationController
   def show
-    # Only ministerial roles have base paths, other role types aren't rendered
-    @role = Role.find!("/government/ministers/#{params[:role_name]}")
+    @role = Role.find!(request.path)
     setup_content_item_and_navigation_helpers(@role)
     render :show, locals: {
-        role: @role,
+      role: @role,
     }
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,19 +3,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "09675c8c0a58117c047450d03a97d966185563d1772d22ac99487d7de702dfc7",
+      "fingerprint": "344ea763c233c1799950725baf2a9cd55fca8ccb96a0e67af99fbaee080b4487",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/roles/_organisations.html.erb",
       "line": 4,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").organisations.map do\n link_to(organisation[\"title\"], organisation[\"base_path\"])\n end.to_sentence",
+      "code": "Role.find!(request.path).organisations.map do\n link_to(organisation[\"title\"], organisation[\"base_path\"])\n end.to_sentence",
       "render_path": [
         {
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 6,
+          "line": 5,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -37,50 +37,9 @@
         "type": "template",
         "template": "roles/_organisations"
       },
-      "user_input": "Role.find!(\"/government/ministers/#{params[:role_name]}\").organisations",
+      "user_input": "Role.find!(request.path).organisations",
       "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "41d918e3e7218ab94e6f8beaa0caaebeefc28aad188b68fe83ed122dc936e6d5",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").biography",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "RolesController",
-          "method": "show",
-          "line": 6,
-          "file": "app/controllers/roles_controller.rb",
-          "rendered": {
-            "name": "roles/show",
-            "file": "app/views/roles/show.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "roles/show",
-          "line": 21,
-          "file": "app/views/roles/show.html.erb",
-          "rendered": {
-            "name": "roles/_current_role_holder_with_biography",
-            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "roles/_current_role_holder_with_biography"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": ""
+      "note": "We trust the content from the content-store."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -126,43 +85,43 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "6d00e707632cb298c5b6b44edcf141569cc3c81f0c09a99b91ab41ac8cc10602",
+      "fingerprint": "99342e4a797343171ee3adf1765bce6d0726c090b505f28f013003a1d200f725",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
-      "file": "app/views/people/_biography.html.erb",
-      "line": 9,
+      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
+      "line": 17,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Person.find!(\"/government/people/#{params[:name]}\").biography",
+      "code": "Role.find!(request.path).current_holder_biography",
       "render_path": [
         {
           "type": "controller",
-          "class": "PeopleController",
+          "class": "RolesController",
           "method": "show",
           "line": 5,
-          "file": "app/controllers/people_controller.rb",
+          "file": "app/controllers/roles_controller.rb",
           "rendered": {
-            "name": "people/show",
-            "file": "app/views/people/show.html.erb"
+            "name": "roles/show",
+            "file": "app/views/roles/show.html.erb"
           }
         },
         {
           "type": "template",
-          "name": "people/show",
-          "line": 32,
-          "file": "app/views/people/show.html.erb",
+          "name": "roles/show",
+          "line": 21,
+          "file": "app/views/roles/show.html.erb",
           "rendered": {
-            "name": "people/_biography",
-            "file": "app/views/people/_biography.html.erb"
+            "name": "roles/_current_role_holder_with_biography",
+            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
           }
         }
       ],
       "location": {
         "type": "template",
-        "template": "people/_biography"
+        "template": "roles/_current_role_holder_with_biography"
       },
       "user_input": null,
       "confidence": "Medium",
-      "note": "The biography of a person comes from the Content Store which is trusted and provides us with rendered HTML."
+      "note": "We trust the content from the content-store."
     },
     {
       "warning_type": "Cross-Site Scripting",
@@ -207,61 +166,20 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 84,
-      "fingerprint": "a0f6b1ae902ff6177c16772111a8c507679a1f2dacca44586105f07e02417433",
-      "check_name": "RenderInline",
-      "message": "Unescaped model attribute rendered inline",
-      "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
-      "line": 9,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
-      "code": "render(text => Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder[\"title\"], { :id => \"current-role-holder-title\" })",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "RolesController",
-          "method": "show",
-          "line": 6,
-          "file": "app/controllers/roles_controller.rb",
-          "rendered": {
-            "name": "roles/show",
-            "file": "app/views/roles/show.html.erb"
-          }
-        },
-        {
-          "type": "template",
-          "name": "roles/show",
-          "line": 21,
-          "file": "app/views/roles/show.html.erb",
-          "rendered": {
-            "name": "roles/_current_role_holder_with_biography",
-            "file": "app/views/roles/_current_role_holder_with_biography.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "roles/_current_role_holder_with_biography"
-      },
-      "user_input": "Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder[\"title\"]",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "a31c67ced459f8f8fed487bace51003d694decf9b9295bfcb19227bcd687cdbc",
+      "fingerprint": "dd43688e2aa62e218f3ba6ade4d7a2f2083fbfb40ef02be0e88187b4e3508353",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/roles/show.html.erb",
       "line": 18,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").responsibilities",
+      "code": "Role.find!(request.path).responsibilities",
       "render_path": [
         {
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 6,
+          "line": 5,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -275,24 +193,24 @@
       },
       "user_input": null,
       "confidence": "Medium",
-      "note": "The resposibilities of a role comes from the Content Store which is trusted and provides us with rendered HTML."
+      "note": "We trust the content from the content-store."
     },
     {
       "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "e8bcb16e0944f7a9c9ed74a19117e472937e4855539e5a0b762ceafc879ad2f2",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
+      "warning_code": 84,
+      "fingerprint": "fb5fb0c3c4d00aa680fe5648c5f4487e63acb2926abe3924e47231c737983e6b",
+      "check_name": "RenderInline",
+      "message": "Unescaped model attribute rendered inline",
       "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
-      "line": 17,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Role.find!(\"/government/ministers/#{params[:role_name]}\").current_holder_biography",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
+      "code": "render(text => Role.find!(request.path).current_holder[\"title\"], { :id => \"current-role-holder-title\" })",
       "render_path": [
         {
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 6,
+          "line": 5,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -314,11 +232,11 @@
         "type": "template",
         "template": "roles/_current_role_holder_with_biography"
       },
-      "user_input": null,
+      "user_input": "Role.find!(request.path).current_holder[\"title\"]",
       "confidence": "Medium",
-      "note": ""
+      "note": "We trust the content from the content-store."
     }
   ],
-  "updated": "2019-11-26 13:47:27 +0000",
+  "updated": "2019-11-27 11:29:55 +0000",
   "brakeman_version": "4.7.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
     to: "brexit_campaign#show"
 
   get "/government/people/:name(.:locale)", to: "people#show"
-  get "/government/ministers/:role_name", to: "roles#show"
+  get "/government/ministers/:name(.:locale)", to: "roles#show"
 
   scope :api, defaults: { format: :json } do
     get "/organisations",


### PR DESCRIPTION
This adds support for rendering roles with locales by adding it to the routes.

This is necessary as a pre-requisite for https://trello.com/c/R2rzi6je/892-add-switch-language-component-to-role-page.