### PR TITLE
Add "find help" partial to covid landing page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,9 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 $govuk-use-legacy-palette: false;
+$covid-grey: #272828;
+$covid-yellow: #ffe114;
+
 
 // gem components
 @import 'govuk_publishing_components/govuk_frontend_support';

--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -1,11 +1,10 @@
-$nhs_brand_color: #005EB8;
 
 .app-c-header-notice {
-  @include govuk-responsive-margin(8, "bottom");
+  @include govuk-responsive-margin(4, "bottom");
 }
 
 .app-c-header-notice__branding--nhs {
-  border: solid 5px $nhs_brand_color;
+  border: solid 5px $covid-grey;
 
   .app-c-header-notice__header {
     padding-bottom: 0;

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -1,5 +1,3 @@
-$covid-yellow: #ffe114;
-$covid-grey: #272828;
 
 .covid__page {
   .govuk-grid-column-one-third,
@@ -33,6 +31,13 @@ $covid-grey: #272828;
 
 .covid__page-header--hub {
   background-color: $covid-grey;
+}
+
+.covid__page-header--landing-page {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+  
 }
 
 .covid__page-header-light {
@@ -115,6 +120,12 @@ $covid-grey: #272828;
   .covid__page-header-link {
     @include govuk-font(19, $weight: bold);
   }
+}
+
+.covid__find-help {
+  @include govuk-responsive-margin(9, "bottom");
+  background-color: $covid-grey;
+  padding: govuk-spacing(6) govuk-spacing(5);
 }
 
 .covid__list {
@@ -252,6 +263,8 @@ $covid-grey: #272828;
   display: inline-block;
   display: -ms-flexbox;
   display: flex;
+  -ms-flex-align: center;
+  align-items: center;
   box-sizing: border-box;
   padding-left: 35px;
   min-height: 30px;
@@ -274,5 +287,24 @@ $covid-grey: #272828;
     @media screen and (min-width:0\0) {
       height: 45px;
     }
+  }
+}
+
+.covid__page-guidance-link--white {
+  color: govuk-colour("white");
+  text-decoration: underline;
+  padding-left: govuk-spacing(5);
+
+  &:focus {
+    text-decoration: none;
+  }
+
+  &:visited,
+  &:link {
+    color: govuk-colour("white");
+  }
+
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: 0;
   }
 }

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications).freeze
+  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications find_help).freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/landing_page/_find_help.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_find_help.html.erb
@@ -1,0 +1,24 @@
+<%
+  copy ||= false
+  heading ||= false
+  call_to_action ||= false
+%>
+
+<section class="covid__find-help">
+  <% if heading.present? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: heading,
+      inverse: true,
+      font_size: 24,
+      margin_bottom: 4
+    } %>
+  <% end %>
+
+  <% if copy.present? %>
+    <p class="govuk-body covid__inverse"><%= copy %></p>
+  <% end %>
+
+  <% if call_to_action.present? %>
+    <%= link_to(call_to_action[:text], call_to_action[:href], class: "govuk-link covid__page-guidance-link covid__page-guidance-link--white") %>
+  <% end %>
+</section>

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -1,4 +1,4 @@
-<header class="covid__page-header">
+<header class="covid__page-header covid__page-header--landing-page">
   <div class="govuk-width-container">
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
       breadcrumbs: breadcrumbs,

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -33,6 +33,15 @@
           title: details.nhs_banner["call_to_action"]["title"]
         }
       } %>
+
+      <%= render 'coronavirus_landing_page/components/landing_page/find_help',  {
+        heading: details.find_help["heading"],
+        copy: details.find_help["paragraph"],
+        call_to_action: {
+          href: details.find_help["link"]["href"],
+          text: details.find_help["link"]["text"]
+        }
+      } %>
     </div>
 
     <div class="govuk-grid-column-two-thirds">

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -54,6 +54,14 @@
         "href": "https://www.nhs.uk/conditions/coronavirus-covid-19/"
       }
     },
+    "find_help": {
+      "heading": "Find help if you’re struggling because of coronavirus",
+      "paragraph": "For example, with paying bills, being out of work, or taking care of your mental health.",
+      "link": {
+      "href": "/find-coronavirus-support",
+      "text": "Find help"
+      }
+    },
     "sections": [
       {
         "title": "How to protect yourself and others",


### PR DESCRIPTION
- Create new "Find help" box for the coronavirus landing  page
- Change NHS box border colour to Covid grey
- Adjust layout/spacing to be more consistent

https://trello.com/c/52XhjjAr

Before (large screen): ![Screenshot 2020-04-17 at 15 39 19](https://user-images.githubusercontent.com/7116819/79588125-6043e480-80cb-11ea-8872-eae6192c16a5.png)

After (large screen):
![Screenshot 2020-04-17 at 16 31 56](https://user-images.githubusercontent.com/7116819/79588172-6f2a9700-80cb-11ea-82e8-59e77f9045d5.png)

Before (small screen):
![Screenshot 2020-04-17 at 15 42 26](https://user-images.githubusercontent.com/7116819/79588222-81a4d080-80cb-11ea-971a-2ad81962f6e6.png)

After (small screen):
![Screenshot 2020-04-17 at 16 32 26](https://user-images.githubusercontent.com/7116819/79588235-87021b00-80cb-11ea-914c-d85b23ae494a.png)
