### PR TITLE
Link to role history page if so configured

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -81,6 +81,14 @@ class Role
     @announcements ||= AnnouncementsPresenter.new(slug)
   end
 
+  def supports_historical_accounts?
+    details["supports_historical_accounts"]
+  end
+
+  def past_holders_url
+    "/government/history/past-#{title.pluralize.downcase.gsub(/ /, '-')}"
+  end
+
 private
 
   def content_item_data

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -86,7 +86,7 @@ class Role
   end
 
   def past_holders_url
-    "/government/history/past-#{title.pluralize.downcase.gsub(/ /, '-')}"
+    "/government/history/past-#{role_slug.pluralize}"
   end
 
 private
@@ -119,5 +119,9 @@ private
     links.fetch("role_appointments", [])
       .find_all { |rh| rh["details"]["current"] == current }
       .sort_by { |rh| rh["details"]["started_on"] }
+  end
+
+  def role_slug
+    base_path.split("/").last
   end
 end

--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -4,14 +4,18 @@
       text: "Previous holders of this role",
     } %>
 
-    <%= render "components/taxon-list", {
-      items: role.past_holders.map do |rh|
-        {
-          text: rh['title'],
-          path: rh['base_path'],
-          description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
-        }
-      end
-    } %>
+    <% if role.supports_historical_accounts? %>
+      <p>Find out more about previous holders of this role in our <%= link_to "past #{role.title.pluralize}", role.past_holders_url, class: "govuk-link" %> section.</p>
+    <% elsif role.past_holders.present? %>
+      <%= render "components/taxon-list", {
+        items: role.past_holders.map do |rh|
+          {
+            text: rh['title'],
+            path: rh['base_path'],
+            description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
+          }
+        end
+      } %>
+    <% end %>
   </section>
 <% end %>

--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -5,7 +5,9 @@
     } %>
 
     <% if role.supports_historical_accounts? %>
-      <p>Find out more about previous holders of this role in our <%= link_to "past #{role.title.pluralize}", role.past_holders_url, class: "govuk-link" %> section.</p>
+      <p class="govuk-body" lang="en">
+        Find out more about previous holders of this role in our <%= link_to "past #{role.title.pluralize}", role.past_holders_url, class: "govuk-link" %> section.
+      </p>
     <% elsif role.past_holders.present? %>
       <%= render "components/taxon-list", {
         items: role.past_holders.map do |rh|

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,7 +16,7 @@
 # end
 
 ActiveSupport::Inflector.inflections do |inflect|
-  inflect.plural /Secretary of State for (.*)/, "Secretaries of State for \\1"
+  inflect.plural /Secretary of State( for .*)?/, "Secretaries of State\\1"
 end
 
 ActiveSupport::Inflector.inflections do |inflect|

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,7 +15,7 @@
 #   inflect.acronym 'RESTful'
 # end
 
-ActiveSupport::Inflector.inflections do |inflect|
+ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.plural /Secretary of State( for .*)?/, "Secretaries of State\\1"
   inflect.plural /Chancellor of (.*)/, "Chancellors of \\1"
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,3 +18,7 @@
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.plural /Secretary of State for (.*)/, "Secretaries of State for \\1"
 end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.plural /Chancellor of (.*)/, "Chancellors of \\1"
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,8 +17,5 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.plural /Secretary of State( for .*)?/, "Secretaries of State\\1"
-end
-
-ActiveSupport::Inflector.inflections do |inflect|
   inflect.plural /Chancellor of (.*)/, "Chancellors of \\1"
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.plural /Secretary of State for (.*)/, "Secretaries of State for \\1"
+end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -144,7 +144,7 @@ describe Role do
   describe "supports_historical_accounts" do
     context "without a historical account page" do
       it "does not support historical accounts by default" do
-        refute @role.supports_historical_accounts?
+        assert_not @role.supports_historical_accounts?
       end
     end
     context "with a historical account page" do

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -4,6 +4,7 @@ describe Role do
   setup do
     @api_data = {
       "base_path" => "/government/ministers/prime-minister",
+      "details" => {},
       "links" => {
         "ordered_parent_organisations" => [
           {
@@ -137,6 +138,53 @@ describe Role do
 
     it "should have link to news and communications finder" do
       assert_equal "/search/news-and-communications?people=boris-johnson", @role.announcements.links[:link_to_news_and_communications]
+    end
+  end
+
+  describe "supports_historical_accounts" do
+    context "without a historical account page" do
+      it "does not support historical accounts by default" do
+        refute @role.supports_historical_accounts?
+      end
+    end
+    context "with a historical account page" do
+      setup do
+        @api_data["details"]["supports_historical_accounts"] = true
+      end
+      it "supports historical accounts" do
+        assert @role.supports_historical_accounts?
+      end
+      it "points to the correct historical account page" do
+        assert @role.past_holders_url == "/government/history/past-prime-ministers"
+      end
+    end
+
+    context "when applied to a chancellor" do
+      setup do
+        @api_data["title"] = "Chancellor of the Exchequer"
+        @api_data["base_path"] = "/government/ministers/chancellor"
+      end
+      it "pluralises correctly" do
+        assert @role.title.pluralize == "Chancellors of the Exchequer"
+      end
+
+      it "points to the correct historical account page" do
+        assert @role.past_holders_url == "/government/history/past-chancellors"
+      end
+    end
+    context "when applied to a foreign secretary" do
+      setup do
+        @api_data["title"] = "Secretary of State for Foreign and Commonwealth Affairs"
+        @api_data["base_path"] = "/government/ministers/foreign-secretary"
+      end
+
+      it "pluralises correctly" do
+        assert @role.title.pluralize == "Secretaries of State for Foreign and Commonwealth Affairs"
+      end
+
+      it "points to the correct historical account page" do
+        assert @role.past_holders_url == "/government/history/past-foreign-secretaries"
+      end
     end
   end
 end


### PR DESCRIPTION
Whitehall displays a link to a separate page for roles with the `supports_historical_accounts` flag set. This implements the same behaviour in collections.

WIP: in whitehall, the correct page to link to is found using the route definitions, which are hardcoded; as such, the URLs will need to be hardcoded or some other solution found.

https://trello.com/c/W6O1Y0I9/1630-3-add-links-to-historical-past-ministers-pages