### PR TITLE
[Do Not Merge] Add eCommerce tracking to mainstream browse

### DIFF
--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,4 +1,11 @@
-<div id="root" class="pane root-pane">
+<div id="root"
+  class="pane root-pane"
+  data-analytics-ecommerce
+  data-search-query
+  data-ecommerce-start-index="1"
+  data-list-title="Mainstream browse - Column 1"
+ >
+
   <h2 class="visuallyhidden" tabindex="-1">All categories</h2>
   <ul>
     <% top_level_browse_pages.each_with_index do |page, index| %>
@@ -10,6 +17,9 @@
             track_category: 'firstLevelBrowseLinkClicked',
             track_action: "#{index + 1}",
             track_label: page.base_path,
+            ecommerce_row: true,
+            ecommerce_path: page.base_path,
+            ecommerce_subheading: "All categories",
             track_options: {
               dimension28: top_level_browse_pages.count.to_s,
               dimension29: page.title,

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,3 +1,4 @@
+<% ecommerce_page_row_count = 1 %>
 <div class="pane-inner <%= page.lists.curated? ? 'curated-list' : 'a-to-z' %>">
   <h2 tabindex="-1" class="js-heading"><%= page.title %></h2>
 
@@ -8,13 +9,19 @@
       <p class="sort-order"><%= hairspace list.title %></p>
     <% end %>
 
-    <ul>
+    <ul data-analytics-ecommerce
+        data-search-query
+        data-ecommerce-start-index=<%= "#{section_index + 1}" %>
+        data-list-title="Mainstream browse - Column 3">
       <% list.contents.each_with_index do |list_item, index| %>
         <li>
           <%= link_to(
             list_item.title,
             list_item.base_path,
             data: {
+              ecommerce_row: true,
+              ecommerce_path: list_item.base_path,
+              ecommerce_subheading: page.lists.curated? ? list.title : 'A to Z',
               track_category: 'thirdLevelBrowseLinkClicked',
               track_action: "#{section_index + 1}.#{index + 1}",
               track_label: list_item.base_path,
@@ -25,6 +32,7 @@
             },
             class: "govuk-link",
           ) %>
+          <% ecommerce_page_row_count += 1 %>
         </li>
       <% end %>
     </ul>
@@ -33,13 +41,19 @@
   <% if page.related_topics.any? %>
     <div class="detailed-guidance">
       <h2>Detailed guidance</h2>
-      <ul>
+      <ul data-analytics-ecommerce
+          data-search-query
+          data-ecommerce-start-index=<%= "#{ecommerce_page_row_count}" %>
+          data-list-title="Mainstream browse - Column 3">
         <% page.related_topics.each_with_index do |related_topic, index| %>
           <li>
             <%= link_to(
               related_topic.title,
               related_topic.base_path,
               data: {
+                ecommerce_row: true,
+                ecommerce_path: related_topic.base_path,
+                ecommerce_subheading: "Detailed guidance",
                 track_category: 'thirdLevelBrowseLinkClicked',
                 track_action: "#{page.lists.count + 1}.#{index + 1}",
                 track_label: related_topic.base_path,

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -1,4 +1,8 @@
-<div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
+<div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>"
+     data-analytics-ecommerce
+     data-search-query
+     data-ecommerce-start-index="1"
+     data-list-title="Mainstream browse - Column 2">
   <h2 tabindex="-1" class="js-heading"><%= title %></h2>
   <% unless curated_order %>
     <p class="sort-order"><%= hairspace 'A to Z' %></p>
@@ -9,6 +13,9 @@
         <%= link_to(
           browse_page.base_path,
           data: {
+            ecommerce_row: true,
+            ecommerce_path: browse_page.base_path,
+            ecommerce_subheading: "#{title} - #{curated_order ? 'Curated' : 'A to Z'}",
             track_category: 'secondLevelBrowseLinkClicked',
             track_action: "#{index + 1}",
             track_label: browse_page.base_path,

--- a/features/step_definitions/analyitics_steps.rb
+++ b/features/step_definitions/analyitics_steps.rb
@@ -1,0 +1,31 @@
+Then(/^the ecommerce tracking tags are present$/) do
+  assert page.has_selector?("div#root[data-analytics-ecommerce]")
+  assert page.has_selector?('div#root[data-ecommerce-start-index="1"]')
+  assert page.has_selector?('div#root[data-search-query="all categories"]')
+  assert page.has_selector?('div#root[data-list-title="Mainstream browse - Column 1"]')
+
+  assert_equal page.find("div#root li:nth-child(1) a")["data-ecommerce-row"], "1"
+  assert_equal page.find("div#root li:nth-child(1) a")["data-ecommerce-path"], "/browse/benefits"
+
+  assert_equal page.find("div#root li:nth-child(2) a")["data-ecommerce-row"], "2"
+  assert_equal page.find("div#root li:nth-child(2) a")["data-ecommerce-path"], "/browse/crime-and-justice"
+end
+
+And(/^the links on the page have tracking attributes$/) do
+  assert_equal page.find("div#root li:nth-child(1) a")["data-track-action"], "1"
+  assert_equal page.find("div#root li:nth-child(1) a")["data-track-label"], "/browse/benefits"
+  assert_equal page.find("div#root li:nth-child(1) a")["data-track-category"], "firstLevelBrowseLinkClicked"
+  assert_equal page.find("div#root li:nth-child(1) a")["data-track-options"], tracking_options_payloads[0]
+
+  assert_equal page.find("div#root li:nth-child(2) a")["data-track-action"], "2"
+  assert_equal page.find("div#root li:nth-child(2) a")["data-track-label"], "/browse/crime-and-justice"
+  assert_equal page.find("div#root li:nth-child(2) a")["data-track-category"], "firstLevelBrowseLinkClicked"
+  assert_equal page.find("div#root li:nth-child(2) a")["data-track-options"], tracking_options_payloads[1]
+end
+
+def tracking_options_payloads
+  [
+    '{"dimension28":"2","dimension29":"Benefits"}',
+    '{"dimension28":"2","dimension29":"Crime and justice"}',
+  ]
+end

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,6 +1,6 @@
 Then(/^the ecommerce tracking tags are present$/) do
   assert page.has_selector?("div#root[data-analytics-ecommerce]")
-  assert page.has_selector?('div#root[data-search-query]')
+  assert page.has_selector?("div#root[data-search-query]")
   assert page.has_selector?('div#root[data-ecommerce-start-index="1"]')
   assert page.has_selector?('div#root[data-list-title="Mainstream browse - Column 1"]')
   assert page.has_selector?("div#root li:nth-child(1) a[data-ecommerce-row]")

--- a/features/step_definitions/analytics_steps.rb
+++ b/features/step_definitions/analytics_steps.rb
@@ -1,8 +1,10 @@
 Then(/^the ecommerce tracking tags are present$/) do
   assert page.has_selector?("div#root[data-analytics-ecommerce]")
+  assert page.has_selector?('div#root[data-search-query]')
   assert page.has_selector?('div#root[data-ecommerce-start-index="1"]')
-  assert page.has_selector?('div#root[data-search-query="all categories"]')
   assert page.has_selector?('div#root[data-list-title="Mainstream browse - Column 1"]')
+  assert page.has_selector?("div#root li:nth-child(1) a[data-ecommerce-row]")
+  assert page.has_selector?("div#root li:nth-child(2) a[data-ecommerce-row]")
 
   assert_equal page.find("div#root li:nth-child(1) a")["data-ecommerce-row"], "1"
   assert_equal page.find("div#root li:nth-child(1) a")["data-ecommerce-path"], "/browse/benefits"

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -78,11 +78,11 @@ Then(/^I should see the second level browse page$/) do
 end
 
 Then(/^the A to Z label should be present$/) do
-  assert page.has_content?("A\u200Ato\u200AZ")
+  assert page.has_text?("A\u200Ato\u200AZ")
 end
 
 Then(/^the A to Z label should not be present$/) do
-  assert page.has_no_content?("A\u200Ato\u200AZ")
+  assert page.has_no_text?("A\u200Ato\u200AZ")
 end
 
 When(/^I visit that browse page$/) do


### PR DESCRIPTION
Trello: https://trello.com/c/wyHXRVll/138-add-ecommerce-tracking-to-mainstream-browse

## Dependent on
- Fix to the large payload ecommerce bug
- Fix to double event listners firing in ecommerce

##What
We should add Google Analytics Ecommerce tracking to the navigational links across the mainstream browse pages

**List level atributes**

- ` data-analytics-ecommerce`
- ` data-ecommerce-start-index="1"`
- ` data-list-title="Mainstream Browse - Level {x}"`

with the level reflecting how far the user is into the navigation

Also if [the generalisation mentioned here](https://trello.com/c/BTt4TmUG/143-%F0%9F%97%A1-generalise-statics-ecommerce-module) has not been completed the list will require the following empty attribute to work: ` data-search-query`

**Row level attributes**
-  `ecommerce_row: true`
-  `ecommerce_subheading: "All categories"`

if [this PR has been merged](https://github.com/alphagov/static/pull/2068) we can also have an optional `data-ecommerce-subheading` to describe which groups a row item falls into.

##Why
So we can understand the % of users who interact with each element. 

This will inform the mainstream redesign and provide a benchmark against which to judge the re-designed header's performance.