### PR TITLE
Featured links automatically showing description

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -144,6 +144,10 @@
   }
 }
 
+.covid__list-item-description {
+  padding-left: govuk-spacing(6);
+}
+
 .covid__list-item {
   margin-bottom: govuk-spacing(2);
 }

--- a/app/helpers/content_item_helper.rb
+++ b/app/helpers/content_item_helper.rb
@@ -1,0 +1,6 @@
+module ContentItemHelper
+  def content_item_description(content_item_url)
+    content_item = ContentItem.find!(content_item_url)
+    content_item.description
+  end
+end

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -11,6 +11,12 @@
             href: item["url"],
             text: item["label"]
           }%>
+          <% item_description = content_item_description item["url"] %>
+          <% if item_description %>
+            <p class="govuk-body covid__list-item-description">
+              <%= item_description %>
+            </p>
+          <% end %>
         <% else %>
           <%= link_to(
             item["label"],

--- a/test/unit/content_item_helper_test.rb
+++ b/test/unit/content_item_helper_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+describe ContentItemHelper do
+  setup do
+    url = content_store_endpoint + "/content/blah/blah"
+    stub_request(:get, url).to_return(status: 200, body: {
+      description: "This is a description for a content item",
+    }.to_json)
+  end
+
+  describe "#content_item_description" do
+    it "returns description for content item" do
+      assert_equal "This is a description for a content item", content_item_description("/blah/blah")
+    end
+  end
+end


### PR DESCRIPTION
## What
Add meta descriptions automatically below hub links in the accordion. (See attached design).

## Why
To give me context on the hub content, and allow for short links.

<img width="1012" alt="Screenshot 2020-05-14 at 12 23 33" src="https://user-images.githubusercontent.com/4599889/81928827-cdb93700-95dd-11ea-849f-45050786fa7f.png">


https://trello.com/c/rBSB0bIQ/281-automatically-add-the-hub-page-metadescription-below-hub-links-in-the-accordion