### PR TITLE
Update presenter and template to use new key names

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w[live_stream live_stream_enabled stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications find_help page_header].freeze
+  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications find_help page_header].freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -26,22 +26,22 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: rules["pretext"],
+            text: header["title"],
             font_size: 19,
             margin_bottom: 3,
             inverse: true
           } %>
           <p class="govuk-body covid__inverse">
-            <%= guidance["pretext-1"] %>
+            <%= header["pretext-1"] %>
           </p>
           <ul class="covid__list covid__list--header">
-            <% rules["list"].each do | item | %>
+            <% header["list"].each do | item | %>
               <li class="covid__list-item"><%= item %></li>
             <% end %>
           </ul>
 
           <p class="govuk-body covid__inverse">
-            <%= guidance["pretext-2"] %>
+            <%= header["pretext-2"] %>
           </p>
         </div>
       </div>
@@ -50,14 +50,14 @@
         <div class="govuk-grid-column-two-thirds">
           <%= render 'components/action-link', {
             light_text: true,
-            href: guidance["link"]["href"],
-            text: guidance["link"]["link_text"],
-            nowrap_text: guidance["link"]["link_nowrap_text"],
+            href: header["link"]["href"],
+            text: header["link"]["link_text"],
+            nowrap_text: header["link"]["link_nowrap_text"],
             data: {
               module: "track-click",
               track_category: "pageElementInteraction",
               track_action: "Announcements",
-              track_label: guidance["link"]["href"]
+              track_label: header["link"]["href"]
             }
           } %>
         </div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -14,8 +14,7 @@
       details: details,
       breadcrumbs: breadcrumbs,
       title: title,
-      rules: details.stay_at_home,
-      guidance: details.guidance,
+      header: details.header_section
     }
   )
 %>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -13,17 +13,17 @@
   "links": {},
   "details": {
     "page_header": "Coronavirus (COVID-19)",
-    "stay_at_home": {
-      "pretext": "Stay at home",
+    "header_section": {
+      "title": "Stay alert",
+      "pretext-1": "We can all help control the virus if we all stay alert. This means you must:",
+      "pretext-2": "Self-isolate if you or anyone in your household has symptoms",
       "list": [
-        "Only go outside for food, health reasons or work (where this absolutely cannot be done from home)",
-        "If you go out, stay 2 metres (6ft) away from other people",
-        "Wash your hands as soon as you get home"
-      ]
-    },
-    "guidance": {
-      "pretext-1": "Do not meet others, even friends or family",
-      "pretext-2": "You can spread the virus even if you don’t have symptoms",
+        "stay at home as much as possible",
+        "work from home if you can",
+        "limit contact with other people",
+        "keep your distance if you go out (2 metres apart where possible)",
+        "wash your hands regularly"
+      ],
       "link": {
         "href": "/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do",
         "text": "Read more about what you can and cannot do."

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream stay_at_home guidance announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications].each do |method|
+    %i[live_stream header_section announcements_label announcements see_all_announcements_link nhs_banner find_help sections sections_heading additional_country_guidance topic_section notifications live_stream].each do |method|
       assert_respond_to(presenter, method)
     end
   end


### PR DESCRIPTION
The `stay_at_home` hash in the /coronavirus content item has become a bit confusing.
There is a [pr](https://github.com/alphagov/govuk-coronavirus-content/pull/219) to simplify it in the govuk-coronavirus-content repo.
This commit updates the frontend to read from the new simplified structure.

**DO NOT MERGE** until https://github.com/alphagov/govuk-coronavirus-content/pull/219 is merged and the content item has been published!!

[card](https://trello.com/c/m0HMJsP2/270-simplify-the-structure-of-the-content-item-header-section-of-coronavirus-landing-page)