### PR TITLE
Update page header and add announcements section

### DIFF
--- a/app/assets/stylesheets/components/_action-link.scss
+++ b/app/assets/stylesheets/components/_action-link.scss
@@ -13,7 +13,6 @@
 
   @include govuk-media-query($until: tablet) {
     max-width: 410px;
-    margin-bottom: govuk-spacing(8);
   }
 
   @include govuk-media-query($from: desktop) {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -51,19 +51,11 @@
   }
 }
 
-.covid__page-header-announcement {
-  margin-bottom: govuk-spacing(7);
-
-  @include govuk-media-query($from: desktop) {
-    margin-bottom: govuk-spacing(3);
-  }
-
-  .govuk-body {
-    margin-bottom: govuk-spacing(2);
-  }
+.covid__announcements {
+  margin-top: govuk-spacing(5);
 
   .covid__announcement-published-text {
-    @include govuk-font(16);
+    margin-top: govuk-spacing(2);
   }
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -37,26 +37,19 @@
   @include govuk-media-query($until: tablet) {
     margin-bottom: govuk-spacing(3);
   }
-
 }
 
 .covid__page-header-light {
-  padding-top: govuk-spacing(5);
-  padding-bottom: govuk-spacing(2);
+  padding: govuk-spacing(5) 0;
   background: $covid-grey;
 
   @include govuk-media-query($from: tablet) {
-    padding-top: 45px;
-    padding-bottom: govuk-spacing(3);
+    padding: 45px 0;
   }
 }
 
-.covid__announcements {
-  margin-top: govuk-spacing(5);
-
-  .covid__announcement-published-text {
-    margin-top: govuk-spacing(2);
-  }
+.covid__announcement-published-text {
+  margin-top: govuk-spacing(2);
 }
 
 .covid__business-list-wrapper {
@@ -65,34 +58,37 @@
 
 .covid__action-link-wrapper {
   margin-top: govuk-spacing(5);
-  margin-bottom: govuk-spacing(8);
 
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);
   }
 }
 
+.covid__page-header-title-wrapper {
+  @include govuk-media-query($from: tablet) {
+    position: relative;
+  }
+}
+
 .covid__logo-wrapper {
-  margin-bottom: govuk-spacing(7);
+  padding: 0 15px;
+  margin-bottom: govuk-spacing(6);
 
   @include govuk-media-query($from: tablet) {
-    margin-bottom: 0;
-    position: relative;
-    height: 108px;
+    margin-bottom: govuk-spacing(8);
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 33%;
   }
 }
 
 .covid__logos {
   max-width: 100%;
   height: auto;
-  display: block;
-  margin: 0 auto;
 
   @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(2);
     max-height: 38px; // the SVG canvas height is too big on IE
-    position: absolute;
-    bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -71,7 +71,7 @@
   margin-bottom: 45px;
 }
 
-.covid__logo-wrapper {
+.covid__action-link-wrapper {
   margin-top: govuk-spacing(5);
   margin-bottom: govuk-spacing(8);
 
@@ -80,13 +80,27 @@
   }
 }
 
+.covid__logo-wrapper {
+  margin-bottom: govuk-spacing(7);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: 0;
+    position: relative;
+    height: 108px;
+  }
+}
+
 .covid__logos {
   max-width: 100%;
   height: auto;
+  display: block;
+  margin: 0 auto;
 
   @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(2);
     max-height: 38px; // the SVG canvas height is too big on IE
+    position: absolute;
+    bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -79,7 +79,7 @@
     position: absolute;
     bottom: 0;
     right: 0;
-    width: 33%;
+    width: 30%;
   }
 }
 

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -8,12 +8,15 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/title", {
-        context: title[:context],
-        title: title[:text],
-        inverse: true,
-        margin_top: 4
-      } %>
+        <%= render "govuk_publishing_components/components/title", {
+          context: title[:context],
+          title: title[:text],
+          inverse: true,
+          margin_top: 4
+        } %>
+      </div>
+      <div class="govuk-grid-column-one-third covid__logo-wrapper">
+        <%= render 'coronavirus_landing_page/components/shared/covid_logos' %>
       </div>
     </div>
   </div>
@@ -41,7 +44,7 @@
         </div>
       </div>
 
-      <div class="govuk-grid-row covid__logo-wrapper">
+      <div class="govuk-grid-row covid__action-link-wrapper">
         <div class="govuk-grid-column-two-thirds">
           <%= render 'components/action-link', {
             light_text: true,
@@ -56,41 +59,7 @@
             }
           } %>
         </div>
-        <div class="govuk-grid-column-one-third">
-          <%= render 'coronavirus_landing_page/components/shared/covid_logos' %>
-        </div>
       </div>
-
-      <%= render "govuk_publishing_components/components/heading", {
-        text: details.announcements_label,
-        padding: true,
-        font_size: 19,
-        border_top: 2,
-        brand: 'public-health-england',
-        inverse: true
-      } %>
-
-      <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: {
-        announcements: details.announcements
-      } %>
-      <% if details.see_all_announcements_link.present? %>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body covid__inverse">
-              <a
-                href="<%= details.see_all_announcements_link["href"] %>"
-                class="govuk-link covid__page-header-link"
-                data-module="track-click"
-                data-track-category="pageElementInteraction"
-                data-track-action="Announcements"
-                data-track-label="<%= details.see_all_announcements_link["href"] %>"
-              >
-                <%= details.see_all_announcements_link["text"] %>
-              </a>
-            </p>
-          </div>
-        </div>
-      <% end %>
     </div>
   </div>
 </header>

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -6,7 +6,7 @@
       inverse: true
     } %>
 
-    <div class="govuk-grid-row">
+    <div class="govuk-grid-row covid__page-header-title-wrapper">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/title", {
           context: title[:context],
@@ -15,7 +15,7 @@
           margin_top: 4
         } %>
       </div>
-      <div class="govuk-grid-column-one-third covid__logo-wrapper">
+      <div class="covid__logo-wrapper">
         <%= render 'coronavirus_landing_page/components/shared/covid_logos' %>
       </div>
     </div>

--- a/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
@@ -1,27 +1,25 @@
-<div class="govuk-grid-row">
-  <% announcements.each do |announcement| %>
-    <div class="govuk-grid-column-one-third covid__page-header-announcement">
-      <p class="govuk-body covid__inverse">
-        <% if announcement["href"].present? %>
-          <a
-            href="<%= announcement["href"] %>"
-            class="govuk-link covid__page-header-link"
-            data-module="track-click"
-            data-track-category="pageElementInteraction"
-            data-track-action="Announcements"
-            data-track-label="<%= announcement["href"] %>"
-          >
-            <%= announcement["text"] %>
-          </a>
-        <% else %>
+<ul class="govuk-list covid__announcements">
+  <% announcements.each do | announcement | %>
+    <li class="covid__topic-list-item">
+      <% if announcement["href"].present? %>
+        <a
+          href="<%= announcement["href"] %>"
+          class="govuk-link covid__topic-list-link"
+          data-module="track-click"
+          data-track-category="pageElementInteraction"
+          data-track-action="Announcements"
+          data-track-label="<%= announcement["href"] %>"
+        >
           <%= announcement["text"] %>
-        <% end %>
-      </p>
+        </a>
+      <% else %>
+        <%= announcement["text"] %>
+      <% end %>
       <% if announcement["published_text"].present? %>
-        <p class="govuk-body covid__inverse covid__announcement-published-text">
+        <p class="govuk-body covid__announcement-published-text">
           <%= announcement["published_text"] %>
         </p>
       <% end %>
-    </div>
+    </li>
   <% end %>
-</div>
+</ul>

--- a/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
@@ -1,4 +1,4 @@
-<ul class="govuk-list covid__announcements">
+<ul class="govuk-list">
   <% announcements.each do | announcement | %>
     <li class="covid__topic-list-item">
       <% if announcement["href"].present? %>

--- a/app/views/coronavirus_landing_page/components/shared/_announcements_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements_section.html.erb
@@ -1,0 +1,27 @@
+<section class="covid__topic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: details.announcements_label,
+    padding: true,
+    border_top: 2,
+    margin_bottom: 6,
+  } %>
+
+  <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { 
+    announcements: details.announcements
+  } %>
+
+  <% if details.see_all_announcements_link.present? %>
+    <p class="govuk-body">
+      <a
+        href="<%= details.see_all_announcements_link["href"] %>"
+        class="govuk-link"
+        data-module="track-click"
+        data-track-category="pageElementInteraction"
+        data-track-action="Announcements"
+        data-track-label="<%= details.see_all_announcements_link["href"] %>"
+      >
+        <%= details.see_all_announcements_link["text"] %>
+      </a>
+    </p>
+  <% end %>
+</section>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -47,6 +47,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections, heading: details.sections_heading }%>
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 


### PR DESCRIPTION
- Removes announcements
- Removes Live stream
- Moves logo next to heading

# Page header

## What
Update the header design, this entails:

- On desktop moving the logo top right
- On mobile moving the logo up to below the title
- On both, adjust the black and dark grey sections to match the design

Moving announcements out the header is a separate story:

## Why
Getting the logos out of the way, and making it clearer to users that these are part of the heading and not an interactive page element.

https://trello.com/c/NZNvb7ik/213-update-the-header-to-match-the-new-design

# Announcement section

##What
Update the styling and position of the announcements section to move it out of the header and immediately below the guidance accordion.

##Why
Prioritising guidance and support in the page hierachy. 

https://trello.com/c/X4lJmg3w/212-update-the-styling-and-positioning-of-the-announcements-section

## Screenshots

## Before
<img width="916" alt="Screenshot 2020-04-24 at 11 13 19" src="https://user-images.githubusercontent.com/4599889/80201949-d345e180-861c-11ea-9f86-a0aadfa39ec7.png">
<img width="362" alt="Screenshot 2020-04-24 at 11 13 56" src="https://user-images.githubusercontent.com/4599889/80201977-db9e1c80-861c-11ea-85b5-dc844782547d.png">

## After
<img width="1027" alt="Screenshot 2020-04-24 at 11 13 38" src="https://user-images.githubusercontent.com/4599889/80202001-e2c52a80-861c-11ea-9244-13332ed5050f.png">
<img width="360" alt="Screenshot 2020-04-24 at 11 14 12" src="https://user-images.githubusercontent.com/4599889/80202024-e9ec3880-861c-11ea-9716-d5a6e7aa642e.png">
<img width="883" alt="Screenshot 2020-04-24 at 12 04 49" src="https://user-images.githubusercontent.com/4599889/80206312-fd4ed200-8623-11ea-90d5-de848a1bb58c.png">
<img width="384" alt="Screenshot 2020-04-24 at 12 04 58" src="https://user-images.githubusercontent.com/4599889/80206314-ffb12c00-8623-11ea-9095-da726e23065c.png">

