### PR TITLE
Use slug_without_locale to generate links

### DIFF
--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -24,9 +24,9 @@ class AnnouncementsPresenter
 
   def links
     {
-      email_signup: "/email-signup?link=/government/#{slug_prefix}/#{slug}",
-      subscribe_to_feed: "https://www.gov.uk/government/#{slug_prefix}/#{slug}.atom",
-      link_to_news_and_communications: "/search/news-and-communications?#{filter_key}=#{slug}",
+      email_signup: "/email-signup?link=/government/#{slug_prefix}/#{slug_without_locale}",
+      subscribe_to_feed: "https://www.gov.uk/government/#{slug_prefix}/#{slug_without_locale}.atom",
+      link_to_news_and_communications: "/search/news-and-communications?#{filter_key}=#{slug_without_locale}",
     }
   end
 

--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -25,7 +25,7 @@ class AnnouncementsPresenter
   def links
     {
       email_signup: "/email-signup?link=/government/#{slug_prefix}/#{slug_without_locale}",
-      subscribe_to_feed: "https://www.gov.uk/government/#{slug_prefix}/#{slug_without_locale}.atom",
+      subscribe_to_feed: "/government/#{slug_prefix}/#{slug_without_locale}.atom",
       link_to_news_and_communications: "/search/news-and-communications?#{filter_key}=#{slug_without_locale}",
     }
   end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -110,7 +110,7 @@ describe Person do
     end
 
     it "should have link to subscription atom feed" do
-      assert_equal "https://www.gov.uk/government/people/boris-johnson.atom", @person.announcements.links[:subscribe_to_feed]
+      assert_equal "/government/people/boris-johnson.atom", @person.announcements.links[:subscribe_to_feed]
     end
   end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -133,7 +133,7 @@ describe Role do
     end
 
     it "should have link to subscription atom feed" do
-      assert_equal "https://www.gov.uk/government/ministers/prime-minister.atom", @role.announcements.links[:subscribe_to_feed]
+      assert_equal "/government/ministers/prime-minister.atom", @role.announcements.links[:subscribe_to_feed]
     end
 
     it "should have link to news and communications finder" do

--- a/test/presenters/announcements_presenter_test.rb
+++ b/test/presenters/announcements_presenter_test.rb
@@ -9,7 +9,7 @@ describe AnnouncementsPresenter do
     it "uses a locale-less slug in the links" do
       links = @presenter.links
       assert_equal links[:email_signup], "/email-signup?link=/government/people/boris-johnson"
-      assert_equal links[:subscribe_to_feed], "https://www.gov.uk/government/people/boris-johnson.atom"
+      assert_equal links[:subscribe_to_feed], "/government/people/boris-johnson.atom"
       assert_equal links[:link_to_news_and_communications], "/search/news-and-communications?people=boris-johnson"
     end
   end

--- a/test/presenters/announcements_presenter_test.rb
+++ b/test/presenters/announcements_presenter_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+describe AnnouncementsPresenter do
+  describe "slug with a locale" do
+    before :each do
+      @presenter = AnnouncementsPresenter.new("boris-johnson.cy", filter_key: "people")
+    end
+
+    it "uses a locale-less slug in the links" do
+      links = @presenter.links
+      assert_equal links[:email_signup], "/email-signup?link=/government/people/boris-johnson"
+      assert_equal links[:subscribe_to_feed], "https://www.gov.uk/government/people/boris-johnson.atom"
+      assert_equal links[:link_to_news_and_communications], "/search/news-and-communications?people=boris-johnson"
+    end
+  end
+end


### PR DESCRIPTION
Currently we generate links with the locale in which doesn't work because Search API and Email Alert API only support English language content. So rather than it not working, we can instead send the user to the English language content versions which is more useful.

[Trello Card](https://trello.com/c/qmbbJjwx/1666-3-final-review-of-people-pages-mob-session)