### PR TITLE
Tweaks to CV landing page setup

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -2,8 +2,10 @@ class CoronavirusLandingPageController < ApplicationController
   before_action :set_locale
 
   def show
-    @content_item = ContentItem.find!("/government/topical-events/coronavirus-covid-19-uk-government-response").to_hash
-    render :show
+    @content_item = { "locale" => "en" }
+    breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
+
+    render "show", locals: { breadcrumbs: breadcrumbs }
   end
 
 private

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -15,7 +15,7 @@
 <header class="landing-page__header">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
-      breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
+      breadcrumbs: breadcrumbs,
       collapse_on_mobile: true,
       inverse: true
     } %>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -1,6 +1,6 @@
 <%=
   render(
-      partial: 'page_header'
+      partial: 'page_header', locals: { breadcrumbs: breadcrumbs }
   )
 %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+
+  get "/coronavirus", to: "coronavirus_landing_page#show"
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: %i(index show), param: :top_level_slug do
@@ -72,7 +74,6 @@ Rails.application.routes.draw do
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
   get "/brexit(.:locale)", to: "transition_landing_page#show"
   get "/transition(.:locale)", to: "transition_landing_page#show"
-  get "/coronavirus(.:locale)", to: "coronavirus_landing_page#show"
 
   # We get requests for URLs like
   # https://www.gov.uk/topic%2Flegal-aid-for-providers%2Fmake-application%2Flatest

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -6,7 +6,6 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
 
   describe "the coronavirus landing page" do
     it "renders" do
-      given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
       then_i_can_see_the_introduction_section

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -6,14 +6,7 @@ module CoronavirusLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include RummagerHelpers
 
-  CORONAVIRUS_CONTENT_ID = "c4cd0e8a-3ae1-4385-8936-1cfafe5031fb".freeze
   CORONAVIRUS_PATH = "/coronavirus".freeze
-  TE_CORONAVIRUS_PATH = "/government/topical-events/coronavirus-covid-19-uk-government-response".freeze
-
-  def given_there_is_a_content_item
-    stub_content_store_has_item(CORONAVIRUS_PATH)
-    stub_content_store_has_item(TE_CORONAVIRUS_PATH, content_item)
-  end
 
   def when_i_visit_the_coronavirus_landing_page
     visit CORONAVIRUS_PATH
@@ -25,17 +18,5 @@ module CoronavirusLandingPageSteps
 
   def then_i_can_see_the_introduction_section
     assert page.has_selector?("h2.govuk-heading-l", text: "Guidance for Coronavirus")
-  end
-
-  def content_item
-    GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
-      item.merge(
-        "base_path" => TE_CORONAVIRUS_PATH,
-        "content_id" => CORONAVIRUS_CONTENT_ID,
-        "title" => "Coronavirus",
-        "phase" => "live",
-        "links" => {},
-      )
-    end
   end
 end


### PR DESCRIPTION
Moving the route further up, and setting out own breadcrumbs and locale removes the need for content store calls.  This is useful as it simplifies the page, but also simplifies testing.