### PR TITLE
Set the direction of right to left text 

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -5,8 +5,3 @@
     display: block;
   }
 }
-
-[dir="rtl"] {
-  direction: rtl;
-  text-align: start;
-}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,12 +20,15 @@ module ApplicationHelper
   end
 
   def page_text_direction
-    I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr")
+    @page_text_direction ||= I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr")
   end
 
   def t_direction
-    direction = page_text_direction
-    "dir=#{direction}" unless direction == "ltr"
+    "dir=#{page_text_direction}" unless page_text_direction == "ltr"
+  end
+
+  def direction_rtl_class
+    "direction-rtl" unless page_text_direction == "ltr"
   end
 
   def t_lang(key, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
     @page_text_direction ||= I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr")
   end
 
-  def t_direction
+  def dir_attribute
     "dir=#{page_text_direction}" unless page_text_direction == "ltr"
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,8 +27,10 @@ module ApplicationHelper
     "dir=#{page_text_direction}" unless page_text_direction == "ltr"
   end
 
-  def direction_rtl_class
-    "direction-rtl" unless page_text_direction == "ltr"
+  def direction_rtl_class(prefix: false)
+    if page_text_direction == 'rtl'
+      prefix ? "class=direction-rtl" : "direction-rtl"
+    end
   end
 
   def lang_attribute

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,10 @@ module ApplicationHelper
     "direction-rtl" unless page_text_direction == "ltr"
   end
 
+  def lang_attribute
+    "lang=#{I18n.locale}" unless I18n.locale == I18n.default_locale
+  end
+
   def t_lang(key, options = {})
     fallback = t_fallback(key, options)
     if fallback && fallback != I18n.locale

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,4 @@
 module ApplicationHelper
-  def page_text_direction
-    I18n.t("shared.language_direction.#{@content_item['locale']}", default: "ltr")
-  end
-
   def browsing_in_top_level_page?(top_level_page)
     request.path.starts_with?(top_level_page.base_path)
   end
@@ -21,6 +17,15 @@ module ApplicationHelper
 
   def is_testable_taxon_page?
     false
+  end
+
+  def page_text_direction
+    I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr")
+  end
+
+  def t_direction
+    direction = page_text_direction
+    "dir=#{direction}" unless direction == "ltr"
   end
 
   def t_lang(key, options = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,7 +28,7 @@ module ApplicationHelper
   end
 
   def direction_rtl_class(prefix: false)
-    if page_text_direction == 'rtl'
+    if page_text_direction == "rtl"
       prefix ? "class=direction-rtl" : "direction-rtl"
     end
   end

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,4 +1,4 @@
-<section id="biography" class="govuk-!-padding-bottom-9 <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
+<section id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
     margin_bottom: 2,

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,4 +1,4 @@
-<section id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+<section id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
     margin_bottom: 2,

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,4 +1,4 @@
-<section id="biography" class="govuk-!-padding-bottom-9" <%= t_direction %> lang="<%= person.locale %>">
+<section id="biography" class="govuk-!-padding-bottom-9 <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
     margin_bottom: 2,

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,4 +1,4 @@
-<section id="biography" class="govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
+<section id="biography" class="govuk-!-padding-bottom-9" <%= t_direction %> lang="<%= person.locale %>">
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
     margin_bottom: 2,

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" class="<%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+  <section id="current-roles" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %> <%= lang_attribute %>>
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
+  <section id="current-roles" <%= t_direction %> lang="<%= person.locale %>">
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" <%= t_direction %> lang="<%= person.locale %>">
+  <section id="current-roles" class="<%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" class="<%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
+  <section id="current-roles" class="<%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" class="<%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+  <section id="current-roles" class="<%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <% person.current_roles.each do |role| %>
       <section class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -6,7 +6,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third" <%= t_direction %> lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -6,7 +6,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third" <%= t_direction %> lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -6,7 +6,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -6,7 +6,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/translation-nav", {
       translations: person.translations
     } %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_previous_roles? %>
-  <section class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+  <section class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("people.previous_roles_in_government"),
       lang: t_fallback("people.previous_roles_in_government"),

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_previous_roles? %>
-  <section class="previous-roles govuk-!-padding-bottom-9" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
+  <section class="previous-roles govuk-!-padding-bottom-9" <%= t_direction %>" lang="<%= person.locale %>">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("people.previous_roles_in_government"),
       lang: t_fallback("people.previous_roles_in_government"),

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_previous_roles? %>
-  <section class="previous-roles govuk-!-padding-bottom-9" <%= t_direction %>" lang="<%= person.locale %>">
+  <section class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("people.previous_roles_in_government"),
       lang: t_fallback("people.previous_roles_in_government"),

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third" dir="<%= page_text_direction %>" lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third" <%= t_direction %> lang="<%= person.locale %>">
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>
@@ -12,6 +12,6 @@
     <%= render partial: "biography", locals: { person: person } %>
     <%= render partial: "current_roles", locals: { person: person } %>
     <%= render partial: "previous_roles", locals: { person: person } %>
-    <%= render partial: "shared/announcements", locals: { announcements: person.announcements, locale: person.locale } %>
+    <%= render partial: "shared/announcements", locals: { announcements: person.announcements, locale: I18n.locale } %>
   </div>
 </div>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third" <%= t_direction %> lang="<%= person.locale %>">
+  <div class="govuk-grid-column-one-third <%= t_direction_class %>" <%= t_direction %> lang="<%= person.locale %>">
     <%= render partial: "image", locals: { person: person } %>
     <%= render partial: "contents", locals: { person: person } %>
   </div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,5 +1,5 @@
 <% if role.current_holder %>
-  <div class="<%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
+  <div class="<%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
     <span <%= t_lang("roles.headings.current_holder") %>><%= t("roles.headings.current_holder") %></span>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,5 +1,5 @@
 <% if role.current_holder %>
-  <div dir="<%= page_text_direction %>" lang="<%= role.locale %>">
+  <div class="<%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
     <span <%= t_lang("roles.headings.current_holder") %>><%= t("roles.headings.current_holder") %></span>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,5 +1,5 @@
 <% if role.current_holder %>
-  <div class="<%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+  <div <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %> <%= lang_attribute %>>
     <span <%= t_lang("roles.headings.current_holder") %>><%= t("roles.headings.current_holder") %></span>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>

--- a/app/views/roles/_current_holder.html.erb
+++ b/app/views/roles/_current_holder.html.erb
@@ -1,5 +1,5 @@
 <% if role.current_holder %>
-  <div class="<%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+  <div class="<%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <span <%= t_lang("roles.headings.current_holder") %>><%= t("roles.headings.current_holder") %></span>:
     <%= link_to role.current_holder["title"], role.current_holder["base_path"] %>
   </div>

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-grid-row" <%= t_direction %> lang="<%= role.locale %>">
+<header class="govuk-grid-row <%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: t("roles.ministerial"),

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-grid-row <%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
+<header class="govuk-grid-row <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: t("roles.ministerial"),

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-grid-row" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
+<header class="govuk-grid-row" <%= t_direction %> lang="<%= role.locale %>">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: t("roles.ministerial"),

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="govuk-grid-row <%= direction_rtl_class %>" <%= t_direction %> <%= lang_attribute %>>
+<header class="govuk-grid-row <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       context: t("roles.ministerial"),

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,5 +1,5 @@
 <% if role.organisations %>
-  <div class="organisations-list" <%= t_direction %> lang="<%= role.locale %>">
+  <div class="organisations-list <%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
     <span lang="en">Organisations</span>:
     <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
   </div>

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,5 +1,5 @@
 <% if role.organisations %>
-  <div class="organisations-list" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
+  <div class="organisations-list" <%= t_direction %> lang="<%= role.locale %>">
     <span lang="en">Organisations</span>:
     <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
   </div>

--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,5 +1,5 @@
 <% if role.organisations %>
-  <div class="organisations-list <%= t_direction_class %>" <%= t_direction %> lang="<%= role.locale %>">
+  <div class="organisations-list <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <span lang="en">Organisations</span>:
     <%= role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path']) }.to_sentence.html_safe %>
   </div>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -12,13 +12,13 @@
     <%= render partial: "contents", locals: { role: role } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds" dir="<%= page_texdir_attribute %>" lang="<%= role.locale %>">
+  <div class="govuk-grid-column-two-thirds <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>">
     <%= render partial: "responsibilities", locals: { role: role } %>
 
     <%= render partial: "current_role_holder_with_biography", locals: { role: role } %>
 
     <%= render partial: "past_role_holders", locals: { role: role } %>
 
-    <%= render partial: "shared/announcements", locals: { announcements: role.announcements, locale: role.locale } %>
+    <%= render partial: "shared/announcements", locals: { announcements: role.announcements, locale: I18n.locale } %>
   </div>
 </div>

--- a/app/views/roles/show.html.erb
+++ b/app/views/roles/show.html.erb
@@ -12,7 +12,7 @@
     <%= render partial: "contents", locals: { role: role } %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds" dir="<%= page_text_direction %>" lang="<%= role.locale %>">
+  <div class="govuk-grid-column-two-thirds" dir="<%= page_texdir_attribute %>" lang="<%= role.locale %>">
     <%= render partial: "responsibilities", locals: { role: role } %>
 
     <%= render partial: "current_role_holder_with_biography", locals: { role: role } %>

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if announcements.items.present? %>
-  <section id="announcements" class="<%= direction_rtl_class %>" <%= t_direction %>>
+  <section id="announcements" class="<%= direction_rtl_class %>" <%= dir_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
         lang: t_fallback("organisations.content_item.schema_name.announcement.other"),

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if announcements.items.present? %>
-  <section id="announcements" class="<%= t_direction_class %>" <%= t_direction %> lang="<%= locale %>">
+  <section id="announcements" class="<%= direction_rtl_class %>" <%= t_direction %>>
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
         lang: t_fallback("organisations.content_item.schema_name.announcement.other"),

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if announcements.items.present? %>
-  <section id="announcements" dir="<%= page_text_direction %>" lang="<%= locale %>">
+  <section id="announcements" class="<%= t_direction_class %>" <%= t_direction %> lang="<%= locale %>">
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
         lang: t_fallback("organisations.content_item.schema_name.announcement.other"),

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if announcements.items.present? %>
-  <section id="announcements" class="<%= direction_rtl_class %>" <%= dir_attribute %>>
+  <section id="announcements" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
         lang: t_fallback("organisations.content_item.schema_name.announcement.other"),

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -31,6 +31,56 @@ describe ApplicationHelper do
     end
   end
 
+  describe "direction_rtl_class" do
+    context "when a left to right language script" do
+      it "returns nil" do
+        self.stubs(:page_text_direction).returns("ltr")
+        assert_equal nil, direction_rtl_class
+      end
+    end
+
+    context "when a right to right language script" do
+      it "returns the class name" do
+        self.stubs(:page_text_direction).returns("rtl")
+        assert_equal "direction-rtl", direction_rtl_class
+      end
+
+      it "returns the class with prefix when requested" do
+        self.stubs(:page_text_direction).returns("rtl")
+        assert_equal "class=direction-rtl", direction_rtl_class(prefix: true)
+      end
+    end
+  end
+
+  describe "lang_attribute" do
+    it "returns nil for default language" do
+      I18n.with_locale(:en) do
+        assert_equal nil, lang_attribute
+      end
+    end
+    it "returns a lang attribute string for non-default language" do
+      I18n.with_locale(:ar) do
+        assert_equal "lang=ar", lang_attribute
+      end
+    end
+  end
+
+  describe "dir_attribute" do
+    context "when a left to right language script" do
+      it "returns nil" do
+        self.stubs(:page_text_direction).returns("ltr")
+        assert_equal nil, dir_attribute
+      end
+    end
+
+    context "when a right to right language script" do
+      it "returns the rtl dir attribute name" do
+        self.stubs(:page_text_direction).returns("rtl")
+        assert_equal "dir=rtl", dir_attribute
+      end
+    end
+  end
+
   describe "t_lang" do
     it "t_fallback returns false if string is translated successfully" do
       I18n.backend.store_translations :en, document: { one: "string" }


### PR DESCRIPTION
This ensures that any right to left language translations tag components with the `dir` attribute for accessibility, and are assigned the necessary class to make use of govuk-publishing-components stylings. These are only set for specified RTL languages.

For all non-default locales, it also assigns a `lang` attribute.

[Trello Card](https://trello.com/c/G77SR2Nx/1616-improve-accessiblity-for-right-to-left-translations)