### PR TITLE
Add shared tracker pageviews for browse

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -363,14 +363,24 @@
         navigationPageType = 'Second Level Browse';
       }
 
+      this.firePageview(state, sectionTitle, navigationPageType);
+      this.firePageview(state, sectionTitle, navigationPageType, 'govuk');
+    },
+    firePageview: function(state, sectionTitle, navigationPageType, tracker) {
       if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
+        var options = {
+          dimension1: sectionTitle,
+          dimension32: navigationPageType
+        }
+
+        if (typeof tracker !== 'undefined') {
+          options.trackerName = tracker
+        }
+
         GOVUK.analytics.trackPageview(
           state.path,
           null,
-          {
-            dimension1: sectionTitle,
-            dimension32: navigationPageType
-          }
+          options
         );
       }
     }

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -140,12 +140,22 @@ describe('browse-columns.js', function() {
     var bc = new GOVUK.BrowseColumns({ $el: $('<div>') });
     bc.trackPageview(state);
 
+    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledTimes(2)
     expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith(
       'foo',
       null,
       {
         dimension1: 'browse',
         dimension32: 'none'
+      }
+    );
+    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith(
+      'foo',
+      null,
+      {
+        dimension1: 'browse',
+        dimension32: 'none',
+        trackerName: 'govuk'
       }
     );
   });


### PR DESCRIPTION
## What

Update JS so that any pageviews sent when browse pages are updated (when users click columns and the page updates dynamically) are also sent to the cross domain analytics property.

Relies upon [this change to static](https://github.com/alphagov/static/pull/1951) (deployed).

## Why

We want the pageviews coming from GOV.UK to look the same in both properties.

Trello card: https://trello.com/c/FYntaHmw/92-send-virtual-pageviews-for-ajax-page-updates-on-search-finders-and-mainstream-browse
