### PR TITLE
Hide announcements if there aren't any

### DIFF
--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,4 +1,4 @@
-<% if announcements %>
+<% if announcements.items.present? %>
   <section id="announcements" dir="<%= page_text_direction %>" lang="<%= locale %>">
     <%= render "govuk_publishing_components/components/heading", {
         text: "Announcements",


### PR DESCRIPTION
`announcements` will always be truthy whereas `announcements.items.present?` will correctly tell us whether or not there are announcements to display.