### PR TITLE
Landing page accordion tweaks

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -19,8 +19,16 @@ $covid-green: #7eff8e;
 
 .covid__list-item {
   @include govuk-media-query($until: desktop) {
-    padding-bottom: govuk-spacing(2);
+    padding-bottom: govuk-spacing(3);
+
+    &:last-child {
+      padding-bottom: 0;
+    }
   }
+}
+
+.govuk-list ~ .covid__accordion-heading {
+  margin-top: govuk-spacing(4);
 }
 
 .covid__topic-wrapper {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -17,6 +17,12 @@ $covid-green: #7eff8e;
   }
 }
 
+.covid__list-item {
+  @include govuk-media-query($until: desktop) {
+    padding-bottom: govuk-spacing(2);
+  }
+}
+
 .covid__topic-wrapper {
   padding-top: govuk-spacing(6);
 

--- a/app/views/coronavirus_landing_page/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/_accordion_sections.html.erb
@@ -1,7 +1,10 @@
   <% accordion_contents = [] %>
   <% t("coronavirus_landing_page.sections").each do | section | %>
     <% content = capture do %>
-      <%= render( partial: 'section', locals: section ) %>
+      <%# this element captures an override from the accordion that the last item has margin 0 %>
+      <div class="covid__accordion-inner">
+        <%= render( partial: 'section', locals: section ) %>
+      </div>
     <% end %>
     <%
       accordion_contents << {

--- a/app/views/coronavirus_landing_page/_section.html.erb
+++ b/app/views/coronavirus_landing_page/_section.html.erb
@@ -1,6 +1,6 @@
 <% sub_sections.each do |sub_section| %>
   <% if sub_section[:title] %>
-    <h3 class="govuk-heading-s"><%= sub_section[:title] %></h3>
+    <h3 class="govuk-heading-s covid__accordion-heading"><%= sub_section[:title] %></h3>
   <% end %>
   <ul class="govuk-list">
     <% sub_section[:list].each do | item | %>

--- a/app/views/coronavirus_landing_page/_section.html.erb
+++ b/app/views/coronavirus_landing_page/_section.html.erb
@@ -4,7 +4,7 @@
   <% end %>
   <ul class="govuk-list">
     <% sub_section[:list].each do | item | %>
-      <li>
+      <li class="covid__list-item">
         <a class="govuk-link" href="<%= item[:url] %>"><%= item[:label] %></a>
       </li>
     <% end %>


### PR DESCRIPTION
## What / why

A few changes to the landing page accordion and accordion content, particularly on mobile. Specific changes:

- Increase spacing between links in accordion content: https://trello.com/c/WjsDcDRw/52-increase-accordion-touch-target-size
- Increase the space at the end of the accordion after the last link: https://trello.com/c/CsKhUdZW/53-increase-accordion-space-after-last-link
