### PR TITLE
Add tracking for What you can do now section

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
@@ -10,7 +10,14 @@
         <ul class="covid__list">
           <% guidance["list"].each do | item | %>
             <li class="covid__list-item">
-              <a class="govuk-link covid__page-guidance-link" href="<%= item["url"] %>">
+              <a
+                class="govuk-link covid__page-guidance-link"
+                href="<%= item["url"] %>"
+                data-module="track-click"
+                data-track-category="pageElementInteraction"
+                data-track-action="What you can do now"
+                data-track-label="<%= item["url"] %>"
+              >
                 <%= item["text"] %>
               </a>
             </li>


### PR DESCRIPTION
On /Coronavirus we track the announcements section with events so we can differentiate between links being used at the top of the page and them being used in the accordions. 

The format should follow that of the announcement section on the Coronavirus landing page. 

```
Event category: pageElementInteraction
Event Action: What you can do now
Event label: URL slug
```

https://trello.com/c/CC30S31d/205-add-event-tracking-to-what-you-can-do-now-on-business-support-hub