### PR TITLE
Add tracking for super breadcrumbs

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -9,7 +9,14 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <% title_link = capture do %>
-          Part of <a href="<%= title[:context][:href] %>" class="govuk-link covid__page-header-link">
+          Part of <a
+            href="<%= title[:context][:href] %>"
+            class="govuk-link covid__page-header-link"
+            data-module="track-click"
+            data-track-category="breadcrumbClicked"
+            data-track-action="superBreadcrumb"
+            data-track-label="<%= title[:context][:href] %>"
+          >
             <%= title[:context][:text] %>
           </a>
         <% end %>


### PR DESCRIPTION
We don't currently track users who click on the superbread crumbs (on the business & education hubs). As this feature is going to be rolled out with the new taxonomy it would be good to add tracking to understand if it is helping users navigate back through the pages.

Event category: breadcrumbClicked
Event action: superBreadcrumb
Event label: page path link (to hub page)

Its done when: When a users clicks on a super bread crumb an event is triggered in GA and we can track the page they were on and the page they went to.

https://trello.com/c/G2iuimyb/283-add-analytics-tracking-to-super-breadcrumb