### PR TITLE
Read email signup URL from the content item

### DIFF
--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -56,7 +56,7 @@
           <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"/>
         </svg>
         <h3 class="govuk-heading-s landing-page__email-title"><%= details.notifications["intro"] %></h3>
-        <%= link_to(details.notifications["email_link"], "/email-signup?link=/government/topical-events/coronavirus-covid-19-uk-government-response", {
+        <%= link_to(details.notifications["email_link"], details.notifications["email_url"], {
           class: "govuk-body govuk-link",
           data: {
             module: "track-click",

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -362,7 +362,8 @@
     },
     "notifications": {
       "intro": "Stay up to date with GOV.UK",
-      "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+      "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website",
+      "email_url": "/email-signup?topic=/coronavirus-taxon"
     },
     "live_stream": {
       "time": "",


### PR DESCRIPTION
I'm not sure why this was hardcoded :-/

https://trello.com/c/YcHD5ywk/292-switchover-email-signup-links-on-the-landing-page-to-use-the-taxonomy