### PR TITLE
Automatically hide the global banner after viewing coronavirus landing page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,4 +7,5 @@
 //= require modules/feeds.js
 //= require modules/toggle-attribute
 //= require components/accordion
+//= require modules/coronavirus-landing-page
 //= require govuk_publishing_components/all_components

--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -1,0 +1,25 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CoronavirusLandingPage () {}
+
+  CoronavirusLandingPage.prototype.start = function ($module) {
+    // Confirm the user is on the coronavirus landing page
+    if (this.checkOnLandingPage()) {
+      if (window.GOVUK.cookie('global_bar_seen')) {
+        // Get current version of global bar, if cookie has been set
+        var currentBannerVersion = JSON.parse(window.GOVUK.cookie('global_bar_seen')).version
+
+        // Automatically hide the additional information section in the banner by setting the cookie
+        window.GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 999, version: currentBannerVersion }), { days: 84 })
+      }
+    }
+  }
+
+  CoronavirusLandingPage.prototype.checkOnLandingPage = function () {
+    return window.location.pathname === '/coronavirus'
+  }
+
+  Modules.CoronavirusLandingPage = CoronavirusLandingPage
+})(window.GOVUK.Modules)

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -12,7 +12,7 @@
   <meta name="govuk:navigation-page-type" content="Taxon Page" />
 <% end %>
 
-<header class="covid__page-header">
+<header class="covid__page-header" data-module="coronavirus-landing-page">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: breadcrumbs,


### PR DESCRIPTION
## What
When a user lands on the coronavirus landing page, set the global_bar_seen cookie to `999` (manually dismissed) so the main portion of the banner is hidden (see https://github.com/alphagov/static/pull/2109 for the relevant changes to the banner)

## Why
The banner is being changed to include the key information that's also on the coronavirus landing page. We assume that if someone has viewed the landing page, they don't need to see the same information repeated in the banner.

**Note: this doesn't work if a user hasn't accepted cookies before landing on the page. This requires a change to `govuk_publishing_components` - I'll raise a PR for this shortly.**