### PR TITLE
Add ministers section headers

### DIFF
--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -3,7 +3,51 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
-        title: 'Ministers',
+      title: "Ministers",
     } %>
   </div>
 </div>
+
+<section class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Cabinet ministers",
+      id: "cabinet-ministers",
+      margin_bottom: 4,
+      padding: true,
+    } %>
+  </div>
+</section>
+
+<section class="govuk-grid-row govuk-!-padding-top-9">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Also attends Cabinet",
+      id: "also-attends-cabinet-ministers",
+      margin_bottom: 4,
+      padding: true,
+    } %>
+  </div>
+</section>
+
+<section class="govuk-grid-row govuk-!-padding-top-9">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Ministers by department",
+      id: "ministers-by-department",
+      margin_bottom: 4,
+      padding: true,
+    } %>
+  </div>
+</section>
+
+<section class="govuk-grid-row govuk-!-padding-top-9">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Whips",
+      id: "whips",
+      margin_bottom: 4,
+      padding: true,
+    } %>
+  </div>
+</section>

--- a/test/integration/ministers_test.rb
+++ b/test/integration/ministers_test.rb
@@ -18,6 +18,13 @@ class MinistersTest < ActionDispatch::IntegrationTest
     assert page.has_css?(".gem-c-title__text", text: "Ministers")
   end
 
+  it "renders section headers" do
+    assert page.has_css?(".gem-c-heading", text: "Cabinet ministers")
+    assert page.has_css?(".gem-c-heading", text: "Also attends Cabinet")
+    assert page.has_css?(".gem-c-heading", text: "Ministers by department")
+    assert page.has_css?(".gem-c-heading", text: "Whips")
+  end
+
 private
 
   def ministers_content_hash


### PR DESCRIPTION
This adds the various section headers necessary to render the ministers page. Based on https://github.com/alphagov/whitehall/blob/master/app/views/ministerial_roles/index.html.erb.

<img width="450" alt="Screenshot 2020-05-15 at 09 04 38" src="https://user-images.githubusercontent.com/510498/82027065-9739f580-968b-11ea-8c0f-1d0b836f16ff.png">

[Trello Card](https://trello.com/c/TQoflknm/1981-get-ministers-page-rendered-by-collections-using-the-data-in-the-content-item)