### PR TITLE
Risk level indicator

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -264,3 +264,10 @@
   background-color: govuk-colour("light-grey");
   color: govuk-colour("black");
 }
+
+.covid__alert-notice .covid__alert-notice-body {
+  @include govuk-media-query($from: desktop) {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+  }
+}

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section statistics_section notifications find_help page_header].freeze
+  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements risk_level see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section statistics_section notifications find_help page_header].freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/landing_page/_risk_level_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_risk_level_section.html.erb
@@ -1,17 +1,17 @@
 <% if data["show_risk_level_section"] %>
   <%= render "govuk_publishing_components/components/govspeak", {
   } do %>
-    <div class="info-notice">
+    <div class="info-notice covid__alert-notice">
       <% if data["heading"].present? %>
         <h3><%= data["heading"] %></h3>
       <% end %>
       <% if data["paragraph"].present? %>
-        <p class="govuk-body">
+        <p class="govuk-body covid__alert-notice-body">
           <%= highlight(data["paragraph"], data["bold_text"], highlighter: '<strong>\1</strong>') %>
         </p>
       <% end %>
       <% if data["link"].present? %>
-        <p class="govuk-body">
+        <p class="govuk-body covid__alert-notice-body">
           <a href="<%= data["link"]["href"] %>"><%= data["link"]["text"] %></a>
         </p>
       <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_risk_level_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_risk_level_section.html.erb
@@ -1,0 +1,20 @@
+<% if data["show_risk_level_section"] %>
+  <%= render "govuk_publishing_components/components/govspeak", {
+  } do %>
+    <div class="info-notice">
+      <% if data["heading"].present? %>
+        <h3><%= data["heading"] %></h3>
+      <% end %>
+      <% if data["paragraph"].present? %>
+        <p class="govuk-body">
+          <%= highlight(data["paragraph"], data["bold_text"], highlighter: '<strong>\1</strong>') %>
+        </p>
+      <% end %>
+      <% if data["link"].present? %>
+        <p class="govuk-body">
+          <a href="<%= data["link"]["href"] %>"><%= data["link"]["text"] %></a>
+        </p>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/coronavirus_landing_page/components/shared/_announcements_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements_section.html.erb
@@ -6,9 +6,7 @@
     margin_bottom: 6,
   } %>
 
-  <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { 
-    announcements: details.announcements
-  } %>
+  <%= render partial: 'coronavirus_landing_page/components/shared/announcements', locals: { announcements: details.announcements } %>
 
   <% if details.see_all_announcements_link.present? %>
     <p class="govuk-body">
@@ -24,4 +22,5 @@
       </a>
     </p>
   <% end %>
+  <%= render partial: 'coronavirus_landing_page/components/landing_page/risk_level_section', locals: { data: details.risk_level } if details.risk_level %>
 </section>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -44,6 +44,16 @@
         "href": "/government/publications/further-businesses-and-premises-to-close"
       }
     ],
+    "risk_level": {
+      "heading": "COVID-19 alert level",
+      "show_risk_level_section": false,
+      "paragraph":"Level X of 5 – this is the alert level!",
+      "bold_text": "Level X of 5",
+      "link": {
+        "href": "/risk-level",
+        "text": "Read more about COVID-19 alert levels"
+      }
+    },
     "nhs_banner": {
       "heading": "Do not leave home if you or someone you live with has either:",
       "list": [

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -46,6 +46,18 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_popular_questions_link
     end
 
+    it "shows COVID-19 risk level when risk level is enabled" do
+      given_there_is_a_content_item_with_risk_level_element_enabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_see_the_risk_level
+    end
+
+    it "does not show COVID-19 risk level when risk level is not enabled" do
+      given_there_is_a_content_item_with_risk_level_element_not_enabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_not_see_the_risk_level
+    end
+
     it "renders machine readable content" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -56,6 +56,18 @@ def content_item_with_popular_questions_link_enabled
   content_item
 end
 
+def coronavirus_content_item_with_risk_level_element_enabled
+  content_item = coronavirus_content_item
+  content_item["details"]["risk_level"]["show_risk_level_section"] = true
+  content_item
+end
+
+def coronavirus_content_item_with_risk_level_element_not_enabled
+  content_item = coronavirus_content_item
+  content_item["details"]["risk_level"]["show_risk_level_section"] = false
+  content_item
+end
+
 def business_content_item
   random_landing_page do |item|
     item.merge(business_content_item_fixture)

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -35,6 +35,14 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_popular_questions_link_enabled)
   end
 
+  def given_there_is_a_content_item_with_risk_level_element_enabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_risk_level_element_enabled)
+  end
+
+  def given_there_is_a_content_item_with_risk_level_element_not_enabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_risk_level_element_not_enabled)
+  end
+
   def given_there_is_a_business_content_item
     stub_content_store_has_item(BUSINESS_PATH, business_content_item)
   end
@@ -158,6 +166,14 @@ module CoronavirusLandingPageSteps
   def and_i_can_see_business_links_to_search
     assert page.has_link?("News", href: "/search/news-and-communications?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
     assert page.has_link?("Guidance", href: "/search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
+  end
+
+  def then_i_can_see_the_risk_level
+    assert page.has_selector?('[data-module="govspeak"]', text: "COVID-19 alert level")
+  end
+
+  def then_i_can_not_see_the_risk_level
+    assert page.has_no_selector?('[data-module="govspeak"]', text: "COVID-19 alert level")
   end
 
   def then_the_special_announcement_schema_is_rendered


### PR DESCRIPTION
### What
Build a page element to indicate the national coronavirus risk-level.

<img width="685" alt="Screenshot 2020-05-14 at 14 45 54" src="https://user-images.githubusercontent.com/7116819/81942150-ad937300-95f1-11ea-9bc0-146b9ead8f31.png">


### Why
👉 👉 👉 https://trello.com/c/zPDbYoE3

https://github.com/alphagov/govuk-coronavirus-content/pull/234 needs to be reviewed and published first. 




