### PR TITLE
Link directly to the atom feed

### DIFF
--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -25,7 +25,7 @@ class AnnouncementsPresenter
   def links
     {
       email_signup: "/email-signup?link=/government/#{slug_prefix}/#{slug_without_locale}",
-      subscribe_to_feed: "/government/#{slug_prefix}/#{slug_without_locale}.atom",
+      subscribe_to_feed: "/search/news-and-communications.atom?#{filter_key}=#{slug_without_locale}",
       link_to_news_and_communications: "/search/news-and-communications?#{filter_key}=#{slug_without_locale}",
     }
   end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -110,7 +110,7 @@ describe Person do
     end
 
     it "should have link to subscription atom feed" do
-      assert_equal "/government/people/boris-johnson.atom", @person.announcements.links[:subscribe_to_feed]
+      assert_equal "/search/news-and-communications.atom?people=boris-johnson", @person.announcements.links[:subscribe_to_feed]
     end
   end
 end

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -133,7 +133,7 @@ describe Role do
     end
 
     it "should have link to subscription atom feed" do
-      assert_equal "/government/ministers/prime-minister.atom", @role.announcements.links[:subscribe_to_feed]
+      assert_equal "/search/news-and-communications.atom?roles=prime-minister", @role.announcements.links[:subscribe_to_feed]
     end
 
     it "should have link to news and communications finder" do

--- a/test/presenters/announcements_presenter_test.rb
+++ b/test/presenters/announcements_presenter_test.rb
@@ -9,7 +9,7 @@ describe AnnouncementsPresenter do
     it "uses a locale-less slug in the links" do
       links = @presenter.links
       assert_equal links[:email_signup], "/email-signup?link=/government/people/boris-johnson"
-      assert_equal links[:subscribe_to_feed], "/government/people/boris-johnson.atom"
+      assert_equal links[:subscribe_to_feed], "/search/news-and-communications.atom?people=boris-johnson"
       assert_equal links[:link_to_news_and_communications], "/search/news-and-communications?people=boris-johnson"
     end
   end


### PR DESCRIPTION
Going to the old style atom feed link redirects to this one so it seems better to link directly to it.