### PR TITLE
Update landing page header colour

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -15,7 +15,7 @@ $red: #E61E32;
   padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(6);
-  background-color: $govuk-brand-colour;
+  background-color: $dark-blue;
   color: govuk-colour("white");
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/Aru0bAZJ/422-update-the-landing-page-header-colour

## What
Update landing page header to dark blue.

<img width="1019" alt="Screenshot 2020-01-28 at 15 13 36" src="https://user-images.githubusercontent.com/29889908/73276553-c9107480-41e0-11ea-8f90-42374e164b71.png">
