### PR TITLE
Add popular questions link

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -125,6 +125,19 @@
     margin-bottom: govuk-spacing(4);
   }
 }
+.covid__spaced-list>li {
+  &:nth-child(2n) {
+    margin-bottom: govuk-spacing(5);
+
+    @include govuk-media-query($from: desktop) {
+      margin-bottom: govuk-spacing(4);
+    }
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
 
 .covid__list--header {
   padding-left: govuk-spacing(4);

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -1,6 +1,10 @@
+<%
+  list_css_classes = %w(govuk-list)
+  list_css_classes << "covid__spaced-list" if live_stream["spaced_links"]
+%>
 <section class="covid__topic-wrapper">
   <%= render "govuk_publishing_components/components/heading", {
-    text: details.live_stream["title"],
+    text: live_stream["title"],
     heading_level: 2,
     margin_bottom: 6,
     padding: true,
@@ -8,23 +12,30 @@
   } %>
 
   <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream', locals: {
-    live_stream: details.live_stream
+    live_stream: live_stream
   } %>
-  <ul class="govuk-list">
+  <ul class="<%= list_css_classes.join(' ') %>">
     <li class="covid__topic-list-item">
-      <a href="<%= details.live_stream["transcript_link"] %>" class="covid__topic-list-link govuk-link">
-        <%= details.live_stream["transcript_text"] %>
+      <a href="<%= live_stream["transcript_link"] %>" class="covid__topic-list-link govuk-link">
+        <%= live_stream["transcript_text"] %>
       </a>
     </li>
     <li class="covid__topic-list-item">
-      <a href="<%= details.live_stream["previous_videos"]["url"] %>" class="covid__topic-list-link govuk-link">
-        <%= details.live_stream["previous_videos"]["previous_videos_text"] %>
+      <a href="<%= live_stream["previous_videos"]["url"] %>" class="covid__topic-list-link govuk-link">
+        <%= live_stream["previous_videos"]["previous_videos_text"] %>
       </a>
     </li>
-    <% if details.live_stream["ask_a_question_visible"] == true %>
+    <% if live_stream["ask_a_question_visible"] == true %>
       <li class="covid__topic-list-item">
-        <a href="<%= details.live_stream["ask_a_question_link"] %>" class="covid__topic-list-link govuk-link">
-          <%= details.live_stream["ask_a_question_text"] %>
+        <a href="<%= live_stream["ask_a_question_link"] %>" class="covid__topic-list-link govuk-link">
+          <%= live_stream["ask_a_question_text"] %>
+        </a>
+      </li>
+    <% end %>
+    <% if live_stream["popular_questions_link_visible"] == true %>
+      <li class="covid__topic-list-item">
+        <a href="<%= live_stream["see_popular_questions_link"] %>" class="covid__topic-list-link govuk-link">
+          <%= live_stream["see_popular_questions_text"] %>
         </a>
       </li>
     <% end %>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -47,7 +47,7 @@
       <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections, heading: details.sections_heading }%>
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
-      <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { details: details } %>
+      <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { live_stream: details.live_stream } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.statistics_section } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -385,6 +385,9 @@
       },
       "ask_a_question_text": "Ask a question at the next press conference",
       "ask_a_question_link": "https://www.gov.uk",
+      "popular_questions_link_visible": true,
+      "see_popular_questions_text": "See the types of questions submitted by the public",
+      "see_popular_questions_link": "https://www.gov.uk",
       "date_text": "Live streamed"
     },
     "live_stream_enabled": false,

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -40,6 +40,12 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_ask_a_question_section
     end
 
+    it "optionally shows the popular questions link when a live stream is enabled" do
+      given_there_is_a_content_item_with_popular_questions_link_enabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_see_the_popular_questions_link
+    end
+
     it "renders machine readable content" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -50,6 +50,12 @@ def content_item_with_live_stream_enabled_and_ask_a_question_enabled
   content_item
 end
 
+def content_item_with_popular_questions_link_enabled
+  content_item = coronavirus_content_item
+  content_item["details"]["live_stream"]["popular_questions_link_visible"] = true
+  content_item
+end
+
 def business_content_item
   random_landing_page do |item|
     item.merge(business_content_item_fixture)

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -31,6 +31,10 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_live_stream_enabled_and_ask_a_question_enabled)
   end
 
+  def given_there_is_a_content_item_with_popular_questions_link_enabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_popular_questions_link_enabled)
+  end
+
   def given_there_is_a_business_content_item
     stub_content_store_has_item(BUSINESS_PATH, business_content_item)
   end
@@ -112,6 +116,10 @@ module CoronavirusLandingPageSteps
 
   def then_i_can_see_the_ask_a_question_section
     assert page.has_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
+  end
+
+  def then_i_can_see_the_popular_questions_link
+    assert page.has_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
   end
 
   def and_there_is_no_ask_a_question_section


### PR DESCRIPTION
Add template logic to allow for an optional popular questions link to be added after the other links in the live stream section.

Add (optional) CSS class to the group of links. The CSS class adds additional margin after every 2nd link in the list, for increased legibility. 
The default state will be no extra spacing, unless `spaced_links` is set to `true` in YML

----
Relevant content PR to go with this change 👉  https://github.com/alphagov/govuk-coronavirus-content/pull/236
Trello card 👉 https://trello.com/c/tGEzCbPw