### PR TITLE
Adjust space between announcements subsections

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -50,6 +50,10 @@
 
 .covid__announcement-published-text {
   margin-top: govuk-spacing(1);
+
+  @include govuk-media-query($from: desktop) {
+    margin-bottom: govuk-spacing(6);
+  }
 }
 
 .covid__business-list-wrapper {


### PR DESCRIPTION
Adjust spacing between the Announcement area sections to be `govuk-spacing(6)` on the desktop adaption.

**Before**
![20 (current)](https://user-images.githubusercontent.com/7116819/80386850-d7356600-889f-11ea-9c25-4c3d8b044498.png)
**After**
![30](https://user-images.githubusercontent.com/7116819/80386859-d997c000-889f-11ea-923d-2f815fbc0bfe.png)


https://trello.com/c/X4lJmg3w