### PR TITLE
Update Organisation breadcrumb to show parent

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -13,10 +13,6 @@ module Organisations
           url: "/",
         },
         index_page_breadcrumb,
-        {
-          title: @org.title,
-          is_current_page: true,
-        },
       ]
     end
 

--- a/test/integration/courts_pages_test.rb
+++ b/test/integration/courts_pages_test.rb
@@ -5,8 +5,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
 
   it "renders a courts page correctly" do
     when_i_visit_a_courts_page
-    i_see_the_current_page_breadcrumb
-    and_the_courts_breadcrumb
+    i_see_the_courts_breadcrumb
     the_courts_title
     and_featured_links
     and_the_what_we_do_section
@@ -19,8 +18,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
 
   it "renders an HMCTS tribunal page correctly" do
     when_i_visit_an_hmcts_tribunal_page
-    i_see_the_current_page_breadcrumb
-    and_the_courts_breadcrumb
+    i_see_the_courts_breadcrumb
     the_courts_title
     and_featured_links
     and_the_what_we_do_section

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -525,15 +525,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     within ".gem-c-breadcrumbs" do
       assert page.has_link?("Home", href: "/")
       assert page.has_link?("Organisations", href: "/government/organisations")
-
-      assert page.has_css?(".govuk-breadcrumbs__link", text: "Prime Minister's Office, 10 Downing Street")
     end
 
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?(".govuk-breadcrumbs__link", text: "Attorney General's Office")
+    assert page.has_css?(".govuk-breadcrumbs__link", text: "Organisations")
 
     visit "/government/organisations/charity-commission"
-    assert page.has_css?(".govuk-breadcrumbs__link", text: "The Charity Commission")
+    assert page.has_css?(".govuk-breadcrumbs__link", text: "Organisations")
   end
 
   it "sets the page title" do

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -701,11 +701,7 @@ module OrganisationHelpers
     visit content["base_path"]
   end
 
-  def i_see_the_current_page_breadcrumb
-    assert page.has_css?(".gem-c-breadcrumbs", text: @title)
-  end
-
-  def and_the_courts_breadcrumb
+  def i_see_the_courts_breadcrumb
     assert page.has_css?(".gem-c-breadcrumbs", text: "Courts and Tribunals")
   end
 


### PR DESCRIPTION
Adjust the breadcrumb to show the parent organisation link as the last item instead of the current page the anchor links to itself.

Removed "is_current_page" attribute from the organisation breadcrumb as it is inconsistent with mobile breadcrumb styling

https://trello.com/c/i1LS8Acr/24-fix-breadcrumbs-for-organisation-pages