### PR TITLE
Add statistics content section

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section notifications find_help page_header].freeze
+  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section statistics_section notifications find_help page_header].freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -48,6 +48,7 @@
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.statistics_section } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 
       <div class="landing-page__email-wrapper">

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -314,24 +314,6 @@
             ]
           }
         ]
-      },
-      {
-        "title": "Coronavirus (COVID-19) cases in the UK",
-        "sub_sections": [
-          {
-            "title": "",
-            "list": [
-              {
-                "label": "Track coronavirus cases in the UK",
-                "url": "/government/publications/covid-19-track-coronavirus-cases"
-              },
-              {
-                "label": "Latest number of coronavirus cases in the UK",
-                "url": "/guidance/coronavirus-covid-19-information-for-the-public"
-              }
-            ]
-          }
-        ]
       }
     ],
     "country_section": {
@@ -349,6 +331,19 @@
         {
           "label": "Northern Ireland",
           "url": "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
+        }
+      ]
+    },
+    "statistics_section": {
+      "header": "Statistics",
+      "links": [
+        {
+          "label": "Track coronavirus cases in the UK",
+          "url": "/government/publications/covid-19-track-coronavirus-cases"
+        },
+        {
+          "label": "Latest number of coronavirus cases in the UK",
+          "url": "/guidance/coronavirus-covid-19-information-for-the-public"
         }
       ]
     },

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,7 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream header_section announcements_label announcements see_all_announcements_link nhs_banner find_help sections sections_heading additional_country_guidance topic_section notifications live_stream].each do |method|
+    %i[live_stream header_section announcements_label announcements see_all_announcements_link nhs_banner find_help sections sections_heading additional_country_guidance topic_section statistics_section notifications live_stream].each do |method|
       assert_respond_to(presenter, method)
     end
   end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -138,6 +138,10 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".govuk-link", text: "Staying at home if you think you have coronavirus (self-isolating)")
   end
 
+  def and_i_can_see_links_to_statistics
+    assert page.has_link?("Track coronavirus cases in the UK", href: "Track coronavirus cases in the UK")
+  end
+
   def and_i_can_see_links_to_search
     assert page.has_link?("News", href: "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response")
     assert page.has_link?("Guidance", href: "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -139,7 +139,7 @@ module CoronavirusLandingPageSteps
   end
 
   def and_i_can_see_links_to_statistics
-    assert page.has_link?("Track coronavirus cases in the UK", href: "Track coronavirus cases in the UK")
+    assert page.has_link?("Track coronavirus cases in the UK", href: "/government/publications/covid-19-track-coronavirus-cases")
   end
 
   def and_i_can_see_links_to_search


### PR DESCRIPTION
Add new statistics section below live stream. 
This section is using the links that are currently in the "Coronavirus (COVID-19) cases in the
UK" accordion section on the live site.
I did not create a new component for this new section as I found that I could simply pass through the statistics section data to `topic_section`

~Relevant content update which will make this   ✨ _work_ ✨ is  https://github.com/alphagov/govuk-coronavirus-content/pull/223~ ✅ merged

-----
### Before (no stats section) vs After  (stats section under stream section)
![png](https://user-images.githubusercontent.com/7116819/81718954-5025e780-9474-11ea-86e6-a6ad4eebd7f3.png)




Relevant Trello https://trello.com/c/bjPJsGNf
