### PR TITLE
Redirect traffic for the employee taxon to new hub page

### DIFF
--- a/app/controllers/taxons_redirection_controller.rb
+++ b/app/controllers/taxons_redirection_controller.rb
@@ -1,13 +1,13 @@
-class TaxonsRedirectionController < ApplicationController
-  CORONAVIRUS_LANDING_PAGE_PATH = "/coronavirus".freeze
-  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
+# frozen_string_literal: true
 
-  CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID = "65666cdf-b177-4d79-9687-b9c32805e450".freeze
-  CORONAVIRUS_EDUCATION_TAXON_CONTENT_ID = "272308f4-05c8-4d0d-abc7-b7c2e3ccd249".freeze
+class TaxonsRedirectionController < ApplicationController
+  CORONAVIRUS_LANDING_PAGE_PATH = "/coronavirus"
+  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon"
 
   HUB_PAGE_FROM_CONTENT_ID = {
-    CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID => "/coronavirus/business-support",
-    CORONAVIRUS_EDUCATION_TAXON_CONTENT_ID => "/coronavirus/education-and-childcare",
+    "65666cdf-b177-4d79-9687-b9c32805e450" => "/coronavirus/business-support",
+    "272308f4-05c8-4d0d-abc7-b7c2e3ccd249" => "/coronavirus/education-and-childcare",
+    "b7f57213-4b16-446d-8ded-81955d782680" => "/coronavirus/worker-support",
   }.freeze
 
   def redirect

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -94,7 +94,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_am_redirected_to_the_landing_page
     end
 
-    it "redirects subtaxons to appropriate hub pages" do
+    it "redirects taxons to appropriate hub pages" do
       given_there_is_a_business_content_item
       and_a_coronavirus_business_taxon
       when_i_visit_the_coronavirus_business_taxon

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -71,7 +71,7 @@ end
 
 def business_taxon_content_item
   random_taxon_page do |item|
-    item["content_id"] = TaxonsRedirectionController::CORONAVIRUS_BUSINESS_TAXON_CONTENT_ID
+    item["content_id"] = TaxonsRedirectionController::HUB_PAGE_FROM_CONTENT_ID.key("/coronavirus/business-support")
     item
   end
 end


### PR DESCRIPTION
## What
Adds an additional redirect for employee taxon to `/coronavirus/worker-support` 

## Why
We've set up a basic mapping between hub pages and their taxons, so when users click on taxonomy-based navigation links, they end up at the best hub page.

We want to extend this to allow traffic for the Work, financial support and money taxon to go to the new employee hub page.