### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,13 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-Rails/OutputSafety:
-  Enabled: false
-Rails/HelperInstanceVariable:
-  Enabled: false
-
-Metrics/BlockLength:
-  Exclude:
-    - 'config/routes.rb'
-    - 'features/**/*.rb'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
   end
 
   def page_text_direction
-    @page_text_direction ||= I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr")
+    @page_text_direction ||= I18n.t("shared.language_direction.#{I18n.locale}", default: "ltr") # rubocop:disable Rails/HelperInstanceVariable
   end
 
   def dir_attribute


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

We should avoid disabling Cops for the entire repo on the basis of
a single linting issue, which can be easily fixed/ignored in-place.