### PR TITLE
Add beginning of business page

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -9,10 +9,22 @@ class CoronavirusLandingPageController < ApplicationController
       special_announcement: special_announcement }
   end
 
+  def business
+    @content_item = content_item.to_hash
+    breadcrumbs = [
+      { title: "Home", url: "/" },
+      { title: "Coronavirus (COVID-19)", url: "/coronavirus", is_page_parent: true },
+    ]
+    render "business", locals: {
+      breadcrumbs: breadcrumbs,
+      details: business_presenter,
+    }
+  end
+
 private
 
   def content_item
-    ContentItem.find!("/coronavirus")
+    ContentItem.find!(request.path)
   end
 
   def presenter
@@ -21,5 +33,9 @@ private
 
   def special_announcement
     SpecialAnnouncementPresenter.new(@content_item)
+  end
+
+  def business_presenter
+    BusinessSupportPagePresenter.new(@content_item)
   end
 end

--- a/app/presenters/business_support_page_presenter.rb
+++ b/app/presenters/business_support_page_presenter.rb
@@ -1,0 +1,11 @@
+class BusinessSupportPagePresenter
+  COMPONENTS = %w(header_section guidance announcements_label announcements other_announcements guidance_section sections topic_section notifications).freeze
+
+  def initialize(content_item)
+    COMPONENTS.each do |component|
+      define_singleton_method component do
+        content_item["details"][component]
+      end
+    end
+  end
+end

--- a/app/views/coronavirus_landing_page/business.html.erb
+++ b/app/views/coronavirus_landing_page/business.html.erb
@@ -1,0 +1,63 @@
+<%= render partial: "meta_tags" %>
+
+<%# Have copied in the contents of _page_header.html.erb and removed the bits we don't need %>
+<header class="covid__page-header" data-module="coronavirus-landing-page">
+  <div class="govuk-width-container">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      breadcrumbs: breadcrumbs,
+      collapse_on_mobile: true,
+      inverse: true
+    } %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="covid__page-title">
+          <%= @content_item["title"] %>
+        </h1>
+      </div>
+    </div>
+  </div>
+
+  <div class="covid__page-header-light">
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: details.header_section["pretext"],
+            font_size: 19,
+            margin_bottom: 3,
+            inverse: true
+          } %>
+          <ul class="covid__list covid__list--header">
+            <% details.header_section["list"].each do | item | %>
+              <li class="covid__list-item"><%= item %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: details.announcements_label,
+        padding: true,
+        font_size: 19,
+        border_top: 2,
+        brand: 'public-health-england',
+        inverse: true
+      } %>
+
+      <%= render partial: 'announcements', locals: { announcements: details.announcements } %>
+    </div>
+  </div>
+</header>
+
+
+<div class="govuk-width-container covid__page">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render partial: 'accordion_sections', locals: { accordions: details.sections } %>
+      <%= render partial: 'topic_section', locals: { topic_section: details.topic_section } %>
+
+      <%# Have removed email section here until we work out how to line up the notifications %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
 
 
   get "/coronavirus", to: "coronavirus_landing_page#show"
+  get "/coronavirus/business", to: "coronavirus_landing_page#business"
+
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: %i(index show), param: :top_level_slug do

--- a/test/fixtures/content_store/business_support_page.json
+++ b/test/fixtures/content_store/business_support_page.json
@@ -1,0 +1,387 @@
+{
+  "base_path": "/coronavirus/business",
+  "content_id": "09944b84-02ba-4742-a696-9e562fc9b29d",
+  "document_type": "coronavirus_landing_page",
+  "description": "Business support page",
+  "phase": "live",
+  "publishing_app": "collections-publisher",
+  "rendering_app": "collections",
+  "schema_name": "coronavirus_landing_page",
+  "title": "Business support",
+  "locale": "en",
+  "updated_at": "2020-03-25T14:40:22Z",
+  "links": {},
+  "details": {
+    "header_section": {
+      "pretext": "Support will be available to businesses",
+      "list": [
+        "Loans, tax relief and cash grants will be available",
+        "Employers can apply for staff to get up to 80% pay if they can’t work",
+        "Self-employed people will receive up to £2,500 per month in grants for at least 3 months"
+      ]
+    },
+    "announcements_label": "Announcements",
+    "announcements": [
+      {
+        "text": "If you're self employed you'll get up to £2500 in grants for at least 3 months",
+        "href": "/"
+      },
+      {
+        "text": "Estate agents, lettings agencies and bingo halls to pay no business rates this coming financial year",
+        "href": "/"
+      },
+      {
+        "text": "High street businesses will receive grants",
+        "href": "government/news/high-street-benefits-from-22-billion-grants-and-business-rates-package"
+      }
+    ],
+    "other_announcements": [
+      {
+        "text": "Rules on carrying over annual leave to be relaxed to support key industries during COVID-19",
+        "href": "/government/news/rules-on-carrying-over-annual-leave-to-be-relaxed-to-support-key-industries-during-covid-19"
+      },
+      {
+        "text": "Covid-19: Estate agents, lettings agencies and bingo halls to pay no business rates this coming financial year",
+        "href": "/government/news/covid-19-estate-agents-lettings-agencies-and-bingo-halls-to-pay-no-business-rates-this-coming-financial-year"
+      },
+      {
+        "text": "Call for businesses to help make NHS ventilators",
+        "href": "/government/news/production-and-supply-of-ventilators-and-ventilator-components"
+      },
+      {
+        "text": "COVID-19: Call for rapid sanitising technology for ambulances",
+        "href": "/government/news/covid-19-call-for-rapid-sanitising-technology-for-ambulances"},
+      {
+        "text": "Coronavirus support for employees, benefit claimants and businesses",
+        "href": "/government/news/coronavirus-support-for-employees-benefit-claimants-and-businesses"},
+      {
+        "text": "If you're self employed, you'll get up to £2,500 a month in grants, for up to 3 months",
+        "href": "/government/news/chancellor-gives-support-to-millions-of-self-employed-individuals"
+      }
+    ],
+    "guidance_section": {
+      "header": "What you can do now",
+      "list": [
+        {
+          "text": "Find out what financial support you can get for your business",
+          "url": "https://www.businesssupport.gov.uk/"
+        },
+        {
+          "text": "Find out how to claim for your employee’s wages if they’re on temporary leave",
+          "url": "/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
+        },
+        {
+          "text": "Find out how to apply for a grant if you’re self-employed",
+          "url": "/"
+        }
+      ]
+    },
+    "sections": [
+      {
+        "title": "Funding and support",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Staying at home if you think you have coronavirus (self-isolating)",
+                "url": "/government/publications/covid-19-stay-at-home-guidance"
+              },
+              {
+                "label": "Full guidance on staying at home and away from others",
+                "url": "/government/publications/full-guidance-on-staying-at-home-and-away-from-others"
+              },
+              {
+                "label": "How to protect extremely vulnerable people (shielding)",
+                "url": "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Employment and financial support",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Check if you can get statutory sick pay (SSP)",
+                "url": "/statutory-sick-pay"
+              },
+              {
+                "label": "Check if you're eligible for Universal Credit",
+                "url": "/universal-credit"
+              },
+              {
+                "label": "Check if you're eligible for Employment and Support Allowance (ESA)",
+                "url": "/employment-support-allowance"
+              },
+              {
+                "label": "Your rights if your hours are cut or you’re laid off",
+                "url": "/lay-offs-short-timeworking"
+              },
+              {
+                "label": "What to do if you cannot pay your tax bill on time",
+                "url": "/difficulties-paying-hmrc"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "School closures, education, and childcare",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "What parents and carers need to know about closures",
+                "url": "/government/publications/closure-of-educational-settings-information-for-parents-and-carers"
+              },
+              {
+                "label": "Guidance for schools and local authorities on closures",
+                "url": "/government/publications/covid-19-school-closures"
+              },
+              {
+                "label": "School opening for children of key workers",
+                "url": "/government/publications/coronavirus-covid-19-maintaining-educational-provision"
+              },
+              {
+                "label": "Cancelled exams",
+                "url": "/government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020"
+              },
+              {
+                "label": "Dealing with COVID-19 in nurseries, schools and universities",
+                "url": "/government/publications/guidance-to-educational-settings-about-covid-19"
+              },
+              {
+                "label": "Supporting vulnerable children",
+                "url": "/government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Businesses and other organisations",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "How to keep your employees safe",
+                "url": "/government/publications/guidance-to-employers-and-businesses-about-covid-19"
+              },
+              {
+                "label": "How to clean workplaces safely",
+                "url": "/government/publications/covid-19-decontamination-in-non-healthcare-settings"
+              },
+              {
+                "label": "Check what you need to do about Statutory Sick Pay",
+                "url": "/employers-sick-pay"
+              },
+              {
+                "label": "Find out what to do for different businesses and organisations",
+                "url": "/government/collections/coronavirus-covid-19-list-of-guidance"
+              },
+              {
+                "label": "UK businesses trading internationally",
+                "url": "/government/publications/coronavirus-covid-19-guidance-for-uk-businesses"
+              },
+              {
+                "label": "What the government is doing to support businesses",
+                "url": "/government/publications/guidance-to-employers-and-businesses-about-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Healthcare workers and carers",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "NHS guidance for people working in healthcare",
+                "url": "https://www.england.nhs.uk/coronavirus/"
+              },
+              {
+                "label": "How to protect people in residential care, supported living and home care",
+                "url": "/government/publications/covid-19-residential-care-supported-living-and-home-care-guidance"
+              },
+              {
+                "label": "How to manage adult social care",
+                "url": "/government/publications/covid-19-ethical-framework-for-adult-social-care"
+              },
+              {
+                "label": "How to protect extremely vulnerable people (shielding)",
+                "url": "/government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Travel",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Information for British citizens travelling abroad",
+                "url": "/guidance/travel-advice-novel-coronavirus"
+              },
+              {
+                "label": "Foreign travel advice for each country",
+                "url": "/foreign-travel-advice"
+              },
+              {
+                "label": "What to do if you're visiting the UK from China and you can't travel home",
+                "url": "/guidance/coronavirus-immigration-guidance-if-youre-unable-to-return-to-china-from-the-uk"
+              },
+              {
+                "label": "Avoid travel to second homes, campsites and caravan parks",
+                "url": "/government/news/covid-19-essential-travel-guidance"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "How coronavirus is affecting public services",
+        "sub_sections": [
+          {
+            "title": "Benefits",
+            "list": [
+              {
+                "label": "Employment and Support Allowance (ESA)",
+                "url": "/employment-support-allowance/your-esa-claim"
+              },
+              {
+                "label": "Personal Independence Payment (PIP)",
+                "url": "/pip/how-to-claim"
+              },
+              {
+                "label": "Universal credit",
+                "url": "/universal-credit/how-to-claim"
+              }
+            ]
+          },
+          {
+            "title": "Crime, justice and the law",
+            "list": [
+              {
+                "label": "Court and tribunal cases",
+                "url": "/guidance/coronavirus-covid-19-courts-and-tribunals-planning-and-preparation"
+              },
+              {
+                "label": "Visiting prisoners",
+                "url": "/guidance/coronavirus-covid-19-and-prisons"
+              }
+            ]
+          },
+          {
+            "title": "Driving and transport",
+            "list": [
+              {
+                "label": "Driving and theory tests suspended",
+                "url": "/guidance/coronavirus-covid-19-driving-tests-and-theory-tests"
+              },
+              {
+                "label": "MOTs for heavy vehicles suspended",
+                "url": "/guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers"
+              },
+              {
+                "label": "Relaxation of drivers’ hours rules",
+                "url": "/government/publications/covid-19-guidance-on-drivers-hours-relaxations/coronavirus-covid-19-guidance-on-drivers-hours-relaxations"
+              },
+              {
+                "label": "Vehicle approval tests suspended",
+                "url": "/guidance/coronavirus-covid-19-vehicle-approval-tests"
+              }
+            ]
+          },
+          {
+            "title": "Housing and local services",
+            "list": [
+              {
+                "label": "Planning inspections",
+                "url": "/guidance/coronavirus-covid-19-planning-inspectorate-guidance"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "How you can help",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Help produce ventilators and components",
+                "url": "https://ventilator.herokuapp.com"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Coronavirus (COVID-19) cases in the UK",
+        "sub_sections": [
+          {
+            "title": "",
+            "list": [
+              {
+                "label": "Track coronavirus cases in the UK",
+                "url": "/government/publications/covid-19-track-coronavirus-cases"
+              },
+              {
+                "label": "Latest number of coronavirus cases in the UK",
+                "url": "/guidance/coronavirus-covid-19-information-for-the-public"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "country_section": {
+      "header": "If you live in Scotland, Wales or Northern Ireland",
+      "text": "Additional guidance is available",
+      "links": [
+        {
+          "label": "Scotland",
+          "url": "https://www.gov.scot/coronavirus-covid-19/"
+        },
+        {
+          "label": "Wales",
+          "url": "https://gov.wales/coronavirus"
+        },
+        {
+          "label": "Northern Ireland",
+          "url": "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
+        }
+      ]
+    },
+    "topic_section": {
+      "header": "All coronavirus (COVID-19) information",
+      "text": "Browse information related to coronavirus",
+      "links": [
+        {
+          "label": "News",
+          "url": "/search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        },
+        {
+          "label": "Guidance",
+          "url": "/search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        }
+      ]
+    },
+    "notifications": {
+      "intro": "Stay up to date with GOV.UK",
+      "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    }
+  }
+}

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -12,6 +12,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       and_i_can_see_the_live_stream_section
       then_i_can_see_the_nhs_banner
       then_i_can_see_the_accordions
+      and_i_can_see_links_to_search
     end
 
     it "has sections that can be clicked" do
@@ -32,6 +33,17 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       when_i_visit_the_coronavirus_landing_page
       then_the_special_announcement_schema_is_rendered
       and_the_faqpage_schema_is_rendered
+    end
+  end
+
+  describe "the business support landing page" do
+    it "renders" do
+      given_there_is_a_business_content_item
+      when_i_visit_the_business_landing_page
+      then_i_can_see_the_business_header_section
+      and_i_can_see_the_business_announcements
+      then_i_can_see_the_business_accordions
+      and_i_can_see_business_links_to_search
     end
   end
 end

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -1,12 +1,26 @@
 def coronavirus_landing_page_content_item
+  load_content_item("coronavirus_landing_page.json")
+end
+
+def load_content_item(file_name)
   json = File.read(
-    Rails.root.join("test/fixtures/content_store/coronavirus_landing_page.json"),
+    Rails.root.join("test/fixtures/content_store/", file_name),
   )
   JSON.parse(json)
 end
 
-def coronavirus_content_item
+def business_content_item_fixture
+  load_content_item("business_support_page.json")
+end
+
+def random_landing_page
   GovukSchemas::RandomExample.for_schema(frontend_schema: "coronavirus_landing_page") do |item|
+    yield(item)
+  end
+end
+
+def coronavirus_content_item
+  random_landing_page do |item|
     item.merge(coronavirus_landing_page_content_item)
   end
 end
@@ -15,4 +29,10 @@ def coronavirus_content_item_with_no_time
   content_item = coronavirus_content_item
   content_item["details"]["live_stream"]["time"] = nil
   content_item
+end
+
+def business_content_item
+  random_landing_page do |item|
+    item.merge(business_content_item_fixture)
+  end
 end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -9,6 +9,9 @@ module CoronavirusLandingPageSteps
   CORONAVIRUS_CONTENT_ID = "774cee22-d896-44c1-a611-e3109cce8eae".freeze
   CORONAVIRUS_PATH = "/coronavirus".freeze
 
+  BUSINESS_CONTENT_ID = "09944b84-02ba-4742-a696-9e562fc9b29d".freeze
+  BUSINESS_PATH = "/coronavirus/business".freeze
+
   def given_there_is_a_content_item
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
   end
@@ -17,12 +20,28 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_no_time)
   end
 
+  def given_there_is_a_business_content_item
+    stub_content_store_has_item(BUSINESS_PATH, business_content_item)
+  end
+
   def when_i_visit_the_coronavirus_landing_page
     visit CORONAVIRUS_PATH
   end
 
+  def when_i_visit_the_business_landing_page
+    visit BUSINESS_PATH
+  end
+
   def then_i_can_see_the_header_section
     assert page.has_selector?(".covid__page-header h1", text: "Coronavirus (COVID-19): what you need to do")
+  end
+
+  def then_i_can_see_the_business_header_section
+    assert page.has_selector?(".covid__page-header h1", text: "Business support")
+  end
+
+  def and_i_can_see_the_business_announcements
+    assert page.has_selector?(".covid__page-header-link", text: "High street businesses will receive grants")
   end
 
   def and_i_can_see_the_live_stream_section
@@ -42,12 +61,26 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".govuk-accordion__section-header", text: "How to protect yourself and others")
   end
 
+  def then_i_can_see_the_business_accordions
+    assert page.has_selector?(".govuk-accordion__section-header", text: "Funding and support")
+  end
+
   def and_i_click_on_an_accordion
     first(".govuk-accordion__section").find(".govuk-accordion__section-button").click
   end
 
   def then_i_can_see_the_accordions_content
     assert page.has_selector?(".govuk-link", text: "Staying at home if you think you have coronavirus (self-isolating)")
+  end
+
+  def and_i_can_see_links_to_search
+    assert page.has_link?("News", href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response")
+    assert page.has_link?("Guidance", href: "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
+  end
+
+  def and_i_can_see_business_links_to_search
+    assert page.has_link?("News", href: "/search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
+    assert page.has_link?("Guidance", href: "/search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
   end
 
   def then_the_special_announcement_schema_is_rendered


### PR DESCRIPTION
The skeleton of the business page is based on the coronavirus landing page.

This will be iterated tomorrow.

Note that the `stay_at_home` key in the content item is `header_section` in the new business content item and there are differences between them which may not be totally reflected in the fixture yet

We'll have an alignment session after this is built.