### PR TITLE
Update breadcrumbs

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -27,6 +27,14 @@ $covid-grey: #272828;
   color: govuk-colour("white");
 }
 
+.covid__page-header--business {
+  background-color: $covid-grey;
+}
+
+.covid__page-header--hub {
+  background-color: $covid-grey;
+}
+
 .covid__page-header-light {
   padding-top: govuk-spacing(5);
   padding-bottom: govuk-spacing(2);

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -11,10 +11,7 @@ class CoronavirusLandingPageController < ApplicationController
 
   def business
     @content_item = content_item.to_hash
-    breadcrumbs = [
-      { title: "Home", url: "/" },
-      { title: "Coronavirus (COVID-19)", url: "/coronavirus", is_page_parent: true },
-    ]
+    breadcrumbs = [{ title: "Home", url: "/" }]
     render "business", locals: {
       breadcrumbs: breadcrumbs,
       details: business_presenter,

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -5,15 +5,32 @@ class CoronavirusLandingPageController < ApplicationController
   def show
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
-    render "show", locals: { breadcrumbs: breadcrumbs, details: presenter,
-      special_announcement: special_announcement }
+    title = {
+      text: @content_item["title"],
+    }
+
+    render "show", locals: {
+      breadcrumbs: breadcrumbs,
+      title: title,
+      details: presenter,
+      special_announcement: special_announcement,
+    }
   end
 
   def business
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/" }]
+    title = {
+      text: @content_item["title"],
+      context: {
+        text: "Coronavirus (Covid-19)",
+        href: "/coronavirus",
+      },
+    }
+
     render "business", locals: {
       breadcrumbs: breadcrumbs,
+      title: title,
       details: business_presenter,
     }
   end

--- a/app/views/coronavirus_landing_page/business.html.erb
+++ b/app/views/coronavirus_landing_page/business.html.erb
@@ -2,6 +2,7 @@
 
 <%= render partial: "coronavirus_landing_page/components/business/page_header", locals: {
   details: details,
+  title: title,
   breadcrumbs: breadcrumbs
 } %>
 

--- a/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
@@ -1,4 +1,4 @@
-<header class="covid__page-header" data-module="coronavirus-landing-page">
+<header class="covid__page-header covid__page-header--business" data-module="coronavirus-landing-page">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: breadcrumbs,
@@ -12,7 +12,8 @@
           context: title[:context],
           title: title[:text],
           inverse: true,
-          margin_top: 4
+          margin_top: 4,
+          margin_bottom: 0,
         } %>
       </div>
     </div>

--- a/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
@@ -8,9 +8,12 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="covid__page-title">
-          <%= @content_item["title"] %>
-        </h1>
+        <%= render "govuk_publishing_components/components/title", {
+          context: title[:context],
+          title: title[:text],
+          inverse: true,
+          margin_top: 4
+        } %>
       </div>
     </div>
   </div>

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -8,9 +8,12 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="covid__page-title">
-          <%= @content_item["title"] %>
-        </h1>
+      <%= render "govuk_publishing_components/components/title", {
+        context: title[:context],
+        title: title[:text],
+        inverse: true,
+        margin_top: 4
+      } %>
       </div>
     </div>
   </div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -11,6 +11,7 @@
     partial: 'coronavirus_landing_page/components/landing_page/page_header', locals: {
       details: details,
       breadcrumbs: breadcrumbs,
+      title: title,
       rules: details.stay_at_home,
       guidance: details.guidance,
     }


### PR DESCRIPTION
Trello: https://trello.com/c/UnaD3yvm/134-fix-breadcrumbs-to-look-like-the-design-topic-breadcrumbs

## What

- Removes the coronavirus page from the business breadcrumbs
- Links to the coronavirus page from title context
- Switches hardcoded title for component
- Makes the whole business header section grey rather than black.

## Before
<img width="748" alt="Screenshot 2020-04-03 at 14 09 05" src="https://user-images.githubusercontent.com/29889908/78364025-b2a5e100-75b4-11ea-831e-7e9107bdd5be.png">

## After
<img width="753" alt="Screenshot 2020-04-03 at 14 08 49" src="https://user-images.githubusercontent.com/29889908/78364032-b6396800-75b4-11ea-986e-2931784822ae.png">
