### PR TITLE
Update news story links on transition page

### DIFF
--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -29,13 +29,6 @@ cy:
           public_updated_at: 2020-02-03
           document_type: "Written Statement to Parliament"
       - link:
-          text: "Prime Minister’s address to the nation on leaving the EU"
-          path: "/government/speeches/pm-address-to-the-nation-31-january-2020"
-          description: "Prime Minister Boris Johnson addresses the nation as the UK leaves the EU."
-        metadata:
-          public_updated_at: 2020-01-31
-          document_type: "Speech"
-      - link:
           text: "The Withdrawal Agreement and Political Declaration"
           path: "/government/publications/new-withdrawal-agreement-and-political-declaration"
           description: "The Withdrawal Agreement is the UK and EU’s agreement on the UK leaving the EU. It shows the terms of the UK’s exit and sets out the framework for the future relationship between the UK and EU."

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -15,6 +15,13 @@ cy:
     comms:
       links:
       - link:
+          text: "Government confirms plans to introduce import controls"
+          path: "/government/news/government-confirms-plans-to-introduce-import-controls"
+          description: "The government has confirmed plans to introduce import controls on EU goods at the border after the transition period ends on 31 December 2020."
+        metadata:
+          public_updated_at: 2020-02-10
+          document_type: "Press Release"
+      - link:
           text: "The future relationship between the UK and the EU"
           path: "/government/speeches/the-future-relationship-between-the-uk-and-the-eu"
           description: "This statement sets out the Government’s proposed approach to the negotiations with the EU about our future relationship."

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -15,6 +15,13 @@ en:
     comms:
       links:
       - link:
+          text: "Government confirms plans to introduce import controls"
+          path: "/government/news/government-confirms-plans-to-introduce-import-controls"
+          description: "The government has confirmed plans to introduce import controls on EU goods at the border after the transition period ends on 31 December 2020."
+        metadata:
+          public_updated_at: 2020-02-10
+          document_type: "Press Release"
+      - link:
           text: "The future relationship between the UK and the EU"
           path: "/government/speeches/the-future-relationship-between-the-uk-and-the-eu"
           description: "This statement sets out the Government’s proposed approach to the negotiations with the EU about our future relationship."

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -29,13 +29,6 @@ en:
           public_updated_at: 2020-02-03
           document_type: "Written Statement to Parliament"
       - link:
-          text: "Prime Minister’s address to the nation on leaving the EU"
-          path: "/government/speeches/pm-address-to-the-nation-31-january-2020"
-          description: "Prime Minister Boris Johnson addresses the nation as the UK leaves the EU."
-        metadata:
-          public_updated_at: 2020-01-31
-          document_type: "Speech"
-      - link:
           text: "The Withdrawal Agreement and Political Declaration"
           path: "/government/publications/new-withdrawal-agreement-and-political-declaration"
           description: "The Withdrawal Agreement is the UK and EU’s agreement on the UK leaving the EU. It shows the terms of the UK’s exit and sets out the framework for the future relationship between the UK and EU."


### PR DESCRIPTION
1. Add this news story to the transition landing page, at the top of the news stories list.

### path

`/government/news/government-confirms-plans-to-introduce-import-controls`

### title

_Government confirms plans to introduce import controls_

###  description

_The government has confirmed plans to introduce import controls on EU goods at the border after the transition period ends on 31 December 2020._

2. Remove the second story in the list, i.e. https://www.gov.uk/government/speeches/pm-address-to-the-nation-31-january-2020.

<img width="799" alt="Screenshot 2020-02-11 at 16 00 45" src="https://user-images.githubusercontent.com/3141541/74254505-722e9300-4ce8-11ea-8bb3-a7ef0c3cec49.png">


---

https://trello.com/c/KrxoDTZl/496-add-news-story-to-the-transition-page