### PR TITLE
Transition css tweaks

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -34,6 +34,13 @@ $red: #E61E32;
   }
 }
 
+.landing-page__page_title {
+  @include govuk-font($size: 48, $weight: bold);
+  color: govuk-colour("white");
+  margin-top: govuk-spacing(7);
+  margin-bottom: govuk-spacing(4);
+}
+
 .landing-page__translation {
   @include govuk-media-query($from: tablet) {
     float: right;

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -85,7 +85,7 @@ $red: #E61E32;
 }
 
 .landing-page__section-content {
-  padding-left: 0;
+  padding-left: govuk-spacing(3);
 
   @include govuk-media-query($from: tablet) {
     padding-right: 0;

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -14,6 +14,7 @@ $red: #E61E32;
 .landing-page__header {
   padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(6);
   background-color: $govuk-brand-colour;
   color: govuk-colour("white");
 }
@@ -55,40 +56,24 @@ $red: #E61E32;
   @include govuk-responsive-margin(8, "top");
 }
 
-.full-page-width-wrapper--landing-page {
-  border-top: 2px solid govuk-colour("black");
-}
-
 .landing-page__section {
-  margin-bottom: govuk-spacing(8);
   border-top: 2px solid govuk-colour("black");
-}
-
-.landing-page__section-title {
-  padding: govuk-spacing(7) govuk-spacing(2) govuk-spacing(2) 0;
-  margin-bottom: 20px;
+  padding-top: govuk-spacing(7);
 }
 
 .landing-page__guidance_subheader {
   @include govuk-font(19);
-  margin-bottom: 20px;
+  margin-bottom: govuk-spacing(7);
 }
 
 .landing-page__section-list-wrapper {
-  margin: 0 0 govuk-spacing(6) 0;
-  border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
-  padding-top: govuk-spacing(4);
-}
+  margin-bottom: govuk-spacing(6);
 
-.landing-page__section-row-title {
-  padding-left: 0;
-}
-
-.landing-page__section-content {
-  padding-left: govuk-spacing(3);
-
-  @include govuk-media-query($from: tablet) {
-    padding-right: 0;
+  &:before {
+    border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+    content: "";
+    display: block;
+    margin: 0 govuk-spacing(3) govuk-spacing(6);
   }
 }
 

--- a/app/views/brexit_landing_page/_brexit_finders.html.erb
+++ b/app/views/brexit_landing_page/_brexit_finders.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-body govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m landing-page__section-title">
+    <h2 class="govuk-heading-m">
       <%= t('brexit_landing_page.topic_section_header') %>
     </h2>
     <p class="govuk-body"><%= t('brexit_landing_page.topic_section_subheading') %></p>

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -5,7 +5,7 @@
   data-search-query>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l landing-page__section-title">
+      <h2 class="govuk-heading-l">
         <%= t('brexit_landing_page.guidance_header') %>
       </h2>
        <p class="landing-page__guidance_subheader">
@@ -15,8 +15,8 @@
   </div>
 
   <% buckets.each do |bucket| %>
-    <div class="grid-row landing-page__section-list-wrapper">
-      <div class="govuk-grid-column-one-third landing-page__section-row-title">
+    <div class="govuk-grid-row landing-page__section-list-wrapper">
+      <div class="govuk-grid-column-one-third">
         <% if bucket[:row_title] %>
           <h3 class="govuk-heading-m">
             <%= bucket[:row_title] %>
@@ -24,7 +24,7 @@
         <% end %>
       </div>
 
-      <div class="govuk-grid-column-two-thirds landing-page__section-content" data-module="track-click">
+      <div class="govuk-grid-column-two-thirds" data-module="track-click">
         <%= render "govuk_publishing_components/components/govspeak", {
           } do %>
           <%= bucket[:list_block] %>

--- a/app/views/brexit_landing_page/_explainer.html.erb
+++ b/app/views/brexit_landing_page/_explainer.html.erb
@@ -1,7 +1,7 @@
 <div class="full-page-width-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l landing-page__section-title">
+      <h2 class="govuk-heading-l">
         <%= t('brexit_landing_page.explainer_title') %>
       </h2>
       <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -28,11 +28,9 @@
         } %>
       </div>
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: I18n.t("brexit_landing_page.page_header"),
-          inverse: true,
-          margin_bottom: 5
-        } %>
+        <h1 class="landing-page__page_title">
+          <%= I18n.t("brexit_landing_page.page_header") %>
+        </h1>
       </div>
     </div>
   </div>

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <header class="landing-page__header">
-  <div class="full-page-width-wrapper">
+  <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs',
       breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
       collapse_on_mobile: true,

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -12,11 +12,11 @@
 
 <%= render partial: 'explainer' %>
 
-<div class="landing-page__buckets full-page-width-wrapper">
+<div class="landing-page__buckets govuk-width-container">
   <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
 </div>
 
-<div class="full-page-width-wrapper full-page-width-wrapper--landing-page">
+<div class="govuk-width-container landing-page__section">
   <%= render partial: 'brexit_finders', locals: { supergroups: presented_taxon.supergroup_sections, email_path: presented_taxon.email_path } %>
 
   <div class="landing-page__share">

--- a/test/support/brexit_landing_page_steps.rb
+++ b/test/support/brexit_landing_page_steps.rb
@@ -53,7 +53,7 @@ module BrexitLandingPageSteps
   end
 
   def then_i_can_see_the_what_happens_next_section
-    assert page.has_selector?("h2.landing-page__section-title", text: "What happens next")
+    assert page.has_selector?("h2.govuk-heading-l", text: "What happens next")
   end
 
   def then_i_cannot_see_the_get_ready_section
@@ -65,7 +65,7 @@ module BrexitLandingPageSteps
   end
 
   def then_i_can_see_the_buckets_section
-    assert page.has_selector?("h2.landing-page__section-title", text: "What happens next")
+    assert page.has_selector?("h2.govuk-heading-l", text: "What happens next")
   end
 
   def and_i_can_see_an_email_subscription_link
@@ -74,7 +74,7 @@ module BrexitLandingPageSteps
   end
 
   def and_i_can_see_the_explore_topics_section
-    assert page.has_selector?("h2.landing-page__section-title", text: "All Brexit information")
+    assert page.has_selector?("h2.govuk-heading-m", text: "All Brexit information")
 
     supergroups = [
       "Services": "services",


### PR DESCRIPTION
## What
Designers flagged a few tweaks they wanted following from yesterdays update to the Brexit landing page.

1. Alignment of header with translation options.
<img width="1040" alt="Screenshot 2020-01-17 12 34 51" src="https://user-images.githubusercontent.com/3694062/72620885-1a467b80-3938-11ea-8799-3afe23977da8.png">

2. A bit more breathing space between actions and their subheadings.
<img width="998" alt="Screenshot 2020-01-17 12 34 44" src="https://user-images.githubusercontent.com/3694062/72620916-292d2e00-3938-11ea-91ca-1182e519238d.png">

## Changes

**Breathing space**
### Before
![Screenshot_2020-01-17 Brexit(2)](https://user-images.githubusercontent.com/3694062/72621066-727d7d80-3938-11ea-90d5-76219ebd19be.png)

## After
![Screenshot_2020-01-17 Brexit(1)](https://user-images.githubusercontent.com/3694062/72621060-6e516000-3938-11ea-9916-241e3291c6ed.png)

**Header**
Now aligned,

In order to do this I needed more granular control over CSS, so moved this out of using a govuk_publishing_component and into being a normal dumb h1 with some govuk css applied.

The direction of travel from yesterdays change seems to be to prefer using css design system styling over use of publishing components. This makes sense to me as it will allow us to tweak and fiddle a bit more in response to frequent changes.

![Screenshot 2020-01-17 at 14 50 27](https://user-images.githubusercontent.com/3694062/72621220-c25c4480-3938-11ea-9340-90babc44c616.png)

**Tidy up**
The initial implementation continued some tweaks the the CSS. @andysellick pointed out that some of that functionality should be covered by the govuk spacing system.

This PR now removes a whole welt of code that causes divergence from standard GOV.UK layouts.
The result keeps all horizontal lines (light grey and darker black ones) aligned, but also uses the grid system to set spacing internal to rows.

The result allows us to remove a bunch of custom sass for this app.

Changes also mean a couple tweaks to tests that were looking for specific classes.
