### PR TITLE
Lower the  browser cache of the transition page

### DIFF
--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -1,4 +1,7 @@
 class BrexitLandingPageController < ApplicationController
+  skip_before_action :set_expiry
+  before_action -> { set_expiry(1.minute) }
+
   around_action :switch_locale
 
   def show


### PR DESCRIPTION
Trello: https://trello.com/c/feQSo8wO/412-spike-release-cache-11pm-launch
We need to be able to update the transition page quickly.