### PR TITLE
Education hub page tweaks

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
@@ -25,7 +25,6 @@
           <% end %>
         </ul>
       </div>
-      <%# render partial: 'coronavirus_landing_page/components/shared/related_links', locals: { related: related } %>
     </div>
   </div>
 </div>

--- a/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
@@ -1,3 +1,4 @@
+<% if guidance %>
 <div class="covid__page-guidance">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
@@ -28,3 +29,4 @@
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -41,17 +41,6 @@
           </ul>
         </div>
       </div>
-
-      <%# <%= render "govuk_publishing_components/components/heading", {
-        text: details.announcements_label,
-        padding: true,
-        font_size: 19,
-        border_top: 2,
-        brand: 'public-health-england',
-        inverse: true
-      } %>
-
-      <%# <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { announcements: details.announcements } %>
     </div>
   </div>
   <%= render 'coronavirus_landing_page/components/hub/guidance_section', guidance: details.guidance_section, related: details.related_links %>

--- a/test/fixtures/content_store/coronavirus_education_page.json
+++ b/test/fixtures/content_store/coronavirus_education_page.json
@@ -1,0 +1,154 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/coronavirus/education",
+  "content_id": "b350e61d-1db9-4cc2-bb44-fab02882ac25",
+  "document_type": "coronavirus_landing_page",
+  "first_published_at": "2020-04-23T15:52:56.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2020-04-23T15:52:56.000+00:00",
+  "publishing_app": "collections-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "collections",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "coronavirus_landing_page",
+  "title": "Coronavirus (COVID-19): Education and childcare",
+  "updated_at": "2020-04-23T15:52:56.573Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "30885-1587657176.365-10.1.1.29-1911",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Coronavirus (COVID-19): Education and childcare",
+        "public_updated_at": "2020-04-23T15:52:56Z",
+        "document_type": "coronavirus_landing_page",
+        "schema_name": "coronavirus_landing_page",
+        "base_path": "/coronavirus/education",
+        "api_path": "/api/content/coronavirus/education",
+        "withdrawn": false,
+        "content_id": "b350e61d-1db9-4cc2-bb44-fab02882ac25",
+        "locale": "en",
+        "api_url": "https://www.integration.publishing.service.gov.uk/api/content/coronavirus/education",
+        "web_url": "https://www.integration.publishing.service.gov.uk/coronavirus/education",
+        "links": {}
+      }
+    ]
+  },
+  "description": "Get coronavirus (COVID-19) support",
+  "details": {
+    "sections": [
+      {
+        "title": "School curriculum and teaching",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/guidance/supporting-your-childrens-education-during-coronavirus-covid-19",
+                "label": "Supporting your children's education during coronavirus"
+              }
+            ],
+            "title": null
+          }
+        ]
+      },
+      {
+        "title": "Pupil wellbeing and safety",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/government/publications/covid-19-guidance-on-supporting-children-and-young-peoples-mental-health-and-wellbeing",
+                "label": "Supporting children and young people’s mental health and wellbeing"
+              }
+            ],
+            "title": null
+          }
+        ]
+      },
+      {
+        "title": "Closures, exams and managing a school or early years setting",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/government/publications/coronavirus-covid-19-maintaining-educational-provision",
+                "label": "Schools opening for children of key workers and vulnerable children"
+              }
+            ],
+            "title": null
+          }
+        ]
+      },
+      {
+        "title": "Funding and support for schools and education providers",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/guidance/get-help-with-technology-for-remote-education-during-coronavirus-covid-19",
+                "label": "Get help with technology for remote education during coronavirus"
+              }
+            ],
+            "title": null
+          }
+        ]
+      },
+      {
+        "title": "Student accommodation, travel and financial support",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/guidance/guidance-for-current-students",
+                "label": "Student loans: current students"
+              }
+            ],
+            "title": null
+          }
+        ]
+      },
+      {
+        "title": "Further and higher education, skills and vocational training",
+        "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/government/publications/coronavirus-covid-19-apprenticeship-programme-response",
+                "label": "Apprentices, employers and training providers"
+              }
+            ],
+            "title": null
+          }
+        ]
+      }
+    ],
+    "page_title": "Education and Childcare",
+    "notifications": {
+      "intro": "Stay up to date with GOV.UK",
+      "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+    },
+    "topic_section": {
+      "text": "Browse information related to coronavirus",
+      "links": [
+        {
+          "url": "/search/news-and-communications?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest",
+          "label": "News"
+        },
+        {
+          "url": "/search/all?level_one_taxon=c58fdadd-7743-46d6-9629-90bb3ccc4ef0&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest",
+          "label": "Guidance"
+        }
+      ],
+      "header": "All coronavirus education and childcare information on GOV.UK"
+    },
+    "header_section": {
+      "list": [
+        "Schools and nurseries remain closed to all pupils except children of keyworkers and vulnerable children",
+        "Exams are cancelled and grades will be assessed differently",
+        "Free school meals or food vouchers will be available for pupils not attending school"
+      ],
+      "pretext": "How nurseries, schools, colleges and universities are working during coronavirus (COVID-19)"
+    },
+    "live_stream_enabled": false
+  }
+}

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -47,10 +47,8 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_business_content_item
       when_i_visit_the_business_landing_page
       then_i_can_see_the_business_page
-      # and_i_can_see_the_business_announcements
       then_i_can_see_the_business_accordions
       and_i_can_see_business_links_to_search
-      # and_i_can_see_related_links
     end
   end
 end

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -42,13 +42,21 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
     end
   end
 
-  describe "the business support landing page" do
+  describe "the business support hub page" do
     it "renders" do
       given_there_is_a_business_content_item
-      when_i_visit_the_business_landing_page
+      when_i_visit_the_business_hub_page
       then_i_can_see_the_business_page
       then_i_can_see_the_business_accordions
       and_i_can_see_business_links_to_search
+    end
+  end
+
+  describe "the education hub page" do
+    it "renders" do
+      given_there_is_an_education_content_item
+      when_i_visit_the_education_hub_page
+      then_i_can_see_the_page_title("Education and Childcare")
     end
   end
 end

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -15,6 +15,10 @@ def business_content_item_fixture
   load_content_item("business_support_page.json")
 end
 
+def education_content_item_fixture
+  load_content_item("coronavirus_education_page.json")
+end
+
 def random_landing_page
   GovukSchemas::RandomExample.for_schema(frontend_schema: "coronavirus_landing_page") do |item|
     yield(item)
@@ -48,6 +52,12 @@ end
 def business_content_item
   random_landing_page do |item|
     item.merge(business_content_item_fixture)
+  end
+end
+
+def education_content_item
+  random_landing_page do |item|
+    item.merge(education_content_item_fixture)
   end
 end
 

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -45,10 +45,6 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: "Business support")
   end
 
-  def and_i_can_see_the_business_announcements
-    assert page.has_selector?(".covid__page-header-link", text: "High street businesses will receive grants")
-  end
-
   def and_i_can_see_the_live_stream_placeholder
     assert page.has_text?("The next live press conference will be shown here")
   end
@@ -91,10 +87,6 @@ module CoronavirusLandingPageSteps
   def and_i_can_see_business_links_to_search
     assert page.has_link?("News", href: "/search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
     assert page.has_link?("Guidance", href: "/search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
-  end
-
-  def and_i_can_see_related_links
-    assert page.has_link?("Get an isolation note to give to your employer", href: "https://www.nhs.uk/conditions/coronavirus-covid-19/self-isolation-advice/")
   end
 
   def then_the_special_announcement_schema_is_rendered

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -6,11 +6,9 @@ module CoronavirusLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include RummagerHelpers
 
-  CORONAVIRUS_CONTENT_ID = "774cee22-d896-44c1-a611-e3109cce8eae".freeze
   CORONAVIRUS_PATH = "/coronavirus".freeze
-
-  BUSINESS_CONTENT_ID = "09944b84-02ba-4742-a696-9e562fc9b29d".freeze
   BUSINESS_PATH = "/coronavirus/business-support".freeze
+  EDUCATION_PATH = "/coronavirus/education".freeze
 
   def given_there_is_a_content_item
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
@@ -28,12 +26,20 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(BUSINESS_PATH, business_content_item)
   end
 
+  def given_there_is_an_education_content_item
+    stub_content_store_has_item(EDUCATION_PATH, education_content_item)
+  end
+
   def when_i_visit_the_coronavirus_landing_page
     visit CORONAVIRUS_PATH
   end
 
-  def when_i_visit_the_business_landing_page
+  def when_i_visit_the_business_hub_page
     visit BUSINESS_PATH
+  end
+
+  def when_i_visit_the_education_hub_page
+    visit EDUCATION_PATH
   end
 
   def then_i_can_see_the_header_section
@@ -42,7 +48,11 @@ module CoronavirusLandingPageSteps
 
   def then_i_can_see_the_business_page
     assert page.has_title?("Coronavirus (COVID-19): Business support")
-    assert page.has_selector?(".covid__page-header h1", text: "Business support")
+    then_i_can_see_the_page_title("Business support")
+  end
+
+  def then_i_can_see_the_page_title(title)
+    assert page.has_selector?(".covid__page-header h1", text: title)
   end
 
   def and_i_can_see_the_live_stream_placeholder


### PR DESCRIPTION
I've added a guard clause for an empty guidance section as the Education page doesn't have one.

I've added a test to make sure the page renders using the barebones content item that has all the sections from the draft design.

I've removed the sections that were commented out prior to the business page going live.  They haven't come back yet, so I don't think we should keep these any longer.

![localhost_3070_coronavirus_education(iPhone 6_7_8)](https://user-images.githubusercontent.com/773037/80124184-c7f4a680-8587-11ea-8beb-1a2e5ca9d3c1.png)

