### PR TITLE
Render organisation people from links

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -112,12 +112,12 @@ class Organisation
 
   def all_people
     {
-      ministers: details["ordered_ministers"],
-      military_personnel: details["ordered_military_personnel"],
-      board_members: details["ordered_board_members"],
-      traffic_commissioners: details["ordered_traffic_commissioners"],
-      special_representatives: details["ordered_special_representatives"],
-      chief_professional_officers: details["ordered_chief_professional_officers"],
+      ministers: links.fetch("ordered_ministers", []),
+      military_personnel: links.fetch("ordered_military_personnel", []),
+      board_members: links.fetch("ordered_board_members", []),
+      traffic_commissioners: links.fetch("ordered_traffic_commissioners", []),
+      special_representatives: links.fetch("ordered_special_representatives", []),
+      chief_professional_officers: links.fetch("ordered_chief_professional_officers", []),
     }
   end
 

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -9,11 +9,7 @@ module Organisations
     end
 
     def has_people?
-      all_people.each do |people|
-        return true unless people[:people].empty?
-      end
-
-      false
+      all_people.map { |people| people[:people] }.any?(&:present?)
     end
 
     def all_people

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -18,7 +18,7 @@ module Organisations
           type: person_type,
           title: I18n.t("organisations.people." + person_type.to_s),
           lang: t_fallback("organisations.people.#{person_type}"),
-          people: handle_duplicate_roles(people, person_type),
+          people: people.map { |person| formatted_person_data(person, person_type) },
         }
       end
 
@@ -26,32 +26,6 @@ module Organisations
     end
 
   private
-
-    def handle_duplicate_roles(people, person_type)
-      all_people = []
-
-      people && people.each do |person|
-        person_multiple_roles = all_people.select do |all_people_item|
-          all_people_item[:heading_text] === person["name"]
-        end
-
-        if person_multiple_roles.empty?
-          all_people.push(formatted_person_data(person, person_type))
-        else
-          all_people.map do |all_people_item|
-            if all_people_item[:heading_text].eql?(person_multiple_roles.first[:heading_text])
-              if is_person_ministerial?(person_type)
-                all_people_item[:extra_links] = multiple_role_links(all_people_item, person)
-              else
-                all_people_item[:description] = multiple_role_description(all_people_item, person)
-              end
-            end
-          end
-        end
-      end
-
-      all_people
-    end
 
     def images_for_important_board_members(people)
       people.map do |people_group|
@@ -68,56 +42,45 @@ module Organisations
       end
     end
 
-    def multiple_role_links(existing_person_info, new_person_info)
-      existing_role_links = existing_person_info[:extra_links]
-      new_role_links = [
-        {
-          text: new_person_info["role"],
-          href: new_person_info["role_href"],
-        },
-      ]
-
-      existing_role_links.concat(new_role_links)
-    end
-
-    def multiple_role_description(existing_person_info, new_person_info)
-      existing_role_description = existing_person_info[:description]
-      new_role_description = new_person_info["role"]
-
-      existing_role_description + ", " + new_role_description
-    end
-
     def is_person_ministerial?(type)
       type.eql?(:ministers)
     end
 
+    def current_roles(person)
+      person["links"].fetch("role_appointments", [])
+        .select { |ra| ra["details"]["current"] }
+        .map { |ra| ra["links"]["role"].first }
+    end
+
+    def formatted_role_link(role)
+      {
+        text: role["title"],
+        href: role["base_path"],
+      }
+    end
+
     def formatted_person_data(person, type)
+      roles = current_roles(person)
+
       data = {
         brand: @org.brand,
-        href: person["href"],
-        description: (person["role"] unless is_person_ministerial?(type)),
-        metadata: person["payment_type"],
-        heading_text: person["name"],
+        href: person["base_path"],
+        description: nil,
+        metadata: roles.map { |role| role["role_payment_type"] }.compact.first,
+        heading_text: person["title"],
         heading_level: 0,
         extra_links_no_indent: true,
       }
 
-      if person["name_prefix"]
-        data[:context] = {
-          text: person["name_prefix"],
-        }
-      end
-
       if is_person_ministerial?(type)
-        data[:extra_links] = [{
-          text: person["role"],
-          href: person["role_href"],
-        }]
+        data[:extra_links] = roles.map { |role| formatted_role_link(role) }
+      else
+        data[:description] = roles.map { |role| role["title"] }.join(", ")
       end
 
-      if person["image"]
-        data[:image_src] = image_url_by_size(person["image"]["url"], 465)
-        data[:image_alt] = person["image"]["alt_text"]
+      if (image = person["details"]["image"])
+        data[:image_src] = image["url"]
+        data[:image_alt] = image["alt_text"]
       end
 
       data

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -35,19 +35,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             document_type: "Press release",
           },
         ],
-        ordered_ministers: [
-          {
-            name_prefix: "The Rt Hon",
-            name: "Theresa May MP",
-            role: "Prime Minister",
-            href: "/government/people/theresa-may",
-            role_href: "/government/ministers/prime-minister",
-            image: {
-              url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
-              alt_text: "Theresa May MP",
-            },
-          },
-        ],
         social_media_links: [
           {
             service_type: "twitter",
@@ -103,6 +90,27 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             title: "High Profile Group 2",
           },
         ],
+        ordered_ministers: [
+          {
+            content_id: "ec7cb2ba-3c02-48c5-a918-1f4a211499ae",
+            title: "The Rt Hon Theresa May MP",
+            base_path: "/government/people/theresa-may",
+            details: {
+              image: {
+                url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
+                alt_text: "Theresa May MP",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Prime Minister",
+                  base_path: "/government/ministers/prime-minister",
+                ),
+              ],
+            },
+          },
+        ],
       },
     }
 
@@ -151,37 +159,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             document_type: "Press release",
           },
         ],
-        ordered_ministers: [
-          {
-            name_prefix: "The Rt Hon",
-            name: "Theresa May MP",
-            role: "Prime Minister",
-            href: "/government/people/theresa-may",
-            role_href: "/government/ministers/prime-minister",
-            image: {
-              url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
-              alt_text: "Theresa May MP",
-            },
-          },
-          {
-            name: "Stuart Andrew MP",
-            role: "Parliamentary Under Secretary of State",
-            href: "/government/people/stuart-andrew",
-            role_href: "/government/ministers/parliamentary-under-secretary-of-state--94",
-          },
-        ],
         social_media_links: [
           {
             service_type: "twitter",
             title: "Twitter - @attorneygeneral",
             href: "https://twitter.com/@attorneygeneral",
-          },
-        ],
-        ordered_board_members: [
-          {
-            name: "Sir Jeremy Heywood",
-            role: "Cabinet Secretary",
-            href: "/government/people/jeremy-heywood",
           },
         ],
         ordered_promotional_features: [
@@ -217,6 +199,54 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       },
       links: {
         available_translations: [],
+        ordered_board_members: [
+          {
+            content_id: "ec7cb2ba-3c02-48c5-a918-1f4a211499ae",
+            title: "Sir Jeremy Heywood",
+            base_path: "/government/people/jeremy-heywood",
+            details: {},
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Cabinet Secretary"),
+              ],
+            },
+          },
+        ],
+        ordered_ministers: [
+          {
+            content_id: "ec7cb2ba-3c02-48c5-a918-1f4a211499ae",
+            title: "The Rt Hon Theresa May MP",
+            base_path: "/government/people/theresa-may",
+            details: {
+              image: {
+                url: "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/6/PM_portrait_960x640.jpg",
+                alt_text: "Theresa May MP",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Prime Minister",
+                  base_path: "/government/ministers/prime-minister",
+                ),
+              ],
+            },
+          },
+          {
+            content_id: "d6f8db55-5ff4-4e95-81e7-df2ac6d76a6b",
+            title: "Stuart Andrew MP",
+            base_path: "/government/people/stuart-andrew",
+            details: {},
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Parliamentary Under Secretary of State",
+                  base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
+                ),
+              ],
+            },
+          },
+        ],
         ordered_contacts: [
           {
             title: "Department for International Trade",
@@ -379,13 +409,6 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             href: "https://twitter.com/LlywDUCymru",
           },
         ],
-        ordered_military_personnel: [
-          {
-            name: "Air Chief Marshal Sir  Stuart Peach GBE KCB ADC DL",
-            role: "Chief of the Defence Staff",
-            href: "/government/people/stuart-peach",
-          },
-        ],
       },
       links: {
         available_translations: [
@@ -454,6 +477,18 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 },
               ],
               contact_form_links: [],
+            },
+          },
+        ],
+        ordered_military_personnel: [
+          {
+            title: "Air Chief Marshal Sir  Stuart Peach GBE KCB ADC DL",
+            base_path: "/government/people/stuart-peach",
+            details: {},
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Chief of the Defence Staff"),
+              ],
             },
           },
         ],

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -17,7 +17,7 @@ describe Organisations::PeoplePresenter do
         people: {
           brand: "attorney-generals-office",
           href: "/government/people/oliver-dowden",
-          image_src: "/photo/s465_oliver-dowden",
+          image_src: "/photo/oliver-dowden",
           image_alt: "Oliver Dowden CBE MP",
           description: nil,
           metadata: nil,
@@ -43,14 +43,11 @@ describe Organisations::PeoplePresenter do
         people: {
           brand: "attorney-generals-office",
           href: "/government/people/theresa-may",
-          image_src: "/photo/s465_theresa-may",
+          image_src: "/photo/theresa-may",
           image_alt: "Theresa May MP",
           description: nil,
           metadata: nil,
-          context: {
-            text: "The Rt Hon",
-          },
-          heading_text: "Theresa May MP",
+          heading_text: "The Rt Hon Theresa May MP",
           heading_level: 0,
           extra_links_no_indent: true,
           extra_links: [
@@ -155,7 +152,7 @@ describe Organisations::PeoplePresenter do
     end
 
     it "handles non-ministers with multiple roles" do
-      expected = "Chief Executive of the Civil Service , Permanent Secretary (Cabinet Office)"
+      expected = "Chief Executive of the Civil Service, Permanent Secretary (Cabinet Office)"
 
       assert_equal expected, @people_presenter.all_people.third[:people][1][:description]
     end
@@ -173,14 +170,14 @@ describe Organisations::PeoplePresenter do
         heading_text: "Sir Jeremy Heywood",
         heading_level: 0,
         extra_links_no_indent: true,
-        image_src: "/photo/s465_jeremy-heywood",
+        image_src: "/photo/jeremy-heywood",
         image_alt: "Sir Jeremy Heywood",
       }
 
       expected_non_important = {
         brand: "attorney-generals-office",
         href: "/government/people/john-manzoni",
-        description: "Chief Executive of the Civil Service ",
+        description: "Chief Executive of the Civil Service",
         metadata: nil,
         heading_text: "John Manzoni",
         heading_level: 0,
@@ -191,8 +188,8 @@ describe Organisations::PeoplePresenter do
       assert_equal expected_non_important, @non_important_board_members.all_people.third[:people][1]
     end
 
-    it "fetches small image" do
-      assert_equal "/photo/s465_jeremy-heywood", @people_presenter.all_people.third[:people][0][:image_src]
+    it "fetches image" do
+      assert_equal "/photo/jeremy-heywood", @people_presenter.all_people.third[:people][0][:image_src]
     end
   end
 end

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -84,6 +84,17 @@ module OrganisationHelpers
       ] }.to_json)
   end
 
+  def current_role_appointment(title:, base_path: nil)
+    {
+      details: {
+        current: true,
+      },
+      links: {
+        role: [{ title: title, base_path: base_path }.compact],
+      },
+    }
+  end
+
   def organisation_with_no_people
     {
       title: "Attorney General's Office",
@@ -96,6 +107,7 @@ module OrganisationHelpers
         ordered_chief_professional_officers: [],
         ordered_special_representatives: [],
       },
+      links: {},
     }.with_indifferent_access
   end
 
@@ -109,43 +121,60 @@ module OrganisationHelpers
         organisation_govuk_status: {
           status: "live",
         },
+      },
+      links: {
         ordered_ministers: [
           {
-            name: "Oliver Dowden CBE MP",
-            role: "Parliamentary Secretary (Minister for Implementation)",
-            href: "/government/people/oliver-dowden",
-            role_href: "/government/ministers/parliamentary-secretary",
-            image: {
-              url: "/photo/oliver-dowden",
-              alt_text: "Oliver Dowden CBE MP",
+            title: "Oliver Dowden CBE MP",
+            base_path: "/government/people/oliver-dowden",
+            details: {
+              image: {
+                url: "/photo/oliver-dowden",
+                alt_text: "Oliver Dowden CBE MP",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Parliamentary Secretary (Minister for Implementation)",
+                  base_path: "/government/ministers/parliamentary-secretary",
+                ),
+              ],
             },
           },
           {
-            name: "Stuart Andrew MP",
-            role: "Parliamentary Under Secretary of State",
-            href: "/government/people/stuart-andrew",
-            role_href: "/government/ministers/parliamentary-under-secretary-of-state--94",
-          },
-          {
-            name_prefix: "The Rt Hon",
-            name: "Theresa May MP",
-            role: "Prime Minister",
-            href: "/government/people/theresa-may",
-            role_href: "/government/ministers/prime-minister",
-            image: {
-              url: "/photo/theresa-may",
-              alt_text: "Theresa May MP",
+            title: "Stuart Andrew MP",
+            base_path: "/government/people/stuart-andrew",
+            details: {},
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Parliamentary Under Secretary of State",
+                  base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
+                ),
+              ],
             },
           },
           {
-            name_prefix: "The Rt Hon",
-            name: "Theresa May MP",
-            role: "Minister for the Civil Service",
-            href: "/government/people/theresa-may",
-            role_href: "/government/ministers/minister-for-the-civil-service",
-            image: {
-              url: "/photo/theresa-may",
-              alt_text: "Theresa May MP",
+            title: "The Rt Hon Theresa May MP",
+            base_path: "/government/people/theresa-may",
+            details: {
+              image: {
+                url: "/photo/theresa-may",
+                alt_text: "Theresa May MP",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  title: "Prime Minister",
+                  base_path: "/government/ministers/prime-minister",
+                ),
+                current_role_appointment(
+                  title: "Minister for the Civil Service",
+                  base_path: "/government/ministers/minister-for-the-civil-service",
+                ),
+              ],
             },
           },
         ],
@@ -162,32 +191,38 @@ module OrganisationHelpers
         organisation_govuk_status: {
           status: "live",
         },
+      },
+      links: {
         ordered_board_members: [
           {
-            name: "Sir Jeremy Heywood",
-            role: "Cabinet Secretary",
-            href: "/government/people/jeremy-heywood",
-            image: {
-              url: "/photo/jeremy-heywood",
-              alt_text: "Sir Jeremy Heywood",
+            title: "Sir Jeremy Heywood",
+            base_path: "/government/people/jeremy-heywood",
+            details: {
+              image: {
+                url: "/photo/jeremy-heywood",
+                alt_text: "Sir Jeremy Heywood",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Cabinet Secretary"),
+              ],
             },
           },
           {
-            name: "John Manzoni",
-            role: "Chief Executive of the Civil Service ",
-            href: "/government/people/john-manzoni",
-            image: {
-              url: "/photo/john-manzoni",
-              alt_text: "John Manzoni",
+            title: "John Manzoni",
+            base_path: "/government/people/john-manzoni",
+            details: {
+              image: {
+                url: "/photo/john-manzoni",
+                alt_text: "John Manzoni",
+              },
             },
-          },
-          {
-            name: "John Manzoni",
-            role: "Permanent Secretary (Cabinet Office)",
-            href: "/government/people/john-manzoni",
-            image: {
-              url: "/photo/john-manzoni",
-              alt_text: "John Manzoni",
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Chief Executive of the Civil Service"),
+                current_role_appointment(title: "Permanent Secretary (Cabinet Office)"),
+              ],
             },
           },
         ],
@@ -205,23 +240,37 @@ module OrganisationHelpers
           status: "live",
         },
         important_board_members: 1,
+      },
+      links: {
         ordered_board_members: [
           {
-            name: "Sir Jeremy Heywood",
-            role: "Cabinet Secretary",
-            href: "/government/people/jeremy-heywood",
-            image: {
-              url: "/photo/jeremy-heywood",
-              alt_text: "Sir Jeremy Heywood",
+            title: "Sir Jeremy Heywood",
+            base_path: "/government/people/jeremy-heywood",
+            details: {
+              image: {
+                url: "/photo/jeremy-heywood",
+                alt_text: "Sir Jeremy Heywood",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Cabinet Secretary"),
+              ],
             },
           },
           {
-            name: "John Manzoni",
-            role: "Chief Executive of the Civil Service ",
-            href: "/government/people/john-manzoni",
-            image: {
-              url: "/photo/john-manzoni",
-              alt_text: "John Manzoni",
+            title: "John Manzoni",
+            base_path: "/government/people/john-manzoni",
+            details: {
+              image: {
+                url: "/photo/john-manzoni",
+                alt_text: "John Manzoni",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(title: "Chief Executive of the Civil Service"),
+              ],
             },
           },
         ],


### PR DESCRIPTION
This renders the people section of the organisation pages from the links, rather than from the details hash. We've recently started exposing this information in the links so we can rely on the Publishing API to perform dependency resolution for us rather than Whitehall having to manually republish organisation pages whenever a person changes.

Example: https://govuk-collec-organisati-5obtcx.herokuapp.com/government/organisations/cabinet-office

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)