### PR TITLE
Add spacing to the business announcements section

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -46,6 +46,10 @@ $covid-grey: #272828;
   }
 }
 
+.covid__business-list-wrapper {
+  margin-bottom: 45px;
+}
+
 .covid__logo-wrapper {
   margin-top: govuk-spacing(5);
   margin-bottom: govuk-spacing(8);

--- a/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
@@ -21,7 +21,7 @@
 
   <div class="covid__page-header-light">
     <div class="govuk-width-container">
-      <div class="govuk-grid-row">
+      <div class="govuk-grid-row covid__business-list-wrapper">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
             text: details.header_section["pretext"],


### PR DESCRIPTION
## What
Add spacing above the business announcements section

## Before
<img width="886" alt="Screenshot 2020-04-03 at 16 04 27" src="https://user-images.githubusercontent.com/29889908/78375526-d4a75f80-75c4-11ea-88a5-d17b636c1e72.png">

## After
<img width="793" alt="Screenshot 2020-04-03 at 16 04 17" src="https://user-images.githubusercontent.com/29889908/78375541-da9d4080-75c4-11ea-85ce-b0892ff16bcf.png">
