### PR TITLE
Add contents to roles

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -30,6 +30,10 @@ class Role
     links["ordered_parent_organisations"]
   end
 
+  def currently_occupied?
+    current_holder.present?
+  end
+
   def current_holder
     links
       .fetch("role_appointments", [])

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -7,6 +7,20 @@
 <%= render partial: "current_holder", locals: { role: role } %>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/contents_list", {
+      contents: [
+        {
+          text: "Responsibilities",
+          href: "#responsibiities"
+        },
+        role.currently_occupied? ? {
+          text: "Current Role Holder",
+          href: "#current-role-holder"
+        } : nil
+      ].compact
+    } %>
+  </div>
   <div class="govuk-grid-column-two-thirds" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Responsibilities",


### PR DESCRIPTION
Add Contents list to the Roles page in Collections

https://trello.com/c/cp4b3mue/1589-1-add-contents-list-to-role-pages

Part of the Whitehall migration work

This is how the page now looks with the Contents list showing

![image](https://user-images.githubusercontent.com/24547183/70158643-7e2a2300-16af-11ea-8064-aba7f6e175af.png)

I have chosen to leave out "Announcements", "Previous Roles" and "Policies" as those features have not yet been implemented in Collections, and adding them to the Contents list actually requires doing a fair portion of the work to add the feature as a whole. It makes sense to me to leave adding these items for now and do them when their corresponding features are migrated into Collections.