### PR TITLE
Update all information section of landing page

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
@@ -2,11 +2,9 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: topic_section["header"],
     padding: true,
-    border_top: 2
+    border_top: 2,
+    margin_bottom: 6
   } %>
-  <p class="govuk-body-m">
-    <%= topic_section["text"] %>
-  </p>
 
   <ul class="govuk-list">
     <% topic_section["links"].each do | link | %>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -352,16 +352,15 @@
       ]
     },
     "topic_section": {
-      "header": "All coronavirus (COVID-19) information",
-      "text": "Browse information related to coronavirus",
+      "header": "All coronavirus information on GOV.UK",
       "links": [
-        {
-          "label": "News",
-          "url": "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
-        },
         {
           "label": "Guidance",
           "url": "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        },
+        {
+          "label": "News",
+          "url": "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
         }
       ]
     },


### PR DESCRIPTION
- remove description beneath title
- add spacing beneath title

Related content change: https://github.com/alphagov/govuk-coronavirus-content/pull/164

Trello card: https://trello.com/c/Ypqv4HGc/217-update-all-information-section-with-new-simpler-design
