### PR TITLE
Trigger an error in a known controller for logit tracking

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -10,6 +10,7 @@ class OrganisationsController < ApplicationController
   end
 
   def show
+    raise "This is an intended exception"
     @organisation = Organisation.find!(request.path)
     setup_content_item_and_navigation_helpers(@organisation)
 


### PR DESCRIPTION
This throws an expected error in the organisations controller so we can
trace and repair an issue in our logit/kibana flow.

https://trello.com/c/fX8U5tly/1911-5-fix-whitehall-stacktraces-in-kibana%F0%9F%8D%90