### PR TITLE
Tweaks to covid featured descriptions

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -158,7 +158,8 @@
 }
 
 .covid__list-item-description {
-  margin-top: govuk-spacing(2);
+  @include govuk-font(16);
+  margin-top: govuk-spacing(1);
   padding-left: govuk-spacing(6);
 }
 


### PR DESCRIPTION
Use the 16px font and halve the margin after feedback from designers.
