### PR TITLE
Changes to how we render live stream

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w(live_stream stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications).freeze
+  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications).freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|
@@ -10,7 +10,12 @@ class CoronavirusLandingPagePresenter
   end
 
   def show_live_stream?
-    live_stream && live_stream["show_video"] == true
+    live_stream_enabled == true
+  end
+
+  def todays_date
+    date = DateTime.now
+    date.day.ordinalize + date.strftime(" %B %Y")
   end
 
   def faq_schema(content_item)

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -1,13 +1,13 @@
 <div class="govuk-grid-row covid__video">
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/heading", {
-      text: details["title"],
+      text: live_stream["title"],
       font_size: 19,
       inverse: true,
       margin_bottom: 1
     } %>
     <p class="govuk-body covid__inverse">
-      <%= details["date"] %> <%= ("at " + details["time"]) if details["time"].present? %>
+      <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
     </p>
   </div>
 
@@ -17,23 +17,23 @@
       <div class="covid__video-placeholder">
         <div class="covid__video-logo">Live</div>
         <p class="govuk-body">
-          <a href="<%= details["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
-            <%= details["no_cookies"]["change_settings"] %>
+          <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
+            <%= live_stream["no_cookies"]["change_settings"] %>
           </a>
         </p>
         <p class="govuk-body covid__inverse covid__bold">
-          <%= details["no_cookies"]["to_watch"] %>
+          <%= live_stream["no_cookies"]["to_watch"] %>
         </p>
         <p class="govuk-body covid__inverse">
-          <%= details["no_cookies"]["or"] %>
+          <%= live_stream["no_cookies"]["or"] %>
         </p>
         <a
-          href="<%= details["video_url"] %>"
+          href="<%= live_stream["video_url"] %>"
           class="govuk-body govuk-link covid__page-header-link"
           data-youtube-player-analytics="true"
           data-youtube-player-analytics-category="EmbeddedYoutube"
         >
-          <%= details["no_cookies"]["watch_link_text"] %>
+          <%= live_stream["no_cookies"]["watch_link_text"] %>
         </a>
       </div>
     <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -1,6 +1,7 @@
 <% if details.show_live_stream? %>
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    details: details.live_stream
+    details: details,
+    live_stream: details.live_stream
   } %>
 <% else %>
   <div class="govuk-grid-row covid__video">

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -362,20 +362,24 @@
       "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
     },
     "live_stream": {
+      "time": "",
       "title": "Live press conference",
       "video_url": "https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw",
       "no_cookies_message": "Watch the live stream on YouTube",
       "no_cookies": {
-      "change_settings": "Change your cookie settings",
-      "change_settings_link": "/help/cookies",
-      "to_watch": "to watch the live stream",
-      "or": "or",
-      "watch_link_text": "Watch the live stream on YouTube"
+        "change_settings": "Change your cookie settings",
+        "change_settings_link": "/help/cookies",
+        "to_watch": "to watch the live stream",
+        "or": "or",
+        "watch_link_text": "Watch the live stream on YouTube"
       },
-      "date": "1st April 2020",
-      "time": "5:00pm",
-      "show_video": true
+      "previous_videos": {
+        "url": "https://www.youtube.com/user/Number10gov/videos",
+        "previous_videos_text": "View past coronavirus press conferences on YouTube",
+        "next_conference_text": "The next live press conference will be shown here"
+      }
     },
+    "live_stream_enabled": false,
     "special_announcement_schema": {
       "category": "https://www.wikidata.org/wiki/Q81068910",
       "disease_prevention_info_url": "https://www.gov.uk/coronavirus",

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -9,7 +9,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
-      and_i_can_see_the_live_stream_section
+      and_i_can_see_the_live_stream_placeholder
       then_i_can_see_the_nhs_banner
       then_i_can_see_the_accordions
       and_i_can_see_links_to_search
@@ -22,10 +22,16 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_accordions_content
     end
 
-    it "optionally shows the time" do
-      given_there_is_a_content_item_with_no_time
+    it "shows todays date when a live stream is enabled" do
+      given_there_is_a_content_item_with_live_stream_enabled
       when_i_visit_the_coronavirus_landing_page
-      then_i_can_see_the_live_stream_section_with_no_time
+      then_i_can_see_the_live_stream_section_with_todays_date
+    end
+
+    it "optionally shows the time when a live stream is enabled" do
+      given_there_is_a_content_item_with_live_stream_enabled_and_date
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_see_the_live_stream_section_with_date_and_time
     end
 
     it "renders machine readable content" do

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -27,10 +27,22 @@ def coronavirus_content_item
   end
 end
 
-def coronavirus_content_item_with_no_time
+def coronavirus_content_item_with_live_stream_enabled
   content_item = coronavirus_content_item
-  content_item["details"]["live_stream"]["time"] = nil
+  content_item["details"]["live_stream_enabled"] = true
   content_item
+end
+
+def coronavirus_content_item_with_live_stream_enabled_and_date
+  content_item = coronavirus_content_item
+  content_item["details"]["live_stream_enabled"] = true
+  content_item["details"]["live_stream"]["time"] = "5:00pm"
+  content_item
+end
+
+def todays_date
+  d = DateTime.now
+  d.day.ordinalize + d.strftime(" %B %Y")
 end
 
 def business_content_item

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -16,8 +16,12 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
   end
 
-  def given_there_is_a_content_item_with_no_time
-    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_no_time)
+  def given_there_is_a_content_item_with_live_stream_enabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_enabled)
+  end
+
+  def given_there_is_a_content_item_with_live_stream_enabled_and_date
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_enabled_and_date)
   end
 
   def given_there_is_a_business_content_item
@@ -45,13 +49,18 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header-link", text: "High street businesses will receive grants")
   end
 
-  def and_i_can_see_the_live_stream_section
-    assert page.has_text?("1st April 2020 at 5:00pm")
+  def and_i_can_see_the_live_stream_placeholder
+    assert page.has_text?("The next live press conference will be shown here")
   end
 
-  def then_i_can_see_the_live_stream_section_with_no_time
-    assert_not page.has_text?("1st April 2020 at")
-    assert page.has_text?("1st April 2020")
+  def then_i_can_see_the_live_stream_section_with_todays_date
+    assert page.has_text?(todays_date)
+    assert_not page.has_text?("#{todays_date} at")
+  end
+
+  def then_i_can_see_the_live_stream_section_with_date_and_time
+    assert page.has_text?(todays_date)
+    assert page.has_text?("5:00pm")
   end
 
   def then_i_can_see_the_nhs_banner


### PR DESCRIPTION
- ref: https://github.com/alphagov/collections-publisher/pull/996
- toggle livestream component on presence of new key `live_stream_enabled`
- calculate date instead of fetching from the yaml
[Trello](https://trello.com/c/tsal0J9i/158-create-a-way-for-content-designers-to-switch-the-livestream-on-and-off)