### PR TITLE
Show email signups independently of guidance

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
@@ -1,41 +1,46 @@
-<% if guidance %>
+<% if guidance || email_signup %>
 <div class="covid__page-guidance">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: guidance["header"],
-          font_size: 19,
-          margin_bottom: 5
-        } %>
-        <ul class="covid__list govuk-!-margin-bottom-8">
-          <% guidance["list"].each do | item | %>
-            <li class="covid__list-item">
-              <%= render 'govuk_publishing_components/components/action_link', {
-                dark_icon: true,
-                href: item["url"],
-                text: item["text"],
-                data: {
-                  module: "track-click",
-                  track_category: "pageElementInteraction",
-                  track_action: "What you can do now",
-                  track_label: item["url"]
-                }
-              } %>
-            </li>
-          <% end %>
-        </ul>
-        <%= render partial: 'components/signup-link', locals: {
-          heading_level: 2,
-          link_text: email_signup["email_link"],
-          link_href: email_signup["email_url"],
-          heading: email_signup["intro"],
-          data: {
-            "module": "track-click",
-            "track-category": "emailAlertLinkClicked",
-            "track-action": request.path
-          },
-        } if email_signup %>
+        <% if guidance %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: guidance["header"],
+            font_size: 19,
+            margin_bottom: 5
+          } %>
+          <ul class="covid__list govuk-!-margin-bottom-8">
+            <% guidance["list"].each do | item | %>
+              <li class="covid__list-item">
+                <%= render 'govuk_publishing_components/components/action_link', {
+                  dark_icon: true,
+                  href: item["url"],
+                  text: item["text"],
+                  data: {
+                    module: "track-click",
+                    track_category: "pageElementInteraction",
+                    track_action: "What you can do now",
+                    track_label: item["url"]
+                  }
+                } %>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+
+        <% if email_signup %>
+          <%= render partial: 'components/signup-link', locals: {
+            heading_level: 2,
+            link_text: email_signup["email_link"],
+            link_href: email_signup["email_url"],
+            heading: email_signup["intro"],
+            data: {
+              "module": "track-click",
+              "track-category": "emailAlertLinkClicked",
+              "track-action": request.path
+            },
+          } %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -50,5 +50,5 @@
       </div>
     </div>
   </div>
-  <%= render 'coronavirus_landing_page/components/hub/guidance_section', guidance: details.guidance_section, related: details.related_links, email_signup: details.notifications %>
+  <%= render 'coronavirus_landing_page/components/hub/guidance_section', guidance: details.guidance_section, email_signup: details.notifications %>
 </header>


### PR DESCRIPTION
## What

We pass guidance and email_signups into this partial independently. We can
afford to be a little more granular about what we show.

## Why

The new worker support hub page doesn't have the top level "what you can do
now" style bullet points.

https://govuk-collec-email-hubs-itkyhp.herokuapp.com/coronavirus/business-support (has both sections)
https://govuk-collec-email-hubs-itkyhp.herokuapp.com/coronavirus/worker-support (just has email section)

![localhost_3070_coronavirus_worker-support_ssfsfd(iPad Pro)](https://user-images.githubusercontent.com/773037/83738632-74787c80-a64c-11ea-998a-d0f2000e414d.png)

![localhost_3070_coronavirus_worker-support_ssfsfd(iPhone 6_7_8)](https://user-images.githubusercontent.com/773037/83738635-75a9a980-a64c-11ea-9d8f-f555fff12e3c.png)

https://trello.com/c/hVL0rk7N/336-show-email-signups-on-worker-hub-page