### PR TITLE
Ensure roles match the section they are shown in

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -46,10 +46,19 @@ module Organisations
       type.eql?(:ministers)
     end
 
-    def current_roles(person)
+    def expected_document_type(type)
+      return "ministerial_role" if type == :ministers
+      return "military_role" if type == :military_personnel
+
+      # for example: board_members -> board_member_role
+      type.to_s.delete_suffix("s") + "_role"
+    end
+
+    def current_roles(person, type)
       person["links"].fetch("role_appointments", [])
         .select { |ra| ra["details"]["current"] }
         .map { |ra| ra["links"]["role"].first }
+        .select { |role| role["document_type"] == expected_document_type(type) }
     end
 
     def formatted_role_link(role)
@@ -60,7 +69,7 @@ module Organisations
     end
 
     def formatted_person_data(person, type)
-      roles = current_roles(person)
+      roles = current_roles(person, type)
 
       data = {
         brand: @org.brand,

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -106,6 +106,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 current_role_appointment(
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -207,7 +208,10 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             details: {},
             links: {
               role_appointments: [
-                current_role_appointment(title: "Cabinet Secretary"),
+                current_role_appointment(
+                  title: "Cabinet Secretary",
+                  document_type: "board_member_role",
+                ),
               ],
             },
           },
@@ -228,6 +232,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 current_role_appointment(
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -242,6 +247,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
                 current_role_appointment(
                   title: "Parliamentary Under Secretary of State",
                   base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -487,7 +493,10 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             details: {},
             links: {
               role_appointments: [
-                current_role_appointment(title: "Chief of the Defence Staff"),
+                current_role_appointment(
+                  title: "Chief of the Defence Staff",
+                  document_type: "military_role",
+                ),
               ],
             },
           },

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -84,7 +84,7 @@ module OrganisationHelpers
       ] }.to_json)
   end
 
-  def current_role_appointment(title:, base_path: nil, payment_type: nil)
+  def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil)
     {
       details: {
         current: true,
@@ -94,6 +94,7 @@ module OrganisationHelpers
           {
             title: title,
             base_path: base_path,
+            document_type: document_type,
             details: { role_payment_type: payment_type },
           }.compact,
         ],
@@ -144,6 +145,7 @@ module OrganisationHelpers
                 current_role_appointment(
                   title: "Parliamentary Secretary (Minister for Implementation)",
                   base_path: "/government/ministers/parliamentary-secretary",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -157,6 +159,7 @@ module OrganisationHelpers
                 current_role_appointment(
                   title: "Parliamentary Under Secretary of State",
                   base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -175,10 +178,12 @@ module OrganisationHelpers
                 current_role_appointment(
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
+                  document_type: "ministerial_role",
                 ),
                 current_role_appointment(
                   title: "Minister for the Civil Service",
                   base_path: "/government/ministers/minister-for-the-civil-service",
+                  document_type: "ministerial_role",
                 ),
               ],
             },
@@ -211,7 +216,10 @@ module OrganisationHelpers
             },
             links: {
               role_appointments: [
-                current_role_appointment(title: "Cabinet Secretary"),
+                current_role_appointment(
+                  title: "Cabinet Secretary",
+                  document_type: "board_member_role",
+                ),
               ],
             },
           },
@@ -226,8 +234,14 @@ module OrganisationHelpers
             },
             links: {
               role_appointments: [
-                current_role_appointment(title: "Chief Executive of the Civil Service"),
-                current_role_appointment(title: "Permanent Secretary (Cabinet Office)"),
+                current_role_appointment(
+                  title: "Chief Executive of the Civil Service",
+                  document_type: "board_member_role",
+                ),
+                current_role_appointment(
+                  title: "Permanent Secretary (Cabinet Office)",
+                  document_type: "board_member_role",
+                ),
               ],
             },
           },
@@ -260,7 +274,11 @@ module OrganisationHelpers
             },
             links: {
               role_appointments: [
-                current_role_appointment(title: "Cabinet Secretary", payment_type: "Unpaid"),
+                current_role_appointment(
+                  title: "Cabinet Secretary",
+                  document_type: "board_member_role",
+                  payment_type: "Unpaid",
+                ),
               ],
             },
           },
@@ -275,7 +293,10 @@ module OrganisationHelpers
             },
             links: {
               role_appointments: [
-                current_role_appointment(title: "Chief Executive of the Civil Service"),
+                current_role_appointment(
+                  title: "Chief Executive of the Civil Service",
+                  document_type: "board_member_role",
+                ),
               ],
             },
           },


### PR DESCRIPTION
This is a slightly horrible fix for a wider problem which is that rather than linking directly to the role appointments, we're linking to the people directly. This means that in the link expansion, it's possible that we'll end up seeing roles that aren't relevant for this particular section.

For example, if someone has a board member and a special representative role, they will be linked to twice (`ordered_board_members` and `ordered_special_representative`) and both roles will appear in both of those expanded links, so we need to pull out the correct one.

There is a nice fix here to link to the role appointments, but that is a bigger piece of work so I'll write that up as a separate card. This is a quick fix to get us to a better point than we were before.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)