### PR TITLE
Add eCommerce tracking to mainstream browse

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -353,6 +353,9 @@
       this.$breadcrumbs.html($newBreadcrumbs.html());
     },
     trackPageview: function(state){
+      // We want to track eCommerce on both real page views (done via static)
+      // and also these pretend page views (done here via ajax)
+      GOVUK.Ecommerce.start();
       var sectionTitle = this.$section.find('h1').text();
       sectionTitle = sectionTitle ? sectionTitle.toLowerCase() : 'browse';
       var navigationPageType = 'none';

--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,4 +1,4 @@
-<div id="root" class="pane root-pane">
+<div id="root" class="pane root-pane" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Mainstream browse" data-search-query="all categories">
   <h2 class="visuallyhidden" tabindex="-1">All categories</h2>
   <ul>
     <% top_level_browse_pages.each_with_index do |page, index| %>
@@ -10,6 +10,8 @@
             track_category: 'firstLevelBrowseLinkClicked',
             track_action: "#{index + 1}",
             track_label: page.base_path,
+            ecommerce_row: "#{index + 1}",
+            ecommerce_path: page.base_path,
             track_options: {
               dimension28: top_level_browse_pages.count.to_s,
               dimension29: page.title,

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -8,13 +8,15 @@
       <p class="sort-order"><%= hairspace list.title %></p>
     <% end %>
 
-    <ul>
+    <ul data-analytics-ecommerce data-ecommerce-start-index=<%= "#{section_index + 1}" %> data-list-title="Mainstream browse" data-search-query="<%= page.lists.curated? ? list.title : page.title %>">
       <% list.contents.each_with_index do |list_item, index| %>
         <li>
           <%= link_to(
             list_item.title,
             list_item.base_path,
             data: {
+              ecommerce_row: "#{section_index}.#{index + 1}",
+              ecommerce_path: list_item.base_path,
               track_category: 'thirdLevelBrowseLinkClicked',
               track_action: "#{section_index + 1}.#{index + 1}",
               track_label: list_item.base_path,

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -1,4 +1,4 @@
-<div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
+<div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Mainstream browse" data-search-query="<%= title %>">
   <h2 tabindex="-1" class="js-heading"><%= title %></h2>
   <% unless curated_order %>
     <p class="sort-order"><%= hairspace 'A to Z' %></p>
@@ -9,6 +9,8 @@
         <%= link_to(
           browse_page.base_path,
           data: {
+            ecommerce_row: "#{index + 1}",
+            ecommerce_path: browse_page.base_path,
             track_category: 'secondLevelBrowseLinkClicked',
             track_action: "#{index + 1}",
             track_label: browse_page.base_path,

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,24 @@
+Analytics
+=========
+
+To improve the content navigation experience, we track user behaviour in Google
+Analytics.
+
+What is tracked
+---------------
+
+In addition to the default page view tracking that occurs on every page
+of GOV.UK, we have added additional tracking to collections.
+
+There are three kinds of tracking:
+
+- Enhanced Ecommerce: Provided by [static](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/ecommerce.js); provides analytics on views (impressions) and clicks of lists of items.
+- Event tracking: tracks usage of features such as facets.
+- Page view tracking: tracks each the state of the page when it first loads, or when new page content is added.
+
+## Testing analytics
+
+For Enhanced Ecommerce, the tracking functionality is tested in static.
+
+We have feature tests to check the correct attributes are used in
+[`features/analytics.feature`](features/analytics.feature).

--- a/features/analytics.feature
+++ b/features/analytics.feature
@@ -1,0 +1,15 @@
+Feature: Analytics
+  In order to understand usage to improve our services
+  As a developer
+  I want to be able to track user behaviour
+
+  @javascript
+  Scenario: Ecommerce tracking
+    Given there is an alphabetical browse page set up with links
+    When I visit the main browse page
+    Then the ecommerce tracking tags are present
+
+  Scenario: Link tracking
+    Given there is an alphabetical browse page set up with links
+    When I visit the main browse page
+    Then the links on the page have tracking attributes

--- a/features/step_definitions/analyitics_steps.rb
+++ b/features/step_definitions/analyitics_steps.rb
@@ -1,0 +1,33 @@
+
+Then(/^the ecommerce tracking tags are present$/) do
+  assert page.has_selector?("div#root[data-analytics-ecommerce]")
+  assert page.has_selector?('div#root[data-ecommerce-start-index="1"]')
+  assert page.has_selector?('div#root[data-ecommerce-start-index="1"]')
+  assert page.has_selector?('div#root[data-list-title="Mainstream browse"]')
+  assert page.has_selector?('div#root[data-search-query="all categories"]')
+
+  assert_equal page.find("div#root li:nth-child(1) a")['data-ecommerce-row'], '1'
+  assert_equal page.find("div#root li:nth-child(1) a")['data-ecommerce-path'], '/browse/benefits'
+
+  assert_equal page.find("div#root li:nth-child(2) a")['data-ecommerce-row'], '2'
+  assert_equal page.find("div#root li:nth-child(2) a")['data-ecommerce-path'], '/browse/crime-and-justice'
+end
+
+And(/^the links on the page have tracking attributes$/) do
+  assert_equal page.find("div#root li:nth-child(1) a")['data-track-action'], '1'
+  assert_equal page.find("div#root li:nth-child(1) a")['data-track-label'], '/browse/benefits'
+  assert_equal page.find("div#root li:nth-child(1) a")['data-track-category'], 'firstLevelBrowseLinkClicked'
+  assert_equal page.find("div#root li:nth-child(1) a")['data-track-options'], tracking_options_payloads[0]
+
+  assert_equal page.find("div#root li:nth-child(2) a")['data-track-action'], '2'
+  assert_equal page.find("div#root li:nth-child(2) a")['data-track-label'], '/browse/crime-and-justice'
+  assert_equal page.find("div#root li:nth-child(2) a")['data-track-category'], 'firstLevelBrowseLinkClicked'
+  assert_equal page.find("div#root li:nth-child(2) a")['data-track-options'], tracking_options_payloads[1]
+end
+
+def tracking_options_payloads
+  [
+    '{"dimension28":"2","dimension29":"Benefits"}',
+    '{"dimension28":"2","dimension29":"Crime and justice"}',
+  ]
+end

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -131,6 +131,7 @@ describe('browse-columns.js', function() {
   });
 
   it("should track a page view", function() {
+    GOVUK.Ecommerce = jasmine.createSpyObj('Ecommerce', ['start'])
     GOVUK.analytics = jasmine.createSpyObj('analytics', ['trackPageview']);
 
     var state = {


### PR DESCRIPTION
Trello: https://trello.com/c/dYRMOfsR/59-add-enhanced-ecommerce-tracking-to-browse-topic-and-taxon-pages

## What?

Mainstream browse already has click tracking enabled. This PR adds eCommerce tracking.

## Why?

A click event will record information about the specific item users have interacted with, however that can often be absent of wide content.

eCommerce tracking submits a payload about all possible options (with tracking tags) on a page when the user viewed it. We should be able to use that information to provide greater context about a user's journey. Does a specific link have a great click through rate? Is that because it's the most popular with users, or just because it's at the top of the page? Or because it's the one that always shows up where other links vary?

Before we attempt any iteration on how users browse our content, we want to establish a good baseline of data that can answer these questions, so we can then set smarter KPIs to find out if our changes have made things better or not.

## Examples

### I land on `/browse`
- A page view event fires
- The payload has an Impression list key that describes the feature:

eCommerce Key | eCommerce Value
-- | --
Impression List 1 | Mainstream browse

- The payload has a list that outlines each link in the list as a product, and describes:
  - The section in the list as "Dimension 71" (here at the top level it's all categories)
  - The place the link will send you to, as "Name"
  - Where it is in the list, as "Position" (An acending list, starting at 1)

eCommerce Key | eCommerce Value
-- | --
Impression List 1 Product 1 Dimension 71 | all categories
Impression List 1 Product 1 Name | /browse/benefits
Impression List 1 Product 1 Position | 1
Impression List 1 Product 2 Dimension 71 | all categories
Impression List 1 Product 2 Name | /browse/births-deaths-marriages
Impression List 1 Product 2 Position | 2
Impression List 1 Product 3 Dimension 71 | all categories
Impression List 1 Product 3 Name | /browse/business
Impression List 1 Product 3 Position | 3
Impression List 1 Product 4 Dimension 71 | all categories
Impression List 1 Product 4 Name | /browse/childcare-parenting
Impression List 1 Product 4 Position | 4
Impression List 1 Product 5 Dimension 71 | all categories
Impression List 1 Product 5 Name | /browse/citizenship
Impression List 1 Product 5 Position | 5
Impression List 1 Product 6 Dimension 71 | all categories
Impression List 1 Product 6 Name | /browse/justice
Impression List 1 Product 6 Position | 6
Impression List 1 Product 7 Dimension 71 | all categories
Impression List 1 Product 7 Name | /browse/disabilities
Impression List 1 Product 7 Position | 7
Impression List 1 Product 8 Dimension 71 | all categories
Impression List 1 Product 8 Name | /browse/driving
Impression List 1 Product 8 Position | 8
Impression List 1 Product 9 Dimension 71 | all categories
Impression List 1 Product 9 Name | /browse/education
Impression List 1 Product 9 Position | 9
Impression List 1 Product 10 Dimension 71 | all categories
Impression List 1 Product 10 Name | /browse/employing-people
Impression List 1 Product 10 Position | 10
Impression List 1 Product 11 Dimension 71 | all categories
Impression List 1 Product 11 Name | /browse/environment-countryside
Impression List 1 Product 11 Position | 11
Impression List 1 Product 12 Dimension 71 | all categories
Impression List 1 Product 12 Name | /browse/housing-local-services
Impression List 1 Product 12 Position | 12
Impression List 1 Product 13 Dimension 71 | all categories
Impression List 1 Product 13 Name | /browse/tax
Impression List 1 Product 13 Position | 13
Impression List 1 Product 14 Dimension 71 | all categories
Impression List 1 Product 14 Name | /browse/abroad
Impression List 1 Product 14 Position | 14
Impression List 1 Product 15 Dimension 71 | all categories
Impression List 1 Product 15 Name | /browse/visas-immigration
Impression List 1 Product 15 Position | 15
Impression List 1 Product 16 Dimension 71 | all categories
Impression List 1 Product 16 Name | /browse/working
Impression List 1 Product 16 Position | 16

### I click on `/browse/education` - "Education and learning"
- A click event fires
- A page view event fires (even though we've loaded content with ajax)
- The eCommerce payload now describes BOTH everything in the first level browse AND everything under education and learning. They can be distinguished as lists from the list title in "Dimension 71"

eCommerce Key | eCommerce Value
-- | --
**Impression List 1** | **Mainstream browse**
Impression List 1 Product 1 Dimension 71 | education and learning
Impression List 1 Product 1 Name | /browse/education/find-course
Impression List 1 Product 1 Position | 1
Impression List 1 Product 2 Dimension 71 | education and learning
Impression List 1 Product 2 Name | /browse/education/school-admissions-transport
Impression List 1 Product 2 Position | 2
Impression List 1 Product 3 Dimension 71 | education and learning
Impression List 1 Product 3 Name | /browse/education/school-life
Impression List 1 Product 3 Position | 3
Impression List 1 Product 4 Dimension 71 | education and learning
Impression List 1 Product 4 Name | /browse/education/student-finance
Impression List 1 Product 4 Position | 4
Impression List 1 Product 5 Dimension 71 | education and learning
Impression List 1 Product 5 Name | /browse/education/universities-higher-education
Impression List 1 Product 5 Position | 5
Impression List 1 Product 6 Dimension 71 | all categories
Impression List 1 Product 6 Name | /browse/benefits
Impression List 1 Product 6 Position | 1
Impression List 1 Product 7 Dimension 71 | all categories
Impression List 1 Product 7 Name | /browse/births-deaths-marriages
Impression List 1 Product 7 Position | 2
Impression List 1 Product 8 Dimension 71 | all categories
Impression List 1 Product 8 Name | /browse/business
Impression List 1 Product 8 Position | 3
Impression List 1 Product 9 Dimension 71 | all categories
Impression List 1 Product 9 Name | /browse/childcare-parenting
Impression List 1 Product 9 Position | 4
Impression List 1 Product 10 Dimension 71 | all categories
Impression List 1 Product 10 Name | /browse/citizenship
Impression List 1 Product 10 Position | 5
Impression List 1 Product 11 Dimension 71 | all categories
Impression List 1 Product 11 Name | /browse/justice
Impression List 1 Product 11 Position | 6
Impression List 1 Product 12 Dimension 71 | all categories
Impression List 1 Product 12 Name | /browse/disabilities
Impression List 1 Product 12 Position | 7
Impression List 1 Product 13 Dimension 71 | all categories
Impression List 1 Product 13 Name | /browse/driving
Impression List 1 Product 13 Position | 8
Impression List 1 Product 14 Dimension 71 | all categories
Impression List 1 Product 14 Name | /browse/education
Impression List 1 Product 14 Position | 9
Impression List 1 Product 15 Dimension 71 | all categories
Impression List 1 Product 15 Name | /browse/employing-people
Impression List 1 Product 15 Position | 10
Impression List 1 Product 16 Dimension 71 | all categories
Impression List 1 Product 16 Name | /browse/environment-countryside
Impression List 1 Product 16 Position | 11
Impression List 1 Product 17 Dimension 71 | all categories
Impression List 1 Product 17 Name | /browse/housing-local-services
Impression List 1 Product 17 Position | 12
Impression List 1 Product 18 Dimension 71 | all categories
Impression List 1 Product 18 Name | /browse/tax
Impression List 1 Product 18 Position | 13
Impression List 1 Product 19 Dimension 71 | all categories
Impression List 1 Product 19 Name | /browse/abroad
Impression List 1 Product 19 Position | 14
Impression List 1 Product 20 Dimension 71 | all categories
Impression List 1 Product 20 Name | /browse/visas-immigration
Impression List 1 Product 20 Position | 15
Impression List 1 Product 21 Dimension 71 | all categories
Impression List 1 Product 21 Name | /browse/working
Impression List 1 Product 21 Position | 16

### I click on `/browse/education/school-life` - "Schools and curriculum"
- A click event fires
- A page view event fires (even though we've loaded content with ajax)
- The eCommerce payload now describes the first level browse, second level browse AND the third level.
- Where the list is curated, the list subsection is identified by `Dimension 71`
- Where the list is a-z, `Dimension 71` instead holds the third level list title.

eCommerce Key | eCommerce Value
-- | --
**Impression List 1** | **Mainstream browse**
Impression List 1 Product 1 Dimension 71 | schools and curriculum
Impression List 1 Product 1 Name | /appeal-exam-result
Impression List 1 Product 1 Position | 1
Impression List 1 Product 2 Dimension 71 | schools and curriculum
Impression List 1 Product 2 Name | /apply-free-school-meals
Impression List 1 Product 2 Position | 2
Impression List 1 Product 3 Dimension 71 | schools and curriculum
Impression List 1 Product 3 Name | /become-school-college-governor
Impression List 1 Product 3 Position | 3
Impression List 1 Product 4 Dimension 71 | schools and curriculum
Impression List 1 Product 4 Name | /bullying-at-school
Impression List 1 Product 4 Position | 4
Impression List 1 Product 5 Dimension 71 | schools and curriculum
Impression List 1 Product 5 Name | /check-awarding-body-recognised
Impression List 1 Product 5 Position | 5
Impression List 1 Product 6 Dimension 71 | schools and curriculum
Impression List 1 Product 6 Name | /children-with-special-educational-needs
Impression List 1 Product 6 Position | 6
Impression List 1 Product 7 Dimension 71 | schools and curriculum
Impression List 1 Product 7 Name | /complain-about-school
Impression List 1 Product 7 Position | 7
Impression List 1 Product 8 Dimension 71 | schools and curriculum
Impression List 1 Product 8 Name | /complain-ofsted-report
Impression List 1 Product 8 Position | 8
Impression List 1 Product 9 Dimension 71 | schools and curriculum
Impression List 1 Product 9 Name | /contact-dfe
Impression List 1 Product 9 Position | 9
Impression List 1 Product 10 Dimension 71 | schools and curriculum
Impression List 1 Product 10 Name | /early-years-foundation-stage
Impression List 1 Product 10 Position | 10
Impression List 1 Product 11 Dimension 71 | schools and curriculum
Impression List 1 Product 11 Name | /education-attendance-council
Impression List 1 Product 11 Position | 11
Impression List 1 Product 12 Dimension 71 | schools and curriculum
Impression List 1 Product 12 Name | /find-teaching-job
Impression List 1 Product 12 Position | 12
Impression List 1 Product 13 Dimension 71 | schools and curriculum
Impression List 1 Product 13 Name | /find-ofsted-inspection-report
Impression List 1 Product 13 Position | 13
Impression List 1 Product 14 Dimension 71 | schools and curriculum
Impression List 1 Product 14 Name | /school-performance-tables
Impression List 1 Product 14 Position | 14
Impression List 1 Product 15 Dimension 71 | schools and curriculum
Impression List 1 Product 15 Name | /after-school-holiday-club
Impression List 1 Product 15 Position | 15
Impression List 1 Product 16 Dimension 71 | schools and curriculum
Impression List 1 Product 16 Name | /learning-activities-for-your-child
Impression List 1 Product 16 Position | 16
Impression List 1 Product 17 Dimension 71 | schools and curriculum
Impression List 1 Product 17 Name | /help-school-clothing-costs
Impression List 1 Product 17 Position | 17
Impression List 1 Product 18 Dimension 71 | schools and curriculum
Impression List 1 Product 18 Name | /health-safety-school-children
Impression List 1 Product 18 Position | 18
Impression List 1 Product 19 Dimension 71 | schools and curriculum
Impression List 1 Product 19 Name | /illness-child-education
Impression List 1 Product 19 Position | 19
Impression List 1 Product 20 Dimension 71 | schools and curriculum
Impression List 1 Product 20 Name | /report-teacher-misconduct
Impression List 1 Product 20 Position | 20
Impression List 1 Product 21 Dimension 71 | schools and curriculum
Impression List 1 Product 21 Name | /support-military-bereaved-children
Impression List 1 Product 21 Position | 21
Impression List 1 Product 22 Dimension 71 | schools and curriculum
Impression List 1 Product 22 Name | /school-attendance-absence
Impression List 1 Product 22 Position | 22
Impression List 1 Product 23 Dimension 71 | schools and curriculum
Impression List 1 Product 23 Name | /check-school-closure
Impression List 1 Product 23 Position | 23
Impression List 1 Product 24 Dimension 71 | schools and curriculum
Impression List 1 Product 24 Name | /school-discipline-exclusions
Impression List 1 Product 24 Position | 24
Impression List 1 Product 25 Dimension 71 | schools and curriculum
Impression List 1 Product 25 Name | /know-when-you-can-leave-school
Impression List 1 Product 25 Position | 25
Impression List 1 Product 26 Dimension 71 | schools and curriculum
Impression List 1 Product 26 Name | /school-meals-healthy-eating-standards
Impression List 1 Product 26 Position | 26
Impression List 1 Product 27 Dimension 71 | schools and curriculum
Impression List 1 Product 27 Name | /school-term-holiday-dates
Impression List 1 Product 27 Position | 27
Impression List 1 Product 28 Dimension 71 | schools and curriculum
Impression List 1 Product 28 Name | /school-uniform
Impression List 1 Product 28 Position | 28
Impression List 1 Product 29 Dimension 71 | schools and curriculum
Impression List 1 Product 29 Name | /national-curriculum
Impression List 1 Product 29 Position | 29
Impression List 1 Product 30 Dimension 71 | education and learning
Impression List 1 Product 30 Name | /browse/education/find-course
Impression List 1 Product 30 Position | 1
Impression List 1 Product 31 Dimension 71 | education and learning
Impression List 1 Product 31 Name | /browse/education/school-admissions-transport
Impression List 1 Product 31 Position | 2
Impression List 1 Product 32 Dimension 71 | education and learning
Impression List 1 Product 32 Name | /browse/education/school-life
Impression List 1 Product 32 Position | 3
Impression List 1 Product 33 Dimension 71 | education and learning
Impression List 1 Product 33 Name | /browse/education/student-finance
Impression List 1 Product 33 Position | 4
Impression List 1 Product 34 Dimension 71 | education and learning
Impression List 1 Product 34 Name | /browse/education/universities-higher-education
Impression List 1 Product 34 Position | 5
Impression List 1 Product 35 Dimension 71 | all categories
Impression List 1 Product 35 Name | /browse/benefits
Impression List 1 Product 35 Position | 1
Impression List 1 Product 36 Dimension 71 | all categories
Impression List 1 Product 36 Name | /browse/births-deaths-marriages
Impression List 1 Product 36 Position | 2
Impression List 1 Product 37 Dimension 71 | all categories
Impression List 1 Product 37 Name | /browse/business
Impression List 1 Product 37 Position | 3
Impression List 1 Product 38 Dimension 71 | all categories
Impression List 1 Product 38 Name | /browse/childcare-parenting
Impression List 1 Product 38 Position | 4
Impression List 1 Product 39 Dimension 71 | all categories
Impression List 1 Product 39 Name | /browse/citizenship
Impression List 1 Product 39 Position | 5
Impression List 1 Product 40 Dimension 71 | all categories
Impression List 1 Product 40 Name | /browse/justice
Impression List 1 Product 40 Position | 6
Impression List 1 Product 41 Dimension 71 | all categories
Impression List 1 Product 41 Name | /browse/disabilities
Impression List 1 Product 41 Position | 7
Impression List 1 Product 42 Dimension 71 | all categories
Impression List 1 Product 42 Name | /browse/driving
Impression List 1 Product 42 Position | 8
Impression List 1 Product 43 Dimension 71 | all categories
Impression List 1 Product 43 Name | /browse/education
Impression List 1 Product 43 Position | 9
Impression List 1 Product 44 Dimension 71 | all categories
Impression List 1 Product 44 Name | /browse/employing-people
Impression List 1 Product 44 Position | 10
Impression List 1 Product 45 Dimension 71 | all categories
Impression List 1 Product 45 Name | /browse/environment-countryside
Impression List 1 Product 45 Position | 11
Impression List 1 Product 46 Dimension 71 | all categories
Impression List 1 Product 46 Name | /browse/housing-local-services
Impression List 1 Product 46 Position | 12
Impression List 1 Product 47 Dimension 71 | all categories
Impression List 1 Product 47 Name | /browse/tax
Impression List 1 Product 47 Position | 13
Impression List 1 Product 48 Dimension 71 | all categories
Impression List 1 Product 48 Name | /browse/abroad
Impression List 1 Product 48 Position | 14
Impression List 1 Product 49 Dimension 71 | all categories
Impression List 1 Product 49 Name | /browse/visas-immigration
Impression List 1 Product 49 Position | 15
Impression List 1 Product 50 Dimension 71 | all categories
Impression List 1 Product 50 Name | /browse/working
Impression List 1 Product 50 Position | 16