### PR TITLE
Fix 'Stay up to date' wrapping text

### DIFF
--- a/app/assets/stylesheets/views/_transition-landing-page.scss
+++ b/app/assets/stylesheets/views/_transition-landing-page.scss
@@ -109,6 +109,7 @@ $red: #E61E32;
 
 .landing-page__email-title {
   margin-bottom: govuk-spacing(2);
+  margin-left: govuk-spacing(5);
 }
 
 .landing-page__divide {


### PR DESCRIPTION
On small screens the heading wraps onto a new line underneath the icon, when it should wrap underneath itself.

**Bad:**
<img width="290" alt="Screenshot 2020-05-18 at 16 08 28" src="https://user-images.githubusercontent.com/7116819/82229047-d4b7b080-9921-11ea-84d9-bff0e8a26907.png">


**Not bad:**
<img width="301" alt="Screenshot 2020-05-18 at 16 08 13" src="https://user-images.githubusercontent.com/7116819/82229069-dc775500-9921-11ea-8b06-bd7c42fefa80.png">


Use flexbox to ensure the heading and icon align as expected on small mobiles.

https://trello.com/c/0pGcADKT
