### PR TITLE
Press links markup adjustment

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -164,19 +164,6 @@
   }
 }
 
-.covid__video-sublink {
-  font-weight: bold;
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-
-    &:focus {
-      text-decoration: none;
-    }
-  }
-}
-
 .covid__video-logo {
   @include govuk-font(19, $weight: bold, $line-height: 1);
   position: absolute;

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -10,18 +10,18 @@
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
     live_stream: details.live_stream
   } %>
-
-  <p class="govuk-body">
-    <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="govuk-link covid__video-sublink">
-      <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
-    </a>
-  </p>
-
-<% if details.live_stream["ask_a_question_visible"] == true %>
-  <p class="govuk-body">
-    <a href="<%= details.live_stream["ask_a_question_link"] %>" class="govuk-link covid__video-sublink">
-      <%= details.live_stream["ask_a_question_text"] %>
-    </a>
-  </p>
-<% end %>
+  <ul class="govuk-list">
+    <li class="covid__topic-list-item">
+      <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="covid__topic-list-link govuk-link">
+        <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
+      </a>
+    </li>
+    <% if details.live_stream["ask_a_question_visible"] == true %>
+      <li class="covid__topic-list-item">
+        <a href="<%= details.live_stream["ask_a_question_link"] %>" class="covid__topic-list-link govuk-link">
+          <%= details.live_stream["ask_a_question_text"] %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
 </section>


### PR DESCRIPTION
- Changed press conference section links to use `<ul>` to ensure that spacing is consistent with other lists of links on the page.
- Removed (now redundant) CSS for video sublink class.

https://trello.com/c/kiYL6HsG