### PR TITLE
Tweaks post accordion updates

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section country_section notifications find_help).freeze
+  COMPONENTS = %w(live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications find_help).freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -34,7 +34,7 @@
 <% end %>
 <%= render "govuk_publishing_components/components/heading", {
   text: heading,
-  padding: true,
+  margin_bottom: 3,
 } if heading %>
 <div data-module="track-click">
   <div data-module="toggle-attribute">

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section country_section notifications].each do |method|
+    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications].each do |method|
       assert_respond_to(presenter, method)
     end
   end


### PR DESCRIPTION
- Tweak alignment of accordion title to more closely match spec

**Before (note alignment of title to NHS box)**
![Screenshot 2020-04-27 at 09 34 27](https://user-images.githubusercontent.com/7116819/80351521-6162d780-886a-11ea-97bf-708f15a6625e.png)
**After**
![Screenshot 2020-04-27 at 09 35 16](https://user-images.githubusercontent.com/7116819/80351563-7a6b8880-886a-11ea-9e04-45eaf687eb73.png)

- Remove references to `country_section` content from
  `CoronavirusLandingPagePresenter` as we are now pulling country specific
content from `additional_country_guidance` instead (see #1697)


 https://trello.com/c/WyQxHLMh