### PR TITLE
Add a news story to the Transition Landing Page

### DIFF
--- a/app/views/transition_landing_page/_comms.html.erb
+++ b/app/views/transition_landing_page/_comms.html.erb
@@ -33,6 +33,7 @@
             <% end %>
           <% end %>
         <% end %>
+      </div>
     <% end %>
 
   </div>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -15,6 +15,13 @@ en:
     comms:
       links:
       - link:
+          text: "Our approach to the Future Relationship with the EU"
+          path: "/government/publications/our-approach-to-the-future-relationship-with-the-eu"
+          description: "The UK’s approach to negotiations with the European Union."
+        metadata:
+          public_updated_at: 2020-02-27
+          document_type: "Policy Paper"
+      - link:
           text: "Government confirms plans to introduce import controls"
           path: "/government/news/government-confirms-plans-to-introduce-import-controls"
           description: "The government has confirmed plans to introduce import controls on EU goods at the border after the transition period ends on 31 December 2020."


### PR DESCRIPTION
And fixed a small typo

Trello: https://trello.com/c/abg1wivz/551-update-the-transition-page-to-include-the-uks-negotiating-mandate