### PR TITLE
[Do Not Merge] Add eCommerce tracking to taxon browse

### DIFF
--- a/app/presenters/supergroups/guidance_and_regulation.rb
+++ b/app/presenters/supergroups/guidance_and_regulation.rb
@@ -18,13 +18,13 @@ module Supergroups
       document.content_store_document_type == "guide" || document.content_store_document_type == "answer"
     end
 
-    def format_document_data(documents, data_category = "")
+    def format_document_data(documents, secton_title, data_category = "")
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, document.title, index),
+            data_attributes: data_attributes(document.base_path, document.title, index, secton_title),
           },
           metadata: {
             document_type: document.content_store_document_type.humanize,

--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -10,15 +10,15 @@ module Supergroups
       @content = MostRecentContent.fetch(content_id: taxon_id, filter_content_store_document_type: document_types)
     end
 
-    def document_list(taxon_id)
+    def document_list(taxon_id, secton_title)
       items = tagged_content(taxon_id).drop(promoted_content_count)
 
-      format_document_data(items)
+      format_document_data(items, secton_title)
     end
 
-    def promoted_content(taxon_id)
+    def promoted_content(taxon_id, secton_title)
       items = tagged_content(taxon_id).shift(promoted_content_count)
-      format_document_data(items, "FeaturedLinkClicked", true)
+      format_document_data(items, secton_title, "FeaturedLinkClicked", true)
     end
 
   private

--- a/app/presenters/supergroups/policy_and_engagement.rb
+++ b/app/presenters/supergroups/policy_and_engagement.rb
@@ -6,10 +6,10 @@ module Supergroups
       super("policy_and_engagement")
     end
 
-    def document_list(taxon_id)
+    def document_list(taxon_id, secton_title)
       items = tagged_content(taxon_id)
 
-      format_document_data(items)
+      format_document_data(items, secton_title)
     end
 
     def tagged_content(taxon_id)
@@ -50,13 +50,13 @@ module Supergroups
       consultations + other_document_types
     end
 
-    def format_document_data(documents, data_category = "")
+    def format_document_data(documents, secton_title, data_category = "")
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, document.title, index),
+            data_attributes: data_attributes(document.base_path, document.title, index, secton_title),
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/supergroups/services.rb
+++ b/app/presenters/supergroups/services.rb
@@ -12,14 +12,14 @@ module Supergroups
 
   private
 
-    def format_document_data(documents, data_category = "")
+    def format_document_data(documents, secton_title, data_category = "")
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,
             path: document.base_path,
             description: document.description,
-            data_attributes: data_attributes(document.base_path, document.title, index),
+            data_attributes: data_attributes(document.base_path, document.title, index, secton_title),
           },
         }
 

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -30,10 +30,10 @@ module Supergroups
       raise NotImplementedError.new
     end
 
-    def document_list(taxon_id)
+    def document_list(taxon_id, secton_title)
       items = tagged_content(taxon_id)
 
-      format_document_data(items)
+      format_document_data(items, secton_title)
     end
 
     def data_module_label
@@ -66,11 +66,12 @@ module Supergroups
       }
     end
 
-    def data_attributes(base_path, link_text, index)
+    def data_attributes(base_path, link_text, index, secton_title)
       {
         module: "track-click",
         ecommerce_row: true,
         ecommerce_path: base_path,
+        ecommerce_subheading: secton_title,
         track_category: data_module_label + "DocumentListClicked",
         track_action: index,
         track_label: base_path,
@@ -80,13 +81,13 @@ module Supergroups
       }
     end
 
-    def format_document_data(documents, data_category = "", with_image_url = false)
+    def format_document_data(documents, secton_title, data_category = "", with_image_url = false)
       documents.each.with_index(1).map do |document, index|
         data = {
           link: {
             text: document.title,
             path: document.base_path,
-            data_attributes: data_attributes(document.base_path, document.title, index),
+            data_attributes: data_attributes(document.base_path, document.title, index, secton_title),
           },
           metadata: {
             public_updated_at: document.public_updated_at,

--- a/app/presenters/supergroups/supergroup.rb
+++ b/app/presenters/supergroups/supergroup.rb
@@ -69,6 +69,8 @@ module Supergroups
     def data_attributes(base_path, link_text, index)
       {
         module: "track-click",
+        ecommerce_row: true,
+        ecommerce_path: base_path,
         track_category: data_module_label + "DocumentListClicked",
         track_action: index,
         track_label: base_path,

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -41,12 +41,11 @@ private
   def organisation_list_with_logos
     organisations_with_logos.map.with_index do |org, index|
       {
-
           name: org.logo_formatted_title,
           url: org.link,
           brand: org.brand,
           crest: org.crest,
-          data_attributes: data_attributes(org.link, org.title, index + 1),
+          data_attributes: data_attributes(org.link, org.title, index + 1, "Organisations"),
       }
     end
   end
@@ -61,16 +60,17 @@ private
         link: {
           text: organisation.title,
           path: organisation.link,
-          data_attributes: data_attributes(organisation.link, organisation.title, tracking_number + index),
+          data_attributes: data_attributes(organisation.link, organisation.title, tracking_number + index, "Organisations"),
         },
       }
     end
   end
 
-  def data_attributes(base_path, link_text, index)
+  def data_attributes(base_path, link_text, index, secton_title)
     {
       ecommerce_row: true,
       ecommerce_path:  base_path,
+      ecommerce_subheading: secton_title,
       track_category: "organisationsDocumentListClicked",
       track_action: index,
       track_label: base_path,

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -69,6 +69,8 @@ private
 
   def data_attributes(base_path, link_text, index)
     {
+      ecommerce_row: true,
+      ecommerce_path:  base_path,
       track_category: "organisationsDocumentListClicked",
       track_action: index,
       track_label: base_path,

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -31,6 +31,8 @@ class TaxonPresenter
   def options_for_child_taxon(index:)
     {
       module: "track-click",
+      ecommerce_row: true,
+      ecommerce_path: child_taxons[index].base_path,
       track_category: "navGridContentClicked",
       track_action: (index + 1).to_s,
       track_label: child_taxons[index].base_path,

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -28,11 +28,12 @@ class TaxonPresenter
     child_taxons.count.positive?
   end
 
-  def options_for_child_taxon(index:)
+  def options_for_child_taxon(index, secton_title)
     {
       module: "track-click",
       ecommerce_row: true,
       ecommerce_path: child_taxons[index].base_path,
+      ecommerce_subheading: secton_title,
       track_category: "navGridContentClicked",
       track_action: (index + 1).to_s,
       track_label: child_taxons[index].base_path,

--- a/app/services/supergroup_sections/sections.rb
+++ b/app/services/supergroup_sections/sections.rb
@@ -12,8 +12,8 @@ module SupergroupSections
         {
           id: supergroup.name,
           title: supergroup.title,
-          promoted_content: (supergroup.promoted_content(taxon_id) if supergroup.methods.include? :promoted_content),
-          documents: supergroup.document_list(taxon_id),
+          promoted_content: (supergroup.promoted_content(taxon_id, supergroup.title) if supergroup.methods.include? :promoted_content),
+          documents: supergroup.document_list(taxon_id, supergroup.title),
           partial_template: supergroup.partial_template,
           see_more_link: supergroup.finder_link(base_path, taxon_id),
           show_section: supergroup.show_section?(taxon_id),

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -60,8 +60,14 @@
           } %>
 
           <%= render 'govuk_publishing_components/components/document_list',
-                     items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| { link: { text: child_taxon.title, path: child_taxon.base_path, data_attributes: presented_taxon.options_for_child_taxon(index: index) }} },
-                     margin_bottom: true
+              items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| {
+                link: {
+                  text: child_taxon.title,
+                  path: child_taxon.base_path,
+                  data_attributes: presented_taxon.options_for_child_taxon(index, t('taxons.explore_sub_topics'))
+                }
+              }},
+              margin_bottom: true
           %>
 
         </div>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -20,7 +20,12 @@
     <div class="govuk-grid-column-two-thirds">
       <% presented_taxon.sections.each do |section| %>
         <% if section[:show_section] %>
-          <div id="<%= section[:id] %>" class="taxon-page__section-group">
+          <div id="<%= section[:id] %>"
+               class="taxon-page__section-group"
+               data-analytics-ecommerce
+               data-ecommerce-start-index="1"
+               data-list-title="Taxonomy browse"
+               data-search-query>
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
                 <%= render "govuk_publishing_components/components/heading", {
@@ -42,7 +47,12 @@
       <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
 
       <% if presented_taxon.show_subtopic_grid? %>
-        <div id="sub-topics" class="taxon-page__section-group">
+        <div id="sub-topics"
+             class="taxon-page__section-group"
+             data-analytics-ecommerce
+             data-ecommerce-start-index="1"
+             data-list-title="Taxonomy browse"
+             data-search-query>
           <%= render "govuk_publishing_components/components/heading", {
               text: t('taxons.explore_sub_topics'),
               heading_level: 2,

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -21,6 +21,7 @@ describe Supergroups::GuidanceAndRegulation do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "Guidance and regulation",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -37,7 +38,7 @@ describe Supergroups::GuidanceAndRegulation do
         },
       ]
 
-      assert_equal expected, guidance_and_regulation_supergroup.document_list(taxon_id)
+      assert_equal expected, guidance_and_regulation_supergroup.document_list(taxon_id, "Guidance and regulation")
     end
 
     it "return a document list for guides" do
@@ -55,6 +56,7 @@ describe Supergroups::GuidanceAndRegulation do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "Guidance and regulation",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -70,7 +72,7 @@ describe Supergroups::GuidanceAndRegulation do
         },
       ]
 
-      actual = guidance_and_regulation_supergroup.document_list(taxon_id)
+      actual = guidance_and_regulation_supergroup.document_list(taxon_id, "Guidance and regulation")
 
       assert_equal expected, actual
       assert_equal 1, actual.count

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -19,6 +19,8 @@ describe Supergroups::GuidanceAndRegulation do
             path: "/government/tagged/content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -51,6 +53,8 @@ describe Supergroups::GuidanceAndRegulation do
             description: "Description of tagged content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "guidanceAndRegulationDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -22,6 +22,8 @@ describe Supergroups::NewsAndCommunications do
             path: "/government/tagged/content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "newsAndCommunicationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -78,6 +80,8 @@ describe Supergroups::NewsAndCommunications do
             text: "Tagged Content Title",
             path: "/government/tagged/content",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               module: "track-click",
               track_category: "newsAndCommunicationsFeaturedLinkClicked",
               track_action: 1,

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -24,6 +24,7 @@ describe Supergroups::NewsAndCommunications do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "News and communications",
               track_category: "newsAndCommunicationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -40,7 +41,7 @@ describe Supergroups::NewsAndCommunications do
         },
       ]
 
-      assert_equal expected, news_and_communications_supergroup.document_list(taxon_id)
+      assert_equal expected, news_and_communications_supergroup.document_list(taxon_id, "News and communications")
     end
 
     it "does not returns an image for news items" do
@@ -50,7 +51,7 @@ describe Supergroups::NewsAndCommunications do
         .stubs(:fetch)
         .returns(tagged_content(tagged_document_list))
 
-      news_and_communications_supergroup.document_list(taxon_id).each do |content_item|
+      news_and_communications_supergroup.document_list(taxon_id, "News and communications").each do |content_item|
         assert_not content_item.key?(:image)
       end
     end
@@ -82,6 +83,7 @@ describe Supergroups::NewsAndCommunications do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "News and communications",
               module: "track-click",
               track_category: "newsAndCommunicationsFeaturedLinkClicked",
               track_action: 1,
@@ -102,7 +104,7 @@ describe Supergroups::NewsAndCommunications do
         },
       ]
 
-      assert_equal expected, news_and_communications_supergroup.promoted_content(taxon_id)
+      assert_equal expected, news_and_communications_supergroup.promoted_content(taxon_id, "News and communications")
     end
 
     it "returns an image for the first news item" do
@@ -112,7 +114,7 @@ describe Supergroups::NewsAndCommunications do
         .stubs(:fetch)
         .returns(tagged_content(tagged_document_list))
 
-      promoted_news = news_and_communications_supergroup.promoted_content(taxon_id)
+      promoted_news = news_and_communications_supergroup.promoted_content(taxon_id, "News and communications")
 
       assert_equal 1, promoted_news.size
       assert promoted_news.first.key?(:image)
@@ -125,7 +127,7 @@ describe Supergroups::NewsAndCommunications do
       .stubs(:fetch)
       .returns(content_list)
 
-      assert_equal DEFAULT_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id).first[:image][:url]
+      assert_equal DEFAULT_IMAGE_URL, news_and_communications_supergroup.promoted_content(taxon_id, "News and communications").first[:image][:url]
     end
   end
 

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -47,7 +47,7 @@ describe Supergroups::PolicyAndEngagement do
             .stubs(:fetch)
             .returns(section_tagged_content_list("open_consultation", 4))
 
-          expected = Array.new(4) { |index| expected_result("open_consultation", index).first }
+          expected = Array.new(4) { |index| expected_result("open_consultation", index + 1).first }
           assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
         end
 
@@ -73,6 +73,8 @@ describe Supergroups::PolicyAndEngagement do
                 path: "/government/tagged/content-1",
                 data_attributes: {
                   module: "track-click",
+                  ecommerce_row: true,
+                  ecommerce_path: "/government/tagged/content-1",
                   track_category: "policyAndEngagementDocumentListClicked",
                   track_action: 1,
                   track_label: "/government/tagged/content-1",
@@ -110,21 +112,23 @@ private
 
   def expected_results(document_types)
     results = []
-    document_types.each_with_index do |document_type, index|
+    document_types.each.with_index(1) do |document_type, index|
       results.push(*expected_result(document_type, index))
     end
     results
   end
 
-  def expected_result(document_type, index = 0)
+  def expected_result(document_type, index = 1)
     result = {
       link: {
         text: "Tagged Content Title",
         path: "/government/tagged/content",
         data_attributes: {
           module: "track-click",
+          ecommerce_row: true,
+          ecommerce_path: "/government/tagged/content",
           track_category: "policyAndEngagementDocumentListClicked",
-          track_action: index + 1,
+          track_action: index,
           track_label: "/government/tagged/content",
           track_options: {
             dimension29: "Tagged Content Title",

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -13,7 +13,7 @@ describe Supergroups::PolicyAndEngagement do
         .stubs(:fetch)
         .returns(section_tagged_content_list("case_study"))
 
-      assert_equal expected_result("case_study"), policy_and_engagement_supergroup.document_list(taxon_id)
+      assert_equal expected_result("case_study"), policy_and_engagement_supergroup.document_list(taxon_id, "Policy papers and consultations")
     end
 
     describe "consultations" do
@@ -38,7 +38,7 @@ describe Supergroups::PolicyAndEngagement do
           .stubs(:fetch)
           .returns(tagged_content(tagged_document_list))
 
-        assert_equal expected_results(expected_order), policy_and_engagement_supergroup.document_list(taxon_id)
+        assert_equal expected_results(expected_order), policy_and_engagement_supergroup.document_list(taxon_id, "Policy papers and consultations")
       end
 
       describe "#consultation_closing_date" do
@@ -48,7 +48,7 @@ describe Supergroups::PolicyAndEngagement do
             .returns(section_tagged_content_list("open_consultation", 4))
 
           expected = Array.new(4) { |index| expected_result("open_consultation", index + 1).first }
-          assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+          assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id, "Policy papers and consultations")
         end
 
         it "gets the closing date of future consultations" do
@@ -75,6 +75,7 @@ describe Supergroups::PolicyAndEngagement do
                   module: "track-click",
                   ecommerce_row: true,
                   ecommerce_path: "/government/tagged/content-1",
+                  ecommerce_subheading: "Policy papers and consultations",
                   track_category: "policyAndEngagementDocumentListClicked",
                   track_action: 1,
                   track_label: "/government/tagged/content-1",
@@ -93,7 +94,7 @@ describe Supergroups::PolicyAndEngagement do
           ]
 
           Timecop.freeze("2018-04-18") do
-            assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id)
+            assert_equal expected, policy_and_engagement_supergroup.document_list(taxon_id, "Policy papers and consultations")
           end
         end
       end
@@ -127,6 +128,7 @@ private
           module: "track-click",
           ecommerce_row: true,
           ecommerce_path: "/government/tagged/content",
+          ecommerce_subheading: "Policy papers and consultations",
           track_category: "policyAndEngagementDocumentListClicked",
           track_action: index,
           track_label: "/government/tagged/content",

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -21,6 +21,7 @@ describe Supergroups::ResearchAndStatistics do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "Research and statistics",
               track_category: "researchAndStatisticsDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -37,7 +38,7 @@ describe Supergroups::ResearchAndStatistics do
         },
       ]
 
-      assert_equal expected, research_and_statistics_supergroup.document_list(taxon_id)
+      assert_equal expected, research_and_statistics_supergroup.document_list(taxon_id, "Research and statistics")
     end
   end
 

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -19,6 +19,8 @@ describe Supergroups::ResearchAndStatistics do
             path: "/government/tagged/content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "researchAndStatisticsDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -22,6 +22,7 @@ describe Supergroups::Services do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "Services",
               track_category: "servicesDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -33,7 +34,7 @@ describe Supergroups::Services do
         },
       ]
 
-      assert_equal expected, service_supergroup.document_list(taxon_id)
+      assert_equal expected, service_supergroup.document_list(taxon_id, "Services")
     end
   end
 

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -20,6 +20,8 @@ describe Supergroups::Services do
             description: "Description of tagged content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "servicesDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -21,6 +21,7 @@ describe Supergroups::Transparency do
               module: "track-click",
               ecommerce_row: true,
               ecommerce_path: "/government/tagged/content",
+              ecommerce_subheading: "Transparency and freedom of information releases",
               track_category: "transparencyDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",
@@ -37,7 +38,7 @@ describe Supergroups::Transparency do
         },
       ]
 
-      assert_equal expected, transparency_supergroup.document_list(taxon_id)
+      assert_equal expected, transparency_supergroup.document_list(taxon_id, "Transparency and freedom of information releases")
     end
   end
 

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -19,6 +19,8 @@ describe Supergroups::Transparency do
             path: "/government/tagged/content",
             data_attributes: {
               module: "track-click",
+              ecommerce_row: true,
+              ecommerce_path: "/government/tagged/content",
               track_category: "transparencyDocumentListClicked",
               track_action: 1,
               track_label: "/government/tagged/content",

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -37,6 +37,8 @@ describe TaxonOrganisationsPresenter do
             text: "Department for Education",
             path: "/government/organisations/department-for-education",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path:  "/government/organisations/department-for-education",
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/organisations/department-for-education",
@@ -68,6 +70,8 @@ describe TaxonOrganisationsPresenter do
           brand: "department-for-education",
           crest: "single-identity",
           data_attributes: {
+            ecommerce_row: true,
+            ecommerce_path:  "/government/organisations/department-for-education",
             track_category: "organisationsDocumentListClicked",
             track_action: 1,
             track_label: "/government/organisations/department-for-education",
@@ -97,6 +101,8 @@ describe TaxonOrganisationsPresenter do
             text: "Department for Education",
             path: "/government/organisations/department-for-education",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path:  "/government/organisations/department-for-education",
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/organisations/department-for-education",
@@ -130,6 +136,8 @@ describe TaxonOrganisationsPresenter do
           brand: "department-for-education",
           crest: "single-identity",
           data_attributes: {
+            ecommerce_row: true,
+            ecommerce_path:  "/government/organisations/department-for-education",
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
             track_label: "/government/organisations/department-for-education",
@@ -161,6 +169,8 @@ describe TaxonOrganisationsPresenter do
             text: "Department for Education",
             path: "/government/organisations/department-for-education",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path:  "/government/organisations/department-for-education",
               track_category: "organisationsDocumentListClicked",
               track_action: index + 1,
               track_label: "/government/organisations/department-for-education",
@@ -196,6 +206,8 @@ describe TaxonOrganisationsPresenter do
           brand: "department-for-education",
           crest: "single-identity",
           data_attributes: {
+            ecommerce_row: true,
+            ecommerce_path:  "/government/organisations/department-for-education",
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
             track_label: "/government/organisations/department-for-education",
@@ -212,6 +224,8 @@ describe TaxonOrganisationsPresenter do
             text: "Department for Education",
             path: "/government/organisations/department-for-education",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path:  "/government/organisations/department-for-education",
               track_category: "organisationsDocumentListClicked",
               track_action: 4,
               track_label: "/government/organisations/department-for-education",
@@ -247,6 +261,8 @@ describe TaxonOrganisationsPresenter do
           brand: "department-for-education",
           crest: "single-identity",
           data_attributes: {
+            ecommerce_row: true,
+            ecommerce_path:  "/government/organisations/department-for-education",
             track_category: "organisationsDocumentListClicked",
             track_action: 6,
             track_label: "/government/organisations/department-for-education",
@@ -278,6 +294,8 @@ describe TaxonOrganisationsPresenter do
             text: "Department for Education",
             path: "/government/organisations/department-for-education",
             data_attributes: {
+              ecommerce_row: true,
+              ecommerce_path:  "/government/organisations/department-for-education",
               track_category: "organisationsDocumentListClicked",
               track_action: 6,
               track_label: "/government/organisations/department-for-education",

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -39,6 +39,7 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path:  "/government/organisations/department-for-education",
+              ecommerce_subheading: "Organisations",
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/organisations/department-for-education",
@@ -72,6 +73,7 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             ecommerce_row: true,
             ecommerce_path:  "/government/organisations/department-for-education",
+            ecommerce_subheading: "Organisations",
             track_category: "organisationsDocumentListClicked",
             track_action: 1,
             track_label: "/government/organisations/department-for-education",
@@ -103,6 +105,7 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path:  "/government/organisations/department-for-education",
+              ecommerce_subheading: "Organisations",
               track_category: "organisationsDocumentListClicked",
               track_action: 1,
               track_label: "/government/organisations/department-for-education",
@@ -138,6 +141,7 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             ecommerce_row: true,
             ecommerce_path:  "/government/organisations/department-for-education",
+            ecommerce_subheading: "Organisations",
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
             track_label: "/government/organisations/department-for-education",
@@ -171,6 +175,7 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path:  "/government/organisations/department-for-education",
+              ecommerce_subheading: "Organisations",
               track_category: "organisationsDocumentListClicked",
               track_action: index + 1,
               track_label: "/government/organisations/department-for-education",
@@ -208,6 +213,7 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             ecommerce_row: true,
             ecommerce_path:  "/government/organisations/department-for-education",
+            ecommerce_subheading: "Organisations",
             track_category: "organisationsDocumentListClicked",
             track_action: index + 1,
             track_label: "/government/organisations/department-for-education",
@@ -226,6 +232,7 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path:  "/government/organisations/department-for-education",
+              ecommerce_subheading: "Organisations",
               track_category: "organisationsDocumentListClicked",
               track_action: 4,
               track_label: "/government/organisations/department-for-education",
@@ -263,6 +270,7 @@ describe TaxonOrganisationsPresenter do
           data_attributes: {
             ecommerce_row: true,
             ecommerce_path:  "/government/organisations/department-for-education",
+            ecommerce_subheading: "Organisations",
             track_category: "organisationsDocumentListClicked",
             track_action: 6,
             track_label: "/government/organisations/department-for-education",
@@ -296,6 +304,7 @@ describe TaxonOrganisationsPresenter do
             data_attributes: {
               ecommerce_row: true,
               ecommerce_path:  "/government/organisations/department-for-education",
+              ecommerce_subheading: "Organisations",
               track_category: "organisationsDocumentListClicked",
               track_action: 6,
               track_label: "/government/organisations/department-for-education",

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -17,10 +17,14 @@ describe TaxonPresenter do
           stub_content_for_taxon([taxon.content_id], generate_search_results(15))
         end
 
-        subject { taxon_presenter.options_for_child_taxon(index: 0) }
+        subject { taxon_presenter.options_for_child_taxon(0, "Section Title") }
 
         it "contains the track-click module" do
           assert_equal("track-click", subject[:module])
+        end
+
+        it "contains the ecommerce subheader" do
+          assert_equal("Section Title", subject[:ecommerce_subheading])
         end
 
         it "contains the navGridContentClicked track_category" do


### PR DESCRIPTION
Trello: https://trello.com/c/9UR6LMz0/140-add-ecommerce-tracking-to-taxon-pages

## Dependent on
- Fix to the large payload ecommerce bug
- Fix to double event listners firing in ecommerce
##What
We should add Google Analytics Ecommerce tracking to the navigational links across the taxon pages

**List level atributes**

- ` data-analytics-ecommerce`
- ` data-ecommerce-start-index="1"`
- ` data-list-title="Taxon Browse"`

with the level reflecting how far the user is into the navigation

Also if [the generalisation mentioned here](https://trello.com/c/BTt4TmUG/143-%F0%9F%97%A1-generalise-statics-ecommerce-module) has not been completed the list will require the following empty attribute to work: ` data-search-query`

**Row level attributes**
-  `ecommerce_row: true`
-  `ecommerce_subheading: "All categories"`

if [this PR has been merged](https://github.com/alphagov/static/pull/2068) we can also have an optional `data-ecommerce-subheading` to describe which groups a row item falls into.

##Why
So we can understand the % of users who interact with each element. 

This will inform the taxon pages redesign and provide a benchmark against which to judge the re-designed header's performance.