### PR TITLE
Add translations for hard-coded people and roles text

### DIFF
--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,9 +1,15 @@
 class PeopleController < ApplicationController
+  before_action :set_locale
+
   def show
     @person = Person.find!(request.path)
     setup_content_item_and_navigation_helpers(@person)
-    render :show, locals: {
-      person: @person,
-    }
+    render :show, locals: { person: @person }
+  end
+
+private
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,9 +1,15 @@
 class RolesController < ApplicationController
+  before_action :set_locale
+
   def show
     @role = Role.find!(request.path)
     setup_content_item_and_navigation_helpers(@role)
-    render :show, locals: {
-      role: @role,
-    }
+    render :show, locals: { role: @role }
+  end
+
+private
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,6 +1,6 @@
 <section id="biography" class="govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Biography",
+    text: t("people.biography"),
     margin_bottom: 2,
   } %>
 

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -16,7 +16,7 @@
     } : nil,
 
     person.announcements.items.present? ? {
-      text: "Announcements",
+      text: t("organisations.content_item.schema_name.announcement.other"),
       href: "#announcements"
     } : nil,
   ].compact

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -6,7 +6,7 @@
     },
 
     person.currently_in_a_role? ? {
-      text: "Role",
+      text: t("roles.heading.one"),
       href: "#current-roles"
     } : nil,
 

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -11,7 +11,7 @@
     } : nil,
 
     person.has_previous_roles? ? {
-      text: "Previous roles",
+      text: t("people.previous_roles"),
       href: "#previous-roles"
     } : nil,
 

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/contents_list", {
   contents: [
     {
-      text: "Biography",
+      text: t("people.biography"),
       href: "#biography"
     },
 

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -13,7 +13,9 @@
         <% end  %>
 
         <% if role["document_type"] == "ministerial_role" %>
-          <p class="govuk-body-s"><a href=<%= role["base_path"] %>>More about this role</a></p>
+          <p class="govuk-body-s">
+            <a href="<%= role["base_path"] %>"><%= t('roles.read_more') %></a>
+          </p>
         <% end %>
 
         <p class="govuk-body">

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,7 +1,7 @@
 <% if person.has_previous_roles? %>
   <section class="previous-roles govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Previous roles in government",
+      text: t("people.previous_roles_in_government"),
       id: "previous-roles",
       margin_bottom: 2,
     } %>

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -6,7 +6,7 @@
     },
 
     role.currently_occupied? ? {
-      text: "Current Role Holder",
+      text: t("roles.headings.current_holder"),
       href: "#current-role-holder"
     } : nil,
 

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -11,7 +11,7 @@
     } : nil,
 
     role.announcements.items.present? ? {
-      text: "Announcements",
+      text: t("organisations.content_item.schema_name.announcement.other"),
       href: "#announcements"
     } : nil,
   ].compact

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/contents_list", {
   contents: [
     {
-      text: "Responsibilities",
+      text: t("roles.headings.responsibilities"),
       href: "#responsibilities"
     },
 

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,6 +1,6 @@
 <% if role.current_holder %>
   <div dir="<%= page_text_direction %>" lang="<%= role.locale %>">
-    Current role holder:
+    <%= t("roles.headings.current_holder") %>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>
 <% end %>

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to "More about this person", role.link_to_person, class: "govuk-link" %>
+      <%= link_to t("people.read_more"), role.link_to_person, class: "govuk-link" %>
     </p>
   </section>
 <% end %>

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -1,7 +1,7 @@
 <% if role.current_holder.present? %>
   <section id="current-role-holder" class="govuk-!-padding-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Current role holder:",
+      text: t("roles.headings.current_holder"),
     } %>
 
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,7 +1,7 @@
 <header class="govuk-grid-row" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
-      context: "Ministerial role",
+      context: t("roles.ministerial"),
       title: role.title
     } %>
   </div>

--- a/app/views/roles/_responsibilities.html.erb
+++ b/app/views/roles/_responsibilities.html.erb
@@ -1,6 +1,6 @@
 <section id="responsibilities" class="govuk-!-padding-bottom-9">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "Responsibilities",
+    text: t("roles.headings.responsibilities"),
     margin_bottom: 2,
   } %>
 

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,7 +1,7 @@
 <% if announcements.items.present? %>
   <section id="announcements" dir="<%= page_text_direction %>" lang="<%= locale %>">
     <%= render "govuk_publishing_components/components/heading", {
-        text: "Announcements",
+        text: t("organisations.content_item.schema_name.announcement.other"),
         id: "announcements",
         margin_bottom: 5,
     } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,8 +18,10 @@ module Collections
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    config.i18n.default_locale = :en
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.yml").to_s]
+    config.i18n.fallbacks = true
+
     config.assets.prefix = "/collections/"
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.

--- a/config/locales/ar/people.yml
+++ b/config/locales/ar/people.yml
@@ -1,0 +1,13 @@
+ar:
+  people:
+    heading:
+      zero:
+      one:
+      two:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ar/roles.yml
+++ b/config/locales/ar/roles.yml
@@ -1,0 +1,17 @@
+ar:
+  roles:
+    heading:
+      zero:
+      one:
+      two:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/az/people.yml
+++ b/config/locales/az/people.yml
@@ -1,0 +1,9 @@
+az:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/az/roles.yml
+++ b/config/locales/az/roles.yml
@@ -1,0 +1,13 @@
+az:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/be/people.yml
+++ b/config/locales/be/people.yml
@@ -1,0 +1,11 @@
+be:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/be/roles.yml
+++ b/config/locales/be/roles.yml
@@ -1,0 +1,15 @@
+be:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/bg/people.yml
+++ b/config/locales/bg/people.yml
@@ -1,0 +1,8 @@
+people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/bg/roles.yml
+++ b/config/locales/bg/roles.yml
@@ -1,0 +1,12 @@
+roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/bn/people.yml
+++ b/config/locales/bn/people.yml
@@ -1,0 +1,9 @@
+bn:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/bn/roles.yml
+++ b/config/locales/bn/roles.yml
@@ -1,0 +1,13 @@
+bn:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/cs/people.yml
+++ b/config/locales/cs/people.yml
@@ -1,0 +1,10 @@
+cs:
+  people:
+    heading:
+      one:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/cs/roles.yml
+++ b/config/locales/cs/roles.yml
@@ -1,0 +1,14 @@
+cs:
+  roles:
+    heading:
+      one:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/cy/people.yml
+++ b/config/locales/cy/people.yml
@@ -1,0 +1,13 @@
+cy:
+  people:
+    heading:
+      zero:
+      one: Person
+      two:
+      few:
+      many: Pobl
+      other:
+    biography: Bywgraffiad
+    previous_roles: Rolau blaenorol
+    previous_roles_in_government: Rolau blaenorol mewn llywodraeth
+    read_more: Mwy am y person yma

--- a/config/locales/cy/roles.yml
+++ b/config/locales/cy/roles.yml
@@ -1,0 +1,17 @@
+cy:
+  roles:
+    heading:
+      zero:
+      one: Rôl
+      two:
+      few:
+      many:
+      other: Rolau
+    headings:
+      current_holder: 'Deiliad y rôl  '
+      previous_holders: 'Cyn-ddeiliaid '
+      responsibilities: Cyfrifoldebau
+    ministerial: Rôl Gweinidogol
+    policies_responsible_with_person: dan gyfrifoldeb %{person} fel %{role}
+    previous_holders: Cyn-ddeiliaid y rôl yma
+    read_more: Mwy am y rôl yma

--- a/config/locales/da/people.yml
+++ b/config/locales/da/people.yml
@@ -1,0 +1,9 @@
+da:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/da/roles.yml
+++ b/config/locales/da/roles.yml
@@ -1,0 +1,13 @@
+da:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/de/people.yml
+++ b/config/locales/de/people.yml
@@ -1,0 +1,9 @@
+de:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/de/roles.yml
+++ b/config/locales/de/roles.yml
@@ -1,0 +1,13 @@
+de:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/dr/people.yml
+++ b/config/locales/dr/people.yml
@@ -1,0 +1,9 @@
+dr:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/dr/roles.yml
+++ b/config/locales/dr/roles.yml
@@ -1,0 +1,13 @@
+dr:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/el/people.yml
+++ b/config/locales/el/people.yml
@@ -1,0 +1,9 @@
+el:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/el/roles.yml
+++ b/config/locales/el/roles.yml
@@ -1,0 +1,13 @@
+el:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/en/people.yml
+++ b/config/locales/en/people.yml
@@ -1,0 +1,9 @@
+en:
+  people:
+    heading:
+      one: Person
+      other: People
+    biography: Biography
+    read_more: More about this person
+    previous_roles: Previous roles
+    previous_roles_in_government: Previous roles in government

--- a/config/locales/en/roles.yml
+++ b/config/locales/en/roles.yml
@@ -1,0 +1,13 @@
+en:
+  roles:
+    heading:
+      one: Role
+      other: Roles
+    ministerial: Ministerial role
+    read_more: More about this role
+    previous_holders: Previous holders of this role
+    policies_responsible_with_person: under the responsibility of %{person} as %{role}
+    headings:
+      responsibilities: Responsibilities
+      current_holder: Current role holder
+      previous_holders: Previous holders

--- a/config/locales/es-419/people.yml
+++ b/config/locales/es-419/people.yml
@@ -1,0 +1,9 @@
+es-419:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/es-419/roles.yml
+++ b/config/locales/es-419/roles.yml
@@ -1,0 +1,13 @@
+es-419:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/es/people.yml
+++ b/config/locales/es/people.yml
@@ -1,0 +1,9 @@
+es:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/es/roles.yml
+++ b/config/locales/es/roles.yml
@@ -1,0 +1,13 @@
+es:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/et/people.yml
+++ b/config/locales/et/people.yml
@@ -1,0 +1,9 @@
+et:
+  people:
+    heading:
+      one: Isik
+      other: Inimesed
+    biography: CV
+    previous_roles: Varasemad ülesanded
+    previous_roles_in_government: Varasemad ülesanded valitsuses
+    read_more: Temast lähemalt

--- a/config/locales/et/roles.yml
+++ b/config/locales/et/roles.yml
@@ -1,0 +1,13 @@
+et:
+  roles:
+    heading:
+      one: Ülesanne
+      other: Ülesanded
+    headings:
+      current_holder: Praegu sellel ametikohal
+      previous_holders: Eelmised ametikoha täitjad
+      responsibilities: Vastutusalad
+    ministerial: Ministri ülesanne
+    policies_responsible_with_person: 'Pädevus haldusala järgi: %{person}, %{role}'
+    previous_holders: 'Varem sellel ametikohal '
+    read_more: Sellest ametikohast lähemalt

--- a/config/locales/fa/people.yml
+++ b/config/locales/fa/people.yml
@@ -1,0 +1,9 @@
+fa:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/fa/roles.yml
+++ b/config/locales/fa/roles.yml
@@ -1,0 +1,13 @@
+fa:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/fi/people.yml
+++ b/config/locales/fi/people.yml
@@ -1,0 +1,9 @@
+fi:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/fi/roles.yml
+++ b/config/locales/fi/roles.yml
@@ -1,0 +1,13 @@
+fi:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/fr/people.yml
+++ b/config/locales/fr/people.yml
@@ -1,0 +1,9 @@
+fr:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/fr/roles.yml
+++ b/config/locales/fr/roles.yml
@@ -1,0 +1,13 @@
+fr:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/gd/people.yml
+++ b/config/locales/gd/people.yml
@@ -1,0 +1,11 @@
+gd:
+  people:
+    heading:
+      one:
+      two:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/gd/roles.yml
+++ b/config/locales/gd/roles.yml
@@ -1,0 +1,15 @@
+gd:
+  roles:
+    heading:
+      one:
+      two:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/he/people.yml
+++ b/config/locales/he/people.yml
@@ -1,0 +1,9 @@
+he:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/he/roles.yml
+++ b/config/locales/he/roles.yml
@@ -1,0 +1,13 @@
+he:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/hi/people.yml
+++ b/config/locales/hi/people.yml
@@ -1,0 +1,9 @@
+hi:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/hi/roles.yml
+++ b/config/locales/hi/roles.yml
@@ -1,0 +1,13 @@
+hi:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/hr/people.yml
+++ b/config/locales/hr/people.yml
@@ -1,0 +1,11 @@
+hr:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/hr/roles.yml
+++ b/config/locales/hr/roles.yml
@@ -1,0 +1,15 @@
+hr:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/hu/people.yml
+++ b/config/locales/hu/people.yml
@@ -1,0 +1,9 @@
+hu:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/hu/roles.yml
+++ b/config/locales/hu/roles.yml
@@ -1,0 +1,13 @@
+hu:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/hy/people.yml
+++ b/config/locales/hy/people.yml
@@ -1,0 +1,9 @@
+hy:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/hy/roles.yml
+++ b/config/locales/hy/roles.yml
@@ -1,0 +1,13 @@
+hy:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/id/people.yml
+++ b/config/locales/id/people.yml
@@ -1,0 +1,9 @@
+id:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/id/roles.yml
+++ b/config/locales/id/roles.yml
@@ -1,0 +1,13 @@
+id:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/is/people.yml
+++ b/config/locales/is/people.yml
@@ -1,0 +1,9 @@
+is:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/is/roles.yml
+++ b/config/locales/is/roles.yml
@@ -1,0 +1,13 @@
+is:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/it/people.yml
+++ b/config/locales/it/people.yml
@@ -1,0 +1,9 @@
+it:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/it/roles.yml
+++ b/config/locales/it/roles.yml
@@ -1,0 +1,13 @@
+it:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ja/people.yml
+++ b/config/locales/ja/people.yml
@@ -1,0 +1,9 @@
+ja:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ja/roles.yml
+++ b/config/locales/ja/roles.yml
@@ -1,0 +1,13 @@
+ja:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ka/people.yml
+++ b/config/locales/ka/people.yml
@@ -1,0 +1,9 @@
+ka:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ka/roles.yml
+++ b/config/locales/ka/roles.yml
@@ -1,0 +1,13 @@
+ka:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/kk/people.yml
+++ b/config/locales/kk/people.yml
@@ -1,0 +1,9 @@
+kk:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/kk/roles.yml
+++ b/config/locales/kk/roles.yml
@@ -1,0 +1,13 @@
+kk:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ko/people.yml
+++ b/config/locales/ko/people.yml
@@ -1,0 +1,9 @@
+ko:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ko/roles.yml
+++ b/config/locales/ko/roles.yml
@@ -1,0 +1,13 @@
+ko:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/lt/people.yml
+++ b/config/locales/lt/people.yml
@@ -1,0 +1,10 @@
+lt:
+  people:
+    heading:
+      one:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/lt/roles.yml
+++ b/config/locales/lt/roles.yml
@@ -1,0 +1,14 @@
+lt:
+  roles:
+    heading:
+      one:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/lv/people.yml
+++ b/config/locales/lv/people.yml
@@ -1,0 +1,9 @@
+lv:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/lv/roles.yml
+++ b/config/locales/lv/roles.yml
@@ -1,0 +1,13 @@
+lv:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ms/people.yml
+++ b/config/locales/ms/people.yml
@@ -1,0 +1,9 @@
+ms:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ms/roles.yml
+++ b/config/locales/ms/roles.yml
@@ -1,0 +1,13 @@
+ms:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/mt/people.yml
+++ b/config/locales/mt/people.yml
@@ -1,0 +1,11 @@
+mt:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/mt/roles.yml
+++ b/config/locales/mt/roles.yml
@@ -1,0 +1,15 @@
+mt:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/nl/people.yml
+++ b/config/locales/nl/people.yml
@@ -1,0 +1,9 @@
+nl:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/nl/roles.yml
+++ b/config/locales/nl/roles.yml
@@ -1,0 +1,13 @@
+nl:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/no/people.yml
+++ b/config/locales/no/people.yml
@@ -1,0 +1,9 @@
+"no":
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/no/roles.yml
+++ b/config/locales/no/roles.yml
@@ -1,0 +1,13 @@
+"no":
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/pl/people.yml
+++ b/config/locales/pl/people.yml
@@ -1,0 +1,11 @@
+pl:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/pl/roles.yml
+++ b/config/locales/pl/roles.yml
@@ -1,0 +1,15 @@
+pl:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ps/people.yml
+++ b/config/locales/ps/people.yml
@@ -1,0 +1,9 @@
+ps:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ps/roles.yml
+++ b/config/locales/ps/roles.yml
@@ -1,0 +1,13 @@
+ps:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/pt/people.yml
+++ b/config/locales/pt/people.yml
@@ -1,0 +1,9 @@
+pt:
+  people:
+    heading:
+      one:
+      other:
+    biography: Biografia
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/pt/roles.yml
+++ b/config/locales/pt/roles.yml
@@ -1,0 +1,13 @@
+pt:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ro/people.yml
+++ b/config/locales/ro/people.yml
@@ -1,0 +1,10 @@
+ro:
+  people:
+    heading:
+      one:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ro/roles.yml
+++ b/config/locales/ro/roles.yml
@@ -1,0 +1,14 @@
+ro:
+  roles:
+    heading:
+      one:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ru/people.yml
+++ b/config/locales/ru/people.yml
@@ -1,0 +1,11 @@
+ru:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ru/roles.yml
+++ b/config/locales/ru/roles.yml
@@ -1,0 +1,15 @@
+ru:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/si/people.yml
+++ b/config/locales/si/people.yml
@@ -1,0 +1,9 @@
+si:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/si/roles.yml
+++ b/config/locales/si/roles.yml
@@ -1,0 +1,13 @@
+si:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sk/people.yml
+++ b/config/locales/sk/people.yml
@@ -1,0 +1,10 @@
+sk:
+  people:
+    heading:
+      one:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sk/roles.yml
+++ b/config/locales/sk/roles.yml
@@ -1,0 +1,14 @@
+sk:
+  roles:
+    heading:
+      one:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sl/people.yml
+++ b/config/locales/sl/people.yml
@@ -1,0 +1,11 @@
+sl:
+  people:
+    heading:
+      one:
+      two:
+      few:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sl/roles.yml
+++ b/config/locales/sl/roles.yml
@@ -1,0 +1,15 @@
+sl:
+  roles:
+    heading:
+      one:
+      two:
+      few:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/so/people.yml
+++ b/config/locales/so/people.yml
@@ -1,0 +1,9 @@
+so:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/so/roles.yml
+++ b/config/locales/so/roles.yml
@@ -1,0 +1,13 @@
+so:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sq/people.yml
+++ b/config/locales/sq/people.yml
@@ -1,0 +1,9 @@
+sq:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sq/roles.yml
+++ b/config/locales/sq/roles.yml
@@ -1,0 +1,13 @@
+sq:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sr/people.yml
+++ b/config/locales/sr/people.yml
@@ -1,0 +1,11 @@
+sr:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sr/roles.yml
+++ b/config/locales/sr/roles.yml
@@ -1,0 +1,15 @@
+sr:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sv/people.yml
+++ b/config/locales/sv/people.yml
@@ -1,0 +1,9 @@
+sv:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sv/roles.yml
+++ b/config/locales/sv/roles.yml
@@ -1,0 +1,13 @@
+sv:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/sw/people.yml
+++ b/config/locales/sw/people.yml
@@ -1,0 +1,9 @@
+sw:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/sw/roles.yml
+++ b/config/locales/sw/roles.yml
@@ -1,0 +1,13 @@
+sw:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ta/people.yml
+++ b/config/locales/ta/people.yml
@@ -1,0 +1,9 @@
+ta:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ta/roles.yml
+++ b/config/locales/ta/roles.yml
@@ -1,0 +1,13 @@
+ta:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/th/people.yml
+++ b/config/locales/th/people.yml
@@ -1,0 +1,9 @@
+th:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/th/roles.yml
+++ b/config/locales/th/roles.yml
@@ -1,0 +1,13 @@
+th:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/tk/people.yml
+++ b/config/locales/tk/people.yml
@@ -1,0 +1,9 @@
+tk:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/tk/roles.yml
+++ b/config/locales/tk/roles.yml
@@ -1,0 +1,13 @@
+tk:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/tr/people.yml
+++ b/config/locales/tr/people.yml
@@ -1,0 +1,9 @@
+tr:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/tr/roles.yml
+++ b/config/locales/tr/roles.yml
@@ -1,0 +1,13 @@
+tr:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/uk/people.yml
+++ b/config/locales/uk/people.yml
@@ -1,0 +1,11 @@
+uk:
+  people:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/uk/roles.yml
+++ b/config/locales/uk/roles.yml
@@ -1,0 +1,15 @@
+uk:
+  roles:
+    heading:
+      one:
+      few:
+      many:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/ur/people.yml
+++ b/config/locales/ur/people.yml
@@ -1,0 +1,9 @@
+ur:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/ur/roles.yml
+++ b/config/locales/ur/roles.yml
@@ -1,0 +1,13 @@
+ur:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/uz/people.yml
+++ b/config/locales/uz/people.yml
@@ -1,0 +1,9 @@
+uz:
+  people:
+    heading:
+      one:
+      other:
+    biography:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/uz/roles.yml
+++ b/config/locales/uz/roles.yml
@@ -1,0 +1,13 @@
+uz:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/vi/people.yml
+++ b/config/locales/vi/people.yml
@@ -1,0 +1,9 @@
+vi:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/vi/roles.yml
+++ b/config/locales/vi/roles.yml
@@ -1,0 +1,13 @@
+vi:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/zh-hk/people.yml
+++ b/config/locales/zh-hk/people.yml
@@ -1,0 +1,9 @@
+zh-hk:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/zh-hk/roles.yml
+++ b/config/locales/zh-hk/roles.yml
@@ -1,0 +1,13 @@
+zh-hk:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/zh-tw/people.yml
+++ b/config/locales/zh-tw/people.yml
@@ -1,0 +1,9 @@
+zh-tw:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/zh-tw/roles.yml
+++ b/config/locales/zh-tw/roles.yml
@@ -1,0 +1,13 @@
+zh-tw:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/zh/people.yml
+++ b/config/locales/zh/people.yml
@@ -1,0 +1,9 @@
+zh:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/zh/roles.yml
+++ b/config/locales/zh/roles.yml
@@ -1,0 +1,13 @@
+zh:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:


### PR DESCRIPTION
This adds translations from Whitehall for hard-coded pieces of text on the people and roles pages. See individual commits for more details.

This is the start of some work to improve the accessibility of people and roles pages by adding in the translations, but there is more work to come later including setting the locale of each piece of text in the HTML and properly rendering right-to-left parts.

[Trello Card](https://trello.com/c/Bf2mzxbu/1628-2-add-translations-for-hard-coded-text-in-people-pages)