### PR TITLE
Allow for new path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
 
 
   get "/coronavirus", to: "coronavirus_landing_page#show"
+  # todo: remove this line when the page gets republished
   get "/coronavirus/business", to: "coronavirus_landing_page#business"
+  get "/coronavirus/business-support", to: "coronavirus_landing_page#business"
 
   get "/browse.json" => redirect("/api/content/browse")
 

--- a/test/fixtures/content_store/business_support_page.json
+++ b/test/fixtures/content_store/business_support_page.json
@@ -1,5 +1,5 @@
 {
-  "base_path": "/coronavirus/business",
+  "base_path": "/coronavirus/business-support",
   "content_id": "09944b84-02ba-4742-a696-9e562fc9b29d",
   "document_type": "coronavirus_landing_page",
   "description": "Business support page",

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -10,7 +10,7 @@ module CoronavirusLandingPageSteps
   CORONAVIRUS_PATH = "/coronavirus".freeze
 
   BUSINESS_CONTENT_ID = "09944b84-02ba-4742-a696-9e562fc9b29d".freeze
-  BUSINESS_PATH = "/coronavirus/business".freeze
+  BUSINESS_PATH = "/coronavirus/business-support".freeze
 
   def given_there_is_a_content_item
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)


### PR DESCRIPTION
We'll remove the old route when we've updated the content item and republished

https://trello.com/c/QxlEHpMD/137-update-the-url-to-be-coronavirus-business-support