### PR TITLE
Redirect coronavirus taxon requests

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,6 +1,4 @@
 class TaxonsController < ApplicationController
-  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
-  before_action :redirect_coronavirus_taxons
   rescue_from Taxon::InAlphaPhase, with: :error_404
 
   def show
@@ -37,21 +35,5 @@ private
     end
 
     @presentable_section_items
-  end
-
-  def redirect_coronavirus_taxons
-    if is_coronavirus_taxon? || is_child_of_coronavirus_taxon?
-      redirect_to(coronavirus_landing_page_url, status: :temporary_redirect) && return
-    end
-  end
-
-  def is_child_of_coronavirus_taxon?
-    # The root of the branch is always the first entry
-    taxon.parents? && taxon.parent_taxons.first.base_path == CORONAVIRUS_TAXON_PATH
-  end
-
-  def is_coronavirus_taxon?
-    # The root of the branch is always the first entry
-    request.path == CORONAVIRUS_TAXON_PATH
   end
 end

--- a/app/controllers/taxons_redirection_controller.rb
+++ b/app/controllers/taxons_redirection_controller.rb
@@ -1,0 +1,57 @@
+class TaxonsRedirectionController < ApplicationController
+  CORONAVIRUS_LANDING_PAGE_PATH = "/coronavirus".freeze
+  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
+
+  CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID = "65666cdf-b177-4d79-9687-b9c32805e450".freeze
+  CORONAVIRUS_EDUCATION_TAXON_CONTENT_ID = "272308f4-05c8-4d0d-abc7-b7c2e3ccd249".freeze
+
+  HUB_PAGE_FROM_CONTENT_ID = {
+    CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID => "/coronavirus/business-support",
+    CORONAVIRUS_EDUCATION_TAXON_CONTENT_ID => "/coronavirus/education-and-childcare",
+  }.freeze
+
+  def redirect
+    if is_coronavirus_taxon?
+      redirect_to_landing_page && return
+    else
+      redirect_to_best_coronavirus_page
+    end
+  end
+
+private
+
+  def redirect_to_landing_page
+    redirect_to(CORONAVIRUS_LANDING_PAGE_PATH, status: :temporary_redirect)
+  end
+
+  def redirect_to_best_coronavirus_page
+    redirect_to(best_coronavirus_page, status: :temporary_redirect)
+  end
+
+  def best_coronavirus_page
+    return HUB_PAGE_FROM_CONTENT_ID[taxon.content_id] if hub_taxon?
+    return HUB_PAGE_FROM_CONTENT_ID[parent_hub_taxons.first] if parent_hub_taxons.any?
+
+    CORONAVIRUS_LANDING_PAGE_PATH
+  end
+
+  def hub_taxon?
+    hub_taxon_content_ids.include?(taxon.content_id)
+  end
+
+  def parent_hub_taxons
+    hub_taxon_content_ids & taxon.parent_taxons.map(&:content_id)
+  end
+
+  def hub_taxon_content_ids
+    HUB_PAGE_FROM_CONTENT_ID.keys
+  end
+
+  def taxon
+    @taxon ||= Taxon.find(request.path)
+  end
+
+  def is_coronavirus_taxon?
+    request.path == CORONAVIRUS_TAXON_PATH
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -35,11 +35,13 @@ class Taxon
   end
 
   def child_taxons
-    return [] unless children?
+    @child_taxons ||= begin
+      return [] unless children?
 
-    linked_items("child_taxons")
-      .map { |child_taxon| self.class.new(child_taxon) }
-      .reject(&:alpha_taxon?)
+      linked_items("child_taxons")
+        .map { |child_taxon| self.class.new(child_taxon) }
+        .reject(&:alpha_taxon?)
+    end
   end
 
   def children?
@@ -47,11 +49,13 @@ class Taxon
   end
 
   def parent_taxons
-    return [] unless parents?
+    @parent_taxons ||= begin
+      return [] unless parents?
 
-    linked_items("parent_taxons")
-        .map { |child_taxon| self.class.new(child_taxon) }
-        .reject(&:alpha_taxon?)
+      linked_items("parent_taxons")
+          .map { |child_taxon| self.class.new(child_taxon) }
+          .reject(&:alpha_taxon?)
+    end
   end
 
   def parents?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   mount JasmineRails::Engine => "/specs" if defined?(JasmineRails)
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  ["/coronavirus-taxon", "/coronavirus-taxon/*slug"].each do |path|
+    get path, to: "taxons_redirection#redirect"
+  end
+
   get "/coronavirus", to: "coronavirus_landing_page#show", as: :coronavirus_landing_page
   get "/coronavirus/:hub_slug", to: "coronavirus_landing_page#hub"
 

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -41,28 +41,4 @@ describe TaxonsController do
       assert_response 404
     end
   end
-
-  context "when rendering a taxon that is a child of the coronavirus taxon" do
-    before do
-      stub_content_store_has_item(
-        coronavirus_root_taxon_content_item["base_path"],
-        coronavirus_root_taxon_content_item,
-      )
-      stub_content_store_has_item(
-        coronavirus_taxon_one["base_path"], coronavirus_taxon_one
-      )
-    end
-
-    it "redirects to the coronavirus page" do
-      get :show, params: { taxon_base_path: coronavirus_taxon_one["base_path"][1..-1] }
-      assert_redirected_to "/coronavirus"
-    end
-  end
-
-  context "when rendering the coronavirus taxon" do
-    it "redirects to the coronavirus page" do
-      get :show, params: { taxon_base_path: coronavirus_root_taxon_content_item["base_path"][1..-1] }
-      assert_redirected_to "/coronavirus"
-    end
-  end
 end

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -65,4 +65,33 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_page_title("Education and Childcare")
     end
   end
+
+  describe "redirects from the taxon" do
+    it "redirects /coronavirus-taxon to the landing page" do
+      given_there_is_a_content_item
+      when_i_visit_the_coronavirus_taxon_page
+      then_i_am_redirected_to_the_landing_page
+    end
+
+    it "redirects subtaxons to appropriate hub pages" do
+      given_there_is_a_business_content_item
+      and_a_coronavirus_business_taxon
+      when_i_visit_the_coronavirus_business_taxon
+      then_i_am_redirected_to_the_business_hub_page
+    end
+
+    it "redirects subtaxons to appropriate hub pages" do
+      given_there_is_a_business_content_item
+      and_a_coronavirus_business_subtaxon
+      when_i_visit_the_coronavirus_business_subtaxon
+      then_i_am_redirected_to_the_business_hub_page
+    end
+
+    it "redirects subtaxons to the landing page if there is no overriding rule" do
+      given_there_is_a_content_item
+      and_another_coronavirus_subtaxon
+      when_i_visit_a_coronavirus_subtaxon_without_a_hub_page
+      then_i_am_redirected_to_the_landing_page
+    end
+  end
 end

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -56,6 +56,43 @@ def business_content_item
   end
 end
 
+def random_taxon_page
+  GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
+    yield(item) if block_given?
+    item["phase"] = "live"
+    item
+  end
+end
+
+def business_taxon_content_item
+  random_taxon_page do |item|
+    item["content_id"] = TaxonsRedirectionController::CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID
+    item
+  end
+end
+
+def business_subtaxon_content_item
+  stubbed_business_taxon = business_taxon_content_item.tap do |item|
+    item["links"] = {}
+  end
+
+  random_taxon_page do |item|
+    item["links"]["parent_taxons"] = [stubbed_business_taxon]
+    item
+  end
+end
+
+def other_subtaxon_item
+  random_linked_taxon = random_taxon_page do |item|
+    item["links"] = {}
+  end
+
+  random_taxon_page do |item|
+    item["links"]["parent_taxons"] = [random_linked_taxon]
+    item
+  end
+end
+
 def education_content_item
   random_landing_page do |item|
     item.merge(education_content_item_fixture)

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -10,6 +10,11 @@ module CoronavirusLandingPageSteps
   BUSINESS_PATH = "/coronavirus/business-support".freeze
   EDUCATION_PATH = "/coronavirus/education".freeze
 
+  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
+  BUSINESS_TAXON_PATH = CORONAVIRUS_TAXON_PATH + "/businesses-and-self-employed-people".freeze
+  BUSINESS_SUBTAXON_PATH = CORONAVIRUS_TAXON_PATH + "/business-sub-taxon".freeze
+  OTHER_SUBTAXON_PATH = CORONAVIRUS_TAXON_PATH + "/no-hub-page"
+
   def given_there_is_a_content_item
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
   end
@@ -34,6 +39,18 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(EDUCATION_PATH, education_content_item)
   end
 
+  def and_a_coronavirus_business_taxon
+    stub_content_store_has_item(BUSINESS_TAXON_PATH, business_taxon_content_item)
+  end
+
+  def and_a_coronavirus_business_subtaxon
+    stub_content_store_has_item(BUSINESS_SUBTAXON_PATH, business_subtaxon_content_item)
+  end
+
+  def and_another_coronavirus_subtaxon
+    stub_content_store_has_item(OTHER_SUBTAXON_PATH, other_subtaxon_item)
+  end
+
   def when_i_visit_the_coronavirus_landing_page
     visit CORONAVIRUS_PATH
   end
@@ -44,6 +61,30 @@ module CoronavirusLandingPageSteps
 
   def when_i_visit_the_education_hub_page
     visit EDUCATION_PATH
+  end
+
+  def when_i_visit_the_coronavirus_taxon_page
+    visit CORONAVIRUS_TAXON_PATH
+  end
+
+  def when_i_visit_the_coronavirus_business_taxon
+    visit BUSINESS_TAXON_PATH
+  end
+
+  def when_i_visit_the_coronavirus_business_subtaxon
+    visit BUSINESS_SUBTAXON_PATH
+  end
+
+  def when_i_visit_a_coronavirus_subtaxon_without_a_hub_page
+    visit OTHER_SUBTAXON_PATH
+  end
+
+  def then_i_am_redirected_to_the_landing_page
+    assert_equal page.current_path, "/coronavirus"
+  end
+
+  def then_i_am_redirected_to_the_business_hub_page
+    assert_equal page.current_path, "/coronavirus/business-support"
   end
 
   def then_i_can_see_the_header_section


### PR DESCRIPTION
There is the beginnings of a hierarchy of pages:

/coronavirus (the "landing" page)
  |__ /coronavirus/business-support ("hub" page)
  |__ /coronavirus/education-and-childcare ("hub" page)

We are soon to publish a new branch of the taxonomy which this page hierarchy
will overlay onto. The taxonomy will be used to power navigation, search
and notifications, but we want to use the landing/hub pages as UI for exploring
them, as they're more heavily curated that a taxon page can be.

This commit routes all requests for pages under and including /coronavirus-taxon
and works out where best to send them.

Taxon pages only have a two layer path, so even if a taxon is five levels deep,
it'll still have a path that looks like /sport/badminton-for-pigeon-fanciers.

This means we have to examine the content_item to see if it has an ancestor
that matches one of our hub pages. (Or it might be one of those taxons that
has a hub page itself!)

If it does, then we redirect it to the hub page. If not, we want to send it
to the coronavirus landing page.

https://trello.com/c/ZNbj9Jom/235-check-the-redirect-routes-in-collections-so-that-requests-for-a-taxon-get-redirected-to-the-most-appropriate-hub-page