### PR TITLE
Add tracking for accordion open all link

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -4,21 +4,37 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function CoronavirusLandingPage () {}
 
-  CoronavirusLandingPage.prototype.start = function () {
+  CoronavirusLandingPage.prototype.start = function ($element) {
     // Confirm the user is on the coronavirus landing page
     if (this.checkOnLandingPage()) {
-      if (window.GOVUK.cookie('global_bar_seen')) {
-        // Get current version of global bar, if cookie has been set
-        var currentBannerVersion = JSON.parse(window.GOVUK.cookie('global_bar_seen')).version
-
-        // Automatically hide the additional information section in the banner by setting the cookie
-        window.GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 999, version: currentBannerVersion }), { days: 84 })
-      }
+      this.globarBarSeen()
     }
+    this.addAccordionOpenAllTracking($element)
   }
 
   CoronavirusLandingPage.prototype.checkOnLandingPage = function () {
     return window.location.pathname === '/coronavirus'
+  }
+
+  CoronavirusLandingPage.prototype.globarBarSeen = function () {
+    if (window.GOVUK.cookie('global_bar_seen')) {
+      // Get current version of global bar, if cookie has been set
+      var currentBannerVersion = JSON.parse(window.GOVUK.cookie('global_bar_seen')).version
+
+      // Automatically hide the additional information section in the banner by setting the cookie
+      window.GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 999, version: currentBannerVersion }), { days: 84 })
+    }
+  }
+
+  CoronavirusLandingPage.prototype.addAccordionOpenAllTracking = function ($element) {
+    $element.find('.govuk-accordion__open-all').on('click', function(e) {
+      var expanded = $(e.target).attr('aria-expanded') == 'true'
+      var label = expanded ?  'Collapse all' : 'Expand all'
+      var action = expanded ?  'accordionClosed' : 'accordionOpened'
+      var options = { transport: 'beacon', label: label }
+
+      GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
+    })
   }
 
   Modules.CoronavirusLandingPage = CoronavirusLandingPage

--- a/app/views/coronavirus_landing_page/business.html.erb
+++ b/app/views/coronavirus_landing_page/business.html.erb
@@ -6,7 +6,7 @@
   breadcrumbs: breadcrumbs
 } %>
 
-<div class="govuk-width-container covid__page">
+<div class="govuk-width-container covid__page" data-module="coronavirus-landing-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections } %>

--- a/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/business/_page_header.html.erb
@@ -1,4 +1,4 @@
-<header class="covid__page-header covid__page-header--business" data-module="coronavirus-landing-page">
+<header class="covid__page-header covid__page-header--business">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: breadcrumbs,

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -1,4 +1,4 @@
-<header class="covid__page-header" data-module="coronavirus-landing-page">
+<header class="covid__page-header">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: breadcrumbs,

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -20,7 +20,7 @@
   )
 %>
 
-<div class="govuk-width-container covid__page">
+<div class="govuk-width-container covid__page" data-module="coronavirus-landing-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <%= render 'components/header-notice', {

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -4,6 +4,23 @@ describe('Coronavirus landing page', function () {
   var coronavirusLandingPage;
   var html = '\
   <div id="element" data-module="coronavirus-landing-page">\
+    <div class="gem-c-accordion govuk-accordion" data-module="govuk-accordion">\
+      <div class="govuk-accordion__controls">\
+        <button type="button" class="govuk-accordion__open-all" aria-expanded="false">\
+          Open all<span class="govuk-visually-hidden"> sections</span>\
+        </button>\
+      </div>\
+      <div class="govuk-accordion__section">\
+        <div class="govuk-accordion__section-header">\
+          <h2 class="govuk-accordion__section-heading">\
+            <button type="button">How to protect yourself and others</button><span class="govuk-accordion__icon" aria-hidden="true"></span>\
+          </h2>\
+        </div>\
+        <div class="govuk-accordion__section-content">\
+          accordion content\
+        </div> \
+      </div> \
+    </div>\
   </div>'
   var $element
 
@@ -28,6 +45,40 @@ describe('Coronavirus landing page', function () {
 
     expect(parseCookie(GOVUK.cookie("global_bar_seen")).count).not.toBe(999)
     expect(parseCookie(GOVUK.cookie("global_bar_seen")).version).toBe(1)
+  })
+
+  describe('Clicking the "Open all" button', function () {
+    beforeEach(function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+      coronavirusLandingPage.start($element)
+    })
+
+    it("tracks expanding", function () {
+      var $openCloseAllButton = $element.find('.govuk-accordion__open-all')
+      expect($openCloseAllButton).toExist()
+      expect($openCloseAllButton.attr("aria-expanded")).toBe("false")
+      $openCloseAllButton.trigger('click')
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'pageElementInteraction', 'accordionOpened', { transport: 'beacon', label: 'Expand all' }
+      )
+    })
+
+    it("tracks collapsing", function () {
+      var $openCloseAllButton = $element.find('.govuk-accordion__open-all')
+      $openCloseAllButton.attr('aria-expanded', 'true')
+
+      // collapse check
+      expect($openCloseAllButton).toExist()
+      expect($openCloseAllButton).toHaveAttr("aria-expanded", "true")
+      $openCloseAllButton.trigger('click')
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'pageElementInteraction', 'accordionClosed', { transport: 'beacon', label: 'Collapse all' }
+      )
+    })
   })
 });
 


### PR DESCRIPTION
We currently track users who click on and interact with accordions but what we don't track is the number of users who interact with the expand and collapse all feature. 

Adding tracking to this will help us determine if users that click this option have their journey altered in some way or don't make it through a large proportion of the page.  

The event structure should follow the accordion structure currently in place. 

Event category: pageElementInteraction
Event action: accordionOpened/accordionClosed
Event label: Expand all/Collapse all

It's done when: 

We can see when users interact with the expand and collapse all portions of the accordion interaction. 



https://trello.com/c/so5IN6ZA/157-add-tracking-to-the-expand-all-option-on-accordions