### PR TITLE
Design updates for CV-19

### DIFF
--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -38,5 +38,5 @@ $nhs_brand_color: #005EB8;
 }
 
 .app-c-header-notice__call-to-action-link {
-  @include govuk-font(24, $weight: bold);
+  @include govuk-font(19, $weight: bold);
 }

--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -1,7 +1,7 @@
 $nhs_brand_color: #005EB8;
 
 .app-c-header-notice {
-  margin-bottom: govuk-spacing(8);
+  @include govuk-responsive-margin(8, "bottom");
 }
 
 .app-c-header-notice__branding--nhs {
@@ -25,7 +25,7 @@ $nhs_brand_color: #005EB8;
 }
 
 .app-c-header-notice__title-logo {
-  max-width: 90px;
+  max-width: 60px;
 }
 
 .app-c-header-notice__content {
@@ -34,7 +34,7 @@ $nhs_brand_color: #005EB8;
 }
 
 .app-c-header-notice__list {
-  margin-bottom: govuk-spacing(5);
+  @include govuk-responsive-margin(5, "bottom");
 }
 
 .app-c-header-notice__call-to-action-link {

--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -25,7 +25,7 @@ en:
                 url: /government/publications/covid-19-guidance-on-social-distancing-and-for-vulnerable-people/guidance-on-social-distancing-for-everyone-in-the-uk-and-protecting-older-people-and-vulnerable-adults
       - title: Coronavirus (COVID-19) cases in the UK
         sub_sections:
-          - title: "Data on reported cases of coronavirus around the UK."
+          - title:
             list:
               - label: Number of coronavirus cases in the UK
                 url: /guidance/coronavirus-covid-19-information-for-the-public


### PR DESCRIPTION
Trello tickets:

- https://trello.com/c/lk56cLWI/54-reduce-the-margin-below-the-nhs-box-to-30px-on-mobile
- https://trello.com/c/9HlvAiNB/51-nhs-box-link-needs-to-be-19px
- https://trello.com/c/kU55ud5e/55-remove-subheading-data-on-reported-cases-of-coronavirus-around-the-uk