### PR TITLE
Tweak covid logo layout

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -80,7 +80,7 @@
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(8);
     position: absolute;
-    bottom: 0;
+    bottom: 10px;
     right: 0;
     width: 33%;
   }
@@ -88,7 +88,7 @@
 
 .covid__logos {
   display: block;
-  margin: 0 govuk-spacing(3);
+  margin: 0 auto;
   max-width: 50%;
   min-width: 230px;
   height: auto;


### PR DESCRIPTION
Tweak the logo on the coronavirus landing page.

Before (desktop):

<img width="966" alt="Screenshot 2020-05-29 at 12 00 33" src="https://user-images.githubusercontent.com/861310/83253228-88cbfd80-a1a4-11ea-9d1d-3660265180e3.png">

After (desktop):

<img width="893" alt="Screenshot 2020-05-29 at 12 05 26" src="https://user-images.githubusercontent.com/861310/83253324-b6b14200-a1a4-11ea-912d-2f5034b63e71.png">

Before (mobile):

<img width="535" alt="Screenshot 2020-05-29 at 12 00 26" src="https://user-images.githubusercontent.com/861310/83253253-98e3dd00-a1a4-11ea-806c-9c3694d4a5ba.png">

After (mobile):

<img width="574" alt="Screenshot 2020-05-29 at 12 03 04" src="https://user-images.githubusercontent.com/861310/83253270-a00aeb00-a1a4-11ea-97c3-b7c9af6cd298.png">

Trello card: https://trello.com/c/aGc1KYTd/309-improve-the-responsive-scaling-of-the-stay-alert-logo-in-the-landing-page-header