### PR TITLE
Support showing announcements for all locales

### DIFF
--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -34,9 +34,13 @@ private
     @announcements ||= Services.cached_search(
       count: 10,
       order: "-public_timestamp",
-      filter_people: slug,
+      filter_people: slug_without_locale,
       reject_content_purpose_supergroup: "other",
       fields: %w[title link content_store_document_type public_timestamp],
-      )["results"]
+    )["results"]
+  end
+
+  def slug_without_locale
+    slug.split(".").first
   end
 end

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -5,6 +5,7 @@
       title: person.title
     } %>
   </div>
+
   <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, person.title %>
 
 <%= render partial: "header", locals: { person: person } %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render partial: "image", locals: { person: person } %>

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -1,16 +1,18 @@
 <%= render "govuk_publishing_components/components/contents_list", {
-    contents: [
-        {
-            text: "Responsibilities",
-            href: "#responsibiities"
-        },
-        role.currently_occupied? ? {
-            text: "Current Role Holder",
-            href: "#current-role-holder"
-        } : nil,
-        role.announcements.items.present? ? {
-            text: "Announcements",
-            href: "#announcements"
-        } : nil,
-    ].compact
+  contents: [
+    {
+      text: "Responsibilities",
+      href: "#responsibiities"
+    },
+
+    role.currently_occupied? ? {
+      text: "Current Role Holder",
+      href: "#current-role-holder"
+    } : nil,
+
+    role.announcements.items.present? ? {
+      text: "Announcements",
+      href: "#announcements"
+    } : nil,
+  ].compact
 } %>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,6 +1,6 @@
 <% if role.current_holder %>
   <div dir="<%= page_text_direction %>" lang="<%= role.locale %>">
-      Current role holder:
-      <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
+    Current role holder:
+    <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>
 <% end %>

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -1,13 +1,13 @@
 <% if role.current_holder %>
   <%= render "govuk_publishing_components/components/heading", {
-      text: "Current role holder:",
-      id: "current-role-holder-title",
+    text: "Current role holder:",
+    id: "current-role-holder-title",
   } %>
 
   <div>
     <%= render "govuk_publishing_components/components/heading", {
-        text: role.current_holder["title"],
-        id: "current-role-holder-title",
+      text: role.current_holder["title"],
+      id: "current-role-holder-title",
     } %>
   </div>
 
@@ -22,4 +22,3 @@
     <%= link_to "More about this person", role.link_to_person, class: "govuk-link" %>
   </div>
 <% end %>
-

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -5,6 +5,7 @@
       title: role.title
     } %>
   </div>
+
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: role.translations

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -10,6 +10,7 @@
   <div class="govuk-grid-column-one-third">
     <%= render partial: "contents", locals: { role: role } %>
   </div>
+
   <div class="govuk-grid-column-two-thirds" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Responsibilities",


### PR DESCRIPTION
Search API only supports documents written in English so we should remove the locale from the slug when querying for documents.

I've also fixed some indentation issues.