### PR TITLE
Refactor some coronavirus landing page tests

### DIFF
--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -378,8 +378,9 @@
     "live_stream": {
       "time": "",
       "date": "19 April",
-      "title": "Live press conference",
-      "video_url": "https://www.youtube.com/embed/live_stream?channel=UC8o7mIMg3mmO9-dx3e2iFgw",
+      "date_text": "Live streamed",
+      "title": "Press conferences and speeches",
+      "video_url": "https://www.youtube.com/watch?v=Er09g2LdRmw",
       "no_cookies_message": "Watch the live stream on YouTube",
       "no_cookies": {
         "change_settings": "Change your cookie settings",
@@ -394,6 +395,7 @@
         "previous_videos_text": "Watch all press conferences on YouTube",
         "next_conference_text": "The next live press conference will be shown here"
       },
+      "ask_a_question_visible" : true,
       "ask_a_question_text": "Ask a question at the next press conference",
       "ask_a_question_link": "https://www.gov.uk",
       "popular_questions_link_visible": true,
@@ -401,7 +403,6 @@
       "see_popular_questions_link": "https://www.gov.uk",
       "date_text": "Live streamed"
     },
-    "live_stream_enabled": false,
     "special_announcement_schema": {
       "category": "https://www.wikidata.org/wiki/Q81068910",
       "disease_prevention_info_url": "https://www.gov.uk/coronavirus",

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -11,6 +11,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_header_section
       then_i_can_see_the_nhs_banner
       then_i_can_see_the_accordions
+      then_i_can_see_the_live_stream_section
       and_i_can_see_links_to_search
     end
 
@@ -21,29 +22,30 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_accordions_content
     end
 
-    it "shows livestream date when a live stream is enabled" do
-      given_there_is_a_content_item_with_live_stream_enabled
+    it "displays all livestream information" do
+      given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_streamed_date
-      and_there_is_no_ask_a_question_section
+      then_i_can_see_the_ask_a_question_section
+      then_i_can_see_the_popular_questions_link
     end
 
-    it "optionally shows the time when a live stream is enabled" do
-      given_there_is_a_content_item_with_live_stream_enabled_and_date
+    it "optionally shows the time of a livestream" do
+      given_there_is_a_content_item_with_live_stream_time
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_date_and_time
     end
 
-    it "optionally shows the ask a question link when a live stream is enabled" do
-      given_there_is_a_content_item_with_live_stream_enabled_and_ask_a_question_enabled
+    it "optionally hides the ask a question link" do
+      given_there_is_a_content_item_with_ask_a_question_disabled
       when_i_visit_the_coronavirus_landing_page
-      then_i_can_see_the_ask_a_question_section
+      then_i_cannot_see_the_ask_a_question_section
     end
 
-    it "optionally shows the popular questions link when a live stream is enabled" do
-      given_there_is_a_content_item_with_popular_questions_link_enabled
+    it "optionally hides the popular questions link" do
+      given_there_is_a_content_item_with_popular_questions_link_disabled
       when_i_visit_the_coronavirus_landing_page
-      then_i_can_see_the_popular_questions_link
+      then_i_cannot_see_the_popular_questions_link
     end
 
     it "shows COVID-19 risk level when risk level is enabled" do
@@ -53,7 +55,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
     end
 
     it "does not show COVID-19 risk level when risk level is not enabled" do
-      given_there_is_a_content_item_with_risk_level_element_not_enabled
+      given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_not_see_the_risk_level
     end

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -31,40 +31,27 @@ def coronavirus_content_item
   end
 end
 
-def coronavirus_content_item_with_live_stream_enabled
+def coronavirus_content_item_with_live_stream_time
   content_item = coronavirus_content_item
-  content_item["details"]["live_stream_enabled"] = true
-  content_item
-end
-
-def coronavirus_content_item_with_live_stream_enabled_and_date
-  content_item = coronavirus_content_item_with_live_stream_enabled
   content_item["details"]["live_stream"]["time"] = "5:00pm"
-  content_item["details"]["live_stream"]["date"] = "19 April"
   content_item
 end
 
-def content_item_with_live_stream_enabled_and_ask_a_question_enabled
-  content_item = coronavirus_content_item_with_live_stream_enabled
-  content_item["details"]["live_stream"]["ask_a_question_visible"] = true
-  content_item
-end
-
-def content_item_with_popular_questions_link_enabled
+def content_item_with_ask_a_question_disabled
   content_item = coronavirus_content_item
-  content_item["details"]["live_stream"]["popular_questions_link_visible"] = true
+  content_item["details"]["live_stream"]["ask_a_question_visible"] = false
+  content_item
+end
+
+def content_item_with_popular_questions_link_disabled
+  content_item = coronavirus_content_item
+  content_item["details"]["live_stream"]["popular_questions_link_visible"] = false
   content_item
 end
 
 def coronavirus_content_item_with_risk_level_element_enabled
   content_item = coronavirus_content_item
   content_item["details"]["risk_level"]["show_risk_level_section"] = true
-  content_item
-end
-
-def coronavirus_content_item_with_risk_level_element_not_enabled
-  content_item = coronavirus_content_item
-  content_item["details"]["risk_level"]["show_risk_level_section"] = false
   content_item
 end
 

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -19,20 +19,16 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
   end
 
-  def given_there_is_a_content_item_with_live_stream_enabled
-    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_enabled)
+  def given_there_is_a_content_item_with_live_stream_time
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_time)
   end
 
-  def given_there_is_a_content_item_with_live_stream_enabled_and_date
-    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_enabled_and_date)
+  def given_there_is_a_content_item_with_popular_questions_link_disabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_popular_questions_link_disabled)
   end
 
-  def given_there_is_a_content_item_with_live_stream_enabled_and_ask_a_question_enabled
-    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_live_stream_enabled_and_ask_a_question_enabled)
-  end
-
-  def given_there_is_a_content_item_with_popular_questions_link_enabled
-    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_popular_questions_link_enabled)
+  def given_there_is_a_content_item_with_ask_a_question_disabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, content_item_with_ask_a_question_disabled)
   end
 
   def given_there_is_a_content_item_with_risk_level_element_enabled
@@ -118,20 +114,32 @@ module CoronavirusLandingPageSteps
   end
 
   def then_i_can_see_the_live_stream_section_with_date_and_time
-    assert page.has_text?("19 April")
-    assert page.has_text?("5:00pm")
+    assert page.has_text?("19 April at 5:00pm")
   end
 
   def then_i_can_see_the_ask_a_question_section
     assert page.has_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
   end
 
+  def then_i_cannot_see_the_ask_a_question_section
+    assert page.has_no_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
+  end
+
   def then_i_can_see_the_popular_questions_link
     assert page.has_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
   end
 
+  def then_i_cannot_see_the_popular_questions_link
+    assert page.has_no_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
+  end
+
   def and_there_is_no_ask_a_question_section
     assert page.has_no_link?("Ask a question at the next press conference")
+  end
+
+  def then_i_can_see_the_live_stream_section
+    assert page.has_selector?(".covid__topic-wrapper h2", text: "Press conferences and speeches")
+    assert page.has_selector?(".covid__video-wrapper")
   end
 
   def then_i_can_see_the_nhs_banner


### PR DESCRIPTION
- Remove reference to old `livestream_enabled` key
- Set all optional fields to true in fixture, and turn
off in tests (except risk element tests as that still seems to be somewhat in flight).
[card](https://trello.com/c/02aizrky/287-refactor-and-add-tests-to-collections)