### PR TITLE
Look for announcements by filtering on the role

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -57,7 +57,7 @@ class Person
   end
 
   def announcements
-    @announcements ||= AnnouncementsPresenter.new(slug)
+    @announcements ||= AnnouncementsPresenter.new(slug, filter_key: "people")
   end
 
   def translations

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -78,7 +78,7 @@ class Role
   end
 
   def announcements
-    @announcements ||= AnnouncementsPresenter.new(slug)
+    @announcements ||= AnnouncementsPresenter.new(slug, slug_prefix: "ministers", filter_key: "roles")
   end
 
   def supports_historical_accounts?
@@ -86,7 +86,7 @@ class Role
   end
 
   def past_holders_url
-    "/government/history/past-#{role_slug.pluralize}"
+    "/government/history/past-#{slug.pluralize}"
   end
 
 private
@@ -112,16 +112,12 @@ private
   end
 
   def slug
-    link_to_person.split("/").last
+    base_path.split("/").last
   end
 
   def role_holders(current:)
     links.fetch("role_appointments", [])
       .find_all { |rh| rh["details"]["current"] == current }
       .sort_by { |rh| rh["details"]["started_on"] }
-  end
-
-  def role_slug
-    base_path.split("/").last
   end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -129,15 +129,15 @@ describe Role do
     end
 
     it "should have link to email signup" do
-      assert_equal "/email-signup?link=/government/people/boris-johnson", @role.announcements.links[:email_signup]
+      assert_equal "/email-signup?link=/government/ministers/prime-minister", @role.announcements.links[:email_signup]
     end
 
     it "should have link to subscription atom feed" do
-      assert_equal "https://www.gov.uk/government/people/boris-johnson.atom", @role.announcements.links[:subscribe_to_feed]
+      assert_equal "https://www.gov.uk/government/ministers/prime-minister.atom", @role.announcements.links[:subscribe_to_feed]
     end
 
     it "should have link to news and communications finder" do
-      assert_equal "/search/news-and-communications?people=boris-johnson", @role.announcements.links[:link_to_news_and_communications]
+      assert_equal "/search/news-and-communications?roles=prime-minister", @role.announcements.links[:link_to_news_and_communications]
     end
   end
 


### PR DESCRIPTION
Previously we were showing the announcements only for people (and for roles it was coming from the current holder). This changes that to search directly for announcements tagged to the role, regardless of the person.

[Trello Card](https://trello.com/c/WMmdVNGM/1427-look-for-announcements-by-filtering-on-the-role)