### PR TITLE
Optionally show the ask a question link

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -17,7 +17,7 @@
     </a>
   </p>
 
-<% if false %>
+<% if details.live_stream["ask_a_question_visible"] == true %>
   <p class="govuk-body">
     <a href="<%= details.live_stream["ask_a_question_link"] %>" class="govuk-link covid__video-sublink">
       <%= details.live_stream["ask_a_question_text"] %>

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -25,12 +25,19 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item_with_live_stream_enabled
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_streamed_date
+      and_there_is_no_ask_a_question_section
     end
 
     it "optionally shows the time when a live stream is enabled" do
       given_there_is_a_content_item_with_live_stream_enabled_and_date
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_date_and_time
+    end
+
+    it "optionally shows the ask a question link when a live stream is enabled" do
+      given_there_is_a_content_item_with_live_stream_enabled_and_ask_a_question_enabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_see_the_ask_a_question_section
     end
 
     it "renders machine readable content" do

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -38,10 +38,15 @@ def coronavirus_content_item_with_live_stream_enabled
 end
 
 def coronavirus_content_item_with_live_stream_enabled_and_date
-  content_item = coronavirus_content_item
-  content_item["details"]["live_stream_enabled"] = true
+  content_item = coronavirus_content_item_with_live_stream_enabled
   content_item["details"]["live_stream"]["time"] = "5:00pm"
   content_item["details"]["live_stream"]["date"] = "19 April"
+  content_item
+end
+
+def content_item_with_live_stream_enabled_and_ask_a_question_enabled
+  content_item = coronavirus_content_item_with_live_stream_enabled
+  content_item["details"]["live_stream"]["ask_a_question_visible"] = true
   content_item
 end
 

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -22,6 +22,10 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_enabled_and_date)
   end
 
+  def given_there_is_a_content_item_with_live_stream_enabled_and_ask_a_question_enabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_live_stream_enabled_and_ask_a_question_enabled)
+  end
+
   def given_there_is_a_business_content_item
     stub_content_store_has_item(BUSINESS_PATH, business_content_item)
   end
@@ -63,6 +67,14 @@ module CoronavirusLandingPageSteps
   def then_i_can_see_the_live_stream_section_with_date_and_time
     assert page.has_text?("19 April")
     assert page.has_text?("5:00pm")
+  end
+
+  def then_i_can_see_the_ask_a_question_section
+    assert page.has_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
+  end
+
+  def and_there_is_no_ask_a_question_section
+    assert page.has_no_link?("Ask a question at the next press conference")
   end
 
   def then_i_can_see_the_nhs_banner


### PR DESCRIPTION
We probably want the ability to turn the question link off without needing a deploy.

The question link shows correctly when the content item is configured:

![Screenshot 2020-04-24 at 20 25 07](https://user-images.githubusercontent.com/773037/80249458-c69baa80-8669-11ea-9b4b-e19a8d6d310a.png)
