### PR TITLE
Landing page accordion updates

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections topic_section country_section notifications find_help).freeze
+  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section country_section notifications find_help).freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -35,7 +35,7 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: heading,
   padding: true,
-} %>
+} if heading %>
 <div data-module="track-click">
   <div data-module="toggle-attribute">
     <%= render 'govuk_publishing_components/components/accordion', {

--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -1,42 +1,50 @@
-  <%
-    accordion_contents = []
-    number_of_accordion_sections = accordions.length
-  %>
-  <% accordions.each do | section | %>
-    <% content = capture do %>
-      <%# this element captures an override from the accordion that the last item has margin 0 %>
-      <div class="covid__accordion-inner">
-        <%= render partial: 'coronavirus_landing_page/components/shared/section', locals: { section: section } %>
-      </div>
-    <% end %>
-    <%
-      accordion_contents << {
-        heading: {
-          text: section["title"],
-        },
-        content: {
-          html: content,
-        },
-        data_attributes: {
-          toggle_attribute: "data-track-action",
-          when_closed_text: "accordionClosed",
-          when_open_text: "accordionOpened",
-          track_category: "pageElementInteraction",
-          track_action: "accordionClosed",
-          track_label: section["title"],
-          track_dimension: number_of_accordion_sections,
-          track_dimension_index: 26
-        }
-      }
-    %>
-  <% end %>
-  <div data-module="track-click">
-    <div data-module="toggle-attribute">
-      <%= render 'govuk_publishing_components/components/accordion', {
-        data_attributes: {
-          module: "govuk-accordion"
-        },
-        items: accordion_contents
-      } %>
+<%
+  heading ||= false
+  country_guidance ||= false
+  accordion_contents = []
+  number_of_accordion_sections = accordions.length
+%>
+<% accordions.each do | section | %>
+  <% content = capture do %>
+    <%# this element captures an override from the accordion that the last item has margin 0 %>
+    <div class="covid__accordion-inner">
+      <%= render partial: 'coronavirus_landing_page/components/shared/section', locals: { section: section } %>
     </div>
+  <% end %>
+  <%
+    accordion_contents << {
+      heading: {
+        text: section["title"],
+      },
+      content: {
+        html: content,
+      },
+      data_attributes: {
+        toggle_attribute: "data-track-action",
+        when_closed_text: "accordionClosed",
+        when_open_text: "accordionOpened",
+        track_category: "pageElementInteraction",
+        track_action: "accordionClosed",
+        track_label: section["title"],
+        track_dimension: number_of_accordion_sections,
+        track_dimension_index: 26
+      }
+    }
+  %>
+<% end %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: heading,
+  padding: true,
+} %>
+<div data-module="track-click">
+  <div data-module="toggle-attribute">
+    <%= render 'govuk_publishing_components/components/accordion', {
+      data_attributes: {
+        module: "govuk-accordion"
+      },
+      items: accordion_contents,
+      margin_bottom: 3
+    } %>
   </div>
+</div>
+

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -7,7 +7,7 @@
     content_tag :p, :class => 'govuk-body' do
       concat(guidance["text"] + " ")
       guidance_links.each do | link |
-        elem =  link_to(link["label"],link["url"])
+        elem =  link_to(link["label"],link["url"], class: "govuk-link")
         if  link.equal? guidance_links.last
           concat(elem)
         elsif link.equal? guidance_links[guidance_links.length - 2]

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -1,18 +1,21 @@
-<section class="covid__topic-wrapper">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: country_section["header"],
-    padding: true,
-    border_top: 2
-  } %>
-  <p class="govuk-body-m">
-    <%= country_section["text"] %>
-  </p>
-
-  <ul class="govuk-list">
-    <% country_section["links"].each do | link | %>
-      <li class="covid__topic-list-item">
-        <%= link_to link["label"].html_safe, link["url"], class: 'covid__topic-list-link govuk-link' %>
-      </li>
-    <% end %>
-  </ul>
-</section>
+<%
+  guidance ||= nil
+%>
+<%= 
+  if guidance.present? && guidance["links"].present?
+    guidance_links = guidance["links"]
+    content_tag :p, :class => 'govuk-body' do
+      concat(guidance["text"] + " ")
+      guidance_links.each do | link |
+        elem =  link_to(link["label"],link["url"])
+        if  link.equal? guidance_links.last
+          concat(elem)
+        elsif link.equal? guidance_links[guidance_links.length - 2]
+          concat(elem + " and ")
+        else
+          concat(elem + ", ")
+        end
+      end
+    end
+  end 
+%>

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -1,19 +1,12 @@
 <% guidance ||= nil %>
-<%= 
-  if guidance.present? && guidance["links"].present?
-    guidance_links = guidance["links"]
-    content_tag :p, :class => 'govuk-body' do
-      concat(guidance["text"] + " ")
-      guidance_links.each do | link |
-        elem = link_to(link["label"],link["url"], class: "govuk-link")
-        if  link.equal? guidance_links.last
-          concat(elem)
-        elsif link.equal? guidance_links[guidance_links.length - 2]
-          concat(elem + " and ")
-        else
-          concat(elem + ", ")
-        end
-      end
+
+<% if guidance.present? && guidance["links"].present? %>
+  <%
+    guidance_links = guidance["links"].map do | link |
+      link_to(link["label"],link["url"], class: "govuk-link")
     end
-  end 
-%>
+  %>
+  <p class="govuk-body">
+    <%= "#{guidance["text"]} #{guidance_links.to_sentence(last_word_connector: " and ")}".html_safe %>
+  </p>
+<% end %>

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -1,13 +1,11 @@
-<%
-  guidance ||= nil
-%>
+<% guidance ||= nil %>
 <%= 
   if guidance.present? && guidance["links"].present?
     guidance_links = guidance["links"]
     content_tag :p, :class => 'govuk-body' do
       concat(guidance["text"] + " ")
       guidance_links.each do | link |
-        elem =  link_to(link["label"],link["url"], class: "govuk-link")
+        elem = link_to(link["label"],link["url"], class: "govuk-link")
         if  link.equal? guidance_links.last
           concat(elem)
         elsif link.equal? guidance_links[guidance_links.length - 2]

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -45,9 +45,9 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections }%>
+      <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections, heading: details.sections_heading }%>
+      <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { country_section: details.country_section } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 
       <div class="landing-page__email-wrapper">

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections topic_section country_section notifications].each do |method|
+    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section country_section notifications].each do |method|
       assert_respond_to(presenter, method)
     end
   end


### PR DESCRIPTION
### What
- Update the accordion to add the title: Guidance and support
- Add a line below the accordion with the country specific guidance:

Additional guidance for [Scotland](https://www.gov.uk/guidance/coronavirus-covid-19-information-for-individuals-and-businesses-in-scotland), [Wales](https://gov.wales/coronavirus) and [Northern Ireland](https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19)
- Remove the old 'If you live in Scotland, Wales or Northern Ireland' section



### Why
Titling sections supports scanning in an increasingly long page. We can save a bit of vertical space by condensing this into a line.


Relevant Trello card: https://trello.com/c/WyQxHLMh