### PR TITLE
Add extra route to handle /transition

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,5 +74,6 @@ Rails.application.routes.draw do
 
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
   get "/brexit(.:locale)", to: "brexit_landing_page#show"
+  get "/transition(.:locale)", to: "brexit_landing_page#show"
   get "*taxon_base_path", to: "taxons#show"
 end


### PR DESCRIPTION
Add extra route to handle /transition

We intend to rename the taxon '/brexit' to '/transition'

This adds a route so that the path '/transition' is also rendered
as the brexit landing page.