### PR TITLE
Order High Profile Groups alphabetically

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -38,7 +38,10 @@ module Organisations
     end
 
     def high_profile_groups
-      high_profile_groups = @org.ordered_high_profile_groups && @org.ordered_high_profile_groups.map do |group|
+      alphabetical_high_profile_groups = @org.ordered_high_profile_groups
+                                             &.sort_by { |key| key["base_path"] }
+
+      alphabetical_high_profile_groups&.map! do |group|
         {
           text: group["title"],
           path: group["base_path"],
@@ -48,7 +51,7 @@ module Organisations
       {
         title: I18n.t("organisations.high_profile_groups", title: acronym),
         brand: @org.brand,
-        items: high_profile_groups,
+        items: alphabetical_high_profile_groups,
       }
     end
 

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -79,7 +79,7 @@ describe Organisations::ShowPresenter do
     assert_equal expected, @show_presenter.parent_organisations
   end
 
-  it "formats high profile groups correctly" do
+  it "formats high profile groups correctly and in alphabetical order" do
     content_item = ContentItem.new(organisation_with_high_profile_groups)
     organisation = Organisation.new(content_item)
     @show_presenter = Organisations::ShowPresenter.new(organisation)
@@ -89,12 +89,12 @@ describe Organisations::ShowPresenter do
       brand: "department-for-environment-food-rural-affairs",
       items: [
         {
-          text: "Rural Development Programme for England Network",
-          path: "/government/organisations/rural-development-programme-for-england-network",
+          text: "Another Rural Development Programme for England Network",
+          path: "/government/organisations/another-rural-development-programme-for-england-network",
         },
         {
-          text: "Rural Development Programme for England Network 2",
-          path: "/government/organisations/rural-development-programme-for-england-network-2",
+          text: "Rural Development Programme for England Network",
+          path: "/government/organisations/rural-development-programme-for-england-network",
         },
       ],
     }

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -327,8 +327,8 @@ module OrganisationHelpers
             title: "Rural Development Programme for England Network",
           },
           {
-            base_path: "/government/organisations/rural-development-programme-for-england-network-2",
-            title: "Rural Development Programme for England Network 2",
+            base_path: "/government/organisations/another-rural-development-programme-for-england-network",
+            title: "Another Rural Development Programme for England Network",
           },
         ],
       },


### PR DESCRIPTION
Ticket: https://govuk.zendesk.com/agent/tickets/3918195

We've had a request from a department to order High Profile Groups
alphabetically on organsation pages. This seems like a reasonable ordering and,
while `ordered_high_profile_groups` on a content item suggests that they should
be ordered, there's no suggestion in the Whitehall codebase that there's any
deliberate ordering or opportunity for users to specify ordering.

**Before**
<img width="513" alt="Screenshot 2020-02-21 at 13 37 18" src="https://user-images.githubusercontent.com/13434452/75038892-5036cc80-54af-11ea-825b-b7d1e9d77456.png">

**After**
<img width="441" alt="Screenshot 2020-02-21 at 13 39 13" src="https://user-images.githubusercontent.com/13434452/75038999-9b50df80-54af-11ea-9c65-693dc4fdb015.png">

