### PR TITLE
Use a placeholder image from asset-manager

### DIFF
--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -106,7 +106,8 @@ module Supergroups
     end
 
     def default_news_image_url
-      "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg"
+      # this image has been uploaded to asset-manager
+      "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg"
     end
 
     def document_types

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -4,7 +4,8 @@ describe Supergroups::NewsAndCommunications do
   include RummagerHelpers
   include SupergroupHelpers
 
-  DEFAULT_WHITEHALL_IMAGE_URL = "https://assets.publishing.service.gov.uk/government/assets/placeholder.jpg".freeze
+  DEFAULT_IMAGE_URL = "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg".freeze
+
   let(:taxon_id) { "12345" }
   let(:news_and_communications_supergroup) { Supergroups::NewsAndCommunications.new }
 
@@ -120,7 +121,7 @@ describe Supergroups::NewsAndCommunications do
       .stubs(:fetch)
       .returns(content_list)
 
-      assert_equal DEFAULT_WHITEHALL_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
+      assert_equal DEFAULT_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
     end
   end
 


### PR DESCRIPTION
In the past this linked to an image served by Whitehall, but because of the way Rails generates hashes for assets, we can't guarantee that this URL will always exist. This hasn't been a problem in the past because we've been able to put an unhashed version of the image on the Whitehall machines, but since moving to AWS the machines can be recreated at any moment and won't have the file.

To solve this problem I've uploaded the file to Asset Manager and we can link to that instead. Ideally, we wouldn't depend on a file in a different application, but this solves the problem for now.

[Trello Card](https://trello.com/c/2hsW6TBA/1766-5-investigateplaceholderjpg-being-missing-from-whitehallbackend-machines-now-its-in-aws)