### PR TITLE
Remove share link accessibility workaround

### DIFF
--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -24,36 +24,33 @@
     <%= render partial: 'brexit_finders', locals: { supergroups: presented_taxon.supergroup_sections, email_path: presented_taxon.email_path } %>
 
     <div class="landing-page__share">
-      <% hidden_text = capture do %>
-        <span class="govuk-visually-hidden">Share on</span>
-      <% end %>
       <%= render "govuk_publishing_components/components/share_links", {
         title: t("transition_landing_page.share_links"),
         columns: true,
         links: [
           {
             href: "https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
-            text: hidden_text + "Facebook",
+            text: "Facebook",
             icon: "facebook"
           },
           {
             href: "https://twitter.com/share?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}",
-            text: hidden_text + "Twitter",
+            text: "Twitter",
             icon: "twitter"
           },
           {
             href: "mailto:?body=https://www.gov.uk#{CGI.escape(request.fullpath)}/&subject=#{t('transition_landing_page.email_mailto_subject')}",
-            text: hidden_text + "Email",
+            text: "Email",
             icon: "email"
           },
           {
             href: "https://api.whatsapp.com/send?text=https://www.gov.uk#{CGI.escape(request.fullpath)}",
-            text: hidden_text + "WhatsApp",
+            text: "WhatsApp",
             icon: "whatsapp"
           },
           {
             href: "http://www.linkedin.com/shareArticle?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}&title=#{t('transition_landing_page.email_mailto_subject')}",
-            text: hidden_text + "LinkedIn",
+            text: "LinkedIn",
             icon: "linkedin"
           },
         ]


### PR DESCRIPTION
This workaround was introduced because the publishing component didn't set this or have an option to set this.

That has been rectified with https://github.com/alphagov/govuk_publishing_components/pull/1286
and released in v21.26.1, so this can now be removed.

[Test page](https://govuk-collec-remove-sha-30fpnv.herokuapp.com/transition)