### PR TITLE
Fix world taxon sorting

### DIFF
--- a/app/lib/world_taxonomy_sorter.rb
+++ b/app/lib/world_taxonomy_sorter.rb
@@ -1,7 +1,7 @@
 class WorldTaxonomySorter
   WORLD_TAXONOMY_ORDER = [
     "Emergency help for British nationals",
-    "Brexit",
+    "Transition",
     "Passports and emergency travel documents",
     "Travelling to",
     "Coming to the UK",

--- a/test/lib/world_taxonomy_sorter_test.rb
+++ b/test/lib/world_taxonomy_sorter_test.rb
@@ -12,7 +12,7 @@ describe WorldTaxonomySorter do
   setup do
     child_taxon_titles = [
      "Birth, death and marriage abroad",
-     "Brexit",
+     "Transition",
      "British embassy or high commission",
      "Coming to the UK",
      "Emergency help for British nationals",
@@ -27,7 +27,7 @@ describe WorldTaxonomySorter do
 
     @expected_ordered_taxon_titles = [
       "Emergency help for British nationals",
-      "Brexit",
+      "Transition",
       "Passports and emergency travel documents",
       "Travelling to",
       "Coming to the UK",


### PR DESCRIPTION
This is semi-hardcoded.  Taxons that don't appear in the list appear below those that do.  The Brexit taxon has been renamed to Transition now.

Updating this to perhaps use content_ids may be worth doing, as this should then ignore name changes.

Test on pages like https://www.gov.uk/world/austria vs https://govuk-collec-transition-wgqar6.herokuapp.com/world/austria