### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
-  <%= stylesheet_link_tag "print.css", :media => "print", integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>
 
 <body <% if content_for(:is_full_width_header) %>class="full-width"<% end %>>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)