### PR TITLE
Optimise page title for SEO

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -21,7 +21,7 @@ class CoronavirusLandingPageController < ApplicationController
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/" }]
     title = {
-      text: @content_item["title"],
+      text: @content_item.dig("details", "page_title") || @content_item["title"],
       context: {
         text: "Coronavirus (COVID-19)",
         href: "/coronavirus",

--- a/test/fixtures/content_store/business_support_page.json
+++ b/test/fixtures/content_store/business_support_page.json
@@ -7,11 +7,12 @@
   "publishing_app": "collections-publisher",
   "rendering_app": "collections",
   "schema_name": "coronavirus_landing_page",
-  "title": "Business support",
+  "title": "Coronavirus (COVID-19): Business support",
   "locale": "en",
   "updated_at": "2020-03-25T14:40:22Z",
   "links": {},
   "details": {
+    "page_title": "Business support",
     "header_section": {
       "pretext": "Support will be available to businesses",
       "list": [

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -40,7 +40,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
     it "renders" do
       given_there_is_a_business_content_item
       when_i_visit_the_business_landing_page
-      then_i_can_see_the_business_header_section
+      then_i_can_see_the_business_page
       # and_i_can_see_the_business_announcements
       then_i_can_see_the_business_accordions
       and_i_can_see_business_links_to_search

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -36,7 +36,8 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: "Coronavirus (COVID-19): what you need to do")
   end
 
-  def then_i_can_see_the_business_header_section
+  def then_i_can_see_the_business_page
+    assert page.has_title?("Coronavirus (COVID-19): Business support")
     assert page.has_selector?(".covid__page-header h1", text: "Business support")
   end
 


### PR DESCRIPTION
We need the page and content store titles to mention coronavirus/ COVID-19 so the page has a chance of featuring highly for those terms.

We'll update the content once this is merged and deployed so that the following are true:
- @content_item.dig("details", "page_title") reads "Business support"
- @content_item.dig("title") reads "Coronavirus (COVID-19): Business support

https://trello.com/c/aVewxtbK/149-sort-out-business-support-page-title