### PR TITLE
Capitalise 'covid' in page title context

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -23,7 +23,7 @@ class CoronavirusLandingPageController < ApplicationController
     title = {
       text: @content_item["title"],
       context: {
-        text: "Coronavirus (Covid-19)",
+        text: "Coronavirus (COVID-19)",
         href: "/coronavirus",
       },
     }


### PR DESCRIPTION
## What
Capitalise the page title context 'covid-19'.

## Before
<img width="370" alt="Screenshot 2020-04-03 at 16 39 27" src="https://user-images.githubusercontent.com/29889908/78379033-b3953d80-75c9-11ea-8740-6b0b06c1e6c1.png">

## After
<img width="419" alt="Screenshot 2020-04-03 at 16 38 36" src="https://user-images.githubusercontent.com/29889908/78378951-952f4200-75c9-11ea-8051-60a0a774bee5.png">
