### PR TITLE
Fix green arrow and NHS svg

### DIFF
--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -33,6 +33,7 @@ $nhs_brand_color: #005EB8;
 
 .app-c-header-notice__title-logo {
   max-width: 60px;
+  height: 33px;
 }
 
 .app-c-header-notice__content {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -58,15 +58,19 @@ $covid-grey: #272828;
 }
 
 .covid__highlight-link {
-  box-sizing: border-box;
   display: inline-block;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-align: center;
+  align-items: center;
+  box-sizing: border-box;
   padding-left: 50px;
   min-height: 45px;
   max-width: 460px;
   background-image: image-url("covid-arrow.png"); // PNG fallback for SVG
-  background: image-url("covid-arrow.svg");
+  background-image: image-url("covid-arrow.svg");
   background-repeat: no-repeat;
-  background-position: 0 0;
+  background-position: 0 50%;
   background-size: 37px auto;
 
   @include govuk-media-query($until: tablet) {
@@ -75,8 +79,12 @@ $covid-grey: #272828;
     margin-bottom: govuk-spacing(6);
   }
 
-  @include govuk-media-query($from: tablet) {
-    background-position: 0 3px;
+  @include govuk-media-query($from: desktop) {
+    // IE10/11 specific - vertical align in flexbox is ignored
+    // unless an explicit height is set
+    @media screen and (min-width:0\0) {
+      height: 45px;
+    }
   }
 
   .covid__page-header-link {

--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -14,7 +14,7 @@ en:
       pretext-2: You can spread the virus even if you don’t have symptoms.
       link:
         href: /government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do
-        text: "Read more about what you can and cannot do"
+        text: "Read more about what you can and cannot&nbsp;do"
     announcements_label: Announcements
     announcements:
       - text: You must stay at home apart from certain exceptions or you may be fined


### PR DESCRIPTION
Text for the green arrow link was changed so no longer wraps onto two lines by default. Applying flexbox to fix vertical layout. Before:

<img width="509" alt="Screenshot 2020-03-30 at 09 16 22" src="https://user-images.githubusercontent.com/861310/77890541-8c580c80-7267-11ea-977d-324f7d0ea334.png">

After:

<img width="473" alt="Screenshot 2020-03-30 at 09 16 50" src="https://user-images.githubusercontent.com/861310/77890609-ab569e80-7267-11ea-9c45-f540437fa1e3.png">

At a smaller screen size:

<img width="331" alt="Screenshot 2020-03-30 at 09 17 01" src="https://user-images.githubusercontent.com/861310/77890647-ba3d5100-7267-11ea-9d62-e712801dc88e.png">

At an extremely small screen size:

<img width="163" alt="Screenshot 2020-03-30 at 09 17 26" src="https://user-images.githubusercontent.com/861310/77890666-c2958c00-7267-11ea-917f-435a9361879c.png">

Also fixes a problem with the NHS SVG logo on Internet explorer. There's a weird IE thing where the canvas size doesn't play well with scaling the SVG, but adding a height (apparently even to the containing element) crops it.

Before:

<img width="364" alt="Screenshot 2020-03-30 at 09 15 22" src="https://user-images.githubusercontent.com/861310/77890701-d0e3a800-7267-11ea-91d6-9e7ccfee961c.png">

After:

<img width="344" alt="Screenshot 2020-03-30 at 09 15 59" src="https://user-images.githubusercontent.com/861310/77890715-d80ab600-7267-11ea-94ca-bc3153444146.png">

Trello card: https://trello.com/c/aUQMJcEV/101-re-align-the-green-arrow-icon-to-the-featured-link-in-the-header
