### PR TITLE
Add check for campaign cookie

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -5,7 +5,7 @@ class CoronavirusLandingPageController < ApplicationController
   def show
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
-    render "show", locals: { breadcrumbs: breadcrumbs, details: presenter }
+    render "show", locals: { breadcrumbs: breadcrumbs, details: presenter, campaign_cookie: campaign_cookie }
   end
 
 private
@@ -16,5 +16,17 @@ private
 
   def presenter
     CoronavirusLandingPagePresenter.new(content_item.to_hash)
+  end
+
+  def cookie_policy
+    if cookies.has_key?("cookies_policy")
+      JSON.parse(cookies["cookies_policy"])
+    else
+      {}
+    end
+  end
+
+  def campaign_cookie
+    cookie_policy["campaigns"]
   end
 end

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -102,7 +102,8 @@
           url: details.live_stream["video_url"],
           date: details.live_stream["date"],
           time: details.live_stream["time"],
-          no_cookies_message: details.live_stream["no_cookies_message"]
+          no_cookies_message: details.live_stream["no_cookies_message"],
+          campaign_cookie: campaign_cookie
         } %>
       <% else %>
         <div class="govuk-grid-row covid__video">

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -4,7 +4,8 @@
       details: details,
       breadcrumbs: breadcrumbs,
       rules: details.stay_at_home,
-      guidance: details.guidance }
+      guidance: details.guidance,
+      campaign_cookie: campaign_cookie}
   )
 %>
 

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -167,6 +167,13 @@
              "url":"/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"}]},
         "notifications":
          {"intro":"Stay up to date with GOV.UK",
-          "email_link":"Sign up to get emails when we change any coronavirus information on the GOV.UK website"}
+          "email_link":"Sign up to get emails when we change any coronavirus information on the GOV.UK website"},
+        "live_stream" :
+        { "title": "Live press conference",
+          "video_url": "https://www.youtube.com/watch?v=nB8MZaspQZw",
+          "no_cookies_message": "Watch the live stream on YouTube",
+          "date": "31st March 2020",
+          "time": "5:00pm",
+          "show_video": true }
         }
 }


### PR DESCRIPTION
Check if a user has agreed to campaign cookies and pass that state through to the views. This can be used to make https://github.com/alphagov/collections/pull/new/toggle_video_placeholder work.