### PR TITLE
Adjust action link spacing

### DIFF
--- a/app/assets/stylesheets/components/_action-link.scss
+++ b/app/assets/stylesheets/components/_action-link.scss
@@ -20,13 +20,12 @@
 
 
 .app-c-action-link__link-wrapper {
+  @include govuk-font(19, $weight: bold, $line-height: 20px);
   display: table-cell;
   vertical-align: middle;
 }
 
 .app-c-action-link__link {
-  @include govuk-font(19, $weight: bold);
-
   &:hover {
     text-decoration: underline;
   }

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -44,7 +44,7 @@
   background: $covid-grey;
 
   @include govuk-media-query($from: tablet) {
-    padding: 45px 0;
+    padding: 45px 0 40px 0;
   }
 }
 
@@ -64,7 +64,7 @@
   margin-top: govuk-spacing(5);
 
   @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(6);
+    margin-top: govuk-spacing(3);
   }
 }
 


### PR DESCRIPTION
- reduces the line height of the call to action link on the covid page to match the global banner
- also reduces the spacing around the link on desktop

Visual differences:

Before | After
------ | ------
<img width="570" alt="Screenshot 2020-05-12 at 09 48 12" src="https://user-images.githubusercontent.com/861310/81662692-d838cc80-9435-11ea-82be-c1260211276b.png"> | <img width="557" alt="Screenshot 2020-05-12 at 09 48 19" src="https://user-images.githubusercontent.com/861310/81662710-df5fda80-9435-11ea-8501-02dd89a0d30e.png">
<img width="350" alt="Screenshot 2020-05-12 at 09 48 35" src="https://user-images.githubusercontent.com/861310/81662758-f1da1400-9435-11ea-872a-12759e47076e.png"> | <img width="347" alt="Screenshot 2020-05-12 at 09 48 44" src="https://user-images.githubusercontent.com/861310/81662775-f7cff500-9435-11ea-94d3-9e9b7db6982f.png">


Trello card: https://trello.com/c/r969DUoN/269-improve-the-cta-spacing