### PR TITLE
Fix wonky paths

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,5 +72,16 @@ Rails.application.routes.draw do
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
   get "/brexit(.:locale)", to: "transition_landing_page#show"
   get "/transition(.:locale)", to: "transition_landing_page#show"
+
+  # We get requests for URLs like
+  # https://www.gov.uk/topic%2Flegal-aid-for-providers%2Fmake-application%2Flatest
+  # which fall through to here and error in the taxons controller.
+  # We can fix the path and redirect to the correct place.
+  get "/:slug",
+    to: redirect { |path_params, req|
+      [req.path.gsub("%2F", "/"), req.query_string].join("?").chomp("?")
+    },
+    constraints: lambda { |req| req.path.include? "%2F" }
+
   get "*taxon_base_path", to: "taxons#show"
 end

--- a/test/integration/redirection_test.rb
+++ b/test/integration/redirection_test.rb
@@ -1,0 +1,27 @@
+require "integration_test_helper"
+
+class RedirectionTest < ActionDispatch::IntegrationTest
+  describe "URL encoded paths" do
+    before do
+      base_path = "/government/people/cornelius-fudge"
+      content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person")
+        .merge("base_path" => base_path)
+
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "redirects to their unencoded paths" do
+      get "/government%2Fpeople%2Fcornelius-fudge"
+
+      assert_response :redirect
+      assert_equal response.header["Location"], "http://www.example.com/government/people/cornelius-fudge"
+    end
+
+    it "ignores query strings" do
+      get "/government%2Fpeople%2Fcornelius-fudge?associates=higgs%26mclaggen%2Fshacklebolt%26tonks"
+
+      assert_response :redirect
+      assert_equal response.header["Location"], "http://www.example.com/government/people/cornelius-fudge?associates=higgs%26mclaggen%2Fshacklebolt%26tonks"
+    end
+  end
+end


### PR DESCRIPTION
We get requests for paths that aren't picked up by standard rails routing, eg:
  https://www.gov.uk/topic%2Flegal-aid-for-providers%2Fmake-application%2Flatest
The slashes in the path are encoded to %2F which means it doesn't match routes like:

```
get "/topic/:topic_slug/", to: "thing#action"
```
or resources blocks like:
```
resources :topics
```

If the wrong sort of URL falls down to the taxons controller, then we end up with an error in Sentry (https://sentry.io/organizations/govuk/issues/1399727649/?project=202213&query=is%3Aunresolved).

They seem to get through Router OK ([there's a test exploring this in a branch](https://github.com/alphagov/router/compare/encoded_path_tests?expand=1)), and are directed to applications that would handle them, should they recognise the routes.  Government Frontend seems to deal with these OK, because it uses wildcard routes for the most part, and looks at the document type of the content item to determine how to deal with it.  Frontend generally works in a
similar way to Government Frontend so is also OK.

Collections relies heavily on knowing URL schemes, such as having a `/government/organisation` prefix.  This is broken if the URL doesn't have a slash between `government` and `organisation`.

There are 6000-ish errors tracked at present, and though we seem to fall back to the mirrors OK, we're not handling them very well.
