### PR TITLE
Filter roles to the organisation

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -121,6 +121,10 @@ class Organisation
     }
   end
 
+  def all_roles
+    links.fetch("ordered_roles", [])
+  end
+
   def important_board_member_count
     details["important_board_members"]
   end

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -6,6 +6,7 @@ module Organisations
 
     def initialize(organisation)
       @org = organisation
+      @allowed_role_content_ids = organisation.all_roles.map { |role| role["content_id"] }
     end
 
     def has_people?
@@ -26,6 +27,8 @@ module Organisations
     end
 
   private
+
+    attr_reader :allowed_role_content_ids
 
     def images_for_important_board_members(people)
       people.map do |people_group|
@@ -58,6 +61,7 @@ module Organisations
       person["links"].fetch("role_appointments", [])
         .select { |ra| ra["details"]["current"] }
         .map { |ra| ra["links"]["role"].first }
+        .select { |role| allowed_role_content_ids.include?(role["content_id"]) }
         .select { |role| role["document_type"] == expected_document_type(type) }
     end
 

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -6,6 +6,7 @@ describe OrganisationsController do
       stub_content_store_has_item("/government/organisations/ministry-of-magic",
                                   title: "Ministry of magic",
                                   base_path: "/government/organisations/ministry-of-magic",
+                                  links: {},
                                   details: {
                                     body: "This organisation has a status of exempt.",
                                     logo: {

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -49,6 +49,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_exempt_no_url = {
       title: "Exempt organisation",
       base_path: "/government/organisations/exempt-no-url",
+      links: {},
       details: {
         body: "This organisation has a status of exempt.",
         logo: {
@@ -63,6 +64,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_exempt = {
       title: "Exempt organisation",
       base_path: "/government/organisations/exempt",
+      links: {},
       details: {
         body: "This organisation has a status of exempt.",
         logo: {
@@ -77,6 +79,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_joining = {
       title: "Joining organisation",
       base_path: "/government/organisations/joining",
+      links: {},
       details: {
         body: "This organisation has a status of joining.",
         logo: {
@@ -90,6 +93,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_left_gov = {
       title: "Left_gov organisation",
       base_path: "/government/organisations/left_gov",
+      links: {},
       details: {
         body: "This organisation has a status of left_gov.",
         logo: {
@@ -154,6 +158,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_no_longer_exists = {
       title: "No_longer_exists organisation",
       base_path: "/government/organisations/no_longer_exists",
+      links: {},
       details: {
         body: "This organisation has a status of no_longer_exists.",
         logo: {
@@ -188,6 +193,7 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     @content_item_documents = {
       title: "Fire Service College",
       base_path: "/government/organisations/fire-service-college",
+      links: {},
       details: {
         body: "The Fire Service College (FSC) supplies specialist fire and rescue training to the UK's own fire and rescue services, the private security sector and the international market.\r\n\r\nThe college was formerly an executive agency of the Department for Communities and Local Government and was sold to Capita on 28 February 2013.<abbr title=\"Fire Service College\">FSC</abbr>",
         brand: "null",

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -90,6 +90,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             title: "High Profile Group 2",
           },
         ],
+        ordered_roles: [
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+        ],
         ordered_ministers: [
           {
             content_id: "ec7cb2ba-3c02-48c5-a918-1f4a211499ae",
@@ -104,6 +107,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
                   document_type: "ministerial_role",
@@ -199,6 +203,11 @@ class OrganisationTest < ActionDispatch::IntegrationTest
         ],
       },
       links: {
+        ordered_roles: [
+          { content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339" },
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+          { content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c" },
+        ],
         available_translations: [],
         ordered_board_members: [
           {
@@ -209,6 +218,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339",
                   title: "Cabinet Secretary",
                   document_type: "board_member_role",
                 ),
@@ -230,6 +240,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
                   document_type: "ministerial_role",
@@ -245,6 +256,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c",
                   title: "Parliamentary Under Secretary of State",
                   base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
                   document_type: "ministerial_role",
@@ -486,6 +498,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             },
           },
         ],
+        ordered_roles: [
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+        ],
         ordered_military_personnel: [
           {
             title: "Air Chief Marshal Sir  Stuart Peach GBE KCB ADC DL",
@@ -494,6 +509,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Chief of the Defence Staff",
                   document_type: "military_role",
                 ),

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -84,7 +84,7 @@ module OrganisationHelpers
       ] }.to_json)
   end
 
-  def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil)
+  def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil, content_id: nil)
     {
       details: {
         current: true,
@@ -92,6 +92,7 @@ module OrganisationHelpers
       links: {
         role: [
           {
+            content_id: content_id,
             title: title,
             base_path: base_path,
             document_type: document_type,
@@ -130,6 +131,12 @@ module OrganisationHelpers
         },
       },
       links: {
+        ordered_roles: [
+          { content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339" },
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+          { content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c" },
+          { content_id: "3f4bbf6c-741e-4207-9135-63d1c8f39c28" },
+        ],
         ordered_ministers: [
           {
             title: "Oliver Dowden CBE MP",
@@ -143,6 +150,7 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339",
                   title: "Parliamentary Secretary (Minister for Implementation)",
                   base_path: "/government/ministers/parliamentary-secretary",
                   document_type: "ministerial_role",
@@ -157,6 +165,7 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Parliamentary Under Secretary of State",
                   base_path: "/government/ministers/parliamentary-under-secretary-of-state--94",
                   document_type: "ministerial_role",
@@ -176,11 +185,13 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c",
                   title: "Prime Minister",
                   base_path: "/government/ministers/prime-minister",
                   document_type: "ministerial_role",
                 ),
                 current_role_appointment(
+                  content_id: "3f4bbf6c-741e-4207-9135-63d1c8f39c28",
                   title: "Minister for the Civil Service",
                   base_path: "/government/ministers/minister-for-the-civil-service",
                   document_type: "ministerial_role",
@@ -204,6 +215,11 @@ module OrganisationHelpers
         },
       },
       links: {
+        ordered_roles: [
+          { content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339" },
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+          { content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c" },
+        ],
         ordered_board_members: [
           {
             title: "Sir Jeremy Heywood",
@@ -217,6 +233,7 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339",
                   title: "Cabinet Secretary",
                   document_type: "board_member_role",
                 ),
@@ -235,10 +252,12 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Chief Executive of the Civil Service",
                   document_type: "board_member_role",
                 ),
                 current_role_appointment(
+                  content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c",
                   title: "Permanent Secretary (Cabinet Office)",
                   document_type: "board_member_role",
                 ),
@@ -262,6 +281,10 @@ module OrganisationHelpers
         important_board_members: 1,
       },
       links: {
+        ordered_roles: [
+          { content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339" },
+          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
+        ],
         ordered_board_members: [
           {
             title: "Sir Jeremy Heywood",
@@ -275,6 +298,7 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339",
                   title: "Cabinet Secretary",
                   document_type: "board_member_role",
                   payment_type: "Unpaid",
@@ -294,6 +318,7 @@ module OrganisationHelpers
             links: {
               role_appointments: [
                 current_role_appointment(
+                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
                   title: "Chief Executive of the Civil Service",
                   document_type: "board_member_role",
                 ),


### PR DESCRIPTION
This relates to the same problem that was fixed in #1718. Because we're linking to the people, rather than to the role appointments directly, it's possible that link expansion will include information about roles not associated with the organisation. We need to filter those out by using the `ordered_roles` link to ensure the role belongs to the organisation.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)