### PR TITLE
Add schema.org People structured data

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -93,8 +93,8 @@ private
   def role_appointments(current:)
     links
       .fetch("role_appointments", [])
-      .filter { |role_appointment| role_appointment["details"]["current"] == current }
-      .sort_by { |role_appointment| role_appointment["details"]["person_appointment_order"] }
+      .filter { |role_appointment| role_appointment.dig("details", "current") == current }
+      .sort_by { |role_appointment| role_appointment.dig("details", "person_appointment_order") }
   end
 
   def current_role_appointments
@@ -130,6 +130,6 @@ private
   end
 
   def available_translations
-    links["available_translations"].map(&:symbolize_keys)
+    links["available_translations"]&.map(&:symbolize_keys) || []
   end
 end

--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,3 +1,4 @@
+<% if person.biography %>
 <section id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
@@ -9,3 +10,4 @@
     <%= person.biography.html_safe %>
   <% end %>
 </section>
+<% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, person.title %>
 
+<%= render 'govuk_publishing_components/components/machine_readable_metadata',
+           schema: :person,
+           content_item: person.content_item.content_item_data %>
+
 <%= render partial: "header", locals: { person: person } %>
 
 <div class="govuk-grid-row">

--- a/test/integration/person_test.rb
+++ b/test/integration/person_test.rb
@@ -1,0 +1,39 @@
+require "integration_test_helper"
+
+class PersonTest < ActionDispatch::IntegrationTest
+  before do
+    name = "Rufus Scrimgeour"
+    slug = "rufus-scrimgeour"
+    base_path = "/government/people/#{slug}"
+
+    stub_person_page_content_item(base_path, name)
+    stub_person_page_search_query(slug)
+
+    visit base_path
+  end
+
+  it "displays the person page" do
+    assert_equal page.title, "Rufus Scrimgeour - GOV.UK"
+  end
+
+  def stub_person_page_content_item(base_path, name)
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person").merge(
+      "title" => name,
+      "base_path" => base_path,
+    )
+
+    stub_content_store_has_item(base_path, content_item)
+  end
+
+  def stub_person_page_search_query(slug)
+    stub_request(:get, "https://search.test.gov.uk/search.json").
+      with(query: {
+        count: 10,
+        fields: %w(content_store_document_type link public_timestamp title),
+        filter_people: slug,
+        order: "-public_timestamp",
+        reject_content_purpose_supergroup: "other",
+      }).
+      to_return(body: { results: [] }.to_json)
+  end
+end

--- a/test/integration/person_test.rb
+++ b/test/integration/person_test.rb
@@ -16,6 +16,14 @@ class PersonTest < ActionDispatch::IntegrationTest
     assert_equal page.title, "Rufus Scrimgeour - GOV.UK"
   end
 
+  it "shows schema.org Person structured data" do
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    person_schema = schemas.detect { |schema| schema["@type"] == "Person" }
+    assert_equal person_schema["name"], "Rufus Scrimgeour"
+  end
+
   def stub_person_page_content_item(base_path, name)
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person").merge(
       "title" => name,


### PR DESCRIPTION
Also adds a basic spec to make sure people pages render. In doing that, the spec failed on several potentially `nil` bits (based on the content item generated by `GovukSchemas::RandomExample.for_schema`) , so I've added some defence around those.