### PR TITLE
Fix missing role payment type

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -66,7 +66,7 @@ module Organisations
         brand: @org.brand,
         href: person["base_path"],
         description: nil,
-        metadata: roles.map { |role| role["role_payment_type"] }.compact.first,
+        metadata: roles.map { |role| role["details"]["role_payment_type"] }.compact.first,
         heading_text: person["title"],
         heading_level: 0,
         extra_links_no_indent: true,

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -166,7 +166,7 @@ describe Organisations::PeoplePresenter do
         brand: "attorney-generals-office",
         href: "/government/people/jeremy-heywood",
         description: "Cabinet Secretary",
-        metadata: nil,
+        metadata: "Unpaid",
         heading_text: "Sir Jeremy Heywood",
         heading_level: 0,
         extra_links_no_indent: true,

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -84,13 +84,19 @@ module OrganisationHelpers
       ] }.to_json)
   end
 
-  def current_role_appointment(title:, base_path: nil)
+  def current_role_appointment(title:, base_path: nil, payment_type: nil)
     {
       details: {
         current: true,
       },
       links: {
-        role: [{ title: title, base_path: base_path }.compact],
+        role: [
+          {
+            title: title,
+            base_path: base_path,
+            details: { role_payment_type: payment_type },
+          }.compact,
+        ],
       },
     }
   end
@@ -254,7 +260,7 @@ module OrganisationHelpers
             },
             links: {
               role_appointments: [
-                current_role_appointment(title: "Cabinet Secretary"),
+                current_role_appointment(title: "Cabinet Secretary", payment_type: "Unpaid"),
               ],
             },
           },


### PR DESCRIPTION
We were getting this from a field on the role object itself, when actually this should have come from the details.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)