### PR TITLE
Redirect children of coronavirus taxon to coronavirus page

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -40,7 +40,7 @@ private
   end
 
   def redirect_coronavirus_taxons
-    if is_child_of_coronavirus_taxon? || is_coronavirus_taxon?
+    if is_coronavirus_taxon? || is_child_of_coronavirus_taxon?
       redirect_to(coronavirus_landing_page_url, status: :temporary_redirect) && return
     end
   end
@@ -52,6 +52,6 @@ private
 
   def is_coronavirus_taxon?
     # The root of the branch is always the first entry
-    taxon.base_path == CORONAVIRUS_TAXON_PATH
+    request.path == CORONAVIRUS_TAXON_PATH
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,4 +1,6 @@
 class TaxonsController < ApplicationController
+  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
+  before_action :redirect_coronavirus_taxons
   rescue_from Taxon::InAlphaPhase, with: :error_404
 
   def show
@@ -35,5 +37,21 @@ private
     end
 
     @presentable_section_items
+  end
+
+  def redirect_coronavirus_taxons
+    if is_child_of_coronavirus_taxon? || is_coronavirus_taxon?
+      redirect_to(coronavirus_landing_page_url, status: :temporary_redirect) && return
+    end
+  end
+
+  def is_child_of_coronavirus_taxon?
+    # The root of the branch is always the first entry
+    taxon.parents? && taxon.parent_taxons.first.base_path == CORONAVIRUS_TAXON_PATH
+  end
+
+  def is_coronavirus_taxon?
+    # The root of the branch is always the first entry
+    taxon.base_path == CORONAVIRUS_TAXON_PATH
   end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -46,6 +46,18 @@ class Taxon
     linked_items("child_taxons").present?
   end
 
+  def parent_taxons
+    return [] unless parents?
+
+    linked_items("parent_taxons")
+        .map { |child_taxon| self.class.new(child_taxon) }
+        .reject(&:alpha_taxon?)
+  end
+
+  def parents?
+    linked_items("parent_taxons").present?
+  end
+
   def merge(to_merge)
     Taxon.new(content_item.merge(to_merge))
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
 
-  get "/coronavirus", to: "coronavirus_landing_page#show"
+  get "/coronavirus", to: "coronavirus_landing_page#show", as: :coronavirus_landing_page
   get "/coronavirus/:hub_slug", to: "coronavirus_landing_page#hub"
 
   get "/browse.json" => redirect("/api/content/browse")

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -60,13 +60,6 @@ describe TaxonsController do
   end
 
   context "when rendering the coronavirus taxon" do
-    before do
-      stub_content_store_has_item(
-        coronavirus_root_taxon_content_item["base_path"],
-        coronavirus_root_taxon_content_item,
-      )
-    end
-
     it "redirects to the coronavirus page" do
       get :show, params: { taxon_base_path: coronavirus_root_taxon_content_item["base_path"][1..-1] }
       assert_redirected_to "/coronavirus"

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require_relative "../../test/support/coronavirus_helper"
 
 describe TaxonsController do
   include RummagerHelpers
@@ -38,6 +39,37 @@ describe TaxonsController do
       get :show, params: { taxon_base_path: taxon["base_path"][1..-1] }
 
       assert_response 404
+    end
+  end
+
+  context "when rendering a taxon that is a child of the coronavirus taxon" do
+    before do
+      stub_content_store_has_item(
+        coronavirus_root_taxon_content_item["base_path"],
+        coronavirus_root_taxon_content_item,
+      )
+      stub_content_store_has_item(
+        coronavirus_taxon_one["base_path"], coronavirus_taxon_one
+      )
+    end
+
+    it "redirects to the coronavirus page" do
+      get :show, params: { taxon_base_path: coronavirus_taxon_one["base_path"][1..-1] }
+      assert_redirected_to "/coronavirus"
+    end
+  end
+
+  context "when rendering the coronavirus taxon" do
+    before do
+      stub_content_store_has_item(
+        coronavirus_root_taxon_content_item["base_path"],
+        coronavirus_root_taxon_content_item,
+      )
+    end
+
+    it "redirects to the coronavirus page" do
+      get :show, params: { taxon_base_path: coronavirus_root_taxon_content_item["base_path"][1..-1] }
+      assert_redirected_to "/coronavirus"
     end
   end
 end

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -1,3 +1,5 @@
+CORONAVIRUS_TAXON_PATH = "/coronavirus-taxons".freeze
+
 def coronavirus_landing_page_content_item
   load_content_item("coronavirus_landing_page.json")
 end
@@ -34,5 +36,22 @@ end
 def business_content_item
   random_landing_page do |item|
     item.merge(business_content_item_fixture)
+  end
+end
+
+def coronavirus_root_taxon_content_item
+  GovukSchemas::Example.find("taxon", example_name: "taxon").tap do |item|
+    item["base_path"] = "/coronavirus-taxon"
+  end
+end
+
+def coronavirus_taxon_one
+  GovukSchemas::Example.find("taxon", example_name: "taxon").tap do |item|
+    item["links"]["parent_taxons"] = [coronavirus_root_taxon_content_item]
+    item["links"]["ordered_related_items"] =
+      [
+        GovukSchemas::Example.find("guide", example_name: "guide"),
+        GovukSchemas::Example.find("news_article", example_name: "news_article"),
+      ]
   end
 end


### PR DESCRIPTION
We don't want users visiting those pages so do a redirect if their parent is the coronavirus taxon

NB: The base path of the coronavirus taxon is not yet decided
so that needs to be changed when it is settled on

https://trello.com/c/3r5RsE3D/177-work-out-how-redirects-from-new-topics-will-work