### PR TITLE
Remove references to dynamic lists on Brexit landing page

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -10,7 +10,6 @@ class TransitionLandingPageController < ApplicationController
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
-      show_dynamic_list: show_dynamic_list?,
       show_comms: show_comms?,
     }
   end
@@ -32,10 +31,6 @@ private
         text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
       }
     end
-  end
-
-  def show_dynamic_list?
-    false
   end
 
   def show_comms?

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -4,8 +4,7 @@
   render(
       partial: 'page_header',
       locals: {
-        presented_taxon: presented_taxon,
-        show_dynamic_list: show_dynamic_list
+        presented_taxon: presented_taxon
       }
   )
 %>

--- a/test/integration/transition_landing_page_test.rb
+++ b/test/integration/transition_landing_page_test.rb
@@ -4,10 +4,10 @@ require_relative "../support/transition_landing_page_steps"
 class TransitionLandingPageTest < ActionDispatch::IntegrationTest
   include TransitionLandingPageSteps
 
-  context "when there should be a dynamic list" do
-    it "renders the brexit page" do
+  describe "the transition landing page" do
+    it "renders" do
       given_there_is_a_transition_taxon
-      when_i_visit_the_transition_landing_page_with_dynamic_list
+      when_i_visit_the_transition_landing_page
       then_i_can_see_the_buckets_section
       then_i_can_see_the_title_section
       then_i_can_see_the_header_section
@@ -19,7 +19,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
 
     it "has tracking on all links" do
       given_there_is_a_transition_taxon
-      when_i_visit_the_transition_landing_page_with_dynamic_list
+      when_i_visit_the_transition_landing_page
       then_all_finder_links_have_tracking_data
       and_the_email_link_is_tracked
       and_ecommerce_tracking_is_setup
@@ -27,15 +27,13 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
 
     it "is not noindexed" do
       given_there_is_a_transition_taxon
-      when_i_visit_the_transition_landing_page_with_dynamic_list
+      when_i_visit_the_transition_landing_page
       then_the_page_is_not_noindexed
     end
-  end
 
-  context "when there should not be a dynamic list" do
-    it "does not show the list" do
+    it "does not show the dynamic list" do
       given_there_is_a_transition_taxon
-      when_i_visit_the_transition_landing_page_without_dynamic_list
+      when_i_visit_the_transition_landing_page
       then_i_cannot_see_the_get_ready_section
     end
   end

--- a/test/integration/transition_landing_page_test.rb
+++ b/test/integration/transition_landing_page_test.rb
@@ -6,7 +6,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
 
   context "when there should be a dynamic list" do
     it "renders the brexit page" do
-      given_there_is_a_brexit_taxon
+      given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page_with_dynamic_list
       then_i_can_see_the_buckets_section
       then_i_can_see_the_title_section
@@ -18,7 +18,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
     end
 
     it "has tracking on all links" do
-      given_there_is_a_brexit_taxon
+      given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page_with_dynamic_list
       then_all_finder_links_have_tracking_data
       and_the_email_link_is_tracked
@@ -26,7 +26,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
     end
 
     it "is not noindexed" do
-      given_there_is_a_brexit_taxon
+      given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page_with_dynamic_list
       then_the_page_is_not_noindexed
     end
@@ -34,7 +34,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
 
   context "when there should not be a dynamic list" do
     it "does not show the list" do
-      given_there_is_a_brexit_taxon
+      given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page_without_dynamic_list
       then_i_cannot_see_the_get_ready_section
     end

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -6,32 +6,15 @@ module TransitionLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include RummagerHelpers
 
+  CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+  TRANSITION_TAXON_PATH = "/transition".freeze
+
   def given_there_is_a_transition_taxon
-    stub_content_store_has_item(transition_taxon_path, content_item)
-  end
-
-  def transition_taxon_path
-    "/transition"
-  end
-
-  def content_id
-    "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
-  end
-
-  def content_item
-    GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
-      item.merge(
-        "base_path" => transition_taxon_path,
-        "content_id" => content_id,
-        "title" => "Transition",
-        "phase" => "live",
-        "links" => {},
-      )
-    end
+    stub_content_store_has_item(TRANSITION_TAXON_PATH, content_item)
   end
 
   def when_i_visit_the_transition_landing_page
-    visit transition_taxon_path
+    visit TRANSITION_TAXON_PATH
   end
 
   def then_i_can_see_the_title_section
@@ -63,7 +46,7 @@ module TransitionLandingPageSteps
   end
 
   def and_i_can_see_an_email_subscription_link
-    assert page.has_selector?('a[href="/email-signup/?topic=' + transition_taxon_path + '"]')
+    assert page.has_selector?('a[href="/email-signup/?topic=' + TRANSITION_TAXON_PATH + '"]')
     assert page.has_text?("Sign up for email updates about the transition period")
   end
 
@@ -82,7 +65,7 @@ module TransitionLandingPageSteps
     supergroups.each do |_|
       assert page.has_link?(
         "Services",
-        href: "/search/services?parent=%2Ftransition&topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        href: "/search/services?parent=#{CGI.escape(TRANSITION_TAXON_PATH)}&topic=#{CONTENT_ID}",
       )
     end
   end
@@ -112,5 +95,17 @@ module TransitionLandingPageSteps
 
   def then_the_page_is_not_noindexed
     page.assert_no_selector('meta[name="robots"]', visible: false)
+  end
+
+  def content_item
+    GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
+      item.merge(
+        "base_path" => TRANSITION_TAXON_PATH,
+        "content_id" => CONTENT_ID,
+        "title" => "Transition",
+        "phase" => "live",
+        "links" => {},
+      )
+    end
   end
 end

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -30,13 +30,7 @@ module TransitionLandingPageSteps
     end
   end
 
-  def when_i_visit_the_transition_landing_page_with_dynamic_list
-    TransitionLandingPageController.any_instance.stubs(:show_dynamic_list?).returns(true)
-    visit transition_taxon_path
-  end
-
-  def when_i_visit_the_transition_landing_page_without_dynamic_list
-    TransitionLandingPageController.any_instance.stubs(:show_dynamic_list?).returns(false)
+  def when_i_visit_the_transition_landing_page
     visit transition_taxon_path
   end
 

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -6,7 +6,7 @@ module TransitionLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include RummagerHelpers
 
-  CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
+  TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
   TRANSITION_TAXON_PATH = "/transition".freeze
 
   def given_there_is_a_transition_taxon
@@ -65,7 +65,7 @@ module TransitionLandingPageSteps
     supergroups.each do |_|
       assert page.has_link?(
         "Services",
-        href: "/search/services?parent=#{CGI.escape(TRANSITION_TAXON_PATH)}&topic=#{CONTENT_ID}",
+        href: "/search/services?parent=#{CGI.escape(TRANSITION_TAXON_PATH)}&topic=#{TRANSITION_TAXON_CONTENT_ID}",
       )
     end
   end
@@ -101,7 +101,7 @@ module TransitionLandingPageSteps
     GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
       item.merge(
         "base_path" => TRANSITION_TAXON_PATH,
-        "content_id" => CONTENT_ID,
+        "content_id" => TRANSITION_TAXON_CONTENT_ID,
         "title" => "Transition",
         "phase" => "live",
         "links" => {},

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -6,12 +6,12 @@ module TransitionLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include RummagerHelpers
 
-  def given_there_is_a_brexit_taxon
-    stub_content_store_has_item(brexit_taxon_path, content_item)
+  def given_there_is_a_transition_taxon
+    stub_content_store_has_item(transition_taxon_path, content_item)
   end
 
-  def brexit_taxon_path
-    "/brexit"
+  def transition_taxon_path
+    "/transition"
   end
 
   def content_id
@@ -21,9 +21,9 @@ module TransitionLandingPageSteps
   def content_item
     GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
       item.merge(
-        "base_path" => brexit_taxon_path,
+        "base_path" => transition_taxon_path,
         "content_id" => content_id,
-        "title" => "Brexit",
+        "title" => "Transition",
         "phase" => "live",
         "links" => {},
       )
@@ -32,12 +32,12 @@ module TransitionLandingPageSteps
 
   def when_i_visit_the_transition_landing_page_with_dynamic_list
     TransitionLandingPageController.any_instance.stubs(:show_dynamic_list?).returns(true)
-    visit brexit_taxon_path
+    visit transition_taxon_path
   end
 
   def when_i_visit_the_transition_landing_page_without_dynamic_list
     TransitionLandingPageController.any_instance.stubs(:show_dynamic_list?).returns(false)
-    visit brexit_taxon_path
+    visit transition_taxon_path
   end
 
   def then_i_can_see_the_title_section
@@ -69,7 +69,7 @@ module TransitionLandingPageSteps
   end
 
   def and_i_can_see_an_email_subscription_link
-    assert page.has_selector?('a[href="/email-signup/?topic=' + brexit_taxon_path + '"]')
+    assert page.has_selector?('a[href="/email-signup/?topic=' + transition_taxon_path + '"]')
     assert page.has_text?("Sign up for email updates about the transition period")
   end
 
@@ -88,7 +88,7 @@ module TransitionLandingPageSteps
     supergroups.each do |_|
       assert page.has_link?(
         "Services",
-        href: "/search/services?parent=%2Fbrexit&topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea",
+        href: "/search/services?parent=%2Ftransition&topic=d6c2de5d-ef90-45d1-82d4-5f2438369eea",
       )
     end
   end


### PR DESCRIPTION
This PR removes a lot of old tech debt referencing `dynamic lists`.

https://trello.com/c/KVmOh3Uk/474-remove-dynamic-lists-tech-debt-from-collections