### PR TITLE
Fix 'Part of' styling

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -9,7 +9,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <% title_link = capture do %>
-          Part of <a href="<%= title[:context][:href] %>" class="govuk-link covid__page-header-link">
+          <span class="covid__inverse">Part of</span> <a href="<%= title[:context][:href] %>" class="govuk-link covid__page-header-link">
             <%= title[:context][:text] %>
           </a>
         <% end %>


### PR DESCRIPTION
- was changed within the component but the inverse version of the component doesn't handle this yet, so putting in this fix temporarily while we get that done

Before:

<img width="618" alt="Screenshot 2020-04-23 at 11 26 36" src="https://user-images.githubusercontent.com/861310/80089105-5b60b400-8555-11ea-965f-8a64f05194bc.png">

After:

<img width="679" alt="Screenshot 2020-04-23 at 11 26 43" src="https://user-images.githubusercontent.com/861310/80089127-60bdfe80-8555-11ea-8063-d1a4c4961700.png">
