### PR TITLE
See all announcements

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -51,6 +51,18 @@
   }
 }
 
+.covid__page-header-announcement {
+  margin-bottom: govuk-spacing(7);
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-body {
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
 .covid__business-list-wrapper {
   margin-bottom: 45px;
 }

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications find_help).freeze
+  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections topic_section country_section notifications find_help).freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -70,7 +70,27 @@
         inverse: true
       } %>
 
-      <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { announcements: details.announcements } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { 
+        announcements: details.announcements
+      } %>
+      <% if details.see_all_announcements_link.present? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body covid__inverse">
+              <a
+                href="<%= details.see_all_announcements_link["href"] %>"
+                class="govuk-link covid__page-header-link"
+                data-module="track-click"
+                data-track-category="pageElementInteraction"
+                data-track-action="Announcements"
+                data-track-label="<%= details.see_all_announcements_link["href"] %>"
+              >
+                <%= details.see_all_announcements_link["text"] %>
+              </a>
+            </p>
+          </div>
+        </div>
+      <% end %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
     </div>
   </div>

--- a/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <% announcements.each do |announcement| %>
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third covid__page-header-announcement">
       <p class="govuk-body covid__inverse">
         <% if announcement["href"].present? %>
           <a
@@ -17,6 +17,9 @@
           <%= announcement["text"] %>
         <% end %>
       </p>
+      <% if announcement["published_text"].present? %>
+        <p class="govuk-body covid__inverse"><%= announcement["published_text"] %></p>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/startup.sh
+++ b/startup.sh
@@ -10,6 +10,14 @@ if [[ $1 == "--integration" ]] ; then
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.integration.publishing.service.gov.uk/api} \
   bundle exec rails s -p 3070
 
+elif [[ $1 == "--staging" ]] ; then
+  GOVUK_APP_DOMAIN=www.staging.publishing.service.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.staging.publishing.service.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.staging.publishing.service.gov.uk/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.staging.publishing.service.gov.uk} \
+  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.staging.publishing.service.gov.uk/api} \
+  bundle exec rails s -p 3070
+
 elif [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream stay_at_home guidance announcements_label announcements nhs_banner sections topic_section country_section notifications].each do |method|
+    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections topic_section country_section notifications].each do |method|
       assert_respond_to(presenter, method)
     end
   end


### PR DESCRIPTION
## Context
User research from Italy showed that users struggled to keep track of what they can and can't do as regulations changed over time. Unlike guidance announcements are time-sensitive and foregrounding dates is useful.

## What
Add dates and a [See all announcements](https://www.gov.uk/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response) link to the announcements section.

<img src="https://trello-attachments.s3.amazonaws.com/5e988ff09fa28d3f22a87ab9/750x3306/505c0808069865c69cde89b958e6ba90/Landing_page_announcements_%281%29.png" width="300px">

## Why
To help users understand when announcements have been made, and that they are current.

## Done when
Announcement dates and a 'See all announcements' link are live on the homepage.

https://trello.com/c/2dh1maeg/195-update-announcements-section-with-dates-and-see-all-link