### PR TITLE
Edit covid page with education changes

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -23,6 +23,10 @@ $covid-green: #7eff8e;
 .covid__page-title {
   @include govuk-font(48, $weight: bold);
 
+  @include govuk-media-query($from: mobile) {
+    margin-bottom: govuk-spacing(6);
+  }
+
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(4);
     margin-bottom: govuk-spacing(8);

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -7,16 +7,28 @@ $covid-green: #7eff8e;
   background-color: govuk-colour("black");
   color: govuk-colour("white");
 
-  .gem-c-heading, .govuk-body-m {
-    color: govuk-colour("white");
-  }
-
   .gem-c-heading {
     border-color: $covid-green;
+    color: unset
   }
 
   a {
     color: govuk-colour("white");
+
+    &:link,
+    &:visited {
+      color: govuk-colour("white");
+    }
+
+    &:active,
+    &:hover {
+      color: $govuk-hover-colour;
+    }
+
+    &:focus,
+    &:link:focus {
+      @include govuk-focused-text;
+    }
   }
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -6,6 +6,18 @@ $covid-green: #7eff8e;
   border-top: solid govuk-spacing(2) $covid-green;
   background-color: govuk-colour("black");
   color: govuk-colour("white");
+
+  .gem-c-heading, .govuk-body-m {
+    color: govuk-colour("white");
+  }
+
+  .gem-c-heading {
+    border-color: $covid-green;
+  }
+
+  a {
+    color: govuk-colour("white");
+  }
 }
 
 .covid__page-title {

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -34,37 +34,25 @@
     } %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <a href="https://www.gov.uk/government/publications/closure-of-educational-settings-information-for-parents-and-carers/closure-of-educational-settings-information-for-parents-and-carers">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Schools, universities, and early years settings are closed",
-            padding: true,
-            font_size: 19,
-            border_top: 2,
-            heading_level: 3
-          } %>
-        </a>
+        <h3 class="gem-c-heading  gem-c-heading--font-size-19 gem-c-heading--padding gem-c-heading--border-top-2">
+          <a href="https://www.gov.uk/government/publications/closure-of-educational-settings-information-for-parents-and-carers/closure-of-educational-settings-information-for-parents-and-carers">
+            Schools, universities, and early years settings are closed
+          </a>
+        </h3>
       </div>
       <div class="govuk-grid-column-one-third">
-        <a href="https://www.gov.uk/government/news/government-announces-further-measures-on-social-distancing">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Pubs, restaurants, and entertainment venues are closed",
-            padding: true,
-            font_size: 19,
-            border_top: 2,
-            heading_level: 3
-          } %>
-        </a>
+        <h3 class="gem-c-heading  gem-c-heading--font-size-19 gem-c-heading--padding gem-c-heading--border-top-2">
+          <a href="https://www.gov.uk/government/news/government-announces-further-measures-on-social-distancing">
+            Pubs, restaurants, and entertainment venues are closed
+          </a>
+        </h3>
       </div>
       <div class="govuk-grid-column-one-third">
-        <a href="https://www.gov.uk/government/publications/guidance-to-employers-and-businesses-about-covid-19/covid-19-support-for-businesses">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Government to pay wages of employees unable to work",
-            padding: true,
-            font_size: 19,
-            border_top: 2,
-            heading_level: 3
-          } %>
-        </a>
+        <h3 class="gem-c-heading  gem-c-heading--font-size-19 gem-c-heading--padding gem-c-heading--border-top-2">
+          <a href="https://www.gov.uk/government/publications/guidance-to-employers-and-businesses-about-covid-19/covid-19-support-for-businesses">
+            Government to pay wages of employees unable to work
+          </a>
+        </h3>
       </div>
     </div>
   </div>

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -26,5 +26,46 @@
         </h1>
       </div>
     </div>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Announcements",
+      padding: true,
+      font_size: 19,
+      heading_level: 2
+    } %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <a href="https://www.gov.uk/government/publications/closure-of-educational-settings-information-for-parents-and-carers/closure-of-educational-settings-information-for-parents-and-carers">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Schools, universities, and early years settings are closed",
+            padding: true,
+            font_size: 19,
+            border_top: 2,
+            heading_level: 3
+          } %>
+        </a>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <a href="https://www.gov.uk/government/news/government-announces-further-measures-on-social-distancing">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Pubs, restaurants, and entertainment venues are closed",
+            padding: true,
+            font_size: 19,
+            border_top: 2,
+            heading_level: 3
+          } %>
+        </a>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <a href="https://www.gov.uk/government/publications/guidance-to-employers-and-businesses-about-covid-19/covid-19-support-for-businesses">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Government to pay wages of employees unable to work",
+            padding: true,
+            font_size: 19,
+            border_top: 2,
+            heading_level: 3
+          } %>
+        </a>
+      </div>
+    </div>
   </div>
 </header>


### PR DESCRIPTION
This adds a new "School closures, education, and childcare" section and
removes the "Education" subsection from "Check how coronavirus is
affecting public services".

Co-authored-by: Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk>