### PR TITLE
Display previous holders on role pages

### DIFF
--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -10,6 +10,11 @@
       href: "#current-role-holder"
     } : nil,
 
+    role.past_holders.present? ? {
+      text: "Previous holders",
+      href: "#past-role-holders"
+    } : nil,
+
     role.announcements.items.present? ? {
       text: "Announcements",
       href: "#announcements"

--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -1,0 +1,17 @@
+<% unless role.past_holders.empty? %>
+  <section id="past-role-holders" class="govuk-!-padding-bottom-9">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Previous holders of this role",
+    } %>
+
+    <%= render "components/taxon-list", {
+      items: role.past_holders.map do |rh|
+        {
+          text: rh['title'],
+          path: rh['base_path'],
+          description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
+        }
+      end
+    } %>
+  </section>
+<% end %>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -17,6 +17,8 @@
 
     <%= render partial: "current_role_holder_with_biography", locals: { role: role } %>
 
+    <%= render partial: "past_role_holders", locals: { role: role } %>
+
     <%= render partial: "shared/announcements", locals: { announcements: role.announcements, locale: role.locale } %>
   </div>
 </div>


### PR DESCRIPTION
Adds a `previous_holders` method to the role, and then alters the view
to show these.

https://trello.com/c/Rk6ChPtp/1629-2-add-previous-holders-list-to-role-pages