### PR TITLE
Hubs header spacing adjustment

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -48,16 +48,20 @@
   }
 }
 
+.covid__page-header-light--hub {
+  padding-bottom: 35px;
+
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: govuk-spacing(6);
+  }
+}
+
 .covid__announcement-published-text {
   margin-top: govuk-spacing(1);
 
   @include govuk-media-query($from: desktop) {
     margin-bottom: govuk-spacing(6);
   }
-}
-
-.covid__business-list-wrapper {
-  margin-bottom: 45px;
 }
 
 .covid__action-link-wrapper {

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -31,9 +31,9 @@
     </div>
   </div>
 
-  <div class="covid__page-header-light">
+  <div class="covid__page-header-light covid__page-header-light--hub">
     <div class="govuk-width-container">
-      <div class="govuk-grid-row covid__business-list-wrapper">
+      <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
             text: details.header_section["pretext"],


### PR DESCRIPTION
## What
We should reduce the blank space underneath the bullets on hub pages to match the space underneath the action link on the landing page.

## Why
Visual consistency and bringing the content further up the page


## Trello 
https://trello.com/c/cBaVFUui