### PR TITLE
Add tracking to announcements

### DIFF
--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -55,7 +55,14 @@
       <div class="govuk-grid-row covid__logo-wrapper">
         <div class="govuk-grid-column-two-thirds">
           <span class="covid__highlight-link">
-            <a class="govuk-link covid__page-header-link" href="<%= guidance["link"]["href"] %>">
+            <a
+              class="govuk-link covid__page-header-link"
+              href="<%= guidance["link"]["href"] %>"
+              data-module="track-click"
+              data-track-category="pageElementInteraction"
+              data-track-action="Announcements"
+              data-track-label="<%= guidance["link"]["href"] %>"
+            >
               <%= raw guidance["link"]["text"] %>
             </a>
           </span>

--- a/app/views/coronavirus_landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/_page_header.html.erb
@@ -78,7 +78,14 @@
           <div class="govuk-grid-column-one-third">
             <% announcement_text = capture do %>
               <% if announcement["href"].present? %>
-                <a href="<%= announcement["href"] %>" class="govuk-link covid__page-header-link">
+                <a
+                  href="<%= announcement["href"] %>"
+                  class="govuk-link covid__page-header-link"
+                  data-module="track-click"
+                  data-track-category="pageElementInteraction"
+                  data-track-action="Announcements"
+                  data-track-label="<%= announcement["href"] %>"
+                >
                   <%= announcement["text"] %>
                 </a>
               <% else %>


### PR DESCRIPTION
https://trello.com/c/bSWdBYfn/97-add-more-detailed-tracking-to-landing-page-links

![Screenshot 2020-04-01 at 13 24 09](https://user-images.githubusercontent.com/4599889/78136840-2fea1e00-741c-11ea-9b68-f7bd0f772494.png)