### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -8,15 +8,15 @@ class AnnouncementsPresenter
   end
 
   def items
-    announcements.map do |announcenment|
+    announcements.map do |announcement|
       {
         link: {
-          text: announcenment["title"],
-          path: announcenment["link"],
+          text: announcement["title"],
+          path: announcement["link"],
         },
         metadata: {
-          public_timestamp: Date.parse(announcenment["public_timestamp"]).strftime("%d %B %Y"),
-          content_store_document_type: announcenment["content_store_document_type"].humanize,
+          public_timestamp: Date.parse(announcement["public_timestamp"]).strftime("%d %B %Y"),
+          content_store_document_type: announcement["content_store_document_type"].humanize,
         },
       }
     end

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -109,13 +109,13 @@ def top_level_browse_pages
 end
 
 def add_browse_pages
-  content_store_has_item '/browse', links: {
+  stub_content_store_has_item '/browse', links: {
     top_level_browse_pages: top_level_browse_pages
   }
 end
 
 def add_first_level_browse_pages(child_pages:, order_type:)
-  content_store_has_item('/browse/crime-and-justice', base_path: '/browse/crime-and-justice',
+  stub_content_store_has_item('/browse/crime-and-justice', base_path: '/browse/crime-and-justice',
     links: {
       top_level_browse_pages: top_level_browse_pages,
       second_level_browse_pages: child_pages,
@@ -127,7 +127,7 @@ def add_first_level_browse_pages(child_pages:, order_type:)
 end
 
 def add_second_level_browse_pages(second_level_browse_pages)
-  content_store_has_item '/browse/crime-and-justice/judges', content_id: 'judges-content-id',
+  stub_content_store_has_item '/browse/crime-and-justice/judges', content_id: 'judges-content-id',
     title: 'Judges',
     base_path: '/browse/crime-and-justice/judges',
     links: {

--- a/features/support/services_and_information_helper.rb
+++ b/features/support/services_and_information_helper.rb
@@ -15,7 +15,7 @@ module ServicesAndInformationHelpers
 
     stub_services_and_information_links("hm-revenue-customs")
 
-    content_store_has_item("/government/organisations/hm-revenue-customs/services-information",
+    stub_content_store_has_item("/government/organisations/hm-revenue-customs/services-information",
                            content_id: 'content-id-for-hm-revenue-customs-services-information',
                            base_path: "/government/organisations/hm-revenue-customs/services-information",
                            title: "Services and information - HM Revenue & Customs",

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -20,7 +20,7 @@ module TopicHelper
       page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING
     )
 
-    content_store_has_item("/topic/oil-and-gas/fields-and-wells",
+    stub_content_store_has_item("/topic/oil-and-gas/fields-and-wells",
                            content_id: 'content-id-for-fields-and-wells',
                            base_path: "/topic/oil-and-gas/fields-and-wells",
                            title: "Fields and Wells",

--- a/test/controllers/brexit_landing_page_controller_test.rb
+++ b/test/controllers/brexit_landing_page_controller_test.rb
@@ -7,7 +7,7 @@ describe BrexitLandingPageController do
     before do
       brexit_taxon = taxon
       brexit_taxon["base_path"] = "/brexit"
-      content_store_has_item(brexit_taxon["base_path"], brexit_taxon)
+      stub_content_store_has_item(brexit_taxon["base_path"], brexit_taxon)
     end
 
     it "renders the page" do

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -4,9 +4,9 @@ describe BrowseController do
   describe "GET index" do
     before do
       stub_content_store_has_item("/browse",
-                             links: {
-                               top_level_browse_pages: top_level_browse_pages,
-                             })
+                                  links: {
+                                    top_level_browse_pages: top_level_browse_pages,
+                                  })
     end
 
     it "set correct expiry headers" do
@@ -20,11 +20,11 @@ describe BrowseController do
     describe "for a valid browse page" do
       before do
         stub_content_store_has_item("/browse/benefits",
-                               base_path: "/browse/benefits",
-                               links: {
-                                 top_level_browse_pages: top_level_browse_pages,
-                                 second_level_browse_pages: second_level_browse_pages,
-                               })
+                                    base_path: "/browse/benefits",
+                                    links: {
+                                      top_level_browse_pages: top_level_browse_pages,
+                                      second_level_browse_pages: second_level_browse_pages,
+                                    })
       end
 
       it "sets correct expiry headers" do

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe BrowseController do
   describe "GET index" do
     before do
-      content_store_has_item("/browse",
+      stub_content_store_has_item("/browse",
                              links: {
                                top_level_browse_pages: top_level_browse_pages,
                              })
@@ -19,7 +19,7 @@ describe BrowseController do
   describe "GET top_level_browse_page" do
     describe "for a valid browse page" do
       before do
-        content_store_has_item("/browse/benefits",
+        stub_content_store_has_item("/browse/benefits",
                                base_path: "/browse/benefits",
                                links: {
                                  top_level_browse_pages: top_level_browse_pages,

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -35,7 +35,7 @@ describe BrowseController do
     end
 
     it "404 if the browse page does not exist" do
-      content_store_does_not_have_item("/browse/banana")
+      stub_content_store_does_not_have_item("/browse/banana")
 
       get :show, params: { top_level_slug: "banana" }
 

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -14,7 +14,7 @@ describe EmailSignupsController do
     )
 
     @invalid_subtopic_params = { topic_slug: "invalid", subtopic_slug: "subtopic" }
-    content_store_does_not_have_item("/topic/invalid/subtopic")
+    stub_content_store_does_not_have_item("/topic/invalid/subtopic")
 
     @email_signup = EmailSignup.new(nil)
     @email_signup.stubs(:save)

--- a/test/controllers/email_signups_controller_test.rb
+++ b/test/controllers/email_signups_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe EmailSignupsController do
   setup do
     @valid_subtopic_params = { topic_slug: "oil-and-gas", subtopic_slug: "wells" }
-    content_store_has_item(
+    stub_content_store_has_item(
       "/topic/oil-and-gas/wells",
       content_item_for_base_path("/topic/oil-and-gas/wells").merge("links" => {
           "parent" => [{

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -52,7 +52,7 @@ class FeedsControllerTest < ActionController::TestCase
     document = GovukSchemas::Example.find(schema_name, example_name: schema_name)
     document["base_path"] = "/government/organisations/ministry-of-magic"
     document["title"] = "Ministry of Magic"
-    content_store_has_item(document["base_path"], document)
+    stub_content_store_has_item(document["base_path"], document)
     document
   end
 end

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -4,17 +4,17 @@ describe OrganisationsController do
   describe "GET index" do
     before do
       stub_content_store_has_item("/government/organisations/ministry-of-magic",
-                             title: "Ministry of magic",
-                             base_path: "/government/organisations/ministry-of-magic",
-                             details: {
-                               body: "This organisation has a status of exempt.",
-                               logo: {
-                               },
-                               organisation_govuk_status: {
-                                 status: "exempt",
-                                 url: "https://ministry-of-magic.gov.uk",
-                               },
-                             })
+                                  title: "Ministry of magic",
+                                  base_path: "/government/organisations/ministry-of-magic",
+                                  details: {
+                                    body: "This organisation has a status of exempt.",
+                                    logo: {
+                                    },
+                                    organisation_govuk_status: {
+                                      status: "exempt",
+                                      url: "https://ministry-of-magic.gov.uk",
+                                    },
+                                  })
 
       Services.rummager.stubs(:search)
         .returns(

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 describe OrganisationsController do
   describe "GET index" do
     before do
-      content_store_has_item("/government/organisations/ministry-of-magic",
+      stub_content_store_has_item("/government/organisations/ministry-of-magic",
                              title: "Ministry of magic",
                              base_path: "/government/organisations/ministry-of-magic",
                              details: {

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -42,7 +42,7 @@ describe SecondLevelBrowsePageController do
     end
 
     it "404 if the section does not exist" do
-      content_store_does_not_have_item("/browse/crime-and-justice/frume")
+      stub_content_store_does_not_have_item("/browse/crime-and-justice/frume")
 
       get(
         :show,

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -7,19 +7,19 @@ describe SecondLevelBrowsePageController do
     describe "for a valid browse page" do
       before do
         stub_content_store_has_item("/browse/benefits/entitlement",
-                               content_id: "entitlement-content-id",
-                               title: "Entitlement",
-                               base_path: "/browse/benefits/entitlement",
-                               links: {
-                                 top_level_browse_pages: top_level_browse_pages,
-                                 second_level_browse_pages: second_level_browse_pages,
-                                 active_top_level_browse_page: [{
-                                   content_id: "content-id-for-benefits",
-                                   title: "Benefits",
-                                   base_path: "/browse/benefits",
-                                 }],
-                                 related_topics: [{ title: "A linked topic", base_path: "/browse/linked-topic" }],
-                               })
+                                    content_id: "entitlement-content-id",
+                                    title: "Entitlement",
+                                    base_path: "/browse/benefits/entitlement",
+                                    links: {
+                                      top_level_browse_pages: top_level_browse_pages,
+                                      second_level_browse_pages: second_level_browse_pages,
+                                      active_top_level_browse_page: [{
+                                        content_id: "content-id-for-benefits",
+                                        title: "Benefits",
+                                        base_path: "/browse/benefits",
+                                      }],
+                                      related_topics: [{ title: "A linked topic", base_path: "/browse/linked-topic" }],
+                                    })
 
         rummager_has_documents_for_browse_page(
           "entitlement-content-id",

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -6,7 +6,7 @@ describe SecondLevelBrowsePageController do
   describe "GET second_level_browse_page" do
     describe "for a valid browse page" do
       before do
-        content_store_has_item("/browse/benefits/entitlement",
+        stub_content_store_has_item("/browse/benefits/entitlement",
                                content_id: "entitlement-content-id",
                                title: "Entitlement",
                                base_path: "/browse/benefits/entitlement",

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -17,7 +17,7 @@ describe ServicesAndInformationController do
 
   describe "GET services and information page" do
     it "returns a 404 status for GET services and information with an invalid organisation id" do
-      content_store_does_not_have_item("/government/organisations/hm-revenue-customs/services-information")
+      stub_content_store_does_not_have_item("/government/organisations/hm-revenue-customs/services-information")
 
       get :index, params: { organisation_id: "hm-revenue-customs" }
 

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -24,7 +24,7 @@ describe SubtopicsController do
   end
 
   def stub_services_for_subtopic(content_id, parent_path, path)
-    content_store_has_item(
+    stub_content_store_has_item(
       "/topic/#{parent_path}/#{path}",
       content_item_for_base_path("/topic/#{parent_path}/#{path}").merge(
         "content_id" => content_id,

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -15,7 +15,7 @@ describe SubtopicsController do
     end
 
     it "returns a 404 status for GET subtopic with an invalid subtopic tag" do
-      content_store_does_not_have_item("/topic/oil-and-gas/coal")
+      stub_content_store_does_not_have_item("/topic/oil-and-gas/coal")
 
       get :show, params: { topic_slug: "oil-and-gas", subtopic_slug: "coal" }
 

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -7,7 +7,7 @@ describe TaxonsController do
 
   describe "GET show" do
     before do
-      content_store_has_item(taxon["base_path"], taxon)
+      stub_content_store_has_item(taxon["base_path"], taxon)
       stub_content_for_taxon(taxon["content_id"], [taxon])
       stub_content_for_taxon(taxon["content_id"], generate_search_results(5))
       stub_document_types_for_supergroup("guidance_and_regulation")
@@ -28,7 +28,7 @@ describe TaxonsController do
 
   context "when rendering a taxon in the alpha phase" do
     before do
-      content_store_has_item(
+      stub_content_store_has_item(
         taxon["base_path"],
         taxon.merge("phase" => "alpha"),
       )

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -6,7 +6,7 @@ describe TopicsController do
   describe "GET topic" do
     describe "with a valid topic slug" do
       before do
-        content_store_has_item("/topic/oil-and-gas", topic_example)
+        stub_content_store_has_item("/topic/oil-and-gas", topic_example)
       end
 
       it "sets expiry headers for 30 minutes" do

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -17,7 +17,7 @@ describe TopicsController do
     end
 
     it "returns a 404 status for GET topic with an invalid sector tag" do
-      content_store_does_not_have_item("/topic/oil-and-gas")
+      stub_content_store_does_not_have_item("/topic/oil-and-gas")
       get :show, params: { topic_slug: "oil-and-gas" }
 
       assert_equal 404, response.status

--- a/test/integration/atom_feeds_test.rb
+++ b/test/integration/atom_feeds_test.rb
@@ -131,7 +131,7 @@ class AtomFeedsTest < ActionDispatch::IntegrationTest
     document = GovukSchemas::Example.find(schema_name, example_name: schema_name)
     document["base_path"] = "/government/organisations/ministry-of-magic"
     document["title"] = "Ministry of Magic"
-    content_store_has_item(document["base_path"], document)
+    stub_content_store_has_item(document["base_path"], document)
     document
   end
 

--- a/test/integration/citizen_readiness_test.rb
+++ b/test/integration/citizen_readiness_test.rb
@@ -45,6 +45,6 @@ class CitizenReadinessTest < ActionDispatch::IntegrationTest
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "special_route") do |payload|
       payload.merge(title: "Prepare for Brexit", base_path: base_path, description: "Prepare yourself for Brexit")
     end
-    content_store_has_item(base_path, content_item)
+    stub_content_store_has_item(base_path, content_item)
   end
 end

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -2,7 +2,7 @@ require "integration_test_helper"
 
 class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
   before do
-    content_store_has_item("/government/organisations", organisations_content_hash)
+    stub_content_store_has_item("/government/organisations", organisations_content_hash)
     visit "/government/organisations"
   end
 

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -10,7 +10,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     # Add all examples to the content store and rummager to allow pages to
     # request their parents and links.
     schemas.each do |content_item|
-      content_store_has_item(content_item["base_path"], content_item)
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
       rummager_has_documents_for_browse_page(
         content_item["content_id"],

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -202,17 +202,17 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
       },
     }
 
-    content_store_has_item("/government/organisations/changed_name", @content_item_changed_name)
-    content_store_has_item("/government/organisations/devolved", @content_item_devolved)
-    content_store_has_item("/government/organisations/exempt", @content_item_exempt)
-    content_store_has_item("/government/organisations/exempt-no-url", @content_item_exempt_no_url)
-    content_store_has_item("/government/organisations/joining", @content_item_joining)
-    content_store_has_item("/government/organisations/left_gov", @content_item_left_gov)
-    content_store_has_item("/government/organisations/merged", @content_item_merged)
-    content_store_has_item("/government/organisations/split", @content_item_split)
-    content_store_has_item("/government/organisations/no_longer_exists", @content_item_no_longer_exists)
-    content_store_has_item("/government/organisations/replaced", @content_item_replaced)
-    content_store_has_item("/government/organisations/fire-service-college", @content_item_documents)
+    stub_content_store_has_item("/government/organisations/changed_name", @content_item_changed_name)
+    stub_content_store_has_item("/government/organisations/devolved", @content_item_devolved)
+    stub_content_store_has_item("/government/organisations/exempt", @content_item_exempt)
+    stub_content_store_has_item("/government/organisations/exempt-no-url", @content_item_exempt_no_url)
+    stub_content_store_has_item("/government/organisations/joining", @content_item_joining)
+    stub_content_store_has_item("/government/organisations/left_gov", @content_item_left_gov)
+    stub_content_store_has_item("/government/organisations/merged", @content_item_merged)
+    stub_content_store_has_item("/government/organisations/split", @content_item_split)
+    stub_content_store_has_item("/government/organisations/no_longer_exists", @content_item_no_longer_exists)
+    stub_content_store_has_item("/government/organisations/replaced", @content_item_replaced)
+    stub_content_store_has_item("/government/organisations/fire-service-college", @content_item_documents)
 
     stub_rummager_latest_content_requests("changed_name")
     stub_rummager_latest_content_requests("devolved")

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -490,13 +490,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       },
     }
 
-    content_store_has_item("/government/organisations/prime-ministers-office-10-downing-street", @content_item_no10)
-    content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
-    content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
-    content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
-    content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales.cy", @content_item_wales_office_cy)
-    content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
-    content_store_has_item("/government/organisations/student-loans-company", @content_item_separate_student_loans)
+    stub_content_store_has_item("/government/organisations/prime-ministers-office-10-downing-street", @content_item_no10)
+    stub_content_store_has_item("/government/organisations/attorney-generals-office", @content_item_attorney_general)
+    stub_content_store_has_item("/government/organisations/charity-commission", @content_item_charity_commission)
+    stub_content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales", @content_item_wales_office)
+    stub_content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales.cy", @content_item_wales_office_cy)
+    stub_content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
+    stub_content_store_has_item("/government/organisations/student-loans-company", @content_item_separate_student_loans)
 
     stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
     stub_rummager_latest_content_requests("attorney-generals-office")

--- a/test/integration/step_nav_page_test.rb
+++ b/test/integration/step_nav_page_test.rb
@@ -10,7 +10,7 @@ class StepNavPageTest < ActionDispatch::IntegrationTest
   before do
     sample = GovukContentSchemaTestHelpers::Examples.new.get("step_by_step_nav", "learn_to_drive_a_car")
     content_item = JSON.parse(sample)
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
 
     visit content_item["base_path"]
   end
@@ -37,7 +37,7 @@ class StepNavPageTest < ActionDispatch::IntegrationTest
   it "works for a generated example" do
     content_item = step_nav_example
 
-    content_store_has_item(content_item["base_path"], content_item)
+    stub_content_store_has_item(content_item["base_path"], content_item)
 
     get content_item["base_path"]
     assert_response 200

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -40,7 +40,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   it "renders a curated subtopic" do
     # Given a curated subtopic exists
-    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {
+    stub_content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore", details: {
       groups: [
         {
           name: "Oil rigs",
@@ -92,7 +92,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   it "renders a non-curated subtopic" do
     # Given a non-curated subtopic exists
-    content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
+    stub_content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
     stub_topic_organisations("oil-and-gas/offshore", "content-id-for-offshore")
 
     # When I visit the subtopic page
@@ -122,7 +122,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   describe "latest page for a subtopic" do
     setup do
-      content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
+      stub_content_store_has_item("/topic/oil-and-gas/offshore", oil_and_gas_subtopic_item("offshore"))
       stub_topic_organisations("oil-and-gas/offshore", "content-id-for-offshore")
     end
 
@@ -211,7 +211,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
   it "adds tracking attributes to links within sections" do
     # Given a curated subtopic exists
-    content_store_has_item(
+    stub_content_store_has_item(
       "/topic/oil-and-gas/offshore",
       oil_and_gas_subtopic_item("offshore", details: {
         groups: [

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -70,7 +70,7 @@ private
       "document_type" => "not_a_taxon",
     }
 
-    content_store_has_item("/not-a-taxon", thing)
+    stub_content_store_has_item("/not-a-taxon", thing)
   end
 
   def when_i_visit_that_thing
@@ -101,10 +101,10 @@ private
       "locale" => "en",
     }
 
-    content_store_has_item(child_one_base_path, child_one)
-    content_store_has_item(child_two_base_path, child_two)
+    stub_content_store_has_item(child_one_base_path, child_one)
+    stub_content_store_has_item(child_two_base_path, child_two)
 
-    content_store_has_item("/content-item-1", content_item_for_base_path("/content-item-1"))
+    stub_content_store_has_item("/content-item-1", content_item_for_base_path("/content-item-1"))
 
     given_there_is_a_taxon_without_children
 
@@ -121,7 +121,7 @@ private
 
     @content_item = content_item_without_children(brexit_taxon_path, brexit_content_id)
     @content_item["phase"] = "live"
-    content_store_has_item(brexit_taxon_path, @content_item)
+    stub_content_store_has_item(brexit_taxon_path, @content_item)
 
     and_the_taxon_has_tagged_content(brexit_content_id)
 
@@ -130,12 +130,12 @@ private
 
   def and_the_taxon_is_live
     @content_item["phase"] = "live"
-    content_store_has_item(base_path, @content_item)
+    stub_content_store_has_item(base_path, @content_item)
   end
 
   def and_the_taxon_is_not_live
     @content_item["phase"] = "beta"
-    content_store_has_item(base_path, @content_item)
+    stub_content_store_has_item(base_path, @content_item)
   end
 
   def and_the_taxon_has_tagged_content(taxon_content_id = content_id)

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -16,19 +16,19 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
   it "is possible to visit the topic index page" do
     stub_content_store_has_item("/topic",
-                           base_path: "/topic",
-                           title: "Topics",
-                           format: "topic",
-                           public_updated_at: 10.days.ago.iso8601,
-                           details: {},
-                           links: {
-                             children: [
-                               {
-                                 title: "Oil and Gas",
-                                 base_path: "/topic/oil-and-gas",
-                               },
-                             ],
-                           })
+                                base_path: "/topic",
+                                title: "Topics",
+                                format: "topic",
+                                public_updated_at: 10.days.ago.iso8601,
+                                details: {},
+                                links: {
+                                  children: [
+                                    {
+                                      title: "Oil and Gas",
+                                      base_path: "/topic/oil-and-gas",
+                                    },
+                                  ],
+                                })
 
     visit "/topic"
 
@@ -79,19 +79,19 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
   it "tracks click events on topic pages" do
     stub_content_store_has_item("/topic",
-                           base_path: "/topic",
-                           title: "Topics",
-                           format: "topic",
-                           public_updated_at: 10.days.ago.iso8601,
-                           details: {},
-                           links: {
-                             children: [
-                               {
-                                 title: "Oil and Gas",
-                                 base_path: "/topic/oil-and-gas",
-                               },
-                             ],
-                           })
+                                base_path: "/topic",
+                                title: "Topics",
+                                format: "topic",
+                                public_updated_at: 10.days.ago.iso8601,
+                                details: {},
+                                links: {
+                                  children: [
+                                    {
+                                      title: "Oil and Gas",
+                                      base_path: "/topic/oil-and-gas",
+                                    },
+                                  ],
+                                })
 
     visit "/topic"
 

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -15,7 +15,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "is possible to visit the topic index page" do
-    content_store_has_item("/topic",
+    stub_content_store_has_item("/topic",
                            base_path: "/topic",
                            title: "Topics",
                            format: "topic",
@@ -38,7 +38,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "renders a topic tag page and list its subtopics" do
-    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
+    stub_content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
         "children" => [
           {
             "title" => "Wells",
@@ -78,7 +78,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "tracks click events on topic pages" do
-    content_store_has_item("/topic",
+    stub_content_store_has_item("/topic",
                            base_path: "/topic",
                            title: "Topics",
                            format: "topic",
@@ -134,7 +134,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   it "tracks clicks events on subtopic pages" do
-    content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
+    stub_content_store_has_item("/topic/oil-and-gas", oil_and_gas_topic_item.merge(links: {
         "children" => [
           {
             "title" => "Wells",

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -11,8 +11,8 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     world_usa = world_usa_taxon(base_path: @base_path, phase: "live")
     world_usa_news_events = world_usa_news_events_taxon(base_path: @child_taxon_base_path)
 
-    content_store_has_item(@base_path, world_usa)
-    content_store_has_item(@child_taxon_base_path, world_usa_news_events)
+    stub_content_store_has_item(@base_path, world_usa)
+    stub_content_store_has_item(@child_taxon_base_path, world_usa_news_events)
 
     @taxon = WorldWideTaxon.find(@base_path)
     stub_content_for_taxon(@taxon.content_id, search_results) # For the "general information" taxon
@@ -38,7 +38,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     world_usa = world_usa_taxon(base_path: @base_path)
     world_usa.delete("links")
 
-    content_store_has_item(@base_path, world_usa)
+    stub_content_store_has_item(@base_path, world_usa)
 
     @taxon = WorldWideTaxon.find(@base_path)
     stub_content_for_taxon(@taxon.content_id, search_results)

--- a/test/integration/world_wide_taxon_browsing_test.rb
+++ b/test/integration/world_wide_taxon_browsing_test.rb
@@ -22,7 +22,7 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
   def given_there_is_a_world_wide_country_taxon_without_children
     content_item = content_item_without_children(base_path, content_id)
 
-    content_store_has_item(base_path, content_item)
+    stub_content_store_has_item(base_path, content_item)
     stub_rummager_tagged_content_request(content_id, tagged_content)
   end
 
@@ -46,14 +46,14 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
       "locale" => "en",
     }
 
-    content_store_has_item(child_one_content_id, child_one)
-    content_store_has_item(child_one_content_id, child_two)
+    stub_content_store_has_item(child_one_content_id, child_one)
+    stub_content_store_has_item(child_one_content_id, child_two)
 
     @content_item = content_item_without_children(base_path, content_id)
 
     @content_item["links"]["child_taxons"] = [child_one, child_two]
 
-    content_store_has_item(base_path, @content_item)
+    stub_content_store_has_item(base_path, @content_item)
 
     stub_rummager_tagged_content_request(content_id)
     stub_rummager_tagged_content_request(child_one_content_id)

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -63,7 +63,7 @@ describe Supergroups::NewsAndCommunications do
         },
       )
 
-      content_store_has_item("/government/tagged/content", content)
+      stub_content_store_has_item("/government/tagged/content", content)
     end
 
     it "returns promoted content for the news and communications section" do

--- a/test/support/brexit_landing_page_steps.rb
+++ b/test/support/brexit_landing_page_steps.rb
@@ -7,7 +7,7 @@ module BrexitLandingPageSteps
   include RummagerHelpers
 
   def given_there_is_a_brexit_taxon
-    content_store_has_item(brexit_taxon_path, content_item)
+    stub_content_store_has_item(brexit_taxon_path, content_item)
   end
 
   def brexit_taxon_path

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -694,7 +694,7 @@ module OrganisationHelpers
   end
 
   def setup_and_visit_page(content)
-    content_store_has_item(content["base_path"], content)
+    stub_content_store_has_item(content["base_path"], content)
     @title = content["title"]
     @what_we_do = content.dig("details", "body")
 

--- a/test/support/services_and_information_helpers.rb
+++ b/test/support/services_and_information_helpers.rb
@@ -14,7 +14,7 @@ module ServicesAndInformationHelpers
   end
 
   def stub_content_item(base_path, organisation_title)
-    content_store_has_item(base_path,
+    stub_content_store_has_item(base_path,
                            base_path: base_path,
                            title: "S&I page title",
                            description: "",

--- a/test/support/services_and_information_helpers.rb
+++ b/test/support/services_and_information_helpers.rb
@@ -15,20 +15,20 @@ module ServicesAndInformationHelpers
 
   def stub_content_item(base_path, organisation_title)
     stub_content_store_has_item(base_path,
-                           base_path: base_path,
-                           title: "S&I page title",
-                           description: "",
-                           document_type: "services_and_information",
-                           public_updated_at: 10.days.ago.iso8601,
-                           details: {},
-                           links: {
-                             parent: [
-                               {
-                                 analytics_identifier: "org_analytics_id",
-                                 base_path: "/organisation/base/path",
-                                 title: organisation_title,
-                               },
-                             ],
-                           })
+                                base_path: base_path,
+                                title: "S&I page title",
+                                description: "",
+                                document_type: "services_and_information",
+                                public_updated_at: 10.days.ago.iso8601,
+                                details: {},
+                                links: {
+                                  parent: [
+                                    {
+                                      analytics_identifier: "org_analytics_id",
+                                      base_path: "/organisation/base/path",
+                                      title: organisation_title,
+                                    },
+                                  ],
+                                })
   end
 end

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -35,7 +35,7 @@ describe ApplicationHelper do
     context "when a left to right language script" do
       it "returns nil" do
         self.stubs(:page_text_direction).returns("ltr")
-        assert_equal nil, direction_rtl_class
+        assert_nil direction_rtl_class
       end
     end
 
@@ -55,7 +55,7 @@ describe ApplicationHelper do
   describe "lang_attribute" do
     it "returns nil for default language" do
       I18n.with_locale(:en) do
-        assert_equal nil, lang_attribute
+        assert_nil lang_attribute
       end
     end
     it "returns a lang attribute string for non-default language" do
@@ -69,7 +69,7 @@ describe ApplicationHelper do
     context "when a left to right language script" do
       it "returns nil" do
         self.stubs(:page_text_direction).returns("ltr")
-        assert_equal nil, dir_attribute
+        assert_nil dir_attribute
       end
     end
 


### PR DESCRIPTION
This makes the test output a lot clearer 👇 

### Before

> Running:
>
> .......#content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead
#content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead
#content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead
#content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead
#content_store_has_item is deprecated on GdsApi::TestHelpers::ContentStore and will be removed in a future version. Use #stub_content_store_has_item instead
> .... (100s of similar lines)
> Finished in 38.506430s, 12.4395 runs/s, 29.6054 assertions/s.

### After 

> Running:
> ...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
> 
> Finished in 41.112732s, 11.6509 runs/s, 27.7286 assertions/s.

Individual commits have context on the specific corrections.  I also corrected a spelling that I noticed.  