### PR TITLE
Reverse a persons previous role order

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -141,6 +141,7 @@ private
   def previous_roles
     previous_role_appointments
       .sort_by { |role_appointment| role_appointment["details"]["started_on"] }
+      .reverse
       .map do |role_appointment|
         role_appointment["links"]["role"].first.tap do |role|
           role["start_year"] = Time.parse(role_appointment["details"]["started_on"]).strftime("%Y")


### PR DESCRIPTION
I thought I had fixed this in 58e415120d19c468d0ff53c170a8b2a4d982511c but actually the ordering is supposed to be [reversed as it is in Whitehall](https://github.com/alphagov/whitehall/blob/7dfc172f7ff05b919c35f0f5032c783dcf956a8d/app/models/person.rb#L129).

Surprisingly, to me, that's the quickest way of sorting an array in reverse: https://stackoverflow.com/questions/2642182/sorting-an-array-in-descending-order-in-ruby