### PR TITLE
Landing page spacing

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -58,7 +58,7 @@ $red: #E61E32;
 
 .landing-page__section {
   border-top: 2px solid govuk-colour("black");
-  padding-top: govuk-spacing(7);
+  @include govuk-responsive-padding(6, "top");
 }
 
 .landing-page__guidance_subheader {

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -73,7 +73,9 @@ $red: #E61E32;
     border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
     content: "";
     display: block;
-    margin: 0 govuk-spacing(3) govuk-spacing(6);
+    margin-right: govuk-spacing(3);
+    margin-left: govuk-spacing(3);
+    @include govuk-responsive-margin(6, "bottom");
   }
 }
 

--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -99,7 +99,7 @@ $red: #E61E32;
 }
 
 .landing-page__email-wrapper {
-  margin-top: govuk-spacing(7);
+  @include govuk-responsive-margin(8, "top");
   padding: govuk-spacing(6);
   background-color: govuk-colour("light-grey", $legacy: "grey-4");
   border: 1px solid $govuk-border-colour;
@@ -112,4 +112,8 @@ $red: #E61E32;
 .landing-page__divide {
   border-top: 1px solid govuk-colour("white");
   padding-top: govuk-spacing(4);
+}
+
+.landing-page__finders {
+  margin-bottom: 0;
 }

--- a/app/views/brexit_landing_page/_brexit_finders.html.erb
+++ b/app/views/brexit_landing_page/_brexit_finders.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-body govuk-grid-column-two-thirds">
+  <div class="govuk-body govuk-grid-column-two-thirds landing-page__finders">
     <h2 class="govuk-heading-m">
       <%= t('brexit_landing_page.topic_section_header') %>
     </h2>


### PR DESCRIPTION
Trello: https://trello.com/c/v7YlL73F/413-tweak-landing-page-spacing-on-smaller-devices

## What
Add responsive spacing to landing page.

## Why
Some areas of the landing page were using `govuk-spacing` instead of `govuk-responsive-spacing`. As a result, some spacing on the page looked too large when on smaller screens.

## Section heading (desktop before vs after)
<img width="526" alt="Screenshot 2020-01-27 at 11 21 06" src="https://user-images.githubusercontent.com/29889908/73172497-0f8ba380-40fb-11ea-8ed6-06965de9cc5f.png">
<img width="734" alt="Screenshot 2020-01-27 at 11 20 30" src="https://user-images.githubusercontent.com/29889908/73172517-1b776580-40fb-11ea-8cb4-5cdf2e25ded2.png">

## Section heading (mobile before vs after)
<img width="285" alt="Screenshot 2020-01-27 at 11 21 15" src="https://user-images.githubusercontent.com/29889908/73172558-31852600-40fb-11ea-8d56-a7b227f2019c.png">
<img width="256" alt="Screenshot 2020-01-27 at 11 20 35" src="https://user-images.githubusercontent.com/29889908/73172560-31852600-40fb-11ea-8720-ff16f7b97928.png">

## Bucket heading (mobile before vs after)
<img width="292" alt="Screenshot 2020-01-27 at 11 52 24" src="https://user-images.githubusercontent.com/29889908/73172686-7f9a2980-40fb-11ea-9d09-3784e2033d76.png">

<img width="297" alt="Screenshot 2020-01-27 at 11 52 13" src="https://user-images.githubusercontent.com/29889908/73172692-81fc8380-40fb-11ea-9eb1-695e579526c2.png">


