### PR TITLE
Update colours

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
+$govuk-use-legacy-palette: false;
 
 // gem components
 @import 'govuk_publishing_components/all_components';

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -104,7 +104,7 @@ $red: #E61E32;
   margin-top: govuk-spacing(7);
   padding: govuk-spacing(6);
   background-color: govuk-colour("light-grey", $legacy: "grey-4");
-  border: 1px solid govuk-colour("med-grey", $legacy: "grey-2");
+  border: 1px solid $govuk-border-colour;
 }
 
 .landing-page__email-title {

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -177,16 +177,22 @@
       }
 
       ul .active a {
-        background: $govuk-link-colour;
+        background: $govuk-brand-colour;
         color: govuk-colour("white");
-
-        &:hover {
-          background: $govuk-link-colour;
-        }
 
         p {
           color: govuk-colour("white");
         }
+
+        &:focus {
+          background: $govuk-focus-colour;
+          color: $govuk-focus-text-colour;
+
+          p {
+          color: $govuk-focus-text-colour;
+          }
+        }
+
       }
     }
 

--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -30,7 +30,7 @@ module Organisations
         link_to(
           parent_organisation["title"],
           parent_organisation["base_path"],
-          class: "brand__color",
+          class: "brand__color govuk-link",
         )
       end
 

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -48,7 +48,7 @@
         </div>
       <% end %>
     </div>
-    <%= auto_link(contact[:description], html: { class: "brand__color" }) if contact[:description] %>
+    <%= auto_link(contact[:description], html: { class: "brand__color govuk-link" }) if contact[:description] %>
   </div>
 <% end %>
 <% end %>

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -19,7 +19,7 @@
 
           <% unless @organisation.is_court_or_hmcts_tribunal? %>
           <p>
-            <a href="<%= t('organisations.about_page_path', organisation: @organisation.slug) %>" class="brand__color">
+            <a href="<%= t('organisations.about_page_path', organisation: @organisation.slug) %>" class="govuk-link brand__color">
               <%= t('organisations.read_more') %>
             </a>
           </p>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -14,7 +14,7 @@
 
 <form class="filter-organisations-list__form" data-filter="form">
   <label class="filter-organisations-list__label" for="filter-organisations-list">What’s the latest<br />from</label>
-  <input class="filter-organisations-list__input" type="text" id="filter-organisations-list" placeholder="For example, Home Office">
+  <input class="filter-organisations-list__input govuk-input" type="text" id="filter-organisations-list" placeholder="For example, Home Office">
   <span class="filter-organisations-list__label" aria-hidden="true">?</span>
 </form>
 
@@ -26,4 +26,4 @@
   <p class="organisations__no-filter-match js-hidden js-no-filter-matches">No departments match that filter.</p>
 </div>
 
-<p>Errors or omissions? <a href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a href="/government/collections/public-bodies">see public bodies</a>.</p>
+<p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -45,7 +45,7 @@ describe Organisations::ShowPresenter do
     organisation = Organisation.new(content_item)
     @show_presenter = Organisations::ShowPresenter.new(organisation)
 
-    expected = "<a class=\"brand__color\" href=\"/international-trade\">Department for International Trade</a>"
+    expected = "<a class=\"brand__color govuk-link\" href=\"/international-trade\">Department for International Trade</a>"
 
     assert_equal expected, @show_presenter.parent_organisations
   end
@@ -74,7 +74,7 @@ describe Organisations::ShowPresenter do
     organisation = Organisation.new(content_item)
     @show_presenter = Organisations::ShowPresenter.new(organisation)
 
-    expected = "<a class=\"brand__color\" href=\"/international-trade-1\">Dept for Trade</a> and <a class=\"brand__color\" href=\"/international-trade-2\">Second Dept for Trade</a>"
+    expected = "<a class=\"brand__color govuk-link\" href=\"/international-trade-1\">Dept for Trade</a> and <a class=\"brand__color govuk-link\" href=\"/international-trade-2\">Second Dept for Trade</a>"
 
     assert_equal expected, @show_presenter.parent_organisations
   end


### PR DESCRIPTION
1) Turns off legacy colours and addresses an error this generated.
2) Sets the focus state for selected items on browse pages 

### Before
Non selected item in focus:
![Screenshot 2020-01-14 at 09 50 28](https://user-images.githubusercontent.com/31649453/72334367-18b95100-36b5-11ea-83fb-772040aca5f8.png)
Selected item in focus
![Screenshot 2020-01-14 at 09 50 38](https://user-images.githubusercontent.com/31649453/72334368-18b95100-36b5-11ea-96db-c9fb2e0f8912.png)

### After
Non selected item in focus:
![Screenshot 2020-01-14 at 09 49 44](https://user-images.githubusercontent.com/31649453/72334438-371f4c80-36b5-11ea-8206-5ff91336ac56.png)
Selected item in focus:
![Screenshot 2020-01-14 at 09 49 52](https://user-images.githubusercontent.com/31649453/72334471-41414b00-36b5-11ea-8e2a-34986b2a5a24.png)



3) Fixes classes on some areas of the organisations page that were previously overlooked

http://www.gov.uk/government/organisations
Adds appropriate classes to these parts of the page:
![Screenshot 2020-01-14 at 09 03 23](https://user-images.githubusercontent.com/31649453/72334768-cb89af00-36b5-11ea-8090-baefe7463bce.png)
![Screenshot 2020-01-14 at 09 16 46](https://user-images.githubusercontent.com/31649453/72334769-cb89af00-36b5-11ea-8219-c14d437cb67e.png)


4) Fixes classes on some overlooked areas of individual organisation pages

http://www.gov.uk/government/organisations/innovate-uk

![Screenshot 2020-01-14 at 10 13 16](https://user-images.githubusercontent.com/31649453/72335113-5ec2e480-36b6-11ea-8e84-05620a4ec3da.png)


![Screenshot 2020-01-14 at 10 11 59](https://user-images.githubusercontent.com/31649453/72335046-3a670800-36b6-11ea-8aa0-19c435648d26.png)
