### PR TITLE
Edit covid page with education changes

### DIFF
--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -36,6 +36,18 @@ en:
                 url: /lay-offs-short-timeworking
               - label: What to do if you cannot pay your tax bill on time
                 url: /difficulties-paying-hmrc
+      - title: School closures, education, and childcare
+        sub_sections:
+          - title:
+            list:
+              - label: What parents and carers need to know about closures
+                url: /government/publications/closure-of-educational-settings-information-for-parents-and-carers
+              - label: "Who schools should stay open for: advice on children of key workers"
+                url: /government/publications/coronavirus-covid-19-maintaining-educational-provision
+              - label: Cancelled exams
+                url: /government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020
+              - label: Dealing with COVID-19 in nurseries, schools and universities
+                url: /government/publications/guidance-to-educational-settings-about-covid-19
       - title: Businesses and other organisations
         sub_sections:
           - title:
@@ -90,14 +102,6 @@ en:
             list:
               - label: Driving and theory tests
                 url: /guidance/coronavirus-covid-19-driving-tests-and-theory-tests
-          - title: Education
-            list:
-              - label: "School closures: advice for parents and carers"
-                url: /government/publications/closure-of-educational-settings-information-for-parents-and-carers
-              - label: School closures and children of key workers
-                url: /government/publications/coronavirus-covid-19-maintaining-educational-provision
-              - label: "Schools, childcare, further and higher education: advice for headteachers"
-                url: /government/publications/guidance-to-educational-settings-about-covid-19
           - title: Housing and local services
             list:
               - label: Planning inspections


### PR DESCRIPTION
This adds a new "School closures, education, and childcare" section and
removes the "Education" subsection from "Check how coronavirus is
affecting public services".

Co-authored-by: Christopher Baines <christopher.baines@digital.cabinet-office.gov.uk>