### PR TITLE
Sort organisations by type for "works with" section

### DIFF
--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -4,6 +4,24 @@ module Organisations
     include ActionView::Helpers::UrlHelper
     include OrganisationsHelper
 
+    LISTING_ORDER = %w[
+      executive_office
+      ministerial_department
+      non_ministerial_department
+      executive_agency
+      executive_ndpb
+      advisory_ndpb
+      tribunal
+      public_corporation
+      independent_monitoring_body
+      adhoc_advisory_group
+      devolved_administration
+      sub_organisation
+      other
+      civil_service
+      court
+    ].freeze
+
     def initialize(organisations)
       @organisations = organisations
     end
@@ -22,6 +40,10 @@ module Organisations
         public_corporations: @organisations.public_corporations,
         devolved_administrations: @organisations.devolved_administrations,
       }
+    end
+
+    def ordered_works_with(organisation)
+      organisation.fetch("works_with", []).to_a.sort_by { |type, _departments| LISTING_ORDER.index(type) || 999 }
     end
 
     def works_with_statement(organisation)

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -41,7 +41,7 @@
                 <p class="organisation-list__item-works-with"><%= @presented_organisations.works_with_statement(organisation) %></p>
                 <%= render partial: 'expanded_works_with_organisations',
                   locals: {
-                    works_with_organisations: organisation["works_with"],
+                    works_with_organisations: @presented_organisations.ordered_works_with(organisation),
                     current_organisation: organisation["title"]
                   } %>
               </div>

--- a/test/presenters/organisations_presenter_test.rb
+++ b/test/presenters/organisations_presenter_test.rb
@@ -98,7 +98,7 @@ describe Organisations::IndexPresenter do
     end
   end
 
-  describe "#works_with" do
+  describe "#works_with_statement" do
     before :each do
       content_item = ContentItem.new(some_non_ministerial_departments_hash)
       content_store_organisations = ContentStoreOrganisations.new(content_item)
@@ -143,6 +143,60 @@ describe Organisations::IndexPresenter do
       }.with_indifferent_access
 
       assert_equal "Works with 2 agencies and public bodies", @organisations_presenter.works_with_statement(test_org)
+    end
+  end
+
+  describe "#ordered_works_with" do
+    before :each do
+      content_item = ContentItem.new(some_non_ministerial_departments_hash)
+      content_store_organisations = ContentStoreOrganisations.new(content_item)
+      @organisations_presenter = Organisations::IndexPresenter.new(content_store_organisations)
+    end
+
+    it "returns [] when organisation does not work with others" do
+      assert_equal [], @organisations_presenter.ordered_works_with({})
+    end
+
+    it "returns organisation groups in the correct order" do
+      test_org = {
+        works_with: {
+          other: [
+            {
+              title: "HM Crown Prosecution Service Inspectorate",
+              path: "/government/organisations/hm-crown-prosecution-service-inspectorate",
+            },
+          ],
+          non_ministerial_department: [
+            {
+              title: "Crown Prosecution Service",
+              path: "/government/organisations/crown-prosecution-service",
+            },
+          ],
+        },
+      }.with_indifferent_access
+
+      expected = [
+        [
+          "non_ministerial_department",
+          [
+            {
+              "title" => "Crown Prosecution Service",
+              "path" => "/government/organisations/crown-prosecution-service",
+            },
+          ],
+        ],
+        [
+          "other",
+          [
+            {
+              "title" => "HM Crown Prosecution Service Inspectorate",
+              "path" => "/government/organisations/hm-crown-prosecution-service-inspectorate",
+            },
+          ],
+        ],
+      ]
+
+      assert_equal expected, @organisations_presenter.ordered_works_with(test_org)
     end
   end
 


### PR DESCRIPTION
When we switched publishing-api to use JSONB columns, the order of the
works_with hash became arbitrary.  We shouldn't be relying on the
order of a hash anyway, so copy over the ordering from Whitehall and
sort in the presenter.

Compare "view all" for Cabinet Office on [this branch](https://govuk-collec-msw-ordere-4gx4zv.herokuapp.com/government/organisations) and [production](https://www.gov.uk/government/organisations).

---

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4081728)