### PR TITLE
Allow scripts to be rendered Right to Left

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def page_text_direction
+    I18n.t("shared.language_direction.#{@content_item['locale']}", default: "ltr")
+  end
+
   def browsing_in_top_level_page?(top_level_page)
     request.path.starts_with?(top_level_page.base_path)
   end

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -34,7 +34,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" dir="<%=page_text_direction%>">
     <%= render partial: "biography", locals: { person: person } %>
 
     <%= render partial: "current_roles", locals: { person: person } if person.currently_in_a_role? %>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -64,3 +64,5 @@ en:
       zh: 中文
       zh-hk: 中文
       zh-tw: 中文
+    language_direction:
+      ar: rtl

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -66,3 +66,8 @@ en:
       zh-tw: 中文
     language_direction:
       ar: rtl
+      fa: rtl
+      ur: rtl
+      he: rtl
+      dr: rtl
+      ps: rtl

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -13,6 +13,24 @@ describe ApplicationHelper do
     end
   end
 
+  describe "page_text_direction" do
+    context "when a left to right language script" do
+      it "sets the direction wrapper class to ltr" do
+        @content_item = { locale: "test_data" }
+        I18n.stubs(:t).returns("ltr")
+        assert_equal "ltr", page_text_direction
+      end
+    end
+
+    context "when a right to left language script" do
+      it "sets the direction wrapper class to rtl" do
+        @content_item = { locale: "test_data" }
+        I18n.stubs(:t).returns("rtl")
+        assert_equal "rtl", page_text_direction
+      end
+    end
+  end
+
   describe "t_lang" do
     it "t_fallback returns false if string is translated successfully" do
       I18n.backend.store_translations :en, document: { one: "string" }


### PR DESCRIPTION
If a language should read Right to Left, this PR allows the shared
`config/locales/en/shared.yml` to be updated with a direction.

When rendering, required divs can use the application helper method
`page_text_direction` to set a `dir` attribute on an html element which will apply
relevant text direction to the contents..

This follows similar patterns to those in government-frontend and whitehall
https://github.com/alphagov/government-frontend/blob/71927708e97e4d7375ca719cfa861f74e3d7c024/app/helpers/application_helper.rb#L2

This enables the functionality, but individual languages will need to be identified and added to the configuration

Before
<img width="400" alt="Screenshot 2019-11-29 at 13 52 47" src="https://user-images.githubusercontent.com/13475227/69873202-96650100-12af-11ea-8940-b9f5edf696e3.png">

After
<img width="400" alt="Screenshot 2019-11-29 at 13 52 31" src="https://user-images.githubusercontent.com/13475227/69873204-995ff180-12af-11ea-92c1-66379f63a347.png">

[trello](https://trello.com/c/pkVccAv2/1586-3-render-people-pages-right-to-left-for-approriate-languages)