### PR TITLE
Fix test that checks exempt organisations

### DIFF
--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -499,13 +499,15 @@ class OrganisationTest < ActionDispatch::IntegrationTest
       cy[:base_path] = "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
     end
 
-    @content_item_separate_student_loans = org_example.merge(
-      base_path: "/government/organisations/student-loans-company",
-      title: "Student Loans Company",
-      organisation_govuk_status: {
-        status: "exempt",
-        url: "http://www.slc.co.uk/",
-        updated_at: nil,
+    @content_item_separate_student_loans = org_example.deep_merge(
+      "base_path" => "/government/organisations/student-loans-company",
+      "title" => "Student Loans Company",
+      "details" => {
+        "organisation_govuk_status" => {
+          "status" => "exempt",
+          "url" => "http://www.slc.co.uk/",
+          "updated_at" => nil,
+        },
       },
     )
 


### PR DESCRIPTION
We were doing a merge on the content item, but actually we should be merging the details part of the content item to set up this test correctly.

Fixing this should make sure https://github.com/alphagov/govuk-content-schemas/pull/986 builds successfully.