### PR TITLE
Landing page improvements

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -57,6 +57,7 @@ $red: #E61E32;
 }
 
 .landing-page__section {
+  margin-top: govuk-spacing(4);
   border-top: 2px solid govuk-colour("black");
   @include govuk-responsive-padding(6, "top");
 }
@@ -96,7 +97,6 @@ $red: #E61E32;
 }
 
 .landing-page__buckets {
-  padding-top: govuk-spacing(6);
   margin-bottom: govuk-spacing(6);
 }
 

--- a/app/views/brexit_landing_page/_explainer.html.erb
+++ b/app/views/brexit_landing_page/_explainer.html.erb
@@ -1,13 +1,11 @@
-<div class="full-page-width-wrapper">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l">
-        <%= t("transition_landing_page.explainer_title") %>
-      </h2>
-      <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-        <%= t("transition_landing_page.explainer_text").html_safe() %>
-      <% end %>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">
+      <%= t("transition_landing_page.explainer_title") %>
+    </h2>
+    <%= render "govuk_publishing_components/components/govspeak", {
+    } do %>
+      <%= t("transition_landing_page.explainer_text").html_safe() %>
+    <% end %>
   </div>
 </div>

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -10,49 +10,51 @@
   )
 %>
 
-<%= render partial: 'explainer' %>
+<div class="govuk-width-container">
+  <%= render partial: 'explainer' %>
 
-<div class="landing-page__buckets govuk-width-container">
-  <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
-</div>
+  <div class="landing-page__buckets">
+    <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
+  </div>
 
-<div class="govuk-width-container landing-page__section">
-  <%= render partial: 'brexit_finders', locals: { supergroups: presented_taxon.supergroup_sections, email_path: presented_taxon.email_path } %>
+  <div class="landing-page__section">
+    <%= render partial: 'brexit_finders', locals: { supergroups: presented_taxon.supergroup_sections, email_path: presented_taxon.email_path } %>
 
-  <div class="landing-page__share">
-    <% hidden_text = capture do %>
-      <span class="govuk-visually-hidden">Share on</span>
-    <% end %>
-    <%= render "govuk_publishing_components/components/share_links", {
-      title: t("transition_landing_page.share_links"),
-      columns: true,
-      links: [
-        {
-          href: "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
-          text: hidden_text + "Facebook",
-          icon: "facebook"
-        },
-        {
-          href: "https://twitter.com/share?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
-          text: hidden_text + "Twitter",
-          icon: "twitter"
-        },
-        {
-          href: "mailto:?body=https://www.gov.uk#{CGI.escape(request.fullpath)}/&subject=#{t('transition_landing_page.email_mailto_subject')}",
-          text: hidden_text + "Email",
-          icon: "email"
-        },
-        {
-          href: "https://api.whatsapp.com/send?text=https://www.gov.uk#{CGI.escape(request.fullpath)}",
-          text: hidden_text + "WhatsApp",
-          icon: "whatsapp"
-        },
-        {
-          href: "http://www.linkedin.com/shareArticle?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}&title=#{t('transition_landing_page.email_mailto_subject')}",
-          text: hidden_text + "LinkedIn",
-          icon: "linkedin"
-        },
-      ]
-    } %>
+    <div class="landing-page__share">
+      <% hidden_text = capture do %>
+        <span class="govuk-visually-hidden">Share on</span>
+      <% end %>
+      <%= render "govuk_publishing_components/components/share_links", {
+        title: t("transition_landing_page.share_links"),
+        columns: true,
+        links: [
+          {
+            href: "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
+            text: hidden_text + "Facebook",
+            icon: "facebook"
+          },
+          {
+            href: "https://twitter.com/share?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
+            text: hidden_text + "Twitter",
+            icon: "twitter"
+          },
+          {
+            href: "mailto:?body=https://www.gov.uk#{CGI.escape(request.fullpath)}/&subject=#{t('transition_landing_page.email_mailto_subject')}",
+            text: hidden_text + "Email",
+            icon: "email"
+          },
+          {
+            href: "https://api.whatsapp.com/send?text=https://www.gov.uk#{CGI.escape(request.fullpath)}",
+            text: hidden_text + "WhatsApp",
+            icon: "whatsapp"
+          },
+          {
+            href: "http://www.linkedin.com/shareArticle?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}&title=#{t('transition_landing_page.email_mailto_subject')}",
+            text: hidden_text + "LinkedIn",
+            icon: "linkedin"
+          },
+        ]
+      } %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## What

- Move multiple uses of `govuk-width-container` to a common parent
- Remove uses of `full-page-width-wrapper`
- Attempt to standardise landing page section spacing (previously, some sections applied both bottom and top spacing).

There should be no visual changes as a result of this PR.
Example: https://govuk-collec-landing-pa-m9vnq4.herokuapp.com/transition

**Note: this isn't a full refactor, but what is needed to add a new section to the page in a follow-up PR. I'll do a clean-up at some point as it looks like there could be a fair amount of repetition/unused styles left over from previous iterations of the landing page.**