### PR TITLE
Landing page video changes

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -176,10 +176,15 @@
   margin-bottom: govuk-spacing(2);
 }
 
+.covid__video-wrapper {
+  margin-bottom: govuk-spacing(4);
+}
+
 .covid__video-placeholder {
   position: relative;
   padding: 110px 0;
-  border: solid 2px govuk-colour("white");
+  margin-bottom: govuk-spacing(4);
+  border: solid 2px govuk-colour("black");
   text-align: center;
 
   .govuk-body {
@@ -214,8 +219,7 @@
   padding-left: govuk-spacing(5);
   padding-right: govuk-spacing(2);
   margin: govuk-spacing(3);
-  border: solid 1px govuk-colour("white");
-  color: govuk-colour("white");
+  border: solid 1px govuk-colour("black");
   text-transform: uppercase;
 
   &:before {
@@ -232,11 +236,6 @@
 
 .covid__list ~ .covid__accordion-heading {
   margin-top: govuk-spacing(7);
-}
-
-.covid__video {
-  margin-top: govuk-spacing(8);
-  margin-bottom: govuk-spacing(8);
 }
 
 .covid__inverse {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -191,6 +191,19 @@
   }
 }
 
+.covid__video-sublink {
+  font-weight: bold;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}
+
 .covid__video-logo {
   @include govuk-font(19, $weight: bold, $line-height: 1);
   position: absolute;

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -13,11 +13,6 @@ class CoronavirusLandingPagePresenter
     live_stream_enabled == true
   end
 
-  def todays_date
-    date = DateTime.now
-    date.day.ordinalize + date.strftime(" %B %Y")
-  end
-
   def faq_schema(content_item)
     {
       "@context": "https://schema.org",

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -9,7 +9,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <% title_link = capture do %>
-          <span class="covid__inverse">Part of</span> <a href="<%= title[:context][:href] %>" class="govuk-link covid__page-header-link">
+          Part of <a href="<%= title[:context][:href] %>" class="govuk-link covid__page-header-link">
             <%= title[:context][:text] %>
           </a>
         <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -1,41 +1,28 @@
-<div class="govuk-grid-row covid__video">
-  <div class="govuk-grid-column-one-third">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: live_stream["title"],
-      font_size: 19,
-      inverse: true,
-      margin_bottom: 1
-    } %>
-    <p class="govuk-body covid__inverse">
-      <%= live_stream["date_text"] %> <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
+<%= render "govuk_publishing_components/components/govspeak", {
+} do %>
+  <div class="covid__video-placeholder">
+    <div class="covid__video-logo"><%= live_stream["no_cookies"]["icon_text"] %></div>
+    <p class="govuk-body">
+      <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
+        <%= live_stream["no_cookies"]["change_settings"] %>
+      </a>
     </p>
+    <p class="govuk-body covid__bold">
+      <%= live_stream["no_cookies"]["to_watch"] %>
+    </p>
+    <p class="govuk-body">
+      <%= live_stream["no_cookies"]["or"] %>
+    </p>
+    <a
+      href="<%= live_stream["video_url"] %>"
+      class="govuk-body govuk-link covid__page-header-link"
+      data-youtube-player-analytics="true"
+      data-youtube-player-analytics-category="EmbeddedYoutube"
+    >
+      <%= live_stream["no_cookies"]["watch_link_text"] %>
+    </a>
   </div>
-
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/govspeak", {
-    } do %>
-      <div class="covid__video-placeholder">
-        <div class="covid__video-logo"><%= live_stream["no_cookies"]["icon_text"] %></div>
-        <p class="govuk-body">
-          <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
-            <%= live_stream["no_cookies"]["change_settings"] %>
-          </a>
-        </p>
-        <p class="govuk-body covid__inverse covid__bold">
-          <%= live_stream["no_cookies"]["to_watch"] %>
-        </p>
-        <p class="govuk-body covid__inverse">
-          <%= live_stream["no_cookies"]["or"] %>
-        </p>
-        <a
-          href="<%= live_stream["video_url"] %>"
-          class="govuk-body govuk-link covid__page-header-link"
-          data-youtube-player-analytics="true"
-          data-youtube-player-analytics-category="EmbeddedYoutube"
-        >
-          <%= live_stream["no_cookies"]["watch_link_text"] %>
-        </a>
-      </div>
-    <% end %>
-  </div>
-</div>
+<% end %>
+<p class="govuk-body">
+  <%= live_stream["date_text"] %> <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
+</p>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <p class="govuk-body">
-  <%= live_stream["date_text"] %> <%= today %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
+  <%= live_stream["date_text"] %> <%= " " + live_stream["date"] %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
 </p>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -1,28 +1,31 @@
-<%= render "govuk_publishing_components/components/govspeak", {
-} do %>
-  <div class="covid__video-placeholder">
-    <div class="covid__video-logo"><%= live_stream["no_cookies"]["icon_text"] %></div>
-    <p class="govuk-body">
-      <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
-        <%= live_stream["no_cookies"]["change_settings"] %>
+<div class="covid__video-wrapper">
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <div class="covid__video-placeholder">
+      <div class="covid__video-logo"><%= live_stream["no_cookies"]["icon_text"] %></div>
+      <p class="govuk-body">
+        <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
+          <%= live_stream["no_cookies"]["change_settings"] %>
+        </a>
+      </p>
+      <p class="govuk-body covid__bold">
+        <%= live_stream["no_cookies"]["to_watch"] %>
+      </p>
+      <p class="govuk-body">
+        <%= live_stream["no_cookies"]["or"] %>
+      </p>
+      <a
+        href="<%= live_stream["video_url"] %>"
+        class="govuk-body govuk-link covid__page-header-link"
+        data-youtube-player-analytics="true"
+        data-youtube-player-analytics-category="EmbeddedYoutube"
+      >
+        <%= live_stream["no_cookies"]["watch_link_text"] %>
       </a>
-    </p>
-    <p class="govuk-body covid__bold">
-      <%= live_stream["no_cookies"]["to_watch"] %>
-    </p>
-    <p class="govuk-body">
-      <%= live_stream["no_cookies"]["or"] %>
-    </p>
-    <a
-      href="<%= live_stream["video_url"] %>"
-      class="govuk-body govuk-link covid__page-header-link"
-      data-youtube-player-analytics="true"
-      data-youtube-player-analytics-category="EmbeddedYoutube"
-    >
-      <%= live_stream["no_cookies"]["watch_link_text"] %>
-    </a>
-  </div>
-<% end %>
+    </div>
+  <% end %>
+</div>
+
 <p class="govuk-body">
   <%= live_stream["date_text"] %> <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
 </p>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <p class="govuk-body">
-  <%= live_stream["date_text"] %> <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
+  <%= live_stream["date_text"] %> <%= today %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
 </p>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 1
     } %>
     <p class="govuk-body covid__inverse">
-      <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
+      <%= live_stream["date_text"] %> <%= details.todays_date %> <%= ("at " + live_stream["time"]) if live_stream["time"].present? %>
     </p>
   </div>
 
@@ -15,7 +15,7 @@
     <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
       <div class="covid__video-placeholder">
-        <div class="covid__video-logo">Live</div>
+        <div class="covid__video-logo"><%= live_stream["no_cookies"]["icon_text"] %></div>
         <p class="govuk-body">
           <a href="<%= live_stream["no_cookies"]["change_settings_link"] %>" class="govuk-link covid__page-header-link covid__bold">
             <%= live_stream["no_cookies"]["change_settings"] %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -1,23 +1,26 @@
-<% if details.show_live_stream? %>
-  <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    details: details,
-    live_stream: details.live_stream
+<section class="covid__topic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: details.live_stream["title"],
+    heading_level: 2,
+    margin_bottom: 0,
+    padding: true,
+    border_top: 2
   } %>
-<% else %>
-  <div class="govuk-grid-row covid__video">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: details.live_stream["previous_videos"]["next_conference_text"],
-        heading_level: 2,
-        font_size: 19,
-        inverse: true,
-        margin_bottom: 0
-      } %>
-      <p class="govuk-body covid__inverse">
-        <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="govuk-link covid__page-header-link">
-          <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
-        </a>
-      </p>
-    </div>
-  </div>
-<% end %>
+  <% if details.show_live_stream? %>
+    <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
+      details: details,
+      live_stream: details.live_stream
+    } %>
+  <% else %>
+  <% end %>
+  <p class="govuk-body">
+    <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="govuk-link covid__video-sublink">
+      <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
+    </a>
+  </p>
+  <p class="govuk-body">
+    <a href="<%= details.live_stream["ask_a_question_link"] %>" class="govuk-link covid__video-sublink">
+      <%= details.live_stream["ask_a_question_text"] %>
+    </a>
+  </p>
+</section>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -8,7 +8,7 @@
   } %>
 
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    details: details,
+    today: details.todays_date,
     live_stream: details.live_stream
   } %>
 

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -2,25 +2,27 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: details.live_stream["title"],
     heading_level: 2,
-    margin_bottom: 0,
+    margin_bottom: 6,
     padding: true,
     border_top: 2
   } %>
-  <% if details.show_live_stream? %>
-    <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-      details: details,
-      live_stream: details.live_stream
-    } %>
-  <% else %>
-  <% end %>
+
+  <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
+    details: details,
+    live_stream: details.live_stream
+  } %>
+
   <p class="govuk-body">
     <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="govuk-link covid__video-sublink">
       <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
     </a>
   </p>
+
+<% if false %>
   <p class="govuk-body">
     <a href="<%= details.live_stream["ask_a_question_link"] %>" class="govuk-link covid__video-sublink">
       <%= details.live_stream["ask_a_question_text"] %>
     </a>
   </p>
+<% end %>
 </section>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -8,7 +8,6 @@
   } %>
 
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    today: details.todays_date,
     live_stream: details.live_stream
   } %>
 

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -70,7 +70,7 @@
         inverse: true
       } %>
 
-      <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { 
+      <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: {
         announcements: details.announcements
       } %>
       <% if details.see_all_announcements_link.present? %>
@@ -91,7 +91,6 @@
           </div>
         </div>
       <% end %>
-      <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
     </div>
   </div>
 </header>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -46,6 +46,7 @@
 
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections }%>
+      <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { country_section: details.country_section } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -371,6 +371,7 @@
     },
     "live_stream": {
       "time": "",
+      "date": "19 April",
       "title": "Live press conference",
       "video_url": "https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw",
       "no_cookies_message": "Watch the live stream on YouTube",

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -377,15 +377,19 @@
       "no_cookies": {
         "change_settings": "Change your cookie settings",
         "change_settings_link": "/help/cookies",
-        "to_watch": "to watch the live stream",
+        "to_watch": "to watch video",
         "or": "or",
-        "watch_link_text": "Watch the live stream on YouTube"
+        "watch_link_text": "Watch on YouTube",
+        "icon_text": "Video"
       },
       "previous_videos": {
         "url": "https://www.youtube.com/user/Number10gov/videos",
-        "previous_videos_text": "View past coronavirus press conferences on YouTube",
+        "previous_videos_text": "Watch all press conferences on YouTube",
         "next_conference_text": "The next live press conference will be shown here"
-      }
+      },
+      "ask_a_question_text": "Ask a question at the next press conference",
+      "ask_a_question_link": "https://www.gov.uk",
+      "date_text": "Live streamed"
     },
     "live_stream_enabled": false,
     "special_announcement_schema": {

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -9,7 +9,6 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
-      and_i_can_see_the_live_stream_placeholder
       then_i_can_see_the_nhs_banner
       then_i_can_see_the_accordions
       and_i_can_see_links_to_search

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -21,10 +21,10 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_accordions_content
     end
 
-    it "shows todays date when a live stream is enabled" do
+    it "shows livestream date when a live stream is enabled" do
       given_there_is_a_content_item_with_live_stream_enabled
       when_i_visit_the_coronavirus_landing_page
-      then_i_can_see_the_live_stream_section_with_todays_date
+      then_i_can_see_the_live_stream_section_with_streamed_date
     end
 
     it "optionally shows the time when a live stream is enabled" do

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -41,12 +41,8 @@ def coronavirus_content_item_with_live_stream_enabled_and_date
   content_item = coronavirus_content_item
   content_item["details"]["live_stream_enabled"] = true
   content_item["details"]["live_stream"]["time"] = "5:00pm"
+  content_item["details"]["live_stream"]["date"] = "19 April"
   content_item
-end
-
-def todays_date
-  d = DateTime.now
-  d.day.ordinalize + d.strftime(" %B %Y")
 end
 
 def business_content_item

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -55,10 +55,6 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: title)
   end
 
-  def and_i_can_see_the_live_stream_placeholder
-    assert page.has_text?("The next live press conference will be shown here")
-  end
-
   def then_i_can_see_the_live_stream_section_with_todays_date
     assert page.has_text?(todays_date)
     assert_not page.has_text?("#{todays_date} at")

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -55,13 +55,13 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: title)
   end
 
-  def then_i_can_see_the_live_stream_section_with_todays_date
-    assert page.has_text?(todays_date)
-    assert_not page.has_text?("#{todays_date} at")
+  def then_i_can_see_the_live_stream_section_with_streamed_date
+    assert page.has_text?("19 April")
+    assert_not page.has_text?("19 April at")
   end
 
   def then_i_can_see_the_live_stream_section_with_date_and_time
-    assert page.has_text?(todays_date)
+    assert page.has_text?("19 April")
     assert page.has_text?("5:00pm")
   end
 


### PR DESCRIPTION
Update video copy content, move video out of page header section and into page content, update video placeholder styling.

Trello card: https://trello.com/c/43kTZHM5/186-improve-the-livestream-by-keeping-the-latest-video-on-the-page