### PR TITLE
Support featured_link param in accordion links

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -5,7 +5,7 @@
   <ul class="covid__list covid__list--accordion">
     <% sub_section["list"].each do | item | %>
       <li class="covid__list-item">
-        <a class="govuk-link covid__accordion-link" href="<%= item["url"] %>"><%= item["label"] %></a>
+        <a class="govuk-link covid__accordion-link <%= "covid__page-guidance-link" if item["featured_link"] %>" href="<%= item["url"] %>"><%= item["label"] %></a>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
## What
Support featured_link param in accordion links. These links are rendered as bold with an arrow.

A featured link would look like this:
```
"list": [
              {
                "label": "How to keep your employees safe",
                "url": "/government/publications/guidance-to-employers-and-businesses-about-covid-19",
                "featured_link": true
              },
]

```

## What this looks like
On a test link:
<img width="654" alt="Screenshot 2020-04-03 at 17 16 39" src="https://user-images.githubusercontent.com/29889908/78382520-ea218700-75ce-11ea-884e-bf73f2ca7335.png">
