### PR TITLE
Improve landing page spacing

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -67,6 +67,18 @@ $red: #E61E32;
   padding-top: govuk-spacing(4);
 }
 
+.landing-page__section-row-title {
+  padding-left: 0;
+}
+
+.landing-page__section-content {
+  padding-left: 0;
+
+  @include govuk-media-query($from: tablet) {
+    padding-right: 0;
+  }
+}
+
 .landing-page__section-list {
   @include govuk-font(19);
   margin-bottom: govuk-spacing(3);

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -11,11 +11,11 @@
 
   <% buckets.each do |bucket| %>
     <div class="grid-row landing-page__section-list-wrapper">
-      <div class="govuk-grid-column-one-third govuk-!-padding-left-0 govuk-!-padding-right-0">
+      <div class="govuk-grid-column-one-third landing-page__section-row-title">
         <% if bucket[:row_title] %><h3 class="govuk-heading-s"><%= bucket[:row_title] %></h3><% end %>
       </div>
 
-      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0 govuk-!-padding-right-0">
+      <div class="govuk-grid-column-two-thirds landing-page__section-content">
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
           <%= bucket[:list_block] %>


### PR DESCRIPTION
We were removing both the left and right padding from grid columns, which meant they appeared very close together on smaller screens.

## Before
<img width="454" alt="Screenshot 2019-12-17 at 15 25 33" src="https://user-images.githubusercontent.com/29889908/71009045-85a2f080-20e1-11ea-8eb5-36810ee1d09c.png">

## After
<img width="472" alt="Screenshot 2019-12-17 at 15 26 10" src="https://user-images.githubusercontent.com/29889908/71009077-92bfdf80-20e1-11ea-84d6-a07f8ebe35a0.png">
