### PR TITLE
Initialise Toggle Attribute module after Accordions have been initialised

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,3 +9,8 @@
 //= require components/accordion
 //= require modules/coronavirus-landing-page
 //= require govuk_publishing_components/all_components
+
+$(document).on('ready', function(){
+  var toggleAttribute = new GOVUK.Modules.ToggleAttribute();
+  toggleAttribute.start($('[data-module=toggle-attribute]'));
+});


### PR DESCRIPTION
## What
It would appear the tracking on the accordion links broke yesterday (27 May) - with accordionOpen, now reading as accordionClosed.

We should investigate what caused the problem, and either fix it if we can or prod whoever needs to fix it.

https://trello.com/c/qThuLppG/315-investigate-why-the-accordion-track-broke-and-fix-it-if-we-can
