### PR TITLE
Update visually hidden text on share links on government organisation pages

### DIFF
--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -17,6 +17,7 @@ module Organisations
         links << {
           href: link["href"],
           text: link["title"],
+          hidden_text: "Follow on",
           icon: link["service_type"],
         }
       end


### PR DESCRIPTION
The default hidden text is "Share on" which is good in most cases but on government organisation pages the component is used as social links, so that text doesn't make sense.

This updates it to "Follow on"

[Example page](https://govuk-collec-update-sha-4dtxh3.herokuapp.com//government/organisations/competition-and-markets-authority)