### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-task default: [:lint]
 Collections::Application.load_tasks

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,0 @@
-desc "Run govuk-lint with similar params to CI"
-task lint: :environment do
-  unless ENV["JENKINS"]
-    sh "bundle exec rubocop --parallel --format clang app spec lib"
-  end
-end


### PR DESCRIPTION
- This `lint` task is not very useful as it hides the directories that
  it operates on, and we're trying to move away from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.