### PR TITLE
Render translations with right to left scripts

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -5,3 +5,8 @@
     display: block;
   }
 }
+
+[dir="rtl"] {
+  direction: rtl;
+  text-align: start;
+}

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -107,6 +107,10 @@ class Person
         .map { |appointment| appointment["links"]["role"].first }
   end
 
+  def locale
+    @content_item.content_item_data["locale"]
+  end
+
 private
 
   def slug
@@ -164,9 +168,5 @@ private
 
   def available_translations
     links["available_translations"].map(&:symbolize_keys)
-  end
-
-  def locale
-    @content_item.content_item_data["locale"]
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -57,6 +57,10 @@ class Role
     end
   end
 
+  def locale
+    content_item_data["locale"]
+  end
+
 private
 
   def content_item_data
@@ -77,9 +81,5 @@ private
 
   def available_translations
     links["available_translations"].map(&:symbolize_keys)
-  end
-
-  def locale
-    content_item_data["locale"]
   end
 end

--- a/app/views/people/_announcements.html.erb
+++ b/app/views/people/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_announcements? %>
-  <section id="announcements">
+  <section id="announcements" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
         text: "Announcements",
         id: "announcements",

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,4 +1,4 @@
-<section id="biography" class="govuk-!-padding-bottom-9">
+<section id="biography" class="govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
   <%= render "govuk_publishing_components/components/heading", {
     text: "Biography",
     margin_bottom: 2,

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles">
+  <section id="current-roles" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -5,7 +5,7 @@
       title: person.title
     } %>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -5,7 +5,7 @@
       title: person.title
     } %>
   </div>
-  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>">
+  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_previous_roles? %>
-  <section class="previous-roles govuk-!-padding-bottom-9">
+  <section class="previous-roles govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Previous roles in government",
       id: "previous-roles",

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -2,13 +2,13 @@
 
 <%= render partial: "header", locals: { person: person } %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" dir="<%=page_text_direction%>">
   <div class="govuk-grid-column-one-third">
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds" dir="<%=page_text_direction%>">
+  <div class="govuk-grid-column-two-thirds">
     <%= render partial: "biography", locals: { person: person } %>
     <%= render partial: "current_roles", locals: { person: person } %>
     <%= render partial: "previous_roles", locals: { person: person } %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,9 +1,8 @@
 <% content_for :title, person.title %>
 
 <%= render partial: "header", locals: { person: person } %>
-
-<div class="govuk-grid-row" dir="<%=page_text_direction%>">
-  <div class="govuk-grid-column-one-third">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,5 +1,5 @@
 <% if role.current_holder %>
-  <div>
+  <div dir="<%= page_text_direction %>" lang="<%= role.locale %>">
       Current role holder:
       <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-grid-row">
+<header class="govuk-grid-row" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: "Ministerial role",

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,5 +1,5 @@
 <% if role.organisations %>
-  <div class="organisations-list">
+  <div class="organisations-list" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
     Organisations:
     <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
   </div>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -7,7 +7,7 @@
 <%= render partial: "current_holder", locals: { role: role } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Responsibilities",
       id: "responsibilities",


### PR DESCRIPTION
This PR allows any role pages with a translation in a right-to-left script to be rendered accurately.

It also adjusts the right-to-left rendering for people, adding the necessary `dir` attribute to individual elements rather than a shared parent element. 

For accessibility the `lang` attribute is used, which required making a previously private `locale` method public.