### PR TITLE
Show a description on featured links

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -157,6 +157,10 @@
   }
 }
 
+.covid__list-item-description {
+  padding-left: govuk-spacing(6);
+}
+
 .covid__list-item {
   margin-bottom: govuk-spacing(2);
 }

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -158,6 +158,7 @@
 }
 
 .covid__list-item-description {
+  margin-top: govuk-spacing(2);
   padding-left: govuk-spacing(6);
 }
 

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -11,6 +11,12 @@
             href: item["url"],
             text: item["label"]
           }%>
+          <% item_description = item["description"] %>
+          <% if item_description %>
+            <p class="govuk-body covid__list-item-description">
+              <%= item_description %>
+            </p>
+          <% end %>
         <% else %>
           <%= link_to(
             item["label"],


### PR DESCRIPTION
We're doing this from the content item initially to validate the need.

If we want to do this from content items, we should use links in the /coronavirus content item if we can, rather than requesting lots of extra things from the API. We need to make sure that this page can cope with load.

Relies on alphagov/govuk-coronavirus-content#240 being published before they will show.(Now done ✅)

Resurrected from https://github.com/alphagov/collections/pull/1740