### PR TITLE
Add a basic ministers controller

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -1,0 +1,14 @@
+class MinistersController < ApplicationController
+  before_action :set_locale
+
+  def index
+    @ministers = MinistersIndex.find!(request.path)
+    setup_content_item_and_navigation_helpers(@ministers)
+  end
+
+private
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+end

--- a/app/models/ministers_index.rb
+++ b/app/models/ministers_index.rb
@@ -1,0 +1,16 @@
+require "active_model"
+
+class MinistersIndex
+  include ActiveModel::Model
+
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Ministers - GOV.UK" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+        title: 'Ministers',
+    } %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       as: :services_and_information
 
   get "/government/people/:name(.:locale)", to: "people#show"
+  get "/government/ministers(.:locale)", to: "ministers#index"
   get "/government/ministers/:name(.:locale)", to: "roles#show"
 
   scope :api, defaults: { format: :json } do

--- a/test/integration/ministers_test.rb
+++ b/test/integration/ministers_test.rb
@@ -1,0 +1,29 @@
+require "integration_test_helper"
+
+class MinistersTest < ActionDispatch::IntegrationTest
+  before do
+    stub_content_store_has_item("/government/ministers", ministers_content_hash)
+    visit "/government/ministers"
+  end
+
+  it "returns 200 when visiting ministers page" do
+    assert_equal 200, page.status_code
+  end
+
+  it "renders webpage title" do
+    assert page.has_title?("Ministers - GOV.UK")
+  end
+
+  it "renders page title" do
+    assert page.has_css?(".gem-c-title__text", text: "Ministers")
+  end
+
+private
+
+  def ministers_content_hash
+    @content_hash = {
+      title: "Ministers",
+      details: {},
+    }
+  end
+end


### PR DESCRIPTION
This will be used eventually to render the /government/ministers page.

[Trello Card](https://trello.com/c/TQoflknm/1981-get-ministers-page-rendered-by-collections-using-the-data-in-the-content-item)