### PR TITLE
2020 Pre-lords brexit landing page content

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -58,7 +58,13 @@ $red: #E61E32;
 }
 
 .landing-page__section-title {
-  padding: govuk-spacing(3) govuk-spacing(2) govuk-spacing(3) 0;
+  padding: govuk-spacing(7) govuk-spacing(2) govuk-spacing(2) 0;
+  margin-bottom: 20px;
+}
+
+.landing-page__guidance_subheader {
+  @include govuk-font(19);
+  margin-bottom: 20px;
 }
 
 .landing-page__section-list-wrapper {

--- a/app/views/brexit_landing_page/_brexit_finders.html.erb
+++ b/app/views/brexit_landing_page/_brexit_finders.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-body govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
-      text: t('brexit_landing_page.all_brexit_information'),
+      text: t('brexit_landing_page.topic_section_header'),
       padding: true,
     } %>
-    <p class="govuk-body"><%= t('brexit_landing_page.finder_heading') %></p>
+    <p class="govuk-body"><%= t('brexit_landing_page.topic_section_subheading') %></p>
 
     <%= render "components/topic-list", {
       items: supergroups

--- a/app/views/brexit_landing_page/_brexit_finders.html.erb
+++ b/app/views/brexit_landing_page/_brexit_finders.html.erb
@@ -1,9 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-body govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t('brexit_landing_page.topic_section_header'),
-      padding: true,
-    } %>
+    <h2 class="govuk-heading-m landing-page__section-title">
+      <%= t('brexit_landing_page.topic_section_header') %>
+    </h2>
     <p class="govuk-body"><%= t('brexit_landing_page.topic_section_subheading') %></p>
 
     <%= render "components/topic-list", {

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -5,7 +5,7 @@
   data-search-query>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m landing-page__section-title">
+      <h2 class="govuk-heading-l landing-page__section-title">
         <%= t('brexit_landing_page.guidance_header') %>
       </h2>
       <p>
@@ -17,7 +17,11 @@
   <% buckets.each do |bucket| %>
     <div class="grid-row landing-page__section-list-wrapper">
       <div class="govuk-grid-column-one-third landing-page__section-row-title">
-        <% if bucket[:row_title] %><h3 class="govuk-heading-s"><%= bucket[:row_title] %></h3><% end %>
+        <% if bucket[:row_title] %>
+          <h3 class="govuk-heading-m">
+            <%= bucket[:row_title] %>
+          </h3>
+        <% end %>
       </div>
 
       <div class="govuk-grid-column-two-thirds landing-page__section-content">

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -1,11 +1,16 @@
 <div class="landing-page__section"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
-  data-list-title="Brexit landing page: <%= t('brexit_landing_page.browse') %>"
+  data-list-title="Brexit landing page: <%= t('brexit_landing_page.guidance_header') %>"
   data-search-query>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m landing-page__section-title"><%= t('brexit_landing_page.browse') %></h2>
+      <h2 class="govuk-heading-m landing-page__section-title">
+        <%= t('brexit_landing_page.guidance_header') %>
+      </h2>
+      <p>
+        <%= t('brexit_landing_page.guidance_subheader') %>
+      </p>
     </div>
   </div>
 

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -8,7 +8,7 @@
       <h2 class="govuk-heading-l landing-page__section-title">
         <%= t('brexit_landing_page.guidance_header') %>
       </h2>
-      <p>
+       <p class="landing-page__guidance_subheader">
         <%= t('brexit_landing_page.guidance_subheader') %>
       </p>
     </div>

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -24,7 +24,7 @@
         <% end %>
       </div>
 
-      <div class="govuk-grid-column-two-thirds landing-page__section-content">
+      <div class="govuk-grid-column-two-thirds landing-page__section-content" data-module="track-click">
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
           <%= bucket[:list_block] %>

--- a/app/views/brexit_landing_page/_explainer.html.erb
+++ b/app/views/brexit_landing_page/_explainer.html.erb
@@ -1,7 +1,7 @@
 <div class="full-page-width-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m landing-page__section-title">
+      <h2 class="govuk-heading-l landing-page__section-title">
         <%= t('brexit_landing_page.explainer_title') %>
       </h2>
       <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/brexit_landing_page/_explainer.html.erb
+++ b/app/views/brexit_landing_page/_explainer.html.erb
@@ -1,0 +1,13 @@
+<div class="full-page-width-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m landing-page__section-title">
+        <%= t('brexit_landing_page.explainer_title') %>
+      </h2>
+      <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <%= t('brexit_landing_page.explainer_text').html_safe() %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -29,34 +29,10 @@
       </div>
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/title", {
-          title: I18n.t("brexit_landing_page.page_title"),
+          title: I18n.t("brexit_landing_page.page_header"),
           inverse: true,
           margin_bottom: 5
         } %>
-      </div>
-
-      <div class="govuk-grid-column-two-thirds landing-page__intro">
-        <%= render "govuk_publishing_components/components/govspeak", {
-        } do %>
-          <%= t('brexit_landing_page.page_intro').html_safe() %>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <% if show_dynamic_list %>
-          <%= render "govuk_publishing_components/components/chevron_banner", {
-            href: "/get-ready-brexit-check",
-            text: I18n.t("brexit_landing_page.chevron_banner"),
-            hover_border: true,
-            data_attributes: {
-              track_category: "startButtonClicked",
-              track_action: "/get-ready-brexit-check",
-              track_label: I18n.t("brexit_landing_page.chevron_banner")
-            }
-          } %>
-        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -10,6 +10,8 @@
   )
 %>
 
+<%= render partial: 'explainer' %>
+
 <div class="landing-page__buckets full-page-width-wrapper">
   <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
 </div>

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -15,14 +15,15 @@ cy:
         list_block: |
           Gwiriwch beth sydd angen i chi wneud os ydych yn:
           <ul>
-            <li><strong><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">mewnforio nwyddau o’r UE</a></strong></li>
-            <li><strong><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">allforio nwyddau i’r UE</a></strong></li>
-            <li><strong><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">cludo nwyddau allan o’r DU ar y ffyrdd</a></strong></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="mewnforio nwyddau o’r UE">mewnforio nwyddau o’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="allforio nwyddau i’r UE">allforio nwyddau i’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="cludo nwyddau allan o’r DU ar y ffyrdd">cludo nwyddau allan o’r DU ar y ffyrdd</a></li>
           </ul>
       - row_title: "Aros yn y DU os ydych yn ddinesydd yr UE"
         list_block: |
           Gwiriwch os oes angen i chi gyflwyno cais am y cynllun preswylio os ydych chi neu’ch teulu yn dod o’r UE, neu o’r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
-          <strong><a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a></strong>
+
+          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Gwiriwch beth sydd angen i chi wneud i aros yn y DU">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
       - row_title: "Byw a gweithio yn yr UE"
         list_block: |
           Mae byw a gweithio mewn gwlad yn yr UE yn ddibynnol ar reolau’r wlad honno.
@@ -31,10 +32,10 @@ cy:
 
           Efallai bydd angen i chi gyfnewid eich trwydded yrru am drwydded a roddwyd gan wlad yr UE ble rydych yn byw.
 
-          <strong><a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a></strong>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a>
       - row_title: "Cyllid yr UE ar ôl Brexit"
         list_block: |
-          <strong><a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a></strong> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
+          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
     topic_section_header: "Holl wybodaeth Brexit"
     topic_section_subheading: "Pori’r holl wybodaeth sy’n gysylltiedig â Brexit:"
     email_intro: "I gael y manylion diweddaraf"

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -15,15 +15,15 @@ cy:
         list_block: |
           Gwiriwch beth sydd angen i chi wneud os ydych yn:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="mewnforio nwyddau o’r UE">mewnforio nwyddau o’r UE</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="allforio nwyddau i’r UE">allforio nwyddau i’r UE</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="cludo nwyddau allan o’r DU ar y ffyrdd">cludo nwyddau allan o’r DU ar y ffyrdd</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="mewnforio nwyddau o’r UE">mewnforio nwyddau o’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="allforio nwyddau i’r UE">allforio nwyddau i’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="cludo nwyddau allan o’r DU ar y ffyrdd">cludo nwyddau allan o’r DU ar y ffyrdd</a></li>
           </ul>
       - row_title: "Aros yn y DU os ydych yn ddinesydd yr UE"
         list_block: |
           Gwiriwch os oes angen i chi gyflwyno cais am y cynllun preswylio os ydych chi neu’ch teulu yn dod o’r UE, neu o’r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
 
-          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Gwiriwch beth sydd angen i chi wneud i aros yn y DU">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
+          <a href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Gwiriwch beth sydd angen i chi wneud i aros yn y DU">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
       - row_title: "Byw a gweithio yn yr UE"
         list_block: |
           Mae byw a gweithio mewn gwlad yn yr UE yn ddibynnol ar reolau’r wlad honno.
@@ -32,10 +32,10 @@ cy:
 
           Efallai bydd angen i chi gyfnewid eich trwydded yrru am drwydded a roddwyd gan wlad yr UE ble rydych yn byw.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a>
       - row_title: "Cyllid yr UE ar ôl Brexit"
         list_block: |
-          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
+          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
     topic_section_header: "Holl wybodaeth Brexit"
     topic_section_subheading: "Pori’r holl wybodaeth sy’n gysylltiedig â Brexit:"
     email_intro: "I gael y manylion diweddaraf"

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -33,9 +33,6 @@ cy:
           Efallai bydd angen i chi gyfnewid eich trwydded yrru am drwydded a roddwyd gan wlad yr UE ble rydych yn byw.
 
           <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a>
-      - row_title: "Cyllid yr UE ar ôl Brexit"
-        list_block: |
-          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
     topic_section_header: "Holl wybodaeth Brexit"
     topic_section_subheading: "Pori’r holl wybodaeth sy’n gysylltiedig â Brexit:"
     email_intro: "I gael y manylion diweddaraf"

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -1,21 +1,44 @@
 cy:
   brexit_landing_page:
     meta_title: "Brexit"
-    meta_description: "Gwybodaeth a chanllawiau Brexit ar sut i baratoi ar gyfer Brexit heb fargen."
-    page_title: "Brexit"
-    page_intro: |
-      <p>Mae bargen Brexit wedi ei gytuno mewn egwyddor gyda’r UE.</p>
-      <p>Bydd angen i’r DU a’r UE gymeradwyo ac arwyddo’r cytundeb ymadael. Byddent wedyn yn dechrau trafod trefniadau newydd. Bydd cyfnod pontio i baratoi ar gyfer y rheolau newydd.</p>
-      <p>Gall y DU adael heb fargen os nad yw’r cytundeb ymadael wedi ei gymeradwyo erbyn 31 Ionawr 2020, neu ar ddiwedd y cyfnod pontio.</p>
-      <p>Darganfyddwch beth ddylech chi, eich teulu neu’ch busnes wneud os yw’r DU yn gadael yr UE heb fargen.</p>
-      <p><a href="/get-ready-brexit-check">Gwiriwch sut i baratoi ar gyfer Brexit heb fargen</a></p>
-    chevron_banner: "Gwiriwch beth sydd angen i chi wneud os nad oes cytundeb"
-    finder_heading: "Pori drwy’r holl wybodaeth sy’n gysylltiedig â Brexit:"
-    call_to_action_intro: "Atebwch ychydig o gwestiynau i ddarganfod sut y dylech chi neu’ch busnes baratoi."
-    all_brexit_information: "Holl wybodaeth Brexit"
+    meta_description: "Mae’r DU a’r UE wedi cytuno ar gytundeb ymadael. Dysgwch beth fydd yn digwydd nesaf."
+    page_header: "Mae’r DU a’r UE wedi cytuno ar gytundeb ymadael"
+    explainer_title: "Beth sy’n digwydd nesaf"
+    explainer_text: |
+      <p>Mae angen i’r DU a’r UE gadarnhau’r cytundeb ymadael erbyn 31 Ionawr 2020.</p>
+      <p>Bydd cyfnod gweithredu tan 31 Rhagfyr 2020 tra bydd yr UE a’r DU yn trafod trefniadau newydd.</p>
+      <p>Gallwch chi, eich teulu neu’ch busnes gymryd rhai camau nawr i baratoi am ymadawiad y DU o’r UE.</p>
+    guidance_header: "Beth allwch wneud nawr"
+    guidance_subheader: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
+    campaign_buckets:
+      - row_title: "Paratoi eich busnes ar gyfer Brexit"
+        list_block: |
+          Gwiriwch beth sydd angen i chi wneud os ydych yn:
+          <ul>
+            <li><strong><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">mewnforio nwyddau o’r UE</a></strong></li>
+            <li><strong><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">allforio nwyddau i’r UE</a></strong></li>
+            <li><strong><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">cludo nwyddau allan o’r DU ar y ffyrdd</a></strong></li>
+          </ul>
+      - row_title: "Aros yn y DU os ydych yn ddinesydd yr UE"
+        list_block: |
+          Gwiriwch os oes angen i chi gyflwyno cais am y cynllun preswylio os ydych chi neu’ch teulu yn dod o’r UE, neu o’r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
+          <strong><a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a></strong>
+      - row_title: "Byw a gweithio yn yr UE"
+        list_block: |
+          Mae byw a gweithio mewn gwlad yn yr UE yn ddibynnol ar reolau’r wlad honno.
+
+          Efallai bydd angen i chi gyflwyno cais am breswyliaeth. Dylech wirio os ydych yn gymwysedig am ofal iechyd.
+
+          Efallai bydd angen i chi gyfnewid eich trwydded yrru am drwydded a roddwyd gan wlad yr UE ble rydych yn byw.
+
+          <strong><a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw</a></strong>
+      - row_title: "Cyllid yr UE ar ôl Brexit"
+        list_block: |
+          <strong><a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Gwiriwch os yw eich prosiect sydd wedi ei hariannu gan yr UE yn dod o dan warrant ariannu Llywodraeth y DU.</a></strong> TMae’r warrant yn cynnwys Erasmus +, Horizon 2020 ac eraill.
+    topic_section_header: "Holl wybodaeth Brexit"
+    topic_section_subheading: "Pori’r holl wybodaeth sy’n gysylltiedig â Brexit:"
     email_intro: "I gael y manylion diweddaraf"
-    email: "Cofrestrwch i gael hysbysiadau e-bost am Brexit"
-    browse: "Pori’r canllawiau Brexit"
+    email: "Cofrestrwch i gael hysbysiadau ebost am Brexit"
     share_links: "Rhannu’r dudalen hon"
     sections:
       services: Gwasanaethau
@@ -24,37 +47,3 @@ cy:
       research_and_statistics: Ymchwil ag ystadegau
       policy_and_engagement: Polisi ac ymgynghoriadau
       transparency: Tryloywder a datganiadau rhyddid gwybodaeth
-    campaign_buckets:
-      - row_title: "Paratoi eich busnes ar gyfer Brexit"
-        list_block: |
-          <a href="/get-ready-brexit-check" data-ecommerce-row="true" data-ecommerce-path="/get-ready-brexit-check">Gwiriwch sut i baratoi eich busnes ar gyfer Brexit heb fargen.</a>
-
-          Er enghraifft, bydd angen i chi weithredu os ydych yn <a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">allforio nwyddau i’r UE</a> neu’n <a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/transport-goods-from-uk-by-road">cludo nwyddau allan o’r DU ar y ffyrdd</a>.
-
-          Gwiriwch hefyd beth sydd angen i chi wybod os ydych yn <a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">mewnforio nwyddau o’r UE</a> neu'n <a href="/guidance/providing-services-to-any-country-in-the-eu-iceland-liechtenstein-norway-or-switzerland-after-eu-exit" data-ecommerce-row="true" data-ecommerce-path="/guidance/providing-services-to-any-country-in-the-eu-iceland-liechtenstein-norway-or-switzerland-after-eu-exit">gwerthu gwasanaethau i’r UE.</a>
-
-          Mae rheolau gwahanol i <a href="/guidance/trading-and-moving-from-northern-ireland-to-ireland-in-a-no-deal-brexit" data-ecommerce-row="true" data-ecommerce-path="/guidance/trading-and-moving-from-northern-ireland-to-ireland-in-a-no-deal-brexit">symud nwyddau rhwng Iwerddon a Gogledd Iwerddon.</a>
-      - row_title: "Cyllid yr UE ar ôl Brexit"
-        list_block: |
-          <a href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/guidance/european-and-domestic-funding-after-brexit" data-track-options="&#123;&quot;dimension29&quot;:&quot;Gwiriwch os yw eich prosiect a ariennir gan yr UE wedi ei warantu gan arian Llywodraeth y DU&quot;&#125;">Gwiriwch os yw eich prosiect a ariennir gan yr UE wedi ei warantu gan arian Llywodraeth y DU.</a> Mae'r warant yn cwmpasu Erasmus +, Horizon 2020 ac eraill.
-      - row_title: "Ymweld â’r UE"
-        list_block: |
-          I ymweld ag Ewrop ar ôl Brexit, mae pethau sydd angen i chi wneud cyn teithio.
-
-          Er enghraifft, bydd angen i chi wirio eich pasport, prynu yswiriant teithio sy’n cwmpasu gofal iechyd a chael y dolennau gyrru cywir.
-
-          <a href="/visit-europe-brexit" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/visit-europe-brexit" data-track-options="&#123;&quot;dimension29&quot;:&quot;Ymweld ag Ewrop ar ôl Brexit&quot;&#125;"><strong>Ymweld ag Ewrop ar ôl Brexit</strong></a>
-      - row_title: "Byw a gweithio yn yr UE"
-        list_block: |
-          Mae byw a gweithio mewn gwlad yr UE yn ddibynnol ar y rheolau yn y wlad honno.
-
-          Efallai bydd angen i chi gofrestru neu gyflwyno cais am breswyliaeth, gwirio os ydych chi’n gymwys am ofal iechyd.
-
-          Efallai hefyd bydd angen i chi gyfnewid eich trwydded yrru DU am drwydded a roddir gan wlad yr UE ble rydych yn byw.
-
-          <a href="/uk-nationals-living-eu" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/uk-nationals-living-eu" data-track-options="&#123;&quot;dimension29&quot;:&quot;Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi&quot;&#125;"><strong>Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi</strong></a>
-      - row_title: "Aros yn y DU os ydych yn ddinesydd o’r UE"
-        list_block: |
-          Gwiriwch os oes angen i chi gyflwyno cais i’r cynllun setliad os ydych chi neu’ch teulu yn dod o’r UE, Y Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
-
-          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/staying-uk-eu-citizen" data-track-options="&#123;&quot;dimension29&quot;:&quot;Gwiriwch beth sydd angen i chi wneud i aros yn y DU&quot;&#125;"><strong>Gwiriwch beth sydd angen i chi wneud i aros yn y DU</strong></a>

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -1,49 +1,29 @@
 en:
   brexit_landing_page:
     meta_title: "Brexit"
-    meta_description: "Brexit information and guidance on how to prepare for a no deal Brexit."
-    chevron_banner: "Check what you need to do if there is no deal"
-    finder_heading: "Browse all information related to Brexit:"
-    page_title: "Brexit"
-    page_intro: |
-      <p>A Brexit deal has been agreed in principle with the EU.</p>
-      <p>Both the UK and the EU need to approve and sign the withdrawal agreement. They will then start to negotiate new arrangements. There would be a transition period to prepare for new rules.</p>
-      <p>The UK could still leave with no deal if the withdrawal agreement is not approved by 31 January 2020, or at the end of a transition period.</p>
-      <p>Find out what you, your family, or your business should do to be prepared if the UK leaves the EU with no deal.</p>
-      <p><a href="/get-ready-brexit-check">Check how to prepare for a no deal Brexit</a></p>
-    call_to_action_intro: "Answer a few questions to find out how you or your business should prepare."
-    all_brexit_information: "All Brexit information"
-    email_intro: "Stay up to date"
-    email: "Sign up for email alerts about Brexit"
-    browse: "Browse Brexit guidance"
-    share_links: "Share this page"
-    sections:
-      services: Services
-      guidance_and_regulation: Guidance and regulation
-      news_and_communications: News and communications
-      research_and_statistics: Research and statistics
-      policy_and_engagement: Policy papers and consultations
-      transparency: Transparency and freedom of information releases
+    meta_description: "The UK and EU have agreed an exit deal. Find out what happens next."
+    page_header: "The UK and EU have agreed an exit deal"
+    explainer_title: "What happens next"
+    explainer_text: |
+      <p>Both the UK and the EU need to ratify the withdrawal agreement by 31 January 2020.</p>
+      <p>There will then be an implementation period until 31 December 2020 while the EU and UK negotiate new arrangements.</p>
+      <p>You, your family or your business can take some actions now to prepare for the UK’s exit from the EU.</p>
+    guidance_header: "What you can do now"
+    guidance_subheader: "Actions you can take now that do not depend on negotiations."
     campaign_buckets:
       - row_title: "Preparing your business for Brexit"
         list_block: |
-          <a href="/get-ready-brexit-check" data-ecommerce-row="true" data-ecommerce-path="/get-ready-brexit-check">Check how to get your business ready for a no deal Brexit.</a>
-
-          For example, you must take action if you <a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">export goods to the EU</a> or <a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/transport-goods-from-uk-by-road">transport goods out of the UK by road.</a>
-
-          Also check what you must do if you <a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">import goods from the EU</a> or <a href="/guidance/providing-services-to-any-country-in-the-eu-iceland-liechtenstein-norway-or-switzerland-after-eu-exit" data-ecommerce-row="true" data-ecommerce-path="/guidance/providing-services-to-any-country-in-the-eu-iceland-liechtenstein-norway-or-switzerland-after-eu-exit">sell services to the EU.</a>
-
-          There are different rules for <a href="/guidance/trading-and-moving-from-northern-ireland-to-ireland-in-a-no-deal-brexit" data-ecommerce-row="true" data-ecommerce-path="/guidance/trading-and-moving-from-northern-ireland-to-ireland-in-a-no-deal-brexit">moving goods between Ireland and Northern Ireland.</a>
-      - row_title: "EU funding after Brexit"
+          Check what you need to do if you:
+          <ul>
+            <li><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">import goods from the EU</a></li>
+            <li><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">export goods to the EU</a></li>
+            <li><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">transport goods out of the UK by road</a></li>
+          </ul>
+      - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
-          <a href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/guidance/european-and-domestic-funding-after-brexit" data-track-options="&#123;&quot;dimension29&quot;:&quot;Check if your EU-funded project is covered by the UK government’s funding guarantee&quot;&#125;">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
-      - row_title: "Visiting the EU"
-        list_block: |
-          To visit Europe after Brexit there are things you need to do before you travel.
+          Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
-          For example, you will need to check your passport, get travel insurance which covers healthcare, and get the right driving documents.
-
-          <a href="/visit-europe-brexit" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/visit-europe-brexit" data-track-options="&#123;&quot;dimension29&quot;:&quot;Visit Europe after Brexit&quot;&#125;"><strong>Visit Europe after Brexit</strong></a>
+          <a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Check what you need to do to stay in the UK</a>
       - row_title: "Living and working in the EU"
         list_block: |
           Living and working in an EU country after Brexit depends on the rules in that country.
@@ -52,11 +32,20 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <a href="/uk-nationals-living-eu" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/uk-nationals-living-eu" data-track-options="&#123;&quot;dimension29&quot;:&quot;Check what you must do in the country where you live&quot;&#125;"><strong>Check what you must do in the country where you live</strong></a>
-
-      - row_title: "Staying in the UK if you’re an EU citizen"
+          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Check what you must do in the country where you live</a>
+      - row_title: "EU funding after Brexit"
         list_block: |
-          Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
+          <a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
+    topic_section_header: "All Brexit information"
+    topic_section_subheading: "Browse all information related to Brexit:"
+    email_intro: "Stay up to date"
+    email: "Sign up for email alerts about Brexit"
 
-          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-action="Section link" data-track-label="/staying-uk-eu-citizen" data-track-options="&#123;&quot;dimension29&quot;:&quot;Check what you need to do to stay in the UK&quot;&#125;"><strong>Check what you need to do to stay in the UK</strong></a>
-
+    share_links: "Share this page"
+    sections:
+      services: Services
+      guidance_and_regulation: Guidance and regulation
+      news_and_communications: News and communications
+      research_and_statistics: Research and statistics
+      policy_and_engagement: Policy papers and consultations
+      transparency: Transparency and freedom of information releases

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -15,15 +15,15 @@ en:
         list_block: |
           Check what you need to do if you:
           <ul>
-            <li><strong><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">import goods from the EU</a></strong></li>
-            <li><strong><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">export goods to the EU</a></strong></li>
-            <li><strong><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">transport goods out of the UK by road</a></strong></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="import goods from the EU">import goods from the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="export goods to the EU">export goods to the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="transport goods out of the UK by road">transport goods out of the UK by road</a></li>
           </ul>
       - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
           Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
-          <strong><a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Check what you need to do to stay in the UK</a></strong>
+          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Check what you need to do to stay in the UK">Check what you need to do to stay in the UK</a>
       - row_title: "Living and working in the EU"
         list_block: |
           Living and working in an EU country after Brexit depends on the rules in that country.
@@ -32,10 +32,11 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <strong><a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Check what you must do in the country where you live</a></strong>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
       - row_title: "EU funding after Brexit"
         list_block: |
-          <strong><a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a></strong> The guarantee covers Erasmus+, Horizon 2020 and others.
+          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Check if your EU-funded project is covered by the UK government’s funding guarantee.">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
+
     topic_section_header: "All Brexit information"
     topic_section_subheading: "Browse all information related to Brexit:"
     email_intro: "Stay up to date"

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -15,15 +15,15 @@ en:
         list_block: |
           Check what you need to do if you:
           <ul>
-            <li><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">import goods from the EU</a></li>
-            <li><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">export goods to the EU</a></li>
-            <li><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">transport goods out of the UK by road</a></li>
+            <li><strong><a href="/prepare-import-to-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-import-to-uk-after-brexit">import goods from the EU</a></strong></li>
+            <li><strong><a href="/prepare-export-from-uk-after-brexit" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">export goods to the EU</a></strong></li>
+            <li><strong><a href="/transport-goods-from-uk-by-road" data-ecommerce-row="true" data-ecommerce-path="/prepare-export-from-uk-after-brexit">transport goods out of the UK by road</a></strong></li>
           </ul>
       - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
           Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
-          <a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Check what you need to do to stay in the UK</a>
+          <strong><a href="/staying-uk-eu-citizen" data-ecommerce-row="true" data-ecommerce-path="/staying-uk-eu-citizen">Check what you need to do to stay in the UK</a></strong>
       - row_title: "Living and working in the EU"
         list_block: |
           Living and working in an EU country after Brexit depends on the rules in that country.
@@ -32,10 +32,10 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Check what you must do in the country where you live</a>
+          <strong><a href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="brexit-landing-page" data-track-label="/staying-uk-eu-citizen">Check what you must do in the country where you live</a></strong>
       - row_title: "EU funding after Brexit"
         list_block: |
-          <a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
+          <strong><a href="https://www.gov.uk/guidance/european-and-domestic-funding-after-brexit">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a></strong> The guarantee covers Erasmus+, Horizon 2020 and others.
     topic_section_header: "All Brexit information"
     topic_section_subheading: "Browse all information related to Brexit:"
     email_intro: "Stay up to date"

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -33,10 +33,6 @@ en:
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
           <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
-      - row_title: "EU funding after Brexit"
-        list_block: |
-          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Check if your EU-funded project is covered by the UK government’s funding guarantee.">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
-
     topic_section_header: "All Brexit information"
     topic_section_subheading: "Browse all information related to Brexit:"
     email_intro: "Stay up to date"

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -15,15 +15,15 @@ en:
         list_block: |
           Check what you need to do if you:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="import goods from the EU">import goods from the EU</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="export goods to the EU">export goods to the EU</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="transport goods out of the UK by road">transport goods out of the UK by road</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="import goods from the EU">import goods from the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="export goods to the EU">export goods to the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="transport goods out of the UK by road">transport goods out of the UK by road</a></li>
           </ul>
       - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
           Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
-          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Check what you need to do to stay in the UK">Check what you need to do to stay in the UK</a>
+          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Check what you need to do to stay in the UK">Check what you need to do to stay in the UK</a>
       - row_title: "Living and working in the EU"
         list_block: |
           Living and working in an EU country after Brexit depends on the rules in that country.
@@ -32,10 +32,10 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
       - row_title: "EU funding after Brexit"
         list_block: |
-          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-module="track-click" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Check if your EU-funded project is covered by the UK government’s funding guarantee.">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
+          <a class="govuk-!-font-weight-bold" href="/guidance/european-and-domestic-funding-after-brexit" data-track-category="transition-landing-page" data-track-action="/guidance/european-and-domestic-funding-after-brexit" data-track-label="Check if your EU-funded project is covered by the UK government’s funding guarantee.">Check if your EU-funded project is covered by the UK government’s funding guarantee.</a> The guarantee covers Erasmus+, Horizon 2020 and others.
 
     topic_section_header: "All Brexit information"
     topic_section_subheading: "Browse all information related to Brexit:"

--- a/test/integration/brexit_landing_page_test.rb
+++ b/test/integration/brexit_landing_page_test.rb
@@ -11,7 +11,7 @@ class BrexitLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_buckets_section
       then_i_can_see_the_title_section
       then_i_can_see_the_header_section
-      then_i_can_see_the_get_ready_section
+      then_i_can_see_the_what_happens_next_section
       then_i_can_see_the_share_links_section
       and_i_can_see_the_explore_topics_section
       and_i_can_see_an_email_subscription_link
@@ -21,7 +21,6 @@ class BrexitLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_brexit_taxon
       when_i_visit_the_brexit_landing_page_with_dynamic_list
       then_all_finder_links_have_tracking_data
-      and_the_start_button_is_tracked
       and_the_email_link_is_tracked
       and_ecommerce_tracking_is_setup
     end

--- a/test/support/brexit_landing_page_steps.rb
+++ b/test/support/brexit_landing_page_steps.rb
@@ -49,11 +49,11 @@ module BrexitLandingPageSteps
   end
 
   def then_i_can_see_the_header_section
-    assert page.has_selector?(".landing-page__header h1", text: "Brexit")
+    assert page.has_selector?(".landing-page__header h1", text: "The UK and EU have agreed an exit deal")
   end
 
-  def then_i_can_see_the_get_ready_section
-    assert page.has_selector?(".gem-c-chevron-banner__link", text: "Check what you need to do if there is no deal")
+  def then_i_can_see_the_what_happens_next_section
+    assert page.has_selector?("h2.landing-page__section-title", text: "What happens next")
   end
 
   def then_i_cannot_see_the_get_ready_section
@@ -65,7 +65,7 @@ module BrexitLandingPageSteps
   end
 
   def then_i_can_see_the_buckets_section
-    assert page.has_selector?(".landing-page__section h2", text: "Browse Brexit guidance")
+    assert page.has_selector?("h2.landing-page__section-title", text: "What happens next")
   end
 
   def and_i_can_see_an_email_subscription_link
@@ -74,7 +74,7 @@ module BrexitLandingPageSteps
   end
 
   def and_i_can_see_the_explore_topics_section
-    assert page.has_selector?(".gem-c-heading", text: "All Brexit information")
+    assert page.has_selector?("h2.landing-page__section-title", text: "All Brexit information")
 
     supergroups = [
       "Services": "services",
@@ -109,12 +109,6 @@ module BrexitLandingPageSteps
       assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: section)
       assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: section)
     end
-  end
-
-  def and_the_start_button_is_tracked
-    assert page.has_selector?("a[data-track-category='startButtonClicked']")
-    assert page.has_selector?("a[data-track-label='Check what you need to do if there is no deal']")
-    assert page.has_selector?("a[data-track-action='/get-ready-brexit-check']")
   end
 
   def and_the_email_link_is_tracked


### PR DESCRIPTION
Trello: https://trello.com/c/CwSkvo1I/373-brexit-estate-deploy-pre-lords-changes

## What
We need to make the 'pre-lords' changes to the brexit estate live to reflect the current as is reality.

## Why
Current brexit landing page has already fallen out of date with reality.

## Context
The copy and designs have been created, evolved, approved and signed off. We need to update the content so that users have the latest information.

<img width="1320" alt="Screenshot 2020-01-16 at 14 13 05" src="https://user-images.githubusercontent.com/3694062/72531920-5ca18700-386a-11ea-93b9-5d2bfa1bb194.png">