### PR TITLE
Tweak transition tracking

### DIFF
--- a/app/presenters/transition_landing_page_presenter.rb
+++ b/app/presenters/transition_landing_page_presenter.rb
@@ -66,7 +66,7 @@ private
       data_attributes = {
         track_category: "transition-landing-page",
         track_action: link_item[:link][:path],
-        track_label: link_item[:link][:text],
+        track_label: "News",
       }
 
       link_item[:link][:data_attributes] = data_attributes

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -10,7 +10,7 @@ cy:
       <p>Bydd y rheolau cyfredol ar fasnach, teithio a busnes ar gyfer y DU a’r UE yn parhau i fod yn berthnasol yn ystod y cyfnod pontio.</p>
       <p>Bydd rheolau newydd yn dod i rym ar 1 Ionawr 2021.</p>
       <p>Dylech baratoi nawr a thanysgrifio i ddiweddariadau ebost am unrhyw drefniadau ychwanegol.</p>
-      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021">Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021</a>
+      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021" data-module="track-click">Gwiriwch sut i baratoi ar gyfer y rheolau newydd yn 2021</a>
     comms_header: "Newyddion"
     comms:
       links:

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -49,21 +49,21 @@ cy:
         list_block: |
           Ar ôl 1 Ionawr 2021, bydd angen i chi wneud datganiadau tollau i symud nwyddau i mewn ac allan o’r UE. Dylech chi:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="gael rhif EORI">gael rhif EORI</a> os nad oes gennych un yn barod</li>
-            <li>penderfynu sut yr hoffech wneud datganiadau tollau ac os oes angen i chi gael <a class="govuk-!-font-weight-bold" href="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="rhywun i ddelio â’r tollau ar eich rhan">rhywun i ddelio â’r tollau ar eich rhan</a>.</li>
+            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="What you can do now">gael rhif EORI</a> os nad oes gennych un yn barod</li>
+            <li>penderfynu sut yr hoffech wneud datganiadau tollau ac os oes angen i chi gael <a class="govuk-!-font-weight-bold" href="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="What you can do now">rhywun i ddelio â’r tollau ar eich rhan</a>.</li>
           </ul>
       - row_title: "Aros yn y DU os ydych yn ddinesydd o’r UE"
         list_block: |
           Gwiriwch os oes angen i chi gyflwyno cais i’r cynllun setliad os ydych chi, neu’ch teulu, yn dod o’r UE, neu o’r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
 
-          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Gwiriwch beth sydd angen i chi wneud i aros yn y DU">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
+          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="What you can do now">Gwiriwch beth sydd angen i chi wneud i aros yn y DU</a>
       - row_title: "Teithio i’r UE"
         list_block: |
           Gallwch barhau i deithio i’r UE fel arfer yn ystod y cyfnod pontio.
 
           O 1 Ionawr 2021 bydd rheolau newydd i deithio i'r UE, neu i'r Swistir, Norwy, Gwlad yr Iâ neu Liechtenstein.
 
-          <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="Gwiriwch beth sydd angen i chi wneud i deithio i Ewrop o 2021">Gwiriwch beth sydd angen i chi wneud i deithio i Ewrop o 2021</a>
+          <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="What you can do now">Gwiriwch beth sydd angen i chi wneud i deithio i Ewrop o 2021</a>
       - row_title: "Byw a gweithio yn yr UE"
         list_block: |
           Mae byw a gweithio mewn gwlad yr UE yn ddibynnol ar y rheolau yn y wlad honno.
@@ -72,7 +72,7 @@ cy:
 
           Efallai bydd angen i chi gyfnewid eich trwydded yrru DU am drwydded a roddir gan wlad yr UE ble rydych yn byw.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi</a>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="What you can do now">Gwiriwch beth sydd angen i chi wneud yn y wlad yr ydych yn byw ynddi</a>
     topic_section_header: Holl wybodaeth y cyfnod pontio
     topic_section_subheading: Pori’r holl wybodaeth sy’n berthnasol i’r cyfnod pontio
     email_intro: "I gael y manylion diweddaraf"

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -10,7 +10,7 @@ en:
       <p>The current rules on trade, travel, and business for the UK and EU will continue to apply during the transition period.</p>
       <p>New rules will take effect on 1 January 2021.</p>
       <p>You should prepare now and subscribe to email updates about any additional arrangements.</p>
-      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Check how to get ready for new rules in 2021">Check how to get ready for new rules in 2021</a></p>
+      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Check how to get ready for new rules in 2021" data-module="track-click">Check how to get ready for new rules in 2021</a></p>
     comms_header: "News"
     comms:
       links:

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -49,21 +49,21 @@ en:
         list_block: |
           From 1 January 2021 you will need to make customs declarations to move goods into and out of the EU. You should:
           <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="get an EORI number">get an EORI number</a> if you do not already have one</li>
-            <li>decide how you want to make customs declarations and whether you need to <a class="govuk-!-font-weight-bold" href="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="get someone to deal with customs for you">get someone to deal with customs for you</a>.</li>
+            <li><a class="govuk-!-font-weight-bold" href="/eori" data-track-category="transition-landing-page" data-track-action="/eori" data-track-label="What you can do now">get an EORI number</a> if you do not already have one</li>
+            <li>decide how you want to make customs declarations and whether you need to <a class="govuk-!-font-weight-bold" href="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-category="transition-landing-page" data-track-action="/guidance/appoint-someone-to-deal-with-customs-on-your-behalf" data-track-label="What you can do now">get someone to deal with customs for you</a>.</li>
           </ul>
       - row_title: "Staying in the UK if you’re an EU citizen"
         list_block: |
           Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
-          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="Check what you need to do to stay in the UK">Check what you need to do to stay in the UK</a>
+          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="What you can do now">Check what you need to do to stay in the UK</a>
       - row_title: "Travel to the EU"
         list_block: |
           You can continue to travel to the EU as usual during the transition period.
 
           From 1 January 2021 there will be new rules to travel to the EU, or to Switzerland, Norway, Iceland or Liechtenstein.
 
-          <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="Check what you need to do to travel to Europe from 2021">Check what you need to do to travel to Europe from 2021</a>
+          <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="What you can do now">Check what you need to do to travel to Europe from 2021</a>
       - row_title: "Living and working in the EU"
         list_block: |
           Living and working in an EU country depends on the rules in that country.
@@ -72,7 +72,7 @@ en:
 
           You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
 
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="Check what you must do in the country where you live">Check what you must do in the country where you live</a>
+          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="What you can do now">Check what you must do in the country where you live</a>
     topic_section_header: All transition period information
     topic_section_subheading: Browse all information related to the transition period
     email_intro: "Stay up to date"


### PR DESCRIPTION
Trello: https://trello.com/c/9CFX3mvB/306-change-tracking-attributes-on-the-transition-landing-page

## What

- Add missing `data-module='track-click'` attribute which was preventing our tracking event firing on the CTA link
- Change the event label for links in the 'News' and 'What You Can Do Now' sections so they reflect what section they're in.