### PR TITLE
Support roles without current holders

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -34,8 +34,8 @@ class Role
     links
       .fetch("role_appointments", [])
       .find { |ra| ra.dig("details", "current") }
-      .dig("links", "person")
-      .first
+      &.dig("links", "person")
+      &.first
   end
 
   def current_holder_biography

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -69,26 +69,38 @@ describe Role do
   end
 
   describe "current_holder" do
-    setup do
-      @expected = {
-        "title" => "The Rt Hon Boris Johnson",
-        "base_path" => "/government/people/boris-johnson",
-        "details" => {
-          "body" => "<p>Boris Johnson became Prime Minister on 24 July 2019. He was previously Foreign Secretary from 13 July 2016 to 9 July 2018. He was elected Conservative MP for Uxbridge and South Ruislip in May 2015. Previously he was the MP for Henley from June 2001 to June 2008.</p> ",
-        },
-      }
+    context "without a current holder" do
+      setup do
+        @api_data["links"]["role_appointments"][1]["details"]["current"] = false
+      end
+
+      it "should return nil" do
+        assert_nil @role.current_holder
+      end
     end
 
-    it "should have title and base_path" do
-      assert_equal @expected, @role.current_holder
-    end
+    context "with a current holder" do
+      setup do
+        @expected = {
+          "title" => "The Rt Hon Boris Johnson",
+          "base_path" => "/government/people/boris-johnson",
+          "details" => {
+            "body" => "<p>Boris Johnson became Prime Minister on 24 July 2019. He was previously Foreign Secretary from 13 July 2016 to 9 July 2018. He was elected Conservative MP for Uxbridge and South Ruislip in May 2015. Previously he was the MP for Henley from June 2001 to June 2008.</p> ",
+          },
+        }
+      end
 
-    it "should have body with biography" do
-      assert_equal @expected["details"]["body"], @role.current_holder_biography
-    end
+      it "should have title and base_path" do
+        assert_equal @expected, @role.current_holder
+      end
 
-    it "should have link to person" do
-      assert_equal @expected["base_path"], @role.link_to_person
+      it "should have body with biography" do
+        assert_equal @expected["details"]["body"], @role.current_holder_biography
+      end
+
+      it "should have link to person" do
+        assert_equal @expected["base_path"], @role.link_to_person
+      end
     end
   end
 end


### PR DESCRIPTION
This updates the code to support rendering roles which don't currently have a role appointment attached to them.