### PR TITLE
Set the language of translated strings

### DIFF
--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -1,23 +1,25 @@
-<%= render "govuk_publishing_components/components/contents_list", {
-  contents: [
-    {
-      text: t("people.biography"),
-      href: "#biography"
-    },
+<div <%= t_lang("people.biography") %>>
+  <%= render "govuk_publishing_components/components/contents_list", {
+    contents: [
+      {
+        text: t("people.biography"),
+        href: "#biography"
+      },
 
-    person.currently_in_a_role? ? {
-      text: t("roles.heading.one"),
-      href: "#current-roles"
-    } : nil,
+      person.currently_in_a_role? ? {
+        text: t("roles.heading.one"),
+        href: "#current-roles"
+      } : nil,
 
-    person.has_previous_roles? ? {
-      text: t("people.previous_roles"),
-      href: "#previous-roles"
-    } : nil,
+      person.has_previous_roles? ? {
+        text: t("people.previous_roles"),
+        href: "#previous-roles"
+      } : nil,
 
-    person.announcements.items.present? ? {
-      text: t("organisations.content_item.schema_name.announcement.other"),
-      href: "#announcements"
-    } : nil,
-  ].compact
-} %>
+      person.announcements.items.present? ? {
+        text: t("organisations.content_item.schema_name.announcement.other"),
+        href: "#announcements"
+      } : nil,
+    ].compact
+  } %>
+</div>

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -14,7 +14,9 @@
 
         <% if role["document_type"] == "ministerial_role" %>
           <p class="govuk-body-s">
-            <a href="<%= role["base_path"] %>"><%= t('roles.read_more') %></a>
+            <a href="<%= role["base_path"] %>" <%= t_lang("roles.read_more") %> class="govuk-link">
+              <%= t("roles.read_more") %>
+            </a>
           </p>
         <% end %>
 

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -2,6 +2,7 @@
   <section class="previous-roles govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("people.previous_roles_in_government"),
+      lang: t_fallback("people.previous_roles_in_government"),
       id: "previous-roles",
       margin_bottom: 2,
     } %>

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -1,23 +1,25 @@
-<%= render "govuk_publishing_components/components/contents_list", {
-  contents: [
-    {
-      text: t("roles.headings.responsibilities"),
-      href: "#responsibilities"
-    },
+<div <%= t_lang("roles.headings.responsibilities") %>>
+  <%= render "govuk_publishing_components/components/contents_list", {
+    contents: [
+      {
+        text: t("roles.headings.responsibilities"),
+        href: "#responsibilities"
+      },
 
-    role.currently_occupied? ? {
-      text: t("roles.headings.current_holder"),
-      href: "#current-role-holder"
-    } : nil,
+      role.currently_occupied? ? {
+        text: t("roles.headings.current_holder"),
+        href: "#current-role-holder"
+      } : nil,
 
-    role.past_holders.present? ? {
-      text: "Previous holders",
-      href: "#past-role-holders"
-    } : nil,
+      role.past_holders.present? ? {
+        text: t("roles.headings.previous_holders"),
+        href: "#past-role-holders"
+      } : nil,
 
-    role.announcements.items.present? ? {
-      text: t("organisations.content_item.schema_name.announcement.other"),
-      href: "#announcements"
-    } : nil,
-  ].compact
-} %>
+      role.announcements.items.present? ? {
+        text: t("organisations.content_item.schema_name.announcement.other"),
+        href: "#announcements"
+      } : nil,
+    ].compact
+  } %>
+</div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,6 +1,6 @@
 <% if role.current_holder %>
   <div dir="<%= page_text_direction %>" lang="<%= role.locale %>">
-    <%= t("roles.headings.current_holder") %>:
+    <span <%= t_lang("roles.headings.current_holder") %>><%= t("roles.headings.current_holder") %></span>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>
 <% end %>

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -15,7 +15,9 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to t("people.read_more"), role.link_to_person, class: "govuk-link" %>
+      <a href="<%= role.link_to_person %>" class="govuk-link" <%= t_lang("people.read_more") %>>
+        <%= t("people.read_more") %>
+      </a>
     </p>
   </section>
 <% end %>

--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -2,6 +2,7 @@
   <section id="current-role-holder" class="govuk-!-padding-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("roles.headings.current_holder"),
+      lang: t_fallback("roles.headings.current_holder"),
     } %>
 
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -2,6 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: t("roles.ministerial"),
+      context_locale: t_fallback("roles.ministerial"),
       title: role.title
     } %>
   </div>

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,6 +1,6 @@
 <% if role.organisations %>
   <div class="organisations-list" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
-    Organisations:
+    <span lang="en">Organisations</span>:
     <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
   </div>
 <% end %>

--- a/app/views/roles/_responsibilities.html.erb
+++ b/app/views/roles/_responsibilities.html.erb
@@ -1,6 +1,7 @@
 <section id="responsibilities" class="govuk-!-padding-bottom-9">
   <%= render "govuk_publishing_components/components/heading", {
     text: t("roles.headings.responsibilities"),
+    lang: t_fallback("roles.headings.responsibilities"),
     margin_bottom: 2,
   } %>
 

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -2,6 +2,7 @@
   <section id="announcements" dir="<%= page_text_direction %>" lang="<%= locale %>">
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
+        lang: t_fallback("organisations.content_item.schema_name.announcement.other"),
         id: "announcements",
         margin_bottom: 5,
     } %>
@@ -17,7 +18,7 @@
     } %>
 
     <div class="read-more">
-      <%= link_to "View all announcements", announcements.links[:link_to_news_and_communications], class: "govuk-link" %>
+      <%= link_to "View all announcements", announcements.links[:link_to_news_and_communications], class: "govuk-link", lang: "en" %>
     </div>
   </section>
 <% end %>


### PR DESCRIPTION
This ensures that the language of any of our translated strings are set correctly. In practice this means that if they match the locale of the page (i.e. we have a translated string for the current locale) the `lang` attribute will not be written. If the translation doesn't match the locale of the page  (i.e. we don't have a translated string for the current locale and it's fallen back to English) the `lang` attribute will be added.

[Trello Card](https://trello.com/c/G77SR2Nx/1616-improve-accessiblity-for-right-to-left-translations)