### PR TITLE
Add test for new coronavirus landing page javascript

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -4,7 +4,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function CoronavirusLandingPage () {}
 
-  CoronavirusLandingPage.prototype.start = function ($module) {
+  CoronavirusLandingPage.prototype.start = function () {
     // Confirm the user is on the coronavirus landing page
     if (this.checkOnLandingPage()) {
       if (window.GOVUK.cookie('global_bar_seen')) {

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -1,0 +1,43 @@
+describe('Coronavirus landing page', function () {
+  "use strict"
+
+  var coronavirusLandingPage;
+  var html = '\
+  <div id="element" data-module="coronavirus-landing-page">\
+  </div>'
+  var $element
+
+  beforeEach(function () {
+    coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage();
+    $element = $(html);
+    GOVUK.approveAllCookieTypes();
+  })
+
+  it("sets global_bar_seen to automatically hide if on /coronavirus", function () {
+    GOVUK.cookie("global_bar_seen", JSON.stringify({"count": 0, "version": 1}));
+    spyOn(coronavirusLandingPage, "checkOnLandingPage").and.returnValue(true)
+    coronavirusLandingPage.start($element);
+
+    expect(parseCookie(GOVUK.cookie("global_bar_seen")).count).toBe(999)
+  })
+
+  it("only sets global_bar_seen if on /coronavirus", function () {
+    GOVUK.cookie("global_bar_seen", JSON.stringify({"count": 0, "version": 1}));
+    spyOn(coronavirusLandingPage, "checkOnLandingPage").and.returnValue(false)
+    coronavirusLandingPage.start($element);
+
+    expect(parseCookie(GOVUK.cookie("global_bar_seen")).count).not.toBe(999)
+    expect(parseCookie(GOVUK.cookie("global_bar_seen")).version).toBe(1)
+  })
+});
+
+function parseCookie(cookie) {
+  var parsedCookie = JSON.parse(cookie)
+
+  // Tests seem to run differently on CI, and require an extra parse
+  if (typeof parsedCookie !== "object") {
+    parsedCookie = JSON.parse(parsedCookie)
+  }
+
+  return parsedCookie
+}


### PR DESCRIPTION
## What
We introduced some Javascript in https://github.com/alphagov/collections/pull/1600 but due to time constraints we decided to launch without a test. This adds some tests to cover that logic.