### PR TITLE
Add accordion analytics

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,5 +5,6 @@
 //= require organisation-list-filter
 //= require modules/current-location
 //= require modules/feeds.js
+//= require modules/toggle-attribute
 //= require components/accordion
 //= require govuk_publishing_components/all_components

--- a/app/assets/javascripts/modules/toggle-attribute.js
+++ b/app/assets/javascripts/modules/toggle-attribute.js
@@ -1,0 +1,20 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  "use strict";
+
+  Modules.ToggleAttribute = function () {
+    this.start = function ($element) {
+      $element.find('[data-toggle-attribute]').click(function (event) {
+        var clicked = event.target
+        var toggleAttribute = clicked.getAttribute('data-toggle-attribute')
+        var current = clicked.getAttribute(toggleAttribute)
+        var closedText = clicked.getAttribute('data-when-closed-text')
+        var openText = clicked.getAttribute('data-when-open-text')
+
+        clicked.setAttribute(toggleAttribute, current == closedText ? openText : closedText)
+      })
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/views/coronavirus_landing_page/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/_accordion_sections.html.erb
@@ -1,4 +1,7 @@
-  <% accordion_contents = [] %>
+  <%
+    accordion_contents = []
+    number_of_accordion_sections = t("coronavirus_landing_page.sections").length
+  %>
   <% t("coronavirus_landing_page.sections").each do | section | %>
     <% content = capture do %>
       <%# this element captures an override from the accordion that the last item has margin 0 %>
@@ -14,8 +17,26 @@
         content: {
           html: content,
         },
-        data_attributes: nil
+        data_attributes: {
+          toggle_attribute: "data-track-action",
+          when_closed_text: "accordionClosed",
+          when_open_text: "accordionOpened",
+          track_category: "pageElementInteraction",
+          track_action: "accordionClosed",
+          track_label: section[:title],
+          track_dimension: number_of_accordion_sections,
+          track_dimension_index: 26
+        }
       }
     %>
   <% end %>
-  <%= render 'govuk_publishing_components/components/accordion', { items: accordion_contents } %>
+  <div data-module="track-click">
+    <div data-module="toggle-attribute">
+      <%= render 'govuk_publishing_components/components/accordion', {
+        data_attributes: {
+          module: "govuk-accordion"
+        },
+        items: accordion_contents
+      } %>
+    </div>
+  </div>

--- a/spec/javascripts/modules/toggle-attribute_spec.js
+++ b/spec/javascripts/modules/toggle-attribute_spec.js
@@ -1,0 +1,31 @@
+describe('A toggle attribute module', function () {
+  "use strict"
+
+  var $element
+  var toggle
+  var clickon
+  var html = '\
+    <div id="element" data-module="toggle-attribute">\
+      <div id="clickon" data-toggle-attribute="data-state" data-when-closed-text="closed" data-when-open-text="open" data-state="closed">\
+      </div>\
+    </div>'
+
+  beforeEach(function () {
+    toggle = new GOVUK.Modules.ToggleAttribute();
+    $element = $(html);
+    toggle.start($element);
+    clickon = $element.find('#clickon')
+  })
+
+  afterEach(function () {
+    $(document).off()
+  })
+
+  it("sets the state to open when clicked and back again", function () {
+    expect(clickon).toHaveAttr("data-state", "closed")
+    clickon.click()
+    expect(clickon).toHaveAttr("data-state", "open")
+    clickon.click()
+    expect(clickon).toHaveAttr("data-state", "closed")
+  })
+});


### PR DESCRIPTION
Adds analytics to the accordion on the coronavirus landing page.

It does this by wrapping the accordion in a div with the tracking module JS attached and using the accordion component option to attach data attributes to each accordion section for tracking. There's an additional new module to provide toggling of the state of the accordion, so that the GA event includes whether the accordion was opened or closed.

Sadly you can't attach more than one module to a single element, so there's a bit of nesting here.

Trello card: https://trello.com/c/fE13lx7e/42-review-tracking-implementation-on-the-landing-page