### PR TITLE
Consistently collapse breadcrumbs on mobile

### DIFF
--- a/app/controllers/email_signups_controller.rb
+++ b/app/controllers/email_signups_controller.rb
@@ -28,22 +28,20 @@ private
   # Breadcrumbs for this page are hardcoded because it doesn't have a
   # content item with parents.
   def hardcoded_breadcrumbs
-    {
-      breadcrumbs: [
-        {
-          title: "Home",
-          url: "/",
-        },
-        {
-          title: subtopic.parent.title,
-          url: subtopic.parent.base_path,
-        },
-        {
-          title: subtopic.title,
-          url: subtopic.base_path,
-        },
-      ],
-    }
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: subtopic.parent.title,
+        url: subtopic.parent.base_path,
+      },
+      {
+        title: subtopic.title,
+        url: subtopic.base_path,
+      },
+    ]
   end
 
   def meta_section

--- a/app/controllers/latest_changes_controller.rb
+++ b/app/controllers/latest_changes_controller.rb
@@ -34,22 +34,20 @@ private
   # Breadcrumbs for this page are hardcoded because it doesn't have a
   # content item with parents.
   def hardcoded_breadcrumbs
-    {
-      breadcrumbs: [
-        {
-          title: "Home",
-          url: "/",
-        },
-        {
-          title: subtopic.parent.title,
-          url: subtopic.parent.base_path,
-        },
-        {
-          title: subtopic.title,
-          url: subtopic.base_path,
-        },
-      ],
-    }
+    [
+      {
+        title: "Home",
+        url: "/",
+      },
+      {
+        title: subtopic.parent.title,
+        url: subtopic.parent.base_path,
+      },
+      {
+        title: subtopic.title,
+        url: subtopic.base_path,
+      },
+    ]
   end
 
   def pagination_params

--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -1,1 +1,4 @@
-<%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: Breadcrumbs.new(@content_item).breadcrumbs %>
+<%= render 'govuk_publishing_components/components/breadcrumbs', {
+  breadcrumbs: Breadcrumbs.new(@content_item).breadcrumbs,
+  collapse_on_mobile: true
+} %>

--- a/app/views/email_signups/new.html.erb
+++ b/app/views/email_signups/new.html.erb
@@ -7,7 +7,10 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/breadcrumbs', hardcoded_breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    breadcrumbs: hardcoded_breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 <% end %>
 
 <header>

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -12,7 +12,10 @@
 <% end %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/breadcrumbs', hardcoded_breadcrumbs %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    breadcrumbs: hardcoded_breadcrumbs,
+    collapse_on_mobile: true
+  } %>
 <% end %>
 
 <%= render(

--- a/app/views/organisations/_breadcrumb.html.erb
+++ b/app/views/organisations/_breadcrumb.html.erb
@@ -1,5 +1,6 @@
 <% content_for :breadcrumbs do %>
   <%= render "govuk_publishing_components/components/breadcrumbs", {
-    breadcrumbs: @header.breadcrumbs
+    breadcrumbs: @header.breadcrumbs,
+    collapse_on_mobile: true
   } %>
 <% end %>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,10 +1,10 @@
 <%= render "govuk_publishing_components/components/inverse_header", { full_width: true } do %>
   <div class="full-page-width-wrapper">
-    <%= render 'govuk_publishing_components/components/breadcrumbs',
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
       collapse_on_mobile: true,
       inverse: true
-    %>
+    } %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -14,11 +14,11 @@
 
 <header class="landing-page__header">
   <div class="govuk-width-container">
-    <%= render 'govuk_publishing_components/components/breadcrumbs',
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
       collapse_on_mobile: true,
       inverse: true
-    %>
+    } %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third landing-page__translation">

--- a/app/views/world_wide_taxons/_common.html.erb
+++ b/app/views/world_wide_taxons/_common.html.erb
@@ -24,8 +24,8 @@
     phase: "beta",
     message: beta_banner_message
   } %>
-  <%= render 'govuk_publishing_components/components/breadcrumbs',
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
     breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
     collapse_on_mobile: true
-  %>
+  } %>
 <% end %>

--- a/test/integration/courts_pages_test.rb
+++ b/test/integration/courts_pages_test.rb
@@ -6,6 +6,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
   it "renders a courts page correctly" do
     when_i_visit_a_courts_page
     i_see_the_courts_breadcrumb
+    and_the_breadcrumbs_collapse_on_mobile
     the_courts_title
     and_featured_links
     and_the_what_we_do_section
@@ -19,6 +20,7 @@ class CourtsPagesTest < ActionDispatch::IntegrationTest
   it "renders an HMCTS tribunal page correctly" do
     when_i_visit_an_hmcts_tribunal_page
     i_see_the_courts_breadcrumb
+    and_the_breadcrumbs_collapse_on_mobile
     the_courts_title
     and_featured_links
     and_the_what_we_do_section

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -30,7 +30,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
       visit content_item["base_path"]
 
       assert_equal 200, page.status_code
-      assert page.has_css?(".gem-c-breadcrumbs"),
+      assert page.has_css?(".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile"),
              "Expected page at '#{content_item['base_path']}' to display breadcrumbs, but none found"
     end
   end

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -522,7 +522,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   it "displays breadcrumbs" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
 
-    within ".gem-c-breadcrumbs" do
+    within ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile" do
       assert page.has_link?("Home", href: "/")
       assert page.has_link?("Organisations", href: "/government/organisations")
     end

--- a/test/integration/services_and_information_browsing_test.rb
+++ b/test/integration/services_and_information_browsing_test.rb
@@ -26,7 +26,7 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Waste")
     end
 
-    assert page.has_css?(".gem-c-breadcrumbs")
+    assert page.has_css?(".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile")
   end
 
   it "includes tracking attributes on all links" do

--- a/test/integration/step_nav_page_test.rb
+++ b/test/integration/step_nav_page_test.rb
@@ -16,7 +16,7 @@ class StepNavPageTest < ActionDispatch::IntegrationTest
   end
 
   it "renders breadcrumbs" do
-    assert page.has_css?(".gem-c-breadcrumbs")
+    assert page.has_css?(".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile")
   end
 
   it "renders the title" do

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -84,7 +84,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
     assert_not page.has_link?("North sea shipping lanes")
 
-    within ".gem-c-breadcrumbs" do
+    within ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile" do
       assert page.has_link?("Home", href: "/")
       assert page.has_link?("Oil and Gas", href: "/topic/oil-and-gas")
     end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -143,7 +143,7 @@ private
   def then_i_can_see_the_title_section
     assert page.has_selector?("title", text: "Taxon title", visible: false)
 
-    within ".gem-c-breadcrumbs" do
+    within ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile" do
       assert page.has_link?("Home", href: "/")
     end
   end

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -34,7 +34,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?("Oil and Gas")
 
-    assert page.has_css?(".gem-c-breadcrumbs")
+    assert page.has_css?(".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile")
   end
 
   it "renders a topic tag page and list its subtopics" do

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -701,6 +701,10 @@ module OrganisationHelpers
     visit content["base_path"]
   end
 
+  def and_the_breadcrumbs_collapse_on_mobile
+    assert page.has_css?(".gem-c-breadcrumbs--collapse-on-mobile")
+  end
+
   def i_see_the_courts_breadcrumb
     assert page.has_css?(".gem-c-breadcrumbs", text: "Courts and Tribunals")
   end

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -20,7 +20,7 @@ module TransitionLandingPageSteps
   def then_i_can_see_the_title_section
     assert page.has_selector?("title", text: "The transition period", visible: false)
 
-    within ".gem-c-breadcrumbs" do
+    within ".gem-c-breadcrumbs.gem-c-breadcrumbs--collapse-on-mobile" do
       assert page.has_link?("Home", href: "/")
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/qSJWzFjw/53-opt-in-approach-to-collapsing-breadcrumbs-on-mobile

## What
Apply the `collapse_on_mobile` flag to all uses of the breadcrumb component.

## Why
We want breadcrumbs to display consistently across GOVUK. The latest version of the gem makes this opt-in rather than default behaviour.

## Before and after (step by step)
<img width="230" alt="Screenshot 2020-02-28 at 14 39 12" src="https://user-images.githubusercontent.com/29889908/75557544-1a0dc580-5a38-11ea-9ef8-23bc5ec0339a.png">
<hr/>
<img width="231" alt="Screenshot 2020-02-28 at 14 38 59" src="https://user-images.githubusercontent.com/29889908/75557545-1c701f80-5a38-11ea-81f4-d18fc0280868.png">

## Before and after (topic)
<img width="220" alt="Screenshot 2020-02-28 at 14 40 22" src="https://user-images.githubusercontent.com/29889908/75557619-445f8300-5a38-11ea-981e-97f27b740219.png">
<hr/>
<img width="260" alt="Screenshot 2020-02-28 at 14 38 12" src="https://user-images.githubusercontent.com/29889908/75557484-ffd3e780-5a37-11ea-917b-3194e28b8f39.png">

## Pages to test

- [Legacy topic page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/topic/oil-and-gas/carbon-capture-and-storage/latest)
- [Step by step](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/learn-to-drive-a-car)
- [Email signup page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/topic/oil-and-gas/carbon-capture-and-storage/email-signup)
- [Organisations page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/government/organisations/department-for-business-energy-and-industrial-strategy)
- [Taxon page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/education/funding-for-special-educational-needs-and-disability-send)
- [Transition landing page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/transition)
- [World page](https://govuk-collec-collapse-b-ia0dzk.herokuapp.com/world/afghanistan)