### PR TITLE
Switch asset hostname

### DIFF
--- a/app/models/schemas/how_to.rb
+++ b/app/models/schemas/how_to.rb
@@ -7,8 +7,9 @@ class Schemas::HowTo
     to: :step_by_step,
   )
 
-  def initialize(step_by_step)
+  def initialize(step_by_step, view_context)
     @step_by_step = step_by_step
+    @view_context = view_context
     @step_image_index = 1
   end
 
@@ -50,7 +51,7 @@ class Schemas::HowTo
 
 private
 
-  attr_reader :step_by_step, :step_image_index
+  attr_reader :step_by_step, :step_image_index, :view_context
 
   def how_to_direction(content, index)
     {
@@ -92,18 +93,14 @@ private
     end || image_urls["placeholder"]
   end
 
-  def image_url(image_file)
-    ActionController::Base.helpers.asset_url(image_file, type: :image)
-  end
-
   def image_urls
     @image_urls ||= begin
       (1..12).each_with_object({}) { |index, image_urls|
-        image_urls[index.to_s] = image_url("step-#{index}.png")
+        image_urls[index.to_s] = view_context.image_url("step-#{index}.png")
       }.merge(
-        "or" => image_url("step-or.png"),
-        "and" => image_url("step-and.png"),
-        "placeholder" => image_url("govuk_publishing_components/govuk-schema-placeholder-1x1.png"),
+        "or" => view_context.image_url("step-or.png"),
+        "and" => view_context.image_url("step-and.png"),
+        "placeholder" => view_context.image_url("govuk_publishing_components/govuk-schema-placeholder-1x1.png"),
       )
     end
   end

--- a/app/views/step_nav/_structured_data.html.erb
+++ b/app/views/step_nav/_structured_data.html.erb
@@ -1,3 +1,3 @@
 <script type="application/ld+json">
-  <%= raw Schemas::HowTo.new(step_by_step).structured_data.to_json %>
+  <%= raw Schemas::HowTo.new(step_by_step, self).structured_data.to_json %>
 </script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,11 @@ module Collections
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
     config.i18n.fallbacks = true
 
-    config.assets.prefix = "/collections/"
+    config.assets.prefix = "/assets/collections/"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
 
     # Override Rails 4 default which restricts framing to SAMEORIGIN.
     config.action_dispatch.default_headers = {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,9 +34,6 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  if ENV["GOVUK_ASSET_ROOT"].present?
-    config.asset_host = ENV["GOVUK_ASSET_ROOT"]
-  end
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,10 +1,4 @@
 Rails.application.configure do
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -32,9 +26,6 @@ Rails.application.configure do
   config.assets.compile = false
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,4 @@
-Rails.application.config.assets.precompile += %w[
-  print.css
-]
+Rails.application.config.assets.precompile += %w[print.css]
 
 Rails.application.config.assets.prefix = "/collections"
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,5 +1,3 @@
 Rails.application.config.assets.precompile += %w[print.css]
 
-Rails.application.config.assets.prefix = "/collections"
-
 Rails.application.config.assets_version = "1.0"

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,7 +1,3 @@
 Collections::Application.configure do
   config.slimmer.logger = Rails.logger
-
-  if Rails.env.development?
-    config.slimmer.asset_host = Plek.current.find("static")
-  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,6 @@ end
 # Duplicated in test_helper.rb
 ENV["GOVUK_WEBSITE_ROOT"] = "http://www.test.gov.uk"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
-ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 ENV["RAILS_ENV"] ||= "test"
 
 require "cucumber/rails"

--- a/test/models/schemas/how_to_test.rb
+++ b/test/models/schemas/how_to_test.rb
@@ -5,7 +5,8 @@ describe Schemas::HowTo do
     it "generates structured data using the HowTo schema" do
       content_item = GovukSchemas::Example.find("step_by_step_nav", example_name: "learn_to_drive_a_car")
       step_by_step = StepNav.new(ContentItem.new(content_item))
-      how_to = Schemas::HowTo.new(step_by_step)
+      view_context = ApplicationController.new.view_context
+      how_to = Schemas::HowTo.new(step_by_step, view_context)
 
       # Generated with:
       # puts JSON.pretty_generate(how_to.structured_data)

--- a/test/models/schemas/how_to_test.rb
+++ b/test/models/schemas/how_to_test.rb
@@ -13,12 +13,12 @@ describe Schemas::HowTo do
         "@context": "http://schema.org",
         "@type": "HowTo",
         "description": "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
-        "image": "/collections/govuk_publishing_components/govuk-schema-placeholder-1x1-5ceffac04f7f6d4f421bd1d36dbb723ef48c15426d7f77f90be80a83af3c747e.png",
+        "image": "/assets/collections/govuk_publishing_components/govuk-schema-placeholder-1x1-5ceffac04f7f6d4f421bd1d36dbb723ef48c15426d7f77f90be80a83af3c747e.png",
         "name": "Learn to drive a car: step by step",
         "step": [
           {
             "@type": "HowToStep",
-            "image": "/collections/step-1-ba1b6be36d611d7a23778cdfc6f66822209f2a26447233fa6ba5ad8d9b715887.png",
+            "image": "/assets/collections/step-1-ba1b6be36d611d7a23778cdfc6f66822209f2a26447233fa6ba5ad8d9b715887.png",
             "name": "Check you're allowed to drive",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#check-you-re-allowed-to-drive",
             "position": 1,
@@ -50,7 +50,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-2-5684f7637a48dc3805c8f5fdd2ff4a071ae68e4df780f689e98b1b089b6a2a2f.png",
+            "image": "/assets/collections/step-2-5684f7637a48dc3805c8f5fdd2ff4a071ae68e4df780f689e98b1b089b6a2a2f.png",
             "name": "Get a provisional driving licence",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#get-a-provisional-driving-licence",
             "position": 2,
@@ -65,7 +65,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-3-38f4e6cd39f0cde6f8d1b5d8b140edc387eb7763c3d12445fef1d6f97fc91567.png",
+            "image": "/assets/collections/step-3-38f4e6cd39f0cde6f8d1b5d8b140edc387eb7763c3d12445fef1d6f97fc91567.png",
             "name": "Driving lessons and practice",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#driving-lessons-and-practice",
             "position": 3,
@@ -103,7 +103,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-and-74cca23cff1ca95dc07450491bf13915cb46c3d473303e92a9d47e31256824d8.png",
+            "image": "/assets/collections/step-and-74cca23cff1ca95dc07450491bf13915cb46c3d473303e92a9d47e31256824d8.png",
             "name": "Prepare for your theory test",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#prepare-for-your-theory-test",
             "position": 4,
@@ -130,7 +130,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-4-820e35a67c583f6ffd218bb2047b909187b7b657cf2c87510bdf4eef1581e362.png",
+            "image": "/assets/collections/step-4-820e35a67c583f6ffd218bb2047b909187b7b657cf2c87510bdf4eef1581e362.png",
             "name": "Book and manage your theory test",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#book-and-manage-your-theory-test",
             "position": 5,
@@ -174,7 +174,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-5-dbe629ccb75208fa3edc3b581894556f12413d0da257962becc9dbcd085a0ff2.png",
+            "image": "/assets/collections/step-5-dbe629ccb75208fa3edc3b581894556f12413d0da257962becc9dbcd085a0ff2.png",
             "name": "Book and manage your driving test",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#book-and-manage-your-driving-test",
             "position": 6,
@@ -217,7 +217,7 @@ describe Schemas::HowTo do
           },
           {
             "@type": "HowToStep",
-            "image": "/collections/step-6-d8851d68f990a07e721356a56182ec9a7a8e14d6948ec1c4c5bb073bf80d0f06.png",
+            "image": "/assets/collections/step-6-d8851d68f990a07e721356a56182ec9a7a8e14d6948ec1c4c5bb073bf80d0f06.png",
             "name": "When you pass",
             "url": "http://www.test.gov.uk/learn-to-drive-a-car#when-you-pass",
             "position": 7,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ end
 # Duplicated in features/support/env.rb
 ENV["GOVUK_WEBSITE_ROOT"] = "http://www.test.gov.uk"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
-ENV["GOVUK_ASSET_ROOT"] = "http://static.test.gov.uk"
 ENV["RAILS_ENV"] ||= "test"
 
 require File.expand_path("../config/environment", __dir__)


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is marked as a draft until [Puppet](https://github.com/alphagov/govuk-puppet/pull/10360) is merged and deployed.

This removes the configuration in this app that specifies that this app should use the `assets.publishing.service.gov.uk` hostname for serving assets with the expectation that these assets will instead be served off the `www` hostname. This is to implement [RFC 115](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-115-enabling-http2-on-govuk.md). Because of this the path to assets will be changed to be prefixed with `/assets` so all GOV.UK assets are hosted in the same path.

The asset host can still be configured in this app by a `ASSET_HOST` environment variable, this will be used in govuk-docker and publishing-e2e-tests to avoid needing additional nginx configuration.