### PR TITLE
Covid page small design tweaks

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -56,12 +56,14 @@ $covid-green: #7eff8e;
 }
 
 .covid__list-item {
-  @include govuk-media-query($until: desktop) {
-    padding-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
 
-    &:last-child {
-      padding-bottom: 0;
-    }
+  &:last-child {
+    padding-bottom: 0;
+  }
+  
+  @include govuk-media-query($from: desktop) {
+    padding-bottom: govuk-spacing(2);
   }
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -29,6 +29,10 @@ $covid-green: #7eff8e;
   &:focus {
     color: $govuk-text-colour;
   }
+
+  @include govuk-media-query($until: tablet) {
+    font-weight: normal;
+  }
 }
 
 .covid__page-header-guidance-section {
@@ -61,7 +65,7 @@ $covid-green: #7eff8e;
   &:last-child {
     padding-bottom: 0;
   }
-  
+
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(2);
   }


### PR DESCRIPTION
Make some small design changes to the coronavirus landing page, specifically:

- increase space between links in the accordion on desktop
- make announcement links not bold on mobile (bold everywhere else)

Trello card: https://trello.com/c/OKjUe4aE/62-make-a-set-of-small-design-fixes-to-the-landing-page