### PR TITLE
Set a short cache time on coronavirus page

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,4 +1,6 @@
 class CoronavirusLandingPageController < ApplicationController
+  skip_before_action :set_expiry
+  before_action -> { set_expiry(1.minute) }
   before_action :set_locale
 
   def show


### PR DESCRIPTION
We may want to make fast updates to this

This is the same cache expiry as the transition page