### PR TITLE
Add time based intl helper and test intl

### DIFF
--- a/app/helpers/transition_period_helper.rb
+++ b/app/helpers/transition_period_helper.rb
@@ -1,0 +1,28 @@
+module TransitionPeriodHelper
+  SWITCHOVER_TIME = Time.zone.parse("2020-01-31 23:00:00").in_time_zone
+
+  def time_based_intl
+    if before_switchover_and_not_overridden?
+      "brexit_landing_page"
+    else
+      "transition_landing_page"
+    end
+  end
+
+private
+
+  def before_switchover_and_not_overridden?
+    before_switchover? && !override?
+  end
+
+  def before_switchover?
+    Time.zone.now < SWITCHOVER_TIME
+  end
+
+  def override?
+    return false unless File.exist?("/tmp/transition_override")
+
+    param = request.params["transition_override"]
+    !param.nil? && param == File.read("/tmp/transition_override")
+  end
+end

--- a/app/views/brexit_landing_page/_brexit_finders.html.erb
+++ b/app/views/brexit_landing_page/_brexit_finders.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-body govuk-grid-column-two-thirds landing-page__finders">
     <h2 class="govuk-heading-m">
-      <%= t('brexit_landing_page.topic_section_header') %>
+      <%= t("#{time_based_intl}.topic_section_header") %>
     </h2>
-    <p class="govuk-body"><%= t('brexit_landing_page.topic_section_subheading') %></p>
+    <p class="govuk-body"><%= t("#{time_based_intl}.topic_section_subheading") %></p>
 
     <%= render "components/topic-list", {
       items: supergroups
@@ -15,8 +15,8 @@
   <svg  class="app-c-email-link__icon" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
     <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/>
   </svg>
-  <h3 class="govuk-heading-s landing-page__email-title"><%= t('brexit_landing_page.email_intro') %></h3>
-  <%= link_to(t('brexit_landing_page.email'), "/email-signup/?topic=#{email_path}", {
+  <h3 class="govuk-heading-s landing-page__email-title"><%= t("#{time_based_intl}.email_intro") %></h3>
+  <%= link_to(t("#{time_based_intl}.email"), "/email-signup/?topic=#{email_path}", {
     class: "govuk-body govuk-link",
     data: {
       module: "track-click",

--- a/app/views/brexit_landing_page/_buckets.html.erb
+++ b/app/views/brexit_landing_page/_buckets.html.erb
@@ -1,15 +1,15 @@
 <div class="landing-page__section"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
-  data-list-title="Brexit landing page: <%= t('brexit_landing_page.guidance_header') %>"
+  data-list-title="Brexit landing page: <%= t("#{time_based_intl}.guidance_header") %>"
   data-search-query>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l">
-        <%= t('brexit_landing_page.guidance_header') %>
+        <%= t("#{time_based_intl}.guidance_header") %>
       </h2>
        <p class="landing-page__guidance_subheader">
-        <%= t('brexit_landing_page.guidance_subheader') %>
+        <%= t("#{time_based_intl}.guidance_subheader") %>
       </p>
     </div>
   </div>

--- a/app/views/brexit_landing_page/_explainer.html.erb
+++ b/app/views/brexit_landing_page/_explainer.html.erb
@@ -2,11 +2,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l">
-        <%= t('brexit_landing_page.explainer_title') %>
+        <%= t("#{time_based_intl}.explainer_title") %>
       </h2>
       <%= render "govuk_publishing_components/components/govspeak", {
       } do %>
-        <%= t('brexit_landing_page.explainer_text').html_safe() %>
+        <%= t("#{time_based_intl}.explainer_text").html_safe() %>
       <% end %>
     </div>
   </div>

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -1,14 +1,14 @@
 <% content_for :is_full_width_header, true %>
-<% content_for :title, I18n.t("brexit_landing_page.meta_title") %>
+<% content_for :title, t("#{time_based_intl}.meta_title") %>
 <% content_for :meta_tags do %>
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="GOV.UK">
   <meta property="og:url" content="<%= request.base_url + request.path %>">
-  <meta property="og:title" content="<%= I18n.t("brexit_landing_page.meta_title") %>">
-  <meta property="og:description" content="<%= I18n.t("brexit_landing_page.meta_description") %>">
+  <meta property="og:title" content="<%= t("#{time_based_intl}.meta_title") %>">
+  <meta property="og:description" content="<%= t("#{time_based_intl}.meta_description") %>">
   <meta property="og:image" content="<%= image_url("transition-period.png") %>" />
   <meta name="twitter:card" content="summary">
-  <meta name="description" content="<%= I18n.t("brexit_landing_page.meta_description") %>">
+  <meta name="description" content="<%= t("#{time_based_intl}.meta_description") %>">
   <meta name="govuk:navigation-page-type" content="Taxon Page" />
 <% end %>
 
@@ -29,14 +29,14 @@
       </div>
       <div class="govuk-grid-column-two-thirds">
         <h1 class="landing-page__page_title">
-          <%= I18n.t("brexit_landing_page.page_header") %>
+          <%= t("#{time_based_intl}.page_header") %>
         </h1>
       </div>
 
       <div class="govuk-grid-column-two-thirds landing-page__intro">
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
-          <p><%= t('brexit_landing_page.page_header_explainer') %></p>
+          <p><%= t("#{time_based_intl}.page_header_explainer") %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -24,7 +24,7 @@
       <span class="govuk-visually-hidden">Share on</span>
     <% end %>
     <%= render "govuk_publishing_components/components/share_links", {
-      title: I18n.t("brexit_landing_page.share_links"),
+      title: t("#{time_based_intl}.share_links"),
       columns: true,
       links: [
         {

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-          text: I18n.t('organisations.featured'),
+          text: t('organisations.featured'),
           padding: true,
           margin_bottom: 3,
           lang: t_fallback('organisations.featured')

--- a/app/views/taxons/_brexit_preparation.html.erb
+++ b/app/views/taxons/_brexit_preparation.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("taxons.brexit.prepare_for_eu_exit"),
+        text: t("taxons.brexit.prepare_for_eu_exit"),
         heading_level: 2,
         margin_bottom: 3
       } %>
@@ -10,16 +10,16 @@
   </div>
   <ul class="taxon-page__link-list">
     <li class="taxon-page__link-list-item">
-      <a href="/business-uk-leaving-eu"><%= I18n.t("taxons.brexit.business_preparations") %></a>
+      <a href="/business-uk-leaving-eu"><%= t("taxons.brexit.business_preparations") %></a>
     </li>
     <li class="taxon-page__link-list-item">
-      <a href="/prepare-eu-exit"><%= I18n.t("taxons.brexit.uk_resident_preparations") %></a>
+      <a href="/prepare-eu-exit"><%= t("taxons.brexit.uk_resident_preparations") %></a>
     </li>
     <li class="taxon-page__link-list-item">
-      <a href="/uk-nationals-living-eu"><%= I18n.t("taxons.brexit.uk_nationals_in_eu_preparations") %></a>
+      <a href="/uk-nationals-living-eu"><%= t("taxons.brexit.uk_nationals_in_eu_preparations") %></a>
     </li>
     <li class="taxon-page__link-list-item">
-      <a href="/staying-uk-eu-citizen"><%= I18n.t("taxons.brexit.eu_citizens_in_uk_preparations") %></a>
+      <a href="/staying-uk-eu-citizen"><%= t("taxons.brexit.eu_citizens_in_uk_preparations") %></a>
     </li>
   </ul>
 </div>

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -44,50 +44,50 @@ cy:
       policy_and_engagement: Polisi ac ymgynghoriadau
       transparency: Tryloywder a datganiadau rhyddid gwybodaeth
   transition_landing_page:
-    meta_title: Integration Test
-    meta_description: Integration Test
-    page_header: Integration Test
-    page_header_explainer: Integration Test
-    explainer_title: Integration Test
+    meta_title: "Y cyfnod pontio"
+    meta_description: "Mae’r DU wedi gadael yr UE. Ewch i weld beth mae’n ei olygu i chi."
+    page_header: Mae’r DU wedi gadael yr UE
+    page_header_explainer: Darganfyddwch beth mae hyn yn ei olygu i chi.
+    explainer_title: Y cyfnod pontio
     explainer_text: |
-      <p>Integration Test</p>
-      <p>Integration Test</p>
-      <p>Integration Test</p>
-      <p><a href="https://duckduckgo.com">Now with added link</a></p>
-    guidance_header: "Integration Test"
-    guidance_subheader: "Integration Test"
+      <p>Bydd cyfnod pontio tan ddiwedd 2020 tra bod y DU a’r UE yn trafod trefniadau ychwanegol.</p>
+      <p>Bydd y rheolau cyfredol ar fasnach, teithio a busnes ar gyfer y DU a’r UE yn parhau i fod yn berthnasol yn ystod y cyfnod pontio.</p>
+      <p>Bydd rheolau newydd yn dod i rym ar 1 Ionawr 2021.</p>
+      <p>Dylech baratoi nawr a thanysgrifio i ddiweddariadau ebost am unrhyw drefniadau ychwanegol.</p>
+      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021">Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021</a>
+    guidance_header: "Beth allwch chi wneud nawr"
+    guidance_subheader: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
     campaign_buckets:
       - row_title: "Paratoi eich busnes"
         list_block: |
-          Ewch i weld beth mae angen i chi ei wneud os ydych chi’n:
+          Ar ôl 1 Ionawr 2021, bydd angen i chi wneud datganiadau tollau i symud nwyddau i mewn ac allan o’r UE. Dylech chi:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="mewnforio nwyddau o’r UE">mewnforio nwyddau o’r UE</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="allforio nwyddau i’r UE">allforio nwyddau i’r UE</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="cludo nwyddau o’r DU ar y ffyrdd">cludo nwyddau o’r DU ar y ffyrdd</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="gael rhif EORI">gael rhif EORI</a> os nad oes gennych un yn barod</li>
+            <li>penderfynu sut yr hoffech wneud datganiadau tollau ac os oes angen i chi gael <a class="govuk-!-font-weight-bold" href="/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="rhywun i ddelio â’r tollau ar eich rhan">rhywun i ddelio â’r tollau ar eich rhan</a>.</li>
           </ul>
-      - row_title: "Aros yn y DU os ydych yn ddinesydd yr UE"
+      - row_title: "Aros yn y DU os ydych yn ddinesydd o’r UE"
         list_block: |
-          Holwch a oes angen i chi wneud cais ar gyfer y cynllun preswylio os ydych chi neu'ch teulu yn dod o'r UE, neu o'r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
+          Gwiriwch os oes angen i chi gyflwyno cais i’r cynllun setliad os ydych chi, neu’ch teulu, yn dod o’r UE, neu o’r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
 
-          <a href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Ewch i weld beth mae angen i chi ei wneud er mwyn aros yn y DU">Ewch i weld beth mae angen i chi ei wneud er mwyn aros yn y DU</a>
+          <a href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Gwiriwch beth sydd angen i chi wneud i aros yn y DU">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
       - row_title: "Byw a gweithio yn yr UE"
         list_block: |
-          Mae byw a gweithio mewn gwlad yn yr UE yn dibynnu ar y rheolau yn y wlad honno.
+          Mae byw a gweithio mewn gwlad yr UE yn ddibynnol ar y rheolau yn y wlad honno.
 
-          Efallai y bydd angen i chi gofrestru neu wneud cais am breswyliaeth. Dylech gadarnhau beth yw’r trefniadau gofal iechyd.
+          Efallai bydd angen i chi gofrestru neu gyflwyno cais am breswyliaeth. Dylech chi wirio os ydych chi’n gymwys am ofal iechyd.
 
-          Efallai y bydd angen i chi gyfnewid eich trwydded yrru o'r DU am drwydded a gyhoeddwyd gan wlad rydych chi’n byw ynddi yn yr UE.
+          Efallai bydd angen i chi gyfnewid eich trwydded yrru DU am drwydded a roddir gan wlad yr UE ble rydych yn byw.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Ewch i weld beth mae’n rhaid i chi ei wneud yn y wlad rydych chi’n byw ynddi">Ewch i weld beth mae’n rhaid i chi ei wneud yn y wlad rydych chi’n byw ynddi</a>
-    topic_section_header: Integration Test
-    topic_section_subheading: Integration Test
-    email_intro: Integration Test
-    email: Integration Test
-    share_links: Integration Test
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi</a>
+    topic_section_header: Holl wybodaeth y cyfnod pontio
+    topic_section_subheading: Pori’r holl wybodaeth sy’n berthnasol i’r cyfnod pontio
+    email_intro: "I gael y manylion diweddaraf"
+    email: "Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio"
+    share_links: "Rhannu’r dudalen hon"
     sections:
-      services: Services
-      guidance_and_regulation: Guidance and regulation
-      news_and_communications: News and communications
-      research_and_statistics: Research and statistics
-      policy_and_engagement: Policy papers and consultations
-      transparency: Transparency and freedom of information releases
+      services: Gwasanaethau
+      guidance_and_regulation: Canllawiau a rheoliadau
+      news_and_communications: Newyddion a chyfathrebu
+      research_and_statistics: Ymchwil ag ystadegau
+      policy_and_engagement: Polisi ac ymgynghoriadau
+      transparency: Tryloywder a datganiadau rhyddid gwybodaeth

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -43,3 +43,51 @@ cy:
       research_and_statistics: Ymchwil ag ystadegau
       policy_and_engagement: Polisi ac ymgynghoriadau
       transparency: Tryloywder a datganiadau rhyddid gwybodaeth
+  transition_landing_page:
+    meta_title: Integration Test
+    meta_description: Integration Test
+    page_header: Integration Test
+    page_header_explainer: Integration Test
+    explainer_title: Integration Test
+    explainer_text: |
+      <p>Integration Test</p>
+      <p>Integration Test</p>
+      <p>Integration Test</p>
+      <p><a href="https://duckduckgo.com">Now with added link</a></p>
+    guidance_header: "Integration Test"
+    guidance_subheader: "Integration Test"
+    campaign_buckets:
+      - row_title: "Paratoi eich busnes"
+        list_block: |
+          Ewch i weld beth mae angen i chi ei wneud os ydych chi’n:
+          <ul>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="mewnforio nwyddau o’r UE">mewnforio nwyddau o’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="allforio nwyddau i’r UE">allforio nwyddau i’r UE</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="cludo nwyddau o’r DU ar y ffyrdd">cludo nwyddau o’r DU ar y ffyrdd</a></li>
+          </ul>
+      - row_title: "Aros yn y DU os ydych yn ddinesydd yr UE"
+        list_block: |
+          Holwch a oes angen i chi wneud cais ar gyfer y cynllun preswylio os ydych chi neu'ch teulu yn dod o'r UE, neu o'r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
+
+          <a href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Ewch i weld beth mae angen i chi ei wneud er mwyn aros yn y DU">Ewch i weld beth mae angen i chi ei wneud er mwyn aros yn y DU</a>
+      - row_title: "Byw a gweithio yn yr UE"
+        list_block: |
+          Mae byw a gweithio mewn gwlad yn yr UE yn dibynnu ar y rheolau yn y wlad honno.
+
+          Efallai y bydd angen i chi gofrestru neu wneud cais am breswyliaeth. Dylech gadarnhau beth yw’r trefniadau gofal iechyd.
+
+          Efallai y bydd angen i chi gyfnewid eich trwydded yrru o'r DU am drwydded a gyhoeddwyd gan wlad rydych chi’n byw ynddi yn yr UE.
+
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Ewch i weld beth mae’n rhaid i chi ei wneud yn y wlad rydych chi’n byw ynddi">Ewch i weld beth mae’n rhaid i chi ei wneud yn y wlad rydych chi’n byw ynddi</a>
+    topic_section_header: Integration Test
+    topic_section_subheading: Integration Test
+    email_intro: Integration Test
+    email: Integration Test
+    share_links: Integration Test
+    sections:
+      services: Services
+      guidance_and_regulation: Guidance and regulation
+      news_and_communications: News and communications
+      research_and_statistics: Research and statistics
+      policy_and_engagement: Policy papers and consultations
+      transparency: Transparency and freedom of information releases

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -44,26 +44,26 @@ en:
       policy_and_engagement: Policy papers and consultations
       transparency: Transparency and freedom of information releases
   transition_landing_page:
-    meta_title: Integration Test
-    meta_description: Integration Test
-    page_header: Integration Test
-    page_header_explainer: Integration Test
-    explainer_title: Integration Test
+    meta_title: The transition period
+    meta_description: The UK has left the EU. Find out what this means for you.
+    page_header: The UK has left the EU
+    page_header_explainer: Find out what this means for you.
+    explainer_title: The transition period
     explainer_text: |
-      <p>Integration Test</p>
-      <p>Integration Test</p>
-      <p>Integration Test</p>
-      <p><a href="https://duckduckgo.com">Now with added link</a></p>
-    guidance_header: "Integration Test"
-    guidance_subheader: "Integration Test"
+      <p>There is now a transition period until the end of 2020 while the UK and EU negotiate additional arrangements.</p>
+      <p>The current rules on trade, travel, and business for the UK and EU will continue to apply during the transition period.</p>
+      <p>New rules will take effect on 1 January 2021.</p>
+      <p>You should prepare now and subscribe to email updates about any additional arrangements.</p>
+      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Check how to get ready for new rules in 2021">Check how to get ready for new rules in 2021</a></p>
+    guidance_header: "What you can do now"
+    guidance_subheader: "Actions you can take now that do not depend on negotiations."
     campaign_buckets:
       - row_title: "Preparing your business"
         list_block: |
-          Check what you need to do if you:
+          From 1 January 2021 you will need to make customs declarations to move goods into and out of the EU. You should:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="import goods from the EU">import goods from the EU</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="export goods to the EU">export goods to the EU</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="transport goods out of the UK by road">transport goods out of the UK by road</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="get an EORI number">get an EORI number</a> if you do not already have one</li>
+            <li>decide how you want to make customs declarations and whether you need to <a class="govuk-!-font-weight-bold" href="/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="get someone to deal with customs for you">get someone to deal with customs for you</a>.</li>
           </ul>
       - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
@@ -78,12 +78,12 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a
-    topic_section_header: Integration Test
-    topic_section_subheading: Integration Test
-    email_intro: Integration Test
-    email: Integration Test
-    share_links: Integration Test
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
+    topic_section_header: All transition period information
+    topic_section_subheading: Browse all information related to the transition period
+    email_intro: "Stay up to date"
+    email: Sign up for email updates about the transition period
+    share_links: "Share this page"
     sections:
       services: Services
       guidance_and_regulation: Guidance and regulation

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -43,3 +43,51 @@ en:
       research_and_statistics: Research and statistics
       policy_and_engagement: Policy papers and consultations
       transparency: Transparency and freedom of information releases
+  transition_landing_page:
+    meta_title: Integration Test
+    meta_description: Integration Test
+    page_header: Integration Test
+    page_header_explainer: Integration Test
+    explainer_title: Integration Test
+    explainer_text: |
+      <p>Integration Test</p>
+      <p>Integration Test</p>
+      <p>Integration Test</p>
+      <p><a href="https://duckduckgo.com">Now with added link</a></p>
+    guidance_header: "Integration Test"
+    guidance_subheader: "Integration Test"
+    campaign_buckets:
+      - row_title: "Preparing your business"
+        list_block: |
+          Check what you need to do if you:
+          <ul>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-import-to-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-import-to-uk-after-brexit" data-track-label="import goods from the EU">import goods from the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/prepare-export-from-uk-after-brexit" data-track-category="transition-landing-page" data-track-action="/prepare-export-from-uk-after-brexit" data-track-label="export goods to the EU">export goods to the EU</a></li>
+            <li><a class="govuk-!-font-weight-bold" href="/transport-goods-from-uk-by-road" data-track-category="transition-landing-page" data-track-action="/transport-goods-from-uk-by-road" data-track-label="transport goods out of the UK by road">transport goods out of the UK by road</a></li>
+          </ul>
+      - row_title: "Staying in the UK if you’re an EU citizen"
+        list_block: |
+          Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
+
+          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Check what you need to do to stay in the UK">Check what you need to do to stay in the UK</a>
+      - row_title: "Living and working in the EU"
+        list_block: |
+          Living and working in an EU country depends on the rules in that country.
+
+          You may need to register or apply for residency. You should check that you’re covered for healthcare.
+
+          You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
+
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a
+    topic_section_header: Integration Test
+    topic_section_subheading: Integration Test
+    email_intro: Integration Test
+    email: Integration Test
+    share_links: Integration Test
+    sections:
+      services: Services
+      guidance_and_regulation: Guidance and regulation
+      news_and_communications: News and communications
+      research_and_statistics: Research and statistics
+      policy_and_engagement: Policy papers and consultations
+      transparency: Transparency and freedom of information releases


### PR DESCRIPTION
Trello: https://trello.com/c/feQSo8wO/412-spike-release-cache-11pm-launch

## Background
We will need to deploy new content to the landing page at a fixed time to meet upcoming brexit deadlines.

Deployment pipelines vary and are unreliable, so in order to get a time-specific deploy we don't want tor rely on them.

Instead this adds flow control to use alongside an intl migration with a timegate.
It also allows for an override to check that all is functioning well, based on a shared secret in ENV.

## Specific changes
- Added fake test integration intl translations to test
- Set a test time of 13:45, at which we can clear a cache and see if it rolls over in <1min
- Standardised a few differences between where we were using `I18t.t()` and `t()`