### PR TITLE
[Do Not Merge] Add eCommerce tracking to topic browse

### DIFF
--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -46,7 +46,7 @@ private
 
   def data_attributes(tracking_attributes, list_item, list_index)
     {
-      ecommerce_row: list_index ? "#{list_index + 1}." : "",
+      ecommerce_row: list_index ? "#{list_index + 1}" : "",
       ecommerce_path: list_item.base_path,
     }.merge(
       topic_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_index),

--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -26,27 +26,28 @@ module TopicListHelper
   end
 
   def root_topic?(topic)
-    topic.base_path == '/topic'
+    topic.base_path == "/topic"
   end
 
   def tracking_category(topic)
-    root_topic?(topic) ? "navTopicLinkClicked" : 'navSubtopicLinkClicked'
+    root_topic?(topic) ? "navTopicLinkClicked" : "navSubtopicLinkClicked"
   end
 
   def ecommerce_subtopic_category(list, subtopic_title)
     return subtopic_title if list.title == "A to Z"
+
     list.title
   end
 
-  def eCommerce_topic_category(topic)
-     root_topic?(topic) ? "topic index" : topic.title.downcase.to_s
+  def ecommerce_topic_category(topic)
+    root_topic?(topic) ? "topic index" : topic.title.downcase.to_s
   end
 
 private
 
   def data_attributes(tracking_attributes, list_item, list_index)
     {
-      ecommerce_row: list_index ? "#{list_index + 1}" : "",
+      ecommerce_row: list_index ? (list_index + 1).to_s : "",
       ecommerce_path: list_item.base_path,
     }.merge(
       topic_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_index),

--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -25,6 +25,23 @@ module TopicListHelper
     }
   end
 
+  def is_root_topic(topic)
+    topic.base_path == '/topic'
+  end
+
+  def tracking_category(topic)
+    is_root_topic(topic) ? "navTopicLinkClicked" : 'navSubtopicLinkClicked'
+  end
+
+  def eCommerce_subtopic_category(list, subtopic_title)
+    return subtopic_title if list.title == "A to Z"
+    list.title
+  end
+
+  def eCommerce_topic_category(topic)
+     is_root_topic(topic) ? "topic index" : topic.title.downcase.to_s
+  end
+
 private
 
   def data_attributes(tracking_attributes, list_item, list_index)

--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -25,21 +25,21 @@ module TopicListHelper
     }
   end
 
-  def is_root_topic(topic)
+  def root_topic?(topic)
     topic.base_path == '/topic'
   end
 
   def tracking_category(topic)
-    is_root_topic(topic) ? "navTopicLinkClicked" : 'navSubtopicLinkClicked'
+    root_topic?(topic) ? "navTopicLinkClicked" : 'navSubtopicLinkClicked'
   end
 
-  def eCommerce_subtopic_category(list, subtopic_title)
+  def ecommerce_subtopic_category(list, subtopic_title)
     return subtopic_title if list.title == "A to Z"
     list.title
   end
 
   def eCommerce_topic_category(topic)
-     is_root_topic(topic) ? "topic index" : topic.title.downcase.to_s
+     root_topic?(topic) ? "topic index" : topic.title.downcase.to_s
   end
 
 private

--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -27,12 +27,21 @@ module TopicListHelper
 
 private
 
+  def data_attributes(tracking_attributes, list_item, list_index)
+    {
+      ecommerce_row: list_index ? "#{list_index + 1}." : "",
+      ecommerce_path: list_item.base_path,
+    }.merge(
+      topic_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_index),
+    )
+  end
+
   def topic_list_items(list, tracking_attributes)
     list.each_with_index.map do |list_item, list_item_index|
       {
         text: list_item.title,
         path: list_item.base_path,
-        data_attributes: topic_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_item_index),
+        data_attributes: data_attributes(tracking_attributes, list_item, list_item_index),
       }
     end
   end

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -23,7 +23,6 @@
     </div>
   </div>
 </header>
-
 <div class="browse-container full-width" data-module="track-click">
   <%= yield %>
 </div>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -25,7 +25,7 @@
     link_to_latest_feed: true,
   }) do %>
   <% subtopic.lists.each_with_index do |list, list_index| -%>
-    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= list.title %>">
+    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= eCommerce_subtopic_category(list, subtopic.title) %>">
       <div class="govuk-grid-column-one-third">
         <h1 id="<%= list.title.parameterize %>"><%= list.title %></h1>
       </div>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -25,7 +25,7 @@
     link_to_latest_feed: true,
   }) do %>
   <% subtopic.lists.each_with_index do |list, list_index| -%>
-    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= eCommerce_subtopic_category(list, subtopic.title) %>">
+    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= ecommerce_subtopic_category(list, subtopic.title) %>">
       <div class="govuk-grid-column-one-third">
         <h1 id="<%= list.title.parameterize %>"><%= list.title %></h1>
       </div>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -25,7 +25,7 @@
     link_to_latest_feed: true,
   }) do %>
   <% subtopic.lists.each_with_index do |list, list_index| -%>
-    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>">
+    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= list.title %>">
       <div class="govuk-grid-column-one-third">
         <h1 id="<%= list.title.parameterize %>"><%= list.title %></h1>
       </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -10,7 +10,7 @@
 </header>
 
 <div class="browse-container full-width topics-page" data-module="track-click">
-  <nav class="topics" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= eCommerce_topic_category(topic) %>">
+  <nav class="topics" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= ecommerce_topic_category(topic) %>">
     <%= render 'components/topic-list', topic_list_params(topic.children, category: tracking_category(topic)) %>
   </nav>
 </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -10,7 +10,7 @@
 </header>
 
 <div class="browse-container full-width topics-page" data-module="track-click">
-  <nav class="topics">
+  <nav class="topics" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= topic.title %>">
     <% tracking_category = topic.base_path == '/topic' ? 'navTopicLinkClicked' : 'navSubtopicLinkClicked' %>
     <%= render 'components/topic-list', topic_list_params(topic.children, category: tracking_category) %>
   </nav>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -10,8 +10,7 @@
 </header>
 
 <div class="browse-container full-width topics-page" data-module="track-click">
-  <nav class="topics" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= topic.title %>">
-    <% tracking_category = topic.base_path == '/topic' ? 'navTopicLinkClicked' : 'navSubtopicLinkClicked' %>
-    <%= render 'components/topic-list', topic_list_params(topic.children, category: tracking_category) %>
+  <nav class="topics" data-analytics-ecommerce data-ecommerce-start-index="1" data-list-title="Topic browse" data-search-query="<%= eCommerce_topic_category(topic) %>">
+    <%= render 'components/topic-list', topic_list_params(topic.children, category: tracking_category(topic)) %>
   </nav>
 </div>

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -90,7 +90,7 @@ def leaf_node_ecommerce_tracking_is_present(groups_css_selector, list_title, top
     group_fixture = topic_fixtures[:details][:groups][nav_index]
     list_has_ecommerce_attributes("#{groups_css_selector}:nth-child(#{nav_index + 1})", list_title, group_fixture[:name])
     group_css_selector = "#{groups_css_selector}:nth-child(#{nav_index + 1})"
-    nav_group.find_all("li").each.with_index do |list_item, list_item_index|
+    nav_group.find_all("li").each.with_index do |_list_item, list_item_index|
       list_item_css_selector = "#{group_css_selector} li:nth-child(#{list_item_index + 1}) a"
       expected_href = group_fixture[:contents][list_item_index]
       assert_equal page.find(list_item_css_selector)["data-ecommerce-row"], (list_item_index + start_index).to_s
@@ -99,12 +99,12 @@ def leaf_node_ecommerce_tracking_is_present(groups_css_selector, list_title, top
   end
 end
 
-def topic_leaf_nodes_have_ecommerce_tracking_attributes(group_list_selector, list_items, list_element, start_index = 1)
+def topic_leaf_nodes_have_ecommerce_tracking_attributes(_group_list_selector, list_items, list_element, start_index = 1)
   alphabetised_groups = list_items[:details][:groups].sort_by { |item| item[:name] }
   alphabetised_groups.each.with_index do |group, group_index|
-    group_row_selector = "#{}:nth-child(#{group_index}) li"
+    group_row_selector = ":nth-child(#{group_index}) li"
     group[:contents].each.with_index do |document_path, index|
-      css_selector = "#{css_list_selector}:nth-child(#{index + 1}) #{list_element}"
+      css_selector = "#{css_list_selector}#{group_row_selector} #{list_element}"
       assert_equal page.find(css_selector)["data-ecommerce-row"], (index + start_index).to_s
       puts page.find(css_selector)["data-ecommerce-path"]
       puts document_path
@@ -136,7 +136,7 @@ def topics_root_node_search_data
       content_id: "/topic/oil-and-gas",
       title: "Oil and Gas",
       base_path: "/topic/oil-and-gas",
-    }
+    },
   ]
 end
 
@@ -146,7 +146,7 @@ def topics_branch_node_search_data
       content_id: "/topic/oil-and-gas/fields-and-wells",
       title: "Fields and wells",
       base_path: "/topic/oil-and-gas/fields-and-wells",
-    }
+    },
   ]
 end
 
@@ -163,13 +163,13 @@ def topics_leaf_node_search_data
             contents: [
               "/what-is-oil",
               "/apply-for-an-oil-licence",
-            ]
+            ],
           },
           {
             name: "Piping",
             contents: [
               "/well-application-form",
-            ]
+            ],
           },
         ],
       },

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,3 +1,30 @@
+Given(/^there are topic content items$/) do
+  stub_topic_lookups
+end
+
+When(/^I visit the topic browse page$/) do
+  visit "/topic"
+end
+
+Then(/^I click on topic (.*)$/) do |topic_link|
+  click_on topic_link
+end
+
+Then(/^the eCommerce tracking tags are present for the topics root node$/) do
+  list_has_ecommerce_attributes("#content > div > nav.topics", "Topic browse", "topic index")
+  list_items_have_ecommerce_tracking_attributes("#content > div > nav.topics li", topics_root_node_search_data, "a")
+end
+
+Then(/^the eCommerce tracking tags are present for the topics branch node$/) do
+  list_has_ecommerce_attributes("#content > div > nav.topics", "Topic browse", "oil and gas")
+  list_items_have_ecommerce_tracking_attributes("#content > div > nav.topics li", topics_branch_node_search_data, "a")
+end
+
+Then(/^the eCommerce tracking tags are present for a curated topic leaf node$/) do
+  assert_equal page.find_all("#content > div > nav.govuk-grid-row").count, 2
+  leaf_node_ecommerce_tracking_is_present("#content > div > nav.govuk-grid-row", "Topic browse", topics_leaf_node_search_data[0])
+end
+
 Then(/^the eCommerce tracking tags are present in mainstream browse level (\w*)$/) do |browse_level|
   case browse_level
   when "first_level"
@@ -53,16 +80,46 @@ end
 
 def list_has_ecommerce_attributes(css_selector, list_title, list_subtitle, start_index = 1)
   assert page.has_selector?("#{css_selector}[data-analytics-ecommerce]")
-  assert_equal page.find?(css_selector)["data-ecommerce-start-index"], start_index
-  assert_equal page.find?(css_selector)["data-list-title"], list_title
-  assert_equal page.find?(css_selector)["data-search-query"], list_subtitle
+  assert_equal page.find(css_selector)["data-ecommerce-start-index"], start_index.to_s
+  assert_equal page.find(css_selector)["data-list-title"], list_title
+  assert_equal page.find(css_selector)["data-search-query"], list_subtitle
+end
+
+def leaf_node_ecommerce_tracking_is_present(groups_css_selector, list_title, topic_fixtures, start_index = 1)
+  page.find_all(groups_css_selector).each.with_index do |nav_group, nav_index|
+    group_fixture = topic_fixtures[:details][:groups][nav_index]
+    list_has_ecommerce_attributes("#{groups_css_selector}:nth-child(#{nav_index + 1})", list_title, group_fixture[:name])
+    group_css_selector = "#{groups_css_selector}:nth-child(#{nav_index + 1})"
+    nav_group.find_all("li").each.with_index do |list_item, list_item_index|
+      list_item_css_selector = "#{group_css_selector} li:nth-child(#{list_item_index + 1}) a"
+      expected_href = group_fixture[:contents][list_item_index]
+      assert_equal page.find(list_item_css_selector)["data-ecommerce-row"], (list_item_index + start_index).to_s
+      assert_equal page.find(list_item_css_selector)["data-ecommerce-path"], expected_href
+    end
+  end
+end
+
+def topic_leaf_nodes_have_ecommerce_tracking_attributes(group_list_selector, list_items, list_element, start_index = 1)
+  alphabetised_groups = list_items[:details][:groups].sort_by { |item| item[:name] }
+  alphabetised_groups.each.with_index do |group, group_index|
+    group_row_selector = "#{}:nth-child(#{group_index}) li"
+    group[:contents].each.with_index do |document_path, index|
+      css_selector = "#{css_list_selector}:nth-child(#{index + 1}) #{list_element}"
+      assert_equal page.find(css_selector)["data-ecommerce-row"], (index + start_index).to_s
+      puts page.find(css_selector)["data-ecommerce-path"]
+      puts document_path
+      puts group[:contents]
+      puts css_selec
+      assert_equal page.find(css_selector)["data-ecommerce-path"], document_path
+    end
+  end
 end
 
 def list_items_have_ecommerce_tracking_attributes(css_list_selector, list_items, list_element, start_index = 1)
   list_items.each.with_index do |list_item, index|
-    css_selector = "#{css_list_selector}:nth-child(#{index}) #{list_element}"
+    css_selector = "#{css_list_selector}:nth-child(#{index + 1}) #{list_element}"
     assert_equal page.find(css_selector)["data-ecommerce-row"], (index + start_index).to_s
-    assert_equal page.find(css_selector)["data-ecommerce-path"], list_item.base_path
+    assert_equal page.find(css_selector)["data-ecommerce-path"], list_item[:base_path]
   end
 end
 
@@ -70,5 +127,52 @@ def tracking_options_payloads
   [
     '{"dimension28":"2","dimension29":"Benefits"}',
     '{"dimension28":"2","dimension29":"Crime and justice"}',
+  ]
+end
+
+def topics_root_node_search_data
+  [
+    {
+      content_id: "/topic/oil-and-gas",
+      title: "Oil and Gas",
+      base_path: "/topic/oil-and-gas",
+    }
+  ]
+end
+
+def topics_branch_node_search_data
+  [
+    {
+      content_id: "/topic/oil-and-gas/fields-and-wells",
+      title: "Fields and wells",
+      base_path: "/topic/oil-and-gas/fields-and-wells",
+    }
+  ]
+end
+
+def topics_leaf_node_search_data
+  [
+    {
+      content_id: "/topic/oil-and-gas/fields-and-wells",
+      title: "Fields and Wells",
+      base_path: "/topic/oil-and-gas/fields-and-wells",
+      details: {
+        groups: [
+          {
+            name: "Oil rigs",
+            contents: [
+              "/what-is-oil",
+              "/apply-for-an-oil-licence",
+            ]
+          },
+          {
+            name: "Piping",
+            contents: [
+              "/well-application-form",
+            ]
+          },
+        ],
+      },
+    },
   ]
 end

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,0 +1,74 @@
+Then(/^the eCommerce tracking tags are present in mainstream browse level (\w*)$/) do |browse_level|
+  case browse_level
+  when "first_level"
+    # First level only
+    list_has_ecommerce_attributes("div#root", "Mainstream browse", "all categories")
+    list_items_have_ecommerce_tracking_attributes("div#root li", top_level_browse_pages, "a")
+  when "second_level"
+    # Second level AND first level
+    list_has_ecommerce_attributes("div#root", "Mainstream browse", "all categories")
+    list_items_have_ecommerce_tracking_attributes("div#root li", top_level_browse_pages, "a")
+
+    list_has_ecommerce_attributes("#section > div", "Mainstream browse", "crime and justice")
+    list_items_have_ecommerce_tracking_attributes("#section > div li", second_level_browse_pages, "a")
+  when "third_level"
+    # Third level AND previous two levels
+    list_has_ecommerce_attributes("div#root", "Mainstream browse", "all categories")
+    list_items_have_ecommerce_tracking_attributes("div#root li", top_level_browse_pages, "a")
+
+    list_has_ecommerce_attributes("#section > div", "Mainstream browse", "crime and justice")
+    list_items_have_ecommerce_tracking_attributes("#section > div li", second_level_browse_pages, "a")
+
+    list_has_ecommerce_attributes("#subsection > div > ul", "Mainstream browse", "crime and justice")
+    list_items_have_ecommerce_tracking_attributes("#subsection > div > ul li", third_level_browse_documents, "a")
+  else
+    false
+  end
+end
+
+And(/^the links on the page have tracking attributes at browse level (\w*)$/) do |browse_level|
+  list_items_have_click_tracking_attributes("div#root li", top_level_browse_pages, "a", browse_level)
+end
+
+private
+
+def list_items_have_click_tracking_attributes(css_list_selector, list_items, list_element, browse_level)
+  alphabetised_list = list_items.sort_by { |item| item[:title] }
+  alphabetised_list.each.with_index(1) do |list_item, index|
+    css_selector = "#{css_list_selector}:nth-child(#{index}) #{list_element}"
+    assert_equal page.find(css_selector)["data-track-action"], index.to_s
+    assert_equal page.find(css_selector)["data-track-label"], list_item[:base_path]
+    assert_equal page.find(css_selector)["data-track-category"], track_category(browse_level)
+    assert_equal page.find(css_selector)["data-track-options"], tracking_options_payloads[index - 1]
+  end
+end
+
+def track_category(browse_level)
+  return "firstLevelBrowseLinkClicked" if browse_level == "one"
+  return "secondLevelBrowseLinkClicked" if browse_level == "two"
+  return "thirdLevelBrowseLinkClicked" if browse_level == "three"
+
+  "Invalid browse level"
+end
+
+def list_has_ecommerce_attributes(css_selector, list_title, list_subtitle, start_index = 1)
+  assert page.has_selector?("#{css_selector}[data-analytics-ecommerce]")
+  assert_equal page.find?(css_selector)["data-ecommerce-start-index"], start_index
+  assert_equal page.find?(css_selector)["data-list-title"], list_title
+  assert_equal page.find?(css_selector)["data-search-query"], list_subtitle
+end
+
+def list_items_have_ecommerce_tracking_attributes(css_list_selector, list_items, list_element, start_index = 1)
+  list_items.each.with_index do |list_item, index|
+    css_selector = "#{css_list_selector}:nth-child(#{index}) #{list_element}"
+    assert_equal page.find(css_selector)["data-ecommerce-row"], (index + start_index).to_s
+    assert_equal page.find(css_selector)["data-ecommerce-path"], list_item.base_path
+  end
+end
+
+def tracking_options_payloads
+  [
+    '{"dimension28":"2","dimension29":"Benefits"}',
+    '{"dimension28":"2","dimension29":"Crime and justice"}',
+  ]
+end

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -1,24 +1,11 @@
 Given(/^there is an alphabetical browse page set up with links$/) do
-  second_level_browse_pages = [{
-    content_id: "judges-content-id",
-    title: "Judges",
-    base_path: "/browse/crime-and-justice/judges",
-  }]
-
   add_browse_pages
   add_first_level_browse_pages(
     child_pages: second_level_browse_pages,
     order_type: "alphabetical",
   )
   add_second_level_browse_pages(second_level_browse_pages)
-
-  rummager_has_documents_for_browse_page(
-    "judges-content-id",
-    %w[
-      judge-dredd
-    ],
-    page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
-  )
+  third_level_browse_documents
 end
 
 Given(/^that there are curated second level browse pages$/) do
@@ -106,6 +93,22 @@ def top_level_browse_pages
       base_path: "/browse/benefits",
     },
   ]
+end
+
+def second_level_browse_pages
+  [{
+    content_id: "judges-content-id",
+    title: "Judges",
+    base_path: "/browse/crime-and-justice/judges",
+  }]
+end
+
+def third_level_browse_documents
+  rummager_has_documents_for_browse_page(
+    "judges-content-id",
+    %w(judge-dredd),
+    page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+  )
 end
 
 def add_browse_pages

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -21,38 +21,36 @@ module TopicHelper
     )
 
     stub_content_store_has_item("/topic",
-      content_id: "topics",
-      base_path: "/topic",
-      title: "Topics",
-      document_type: "topic",
-      public_updated_at: 10.days.ago.iso8601,
-      details: {
-        internal_name: "Topic index page",
-      },
-      links: {
-        "children" => [
-          "title" => "Oil and Gas",
-          "base_path" => "/topic/oil-and-gas",
-        ],
-      },
-    )
+                                content_id: "topics",
+                                base_path: "/topic",
+                                title: "Topics",
+                                document_type: "topic",
+                                public_updated_at: 10.days.ago.iso8601,
+                                details: {
+                                  internal_name: "Topic index page",
+                                },
+                                links: {
+                                  "children" => [
+                                    "title" => "Oil and Gas",
+                                    "base_path" => "/topic/oil-and-gas",
+                                  ],
+                                })
     stub_content_store_has_item("/topic/oil-and-gas",
-      content_id: "/topic/oil-and-gas",
-      base_path: "/topic/oil-and-gas",
-      title: "Oil and gas",
-      document_type: "topic",
-      public_updated_at: 10.days.ago.iso8601,
-      details: {
-        "groups": [],
-        "internal_name": "Oil and gas"
-      },
-      links: {
-        "children" => [
-          "title" => "Fields and wells",
-          "base_path" => "/topic/oil-and-gas/fields-and-wells",
-        ],
-      },
-    )
+                                content_id: "/topic/oil-and-gas",
+                                base_path: "/topic/oil-and-gas",
+                                title: "Oil and gas",
+                                document_type: "topic",
+                                public_updated_at: 10.days.ago.iso8601,
+                                details: {
+                                  "groups": [],
+                                  "internal_name": "Oil and gas",
+                                },
+                                links: {
+                                  "children" => [
+                                    "title" => "Fields and wells",
+                                    "base_path" => "/topic/oil-and-gas/fields-and-wells",
+                                  ],
+                                })
 
     stub_content_store_has_item("/topic/oil-and-gas/fields-and-wells",
                                 content_id: "content-id-for-fields-and-wells",

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -20,6 +20,40 @@ module TopicHelper
       page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
     )
 
+    stub_content_store_has_item("/topic",
+      content_id: "topics",
+      base_path: "/topic",
+      title: "Topics",
+      document_type: "topic",
+      public_updated_at: 10.days.ago.iso8601,
+      details: {
+        internal_name: "Topic index page",
+      },
+      links: {
+        "children" => [
+          "title" => "Oil and Gas",
+          "base_path" => "/topic/oil-and-gas",
+        ],
+      },
+    )
+    stub_content_store_has_item("/topic/oil-and-gas",
+      content_id: "/topic/oil-and-gas",
+      base_path: "/topic/oil-and-gas",
+      title: "Oil and gas",
+      document_type: "topic",
+      public_updated_at: 10.days.ago.iso8601,
+      details: {
+        "groups": [],
+        "internal_name": "Oil and gas"
+      },
+      links: {
+        "children" => [
+          "title" => "Fields and wells",
+          "base_path" => "/topic/oil-and-gas/fields-and-wells",
+        ],
+      },
+    )
+
     stub_content_store_has_item("/topic/oil-and-gas/fields-and-wells",
                                 content_id: "content-id-for-fields-and-wells",
                                 base_path: "/topic/oil-and-gas/fields-and-wells",


### PR DESCRIPTION
Trello: https://trello.com/c/djjUxKF3/139-add-ecommerce-tracking-to-specialist-topic-pages

## Dependent on
- Fix to the large payload ecommerce bug
- Fix to double event listners firing in ecommerce
# What
We should add Google Analytics Ecommerce tracking to the navigational links across the topic pages

**List level atributes**

- ` data-analytics-ecommerce`
- ` data-ecommerce-start-index="1"`
- ` data-list-title="Topic Browse - Level {x}"`

with the level reflecting how far the user is into the navigation

Also if [the generalisation mentioned here](https://trello.com/c/BTt4TmUG/143-%F0%9F%97%A1-generalise-statics-ecommerce-module) has not been completed the list will require the following empty attribute to work: ` data-search-query`

**Row level attributes**
-  `ecommerce_row: true`
-  `ecommerce_subheading: "All categories"`

if [this PR has been merged](https://github.com/alphagov/static/pull/2068) we can also have an optional `data-ecommerce-subheading` to describe which groups a row item falls into.

# Why
So we can understand the % of users who interact with each element. 

This will inform the topic pages redesign and provide a benchmark against which to judge the re-designed header's performance.