### PR TITLE
Design tweaks to covid landing page

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -71,10 +71,6 @@ $covid-green: #7eff8e;
 .covid__list-item {
   padding-bottom: govuk-spacing(3);
 
-  &:last-child {
-    padding-bottom: 0;
-  }
-
   @include govuk-media-query($from: desktop) {
     padding-bottom: govuk-spacing(2);
   }
@@ -82,6 +78,18 @@ $covid-green: #7eff8e;
 
 .govuk-list ~ .covid__accordion-heading {
   margin-top: govuk-spacing(4);
+}
+
+.covid__accordion-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+
+    &:focus {
+      text-decoration: none;
+    }
+  }
 }
 
 .covid__topic-wrapper {

--- a/app/views/coronavirus_landing_page/_section.html.erb
+++ b/app/views/coronavirus_landing_page/_section.html.erb
@@ -5,7 +5,7 @@
   <ul class="govuk-list">
     <% sub_section[:list].each do | item | %>
       <li class="covid__list-item">
-        <a class="govuk-link" href="<%= item[:url] %>"><%= item[:label] %></a>
+        <a class="govuk-link covid__accordion-link" href="<%= item[:url] %>"><%= item[:label] %></a>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
- remove underline from links in accordion
- increase spacing after last link in accordion

Before:

<img width="993" alt="Screenshot 2020-03-26 at 17 14 48" src="https://user-images.githubusercontent.com/861310/77675830-5bd15380-6f85-11ea-81d7-7888b8a4a389.png">

After:

<img width="1002" alt="Screenshot 2020-03-26 at 17 14 57" src="https://user-images.githubusercontent.com/861310/77675845-625fcb00-6f85-11ea-9c49-8ad66fa6ec8f.png">

Trello card: https://trello.com/c/OKjUe4aE/62-make-a-set-of-small-design-fixes-to-the-landing-page