### PR TITLE
Adds SpecialAnnouncement schema

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -5,7 +5,8 @@ class CoronavirusLandingPageController < ApplicationController
   def show
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
-    render "show", locals: { breadcrumbs: breadcrumbs, details: presenter }
+    render "show", locals: { breadcrumbs: breadcrumbs, details: presenter,
+      special_announcement: special_announcement }
   end
 
 private
@@ -15,6 +16,10 @@ private
   end
 
   def presenter
-    CoronavirusLandingPagePresenter.new(content_item.to_hash)
+    CoronavirusLandingPagePresenter.new(@content_item)
+  end
+
+  def special_announcement
+    SpecialAnnouncementPresenter.new(@content_item)
   end
 end

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -17,6 +17,8 @@ class CoronavirusLandingPagePresenter
     {
       "@context": "https://schema.org",
       "@type": "FAQPage",
+      "name": content_item["title"],
+      "description": content_item["description"],
       "mainEntity": build_faq_main_entity(content_item),
     }
   end

--- a/app/presenters/special_announcement_presenter.rb
+++ b/app/presenters/special_announcement_presenter.rb
@@ -1,0 +1,36 @@
+class SpecialAnnouncementPresenter
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def payload
+    @payload ||= creative_work.merge(special_announcement_properties)
+  end
+
+private
+
+  def special_announcement_properties
+    schema_specific_links = content_item.dig("details", "special_announcement_schema") || {}
+
+    {
+      "@type" => "SpecialAnnouncement",
+      "category" => schema_specific_links["category"],
+      "datePosted" => content_item["public_updated_at"],
+      "diseasePreventionInfo" => schema_specific_links["disease_prevention_info_url"],
+      "diseaseSpreadStatistics" => schema_specific_links["disease_spread_statistics_url"],
+      "gettingTestedInfo" => schema_specific_links["getting_tested_info_url"],
+      "newsUpdatesAndGuidelines" => schema_specific_links["news_updates_and_guidelines_url"],
+      "publicTransportClosuresInfo" => schema_specific_links["public_transport_closures_info_url"],
+      "quarantineGuidelines" => schema_specific_links["quarantine_guidelines_url"],
+      "schoolClosuresInfo" => schema_specific_links["school_closures_info_url"],
+      "travelBans" => schema_specific_links["travel_bans_url"],
+    }.compact
+  end
+
+  def creative_work
+    page = GovukPublishingComponents::Presenters::Page.new({ content_item: content_item })
+    GovukPublishingComponents::Presenters::CreativeWorkSchema.new(page).structured_data
+  end
+end

--- a/app/views/coronavirus_landing_page/_schema.html.erb
+++ b/app/views/coronavirus_landing_page/_schema.html.erb
@@ -1,3 +1,7 @@
 <script type="application/ld+json">
   <%= (presenter.faq_schema(@content_item).to_json).html_safe %>
 </script>
+
+<script type="application/ld+json">
+  <%= (special_announcement.payload.to_json).html_safe %>
+</script>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -1,4 +1,8 @@
-<%= render(partial: 'schema', locals: { presenter: details } ) %>
+<%= render(partial: 'schema', locals: {
+    presenter: details,
+    special_announcement: special_announcement,
+  })
+%>
 
 <%=
   render(
@@ -6,7 +10,8 @@
       details: details,
       breadcrumbs: breadcrumbs,
       rules: details.stay_at_home,
-      guidance: details.guidance }
+      guidance: details.guidance,
+    }
   )
 %>
 

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -1,4 +1,5 @@
-{ "base_path": "/coronavirus",
+{
+  "base_path": "/coronavirus",
   "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
   "document_type": "coronavirus_landing_page",
   "description": "Find out about the government response to coronavirus (COVID-19) and what you need to do.",
@@ -11,162 +12,354 @@
   "updated_at": "2020-03-25T14:40:22Z",
   "links": {},
   "details": {
-      "stay_at_home":
-        {"pretext":"Stay at home",
-        "list":
-         ["Only go outside for food, health reasons or work (where this absolutely cannot be done from home)",
-          "If you go out, stay 2 metres (6ft) away from other people",
-          "Wash your hands as soon as you get home"]},
-        "guidance":
-         { "pretext-1": "Do not meet others, even friends or family",
-           "pretext-2": "You can spread the virus even if you don’t have symptoms",
-          "link":
-           {"href":"/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do",
-            "text":"Read more about what you can and cannot do."}},
-        "announcements_label":"Announcements",
-        "announcements":
-         [{"text":"You must stay at home apart from essential travel or you may be fined",
-           "href":"/government/publications/full-guidance-on-staying-at-home-and-away-from-others"},
-          {"text":"If you live in the UK and are currently abroad you are strongly advised to return now",
-           "href":"/guidance/travel-advice-novel-coronavirus"},
-          {"text":"All non-essential shops and community spaces are closed",
-           "href":"/government/publications/further-businesses-and-premises-to-close"}],
-        "nhs_banner":
-         {"heading":"Do not leave home if you or someone you live with has either:",
-          "list":["a high temperature", "a new, continuous cough"],
-          "call_to_action":
-           {"title":"Check the NHS website if you have symptoms", "href":"https://www.nhs.uk/conditions/coronavirus-covid-19/"}},
-        "sections":
-         [{"title":"How to protect yourself and others",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"Staying at home if you think you have coronavirus (self-isolating)",
-                 "url":"/government/publications/covid-19-stay-at-home-guidance"},
-                {"label":"Full guidance on staying at home and away from others",
-                 "url":"/government/publications/full-guidance-on-staying-at-home-and-away-from-others"},
-                {"label":"How to protect extremely vulnerable people (shielding)",
-                 "url":
-                  "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"}]}]},
-          {"title":"Employment and financial support",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"Check if you can get statutory sick pay (SSP)", "url":"/statutory-sick-pay"},
-                {"label":"Check if you're eligible for Universal Credit", "url":"/universal-credit"},
-                {"label":"Check if you're eligible for Employment and Support Allowance (ESA)",
-                 "url":"/employment-support-allowance"},
-                {"label":"Your rights if your hours are cut or you’re laid off", "url":"/lay-offs-short-timeworking"},
-                {"label":"What to do if you cannot pay your tax bill on time", "url":"/difficulties-paying-hmrc"}]}]},
-          {"title":"School closures, education, and childcare",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"What parents and carers need to know about closures",
-                 "url":"/government/publications/closure-of-educational-settings-information-for-parents-and-carers"},
-                {"label":"Guidance for schools and local authorities on closures",
-                 "url":"/government/publications/covid-19-school-closures"},
-                {"label":"School opening for children of key workers",
-                 "url":"/government/publications/coronavirus-covid-19-maintaining-educational-provision"},
-                {"label":"Cancelled exams",
-                 "url":
-                  "/government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020"},
-                {"label":"Dealing with COVID-19 in nurseries, schools and universities",
-                 "url":"/government/publications/guidance-to-educational-settings-about-covid-19"},
-                {"label":"Supporting vulnerable children",
-                 "url":"/government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people"}]}]},
-          {"title":"Businesses and other organisations",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"How to keep your employees safe",
-                 "url":"/government/publications/guidance-to-employers-and-businesses-about-covid-19"},
-                {"label":"How to clean workplaces safely",
-                 "url":"/government/publications/covid-19-decontamination-in-non-healthcare-settings"},
-                {"label":"Check what you need to do about Statutory Sick Pay", "url":"/employers-sick-pay"},
-                {"label":"Find out what to do for different businesses and organisations",
-                 "url":"/government/collections/coronavirus-covid-19-list-of-guidance"},
-                {"label":"UK businesses trading internationally",
-                 "url":"/government/publications/coronavirus-covid-19-guidance-for-uk-businesses"},
-                {"label":"What the government is doing to support businesses",
-                 "url":"/government/publications/guidance-to-employers-and-businesses-about-covid-19"}]}]},
-          {"title":"Healthcare workers and carers",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"NHS guidance for people working in healthcare", "url":"https://www.england.nhs.uk/coronavirus/"},
-                {"label":"How to protect people in residential care, supported living and home care",
-                 "url":"/government/publications/covid-19-residential-care-supported-living-and-home-care-guidance"},
-                {"label":"How to manage adult social care",
-                 "url":"/government/publications/covid-19-ethical-framework-for-adult-social-care"},
-                {"label":"How to protect extremely vulnerable people (shielding)",
-                 "url":
-                  "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"}]}]},
-          {"title":"Travel",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"Information for British citizens travelling abroad", "url":"/guidance/travel-advice-novel-coronavirus"},
-                {"label":"Foreign travel advice for each country", "url":"/foreign-travel-advice"},
-                {"label":"What to do if you're visiting the UK from China and you can't travel home",
-                 "url":"/guidance/coronavirus-immigration-guidance-if-youre-unable-to-return-to-china-from-the-uk"},
-                {"label":"Avoid travel to second homes, campsites and caravan parks",
-                 "url":"/government/news/covid-19-essential-travel-guidance"}]}]},
-          {"title":"How coronavirus is affecting public services",
-           "sub_sections":
-            [{"title":"Benefits",
-              "list":
-               [{"label":"Employment and Support Allowance (ESA)", "url":"/employment-support-allowance/your-esa-claim"},
-                {"label":"Personal Independence Payment (PIP)", "url":"/pip/how-to-claim"},
-                {"label":"Universal credit", "url":"/universal-credit/how-to-claim"}]},
-             {"title":"Crime, justice and the law",
-              "list":
-               [{"label":"Court and tribunal cases",
-                 "url":"/guidance/coronavirus-covid-19-courts-and-tribunals-planning-and-preparation"},
-                {"label":"Visiting prisoners", "url":"/guidance/coronavirus-covid-19-and-prisons"}]},
-             {"title":"Driving and transport",
-              "list":
-               [{"label":"Driving and theory tests suspended",
-                 "url":"/guidance/coronavirus-covid-19-driving-tests-and-theory-tests"},
-                {"label":"MOTs for heavy vehicles suspended",
-                 "url":"/guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers"},
-                {"label":"Relaxation of drivers’ hours rules",
-                 "url":
-                  "/government/publications/covid-19-guidance-on-drivers-hours-relaxations/coronavirus-covid-19-guidance-on-drivers-hours-relaxations"},
-                {"label":"Vehicle approval tests suspended", "url":"/guidance/coronavirus-covid-19-vehicle-approval-tests"}]},
-             {"title":"Housing and local services",
-              "list":[{"label":"Planning inspections", "url":"/guidance/coronavirus-covid-19-planning-inspectorate-guidance"}]}]},
-          {"title":"How you can help",
-           "sub_sections":
-            [{"title":"",
-              "list":[{"label":"Help produce ventilators and components", "url":"https://ventilator.herokuapp.com"}]}]},
-          {"title":"Coronavirus (COVID-19) cases in the UK",
-           "sub_sections":
-            [{"title":"",
-              "list":
-               [{"label":"Track coronavirus cases in the UK", "url":"/government/publications/covid-19-track-coronavirus-cases"},
-                {"label":"Latest number of coronavirus cases in the UK",
-                 "url":"/guidance/coronavirus-covid-19-information-for-the-public"}]}]}],
-        "country_section":
-           {"header": "If you live in Scotland, Wales or Northern Ireland",
-           "text": "Additional guidance is available",
-           "links":
-            [{"label": "Scotland",
-            "url": "https://www.gov.scot/coronavirus-covid-19/"},
-            {"label": "Wales",
-            "url": "https://gov.wales/coronavirus"},
-            {"label": "Northern Ireland",
-            "url": "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"}]},
-        "topic_section":
-         {"header":"All coronavirus (COVID-19) information",
-          "text":"Browse information related to coronavirus",
-          "links":
-           [{"label":"News",
-             "url":"/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"},
-            {"label":"Guidance",
-             "url":"/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"}]},
-        "notifications":
-         {"intro":"Stay up to date with GOV.UK",
-          "email_link":"Sign up to get emails when we change any coronavirus information on the GOV.UK website"}
+    "stay_at_home": {
+      "pretext": "Stay at home",
+      "list": [
+        "Only go outside for food, health reasons or work (where this absolutely cannot be done from home)",
+        "If you go out, stay 2 metres (6ft) away from other people",
+        "Wash your hands as soon as you get home"
+      ]
+    },
+    "guidance": {
+      "pretext-1": "Do not meet others, even friends or family",
+      "pretext-2": "You can spread the virus even if you don’t have symptoms",
+      "link": {
+        "href": "/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do",
+        "text": "Read more about what you can and cannot do."
+      }
+    },
+    "announcements_label": "Announcements",
+    "announcements": [
+      {
+        "text": "You must stay at home apart from essential travel or you may be fined",
+        "href": "/government/publications/full-guidance-on-staying-at-home-and-away-from-others"
+      },
+      {
+        "text": "If you live in the UK and are currently abroad you are strongly advised to return now",
+        "href": "/guidance/travel-advice-novel-coronavirus"
+      },
+      {
+        "text": "All non-essential shops and community spaces are closed",
+        "href": "/government/publications/further-businesses-and-premises-to-close"
+      }
+    ],
+    "nhs_banner": {
+      "heading": "Do not leave home if you or someone you live with has either:",
+      "list": [
+        "a high temperature",
+        "a new, continuous cough"
+      ],
+      "call_to_action": {
+        "title": "Check the NHS website if you have symptoms",
+        "href": "https://www.nhs.uk/conditions/coronavirus-covid-19/"
+      }
+    },
+    "sections": [
+      {
+        "title": "How to protect yourself and others",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Staying at home if you think you have coronavirus (self-isolating)",
+                "url": "/government/publications/covid-19-stay-at-home-guidance"
+              },
+              {
+                "label": "Full guidance on staying at home and away from others",
+                "url": "/government/publications/full-guidance-on-staying-at-home-and-away-from-others"
+              },
+              {
+                "label": "How to protect extremely vulnerable people (shielding)",
+                "url": "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Employment and financial support",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Check if you can get statutory sick pay (SSP)",
+                "url": "/statutory-sick-pay"
+              },
+              {
+                "label": "Check if you're eligible for Universal Credit",
+                "url": "/universal-credit"
+              },
+              {
+                "label": "Check if you're eligible for Employment and Support Allowance (ESA)",
+                "url": "/employment-support-allowance"
+              },
+              {
+                "label": "Your rights if your hours are cut or you’re laid off",
+                "url": "/lay-offs-short-timeworking"
+              },
+              {
+                "label": "What to do if you cannot pay your tax bill on time",
+                "url": "/difficulties-paying-hmrc"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "School closures, education, and childcare",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "What parents and carers need to know about closures",
+                "url": "/government/publications/closure-of-educational-settings-information-for-parents-and-carers"
+              },
+              {
+                "label": "Guidance for schools and local authorities on closures",
+                "url": "/government/publications/covid-19-school-closures"
+              },
+              {
+                "label": "School opening for children of key workers",
+                "url": "/government/publications/coronavirus-covid-19-maintaining-educational-provision"
+              },
+              {
+                "label": "Cancelled exams",
+                "url": "/government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020"
+              },
+              {
+                "label": "Dealing with COVID-19 in nurseries, schools and universities",
+                "url": "/government/publications/guidance-to-educational-settings-about-covid-19"
+              },
+              {
+                "label": "Supporting vulnerable children",
+                "url": "/government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Businesses and other organisations",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "How to keep your employees safe",
+                "url": "/government/publications/guidance-to-employers-and-businesses-about-covid-19"
+              },
+              {
+                "label": "How to clean workplaces safely",
+                "url": "/government/publications/covid-19-decontamination-in-non-healthcare-settings"
+              },
+              {
+                "label": "Check what you need to do about Statutory Sick Pay",
+                "url": "/employers-sick-pay"
+              },
+              {
+                "label": "Find out what to do for different businesses and organisations",
+                "url": "/government/collections/coronavirus-covid-19-list-of-guidance"
+              },
+              {
+                "label": "UK businesses trading internationally",
+                "url": "/government/publications/coronavirus-covid-19-guidance-for-uk-businesses"
+              },
+              {
+                "label": "What the government is doing to support businesses",
+                "url": "/government/publications/guidance-to-employers-and-businesses-about-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Healthcare workers and carers",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "NHS guidance for people working in healthcare",
+                "url": "https://www.england.nhs.uk/coronavirus/"
+              },
+              {
+                "label": "How to protect people in residential care, supported living and home care",
+                "url": "/government/publications/covid-19-residential-care-supported-living-and-home-care-guidance"
+              },
+              {
+                "label": "How to manage adult social care",
+                "url": "/government/publications/covid-19-ethical-framework-for-adult-social-care"
+              },
+              {
+                "label": "How to protect extremely vulnerable people (shielding)",
+                "url": "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Travel",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Information for British citizens travelling abroad",
+                "url": "/guidance/travel-advice-novel-coronavirus"
+              },
+              {
+                "label": "Foreign travel advice for each country",
+                "url": "/foreign-travel-advice"
+              },
+              {
+                "label": "What to do if you're visiting the UK from China and you can't travel home",
+                "url": "/guidance/coronavirus-immigration-guidance-if-youre-unable-to-return-to-china-from-the-uk"
+              },
+              {
+                "label": "Avoid travel to second homes, campsites and caravan parks",
+                "url": "/government/news/covid-19-essential-travel-guidance"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "How coronavirus is affecting public services",
+        "sub_sections": [
+          {
+            "title": "Benefits",
+            "list": [
+              {
+                "label": "Employment and Support Allowance (ESA)",
+                "url": "/employment-support-allowance/your-esa-claim"
+              },
+              {
+                "label": "Personal Independence Payment (PIP)",
+                "url": "/pip/how-to-claim"
+              },
+              {
+                "label": "Universal credit",
+                "url": "/universal-credit/how-to-claim"
+              }
+            ]
+          },
+          {
+            "title": "Crime, justice and the law",
+            "list": [
+              {
+                "label": "Court and tribunal cases",
+                "url": "/guidance/coronavirus-covid-19-courts-and-tribunals-planning-and-preparation"
+              },
+              {
+                "label": "Visiting prisoners",
+                "url": "/guidance/coronavirus-covid-19-and-prisons"
+              }
+            ]
+          },
+          {
+            "title": "Driving and transport",
+            "list": [
+              {
+                "label": "Driving and theory tests suspended",
+                "url": "/guidance/coronavirus-covid-19-driving-tests-and-theory-tests"
+              },
+              {
+                "label": "MOTs for heavy vehicles suspended",
+                "url": "/guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers"
+              },
+              {
+                "label": "Relaxation of drivers’ hours rules",
+                "url": "/government/publications/covid-19-guidance-on-drivers-hours-relaxations/coronavirus-covid-19-guidance-on-drivers-hours-relaxations"
+              },
+              {
+                "label": "Vehicle approval tests suspended",
+                "url": "/guidance/coronavirus-covid-19-vehicle-approval-tests"
+              }
+            ]
+          },
+          {
+            "title": "Housing and local services",
+            "list": [
+              {
+                "label": "Planning inspections",
+                "url": "/guidance/coronavirus-covid-19-planning-inspectorate-guidance"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "How you can help",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Help produce ventilators and components",
+                "url": "https://ventilator.herokuapp.com"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Coronavirus (COVID-19) cases in the UK",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Track coronavirus cases in the UK",
+                "url": "/government/publications/covid-19-track-coronavirus-cases"
+              },
+              {
+                "label": "Latest number of coronavirus cases in the UK",
+                "url": "/guidance/coronavirus-covid-19-information-for-the-public"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "country_section": {
+      "header": "If you live in Scotland, Wales or Northern Ireland",
+      "text": "Additional guidance is available",
+      "links": [
+        {
+          "label": "Scotland",
+          "url": "https://www.gov.scot/coronavirus-covid-19/"
+        },
+        {
+          "label": "Wales",
+          "url": "https://gov.wales/coronavirus"
+        },
+        {
+          "label": "Northern Ireland",
+          "url": "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
         }
+      ]
+    },
+    "topic_section": {
+      "header": "All coronavirus (COVID-19) information",
+      "text": "Browse information related to coronavirus",
+      "links": [
+        {
+          "label": "News",
+          "url": "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
+        },
+        {
+          "label": "Guidance",
+          "url": "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        }
+      ]
+    },
+    "notifications": {
+      "intro": "Stay up to date with GOV.UK",
+      "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    }
+  }
 }

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -365,7 +365,6 @@
       "category": "https://www.wikidata.org/wiki/Q81068910",
       "disease_prevention_info_url": "https://www.gov.uk/coronavirus",
       "disease_spread_statistics_url": "https://www.gov.uk//government/publications/covid-19-track-coronavirus-cases",
-      "getting_tested_info_url": "",
       "news_updates_and_guidelines_url": "https://www.gov.uk/coronavirus",
       "public_transport_closures_info_url": "https://www.gov.uk/guidance/coronavirus-covid-19-uk-transport-and-travel-advice",
       "quarantine_guidelines_url": "https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do",

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -360,6 +360,17 @@
     "notifications": {
       "intro": "Stay up to date with GOV.UK",
       "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    },
+    "special_announcement_schema": {
+      "category": "https://www.wikidata.org/wiki/Q81068910",
+      "disease_prevention_info_url": "https://www.gov.uk/coronavirus",
+      "disease_spread_statistics_url": "https://www.gov.uk//government/publications/covid-19-track-coronavirus-cases",
+      "getting_tested_info_url": "",
+      "news_updates_and_guidelines_url": "https://www.gov.uk/coronavirus",
+      "public_transport_closures_info_url": "https://www.gov.uk/guidance/coronavirus-covid-19-uk-transport-and-travel-advice",
+      "quarantine_guidelines_url": "https://www.gov.uk/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do",
+      "school_closures_info_url": "https://www.gov.uk/check-school-closure",
+      "travel_bans_url": "https://www.gov.uk/guidance/travel-advice-novel-coronavirus"
     }
   }
 }

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -24,6 +24,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_the_special_announcement_schema_is_rendered
+      and_the_faqpage_schema_is_rendered
     end
   end
 end

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -19,5 +19,11 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       and_i_click_on_an_accordion
       then_i_can_see_the_accordions_content
     end
+
+    it "renders machine readable content" do
+      given_there_is_a_content_item
+      when_i_visit_the_coronavirus_landing_page
+      then_the_special_announcement_schema_is_rendered
+    end
   end
 end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -41,6 +41,8 @@ module CoronavirusLandingPageSteps
     special_announcement_schema = find_schema("SpecialAnnouncement")
     assert_equal(special_announcement_schema["headline"], "Coronavirus (COVID-19): what you need to do")
     assert_equal(special_announcement_schema["diseasePreventionInfo"], "https://www.gov.uk/coronavirus")
+    # proves that the schema handles non-existent properties OK
+    assert_nil(special_announcement_schema["gettingTestedInfo"])
   end
 
   def find_schema(schema_name)

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -45,6 +45,12 @@ module CoronavirusLandingPageSteps
     assert_nil(special_announcement_schema["gettingTestedInfo"])
   end
 
+  def and_the_faqpage_schema_is_rendered
+    special_announcement_schema = find_schema("FAQPage")
+    assert_equal(special_announcement_schema["name"], "Coronavirus (COVID-19): what you need to do")
+    assert_equal(special_announcement_schema["description"], "Find out about the government response to coronavirus (COVID-19) and what you need to do.")
+  end
+
   def find_schema(schema_name)
     schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
     schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -36,4 +36,17 @@ module CoronavirusLandingPageSteps
   def then_i_can_see_the_accordions_content
     assert page.has_selector?(".govuk-link", text: "Staying at home if you think you have coronavirus (self-isolating)")
   end
+
+  def then_the_special_announcement_schema_is_rendered
+    special_announcement_schema = find_schema("SpecialAnnouncement")
+    assert_equal(special_announcement_schema["headline"], "Coronavirus (COVID-19): what you need to do")
+    assert_equal(special_announcement_schema["diseasePreventionInfo"], "https://www.gov.uk/coronavirus")
+  end
+
+  def find_schema(schema_name)
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    schemas.detect { |schema| schema["@type"] == schema_name }
+  end
 end


### PR DESCRIPTION
This adds https://schema.org/SpecialAnnouncement to the landing page.

This should complement the FAQPage schema that is ongoing.

The category field is recommended to be either the wikipedia or wikidata
URLs for this coronavirus 2019 pandemic, so I've picked the wikidata version.

Corresponds to alphagov/govuk-coronavirus-content#21
though it will not break if deployed before that is published.

https://trello.com/c/kZlkA3eD/126-add-specialannouncement-schema-to-the-landing-page