### PR TITLE
Add video placeholder

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -149,6 +149,47 @@ $covid-grey: #272828;
   margin-bottom: govuk-spacing(2);
 }
 
+.covid__video-placeholder {
+  position: relative;
+  padding: 110px 0;
+  border: solid 2px govuk-colour("white");
+  text-align: center;
+
+  .govuk-body {
+    margin: 0;
+  }
+
+  .covid__bold {
+    font-weight: bold;
+  }
+}
+
+.covid__video-logo {
+  @include govuk-font(19, $weight: bold, $line-height: 1);
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: govuk-spacing(1);
+  padding-top: govuk-spacing(2);
+  padding-left: govuk-spacing(5);
+  padding-right: govuk-spacing(2);
+  margin: govuk-spacing(3);
+  border: solid 1px govuk-colour("white");
+  color: govuk-colour("white");
+  text-transform: uppercase;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 11px;
+    left: 8px;
+    width: 12px;
+    height: 12px;
+    background: govuk-colour("red");
+    border-radius: 100%;
+  }
+}
+
 .covid__list ~ .covid__accordion-heading {
   margin-top: govuk-spacing(7);
 }

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row covid__video">
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/heading", {
-      text: title,
+      text: details["title"],
       font_size: 19,
       inverse: true,
       margin_bottom: 1
@@ -17,16 +17,18 @@
       <div class="covid__video-placeholder">
         <div class="covid__video-logo">Live</div>
         <p class="govuk-body">
-          <a href="/help/cookies" class="govuk-link covid__page-header-link covid__bold">Change your cookie settings</a>
+          <a href="<%= details["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
+            <%= details["no_cookies"]["change_settings"] %>
+          </a>
         </p>
         <p class="govuk-body covid__inverse covid__bold">
-          to watch the live stream
+          <%= details["no_cookies"]["to_watch"] %>
         </p>
         <p class="govuk-body covid__inverse">
-          or
+          <%= details["no_cookies"]["or"] %>
         </p>
-        <a href="<%= url %>" class="govuk-body govuk-link covid__page-header-link">
-          <%= no_cookies_message %>
+        <a href="<%= details["video_url"] %>" class="govuk-body govuk-link covid__page-header-link">
+          <%= details["no_cookies"]["watch_link_text"] %>
         </a>
       </div>
     <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -7,18 +7,28 @@
       margin_bottom: 1
     } %>
     <p class="govuk-body covid__inverse">
-      <%= date %> <%= ("at " + time) if time.present? %>
+      <%= details["date"] %> <%= ("at " + details["time"]) if details["time"].present? %>
     </p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
-      <p class="govuk-body">
-        <a href="<%= url %>" class="govuk-link covid__page-header-link">
+      <div class="covid__video-placeholder">
+        <div class="covid__video-logo">Live</div>
+        <p class="govuk-body">
+          <a href="/help/cookies" class="govuk-link covid__page-header-link covid__bold">Change your cookie settings</a>
+        </p>
+        <p class="govuk-body covid__inverse covid__bold">
+          to watch the live stream
+        </p>
+        <p class="govuk-body covid__inverse">
+          or
+        </p>
+        <a href="<%= url %>" class="govuk-body govuk-link covid__page-header-link">
           <%= no_cookies_message %>
         </a>
-      </p>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -1,10 +1,6 @@
 <% if details.show_live_stream? %>
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    title: details.live_stream["title"],
-    url: details.live_stream["video_url"],
-    date: details.live_stream["date"],
-    time: details.live_stream["time"],
-    no_cookies_message: details.live_stream["no_cookies_message"]
+    details: details.live_stream
   } %>
 <% else %>
   <div class="govuk-grid-row covid__video">


### PR DESCRIPTION
**Do not merge until https://github.com/alphagov/govuk-coronavirus-content/pull/18 is deployed8**

- appears if users have not consented to cookies

<img width="943" alt="Screenshot 2020-04-06 at 14 13 47" src="https://user-images.githubusercontent.com/861310/78562306-0876c500-7811-11ea-8b14-36519c7d6dd5.png">

[trello](https://trello.com/c/fYzEgmTP/116-add-the-ability-to-feature-the-govts-youtube-livestream-on-the-landing-page-and-turn-it-off-again)
