### PR TITLE
Add Iceland to the list of countries on the landing page

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -61,7 +61,7 @@ en:
         list_block: |
           You can continue to travel to the EU as usual during the transition period.
 
-          From 1 January 2021 there will be new rules to travel to the EU, Switzerland, Norway and Liechtenstein.
+          From 1 January 2021 there will be new rules to travel to the EU, or to Switzerland, Norway, Iceland or Liechtenstein.
 
           <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="Check what you need to do to travel to Europe from 2021">Check what you need to do to travel to Europe from 2021</a>
       - row_title: "Living and working in the EU"


### PR DESCRIPTION
Trello: https://trello.com/c/tHtGylNU/72-add-iceland-to-the-list-of-countries-on-the-landing-page

## What
Add Iceland to the list of countries on the landing page

## Why
FCO has raised a Zendesk ticket to correct an error on the landing page. In the list of countries under "travel to the EU" Iceland is missing.

Preview: https://govuk-collec-amend-eu-c-9ublak.herokuapp.com/transition