### PR TITLE
Make spacing changes to the landing page

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -103,28 +103,44 @@ $covid-grey: #272828;
   }
 }
 
-.covid__page-header-list {
-  color: govuk-colour('white');
+.covid__list {
+  @include govuk-font(19);
+  margin-bottom: govuk-spacing(3);
+  list-style-type: none;
 
-  .covid__page-header-list-item {
-    margin-bottom: govuk-spacing(2);
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(4);
   }
 }
 
-.covid__page-header-body-pretext {
-  color: govuk-colour('white');
+.covid__list--header {
+  padding-left: govuk-spacing(4);
+  list-style-type: disc;
+  color: govuk-colour("white");
+}
+
+.covid__list--accordion {
+  margin-bottom: govuk-spacing(6);
+
+  .covid__list-item {
+    margin-bottom: govuk-spacing(4);
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(3);
+    }
+  }
 }
 
 .covid__list-item {
-  padding-bottom: govuk-spacing(3);
-
-  @include govuk-media-query($from: desktop) {
-    padding-bottom: govuk-spacing(2);
-  }
+  margin-bottom: govuk-spacing(2);
 }
 
-.govuk-list ~ .covid__accordion-heading {
-  margin-top: govuk-spacing(4);
+.covid__list ~ .covid__accordion-heading {
+  margin-top: govuk-spacing(7);
+}
+
+.covid__page-header-body-pretext {
+  color: govuk-colour("white");
 }
 
 .covid__accordion-link {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -105,6 +105,10 @@ $covid-grey: #272828;
 
 .covid__page-header-list {
   color: govuk-colour('white');
+
+  .covid__page-header-list-item {
+    margin-bottom: govuk-spacing(2);
+  }
 }
 
 .covid__page-header-body-pretext {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -10,6 +10,16 @@ $covid-grey: #272828;
   }
 }
 
+.covid__page-title {
+  @include govuk-font(48, $weight: bold);
+  margin-bottom: govuk-spacing(5);
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(4);
+    margin-bottom: 45px;
+  }
+}
+
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
   border-top: solid govuk-spacing(2) $covid-green;
@@ -18,20 +28,22 @@ $covid-grey: #272828;
 }
 
 .covid__page-header-light {
-  padding-top: govuk-spacing(3);
-  padding-bottom: govuk-spacing(1);
+  padding-top: govuk-spacing(5);
+  padding-bottom: govuk-spacing(2);
   background: $covid-grey;
 
   @include govuk-media-query($from: tablet) {
+    padding-top: 45px;
     padding-bottom: govuk-spacing(3);
   }
 }
 
 .covid__logo-wrapper {
-  margin-bottom: govuk-spacing(6);
+  margin-top: govuk-spacing(5);
+  margin-bottom: govuk-spacing(8);
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: govuk-spacing(8);
+    margin-top: govuk-spacing(6);
   }
 }
 
@@ -75,8 +87,7 @@ $covid-grey: #272828;
 
   @include govuk-media-query($until: tablet) {
     max-width: 410px;
-    margin-top: govuk-spacing(2);
-    margin-bottom: govuk-spacing(6);
+    margin-bottom: govuk-spacing(8);
   }
 
   @include govuk-media-query($from: desktop) {
@@ -89,16 +100,6 @@ $covid-grey: #272828;
 
   .covid__page-header-link {
     @include govuk-font(19, $weight: bold);
-  }
-}
-
-.covid__page-title {
-  @include govuk-font(48, $weight: bold);
-  margin-bottom: govuk-spacing(6);
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(4);
-    margin-bottom: govuk-spacing(8);
   }
 }
 

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -35,8 +35,8 @@
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
             text: rules["pretext"],
-            padding: true,
             font_size: 19,
+            margin_bottom: 3,
             inverse: true
           } %>
           <ul class="govuk-list govuk-list--bullet covid__page-header-list">

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -41,14 +41,12 @@
           } %>
           <ul class="govuk-list govuk-list--bullet covid__page-header-list">
             <% rules["list"].each do | item | %>
-              <li><%= item %></li>
+              <li class="covid__page-header-list-item"><%= item %></li>
             <% end %>
           </ul>
 
           <p class="govuk-body covid__page-header-body-pretext">
             <%= guidance["pretext-1"] %>
-          </p>
-          <p class="govuk-body covid__page-header-body-pretext">
             <%= guidance["pretext-2"] %>
           </p>
         </div>

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -39,9 +39,9 @@
             margin_bottom: 3,
             inverse: true
           } %>
-          <ul class="govuk-list govuk-list--bullet covid__page-header-list">
+          <ul class="covid__list covid__list--header">
             <% rules["list"].each do | item | %>
-              <li class="covid__page-header-list-item"><%= item %></li>
+              <li class="covid__list-item"><%= item %></li>
             <% end %>
           </ul>
 

--- a/app/views/coronavirus_landing_page/_section.html.erb
+++ b/app/views/coronavirus_landing_page/_section.html.erb
@@ -2,7 +2,7 @@
   <% if sub_section["title"] %>
     <h3 class="govuk-heading-s covid__accordion-heading"><%= sub_section["title"] %></h3>
   <% end %>
-  <ul class="govuk-list">
+  <ul class="covid__list covid__list--accordion">
     <% sub_section["list"].each do | item | %>
       <li class="covid__list-item">
         <a class="govuk-link covid__accordion-link" href="<%= item["url"] %>"><%= item["label"] %></a>


### PR DESCRIPTION
Change spacing on the coronavirus landing page around some elements.

Desktop:

Before | After
------- | ------
<img width="802" alt="Screenshot 2020-03-30 at 15 02 46" src="https://user-images.githubusercontent.com/861310/77921353-9265e180-7297-11ea-86bc-060fcb307c6a.png"> | <img width="823" alt="Screenshot 2020-03-30 at 15 02 55" src="https://user-images.githubusercontent.com/861310/77921371-9a258600-7297-11ea-8c65-7c77485a8095.png">

Mobile:

Before | After
------- | ------
![www gov uk_coronavirus](https://user-images.githubusercontent.com/861310/77922260-bd9d0080-7298-11ea-90ac-1fcbca47affc.png) | ![localhost_3070_coronavirus (1)](https://user-images.githubusercontent.com/861310/77922287-c42b7800-7298-11ea-8ad1-8289af757664.png)



Trello card: https://trello.com/c/CiMHGZNv/103-landing-page-spacing-tweaks
