### PR TITLE
Show only live high profile groups

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -38,20 +38,20 @@ module Organisations
     end
 
     def high_profile_groups
-      alphabetical_high_profile_groups = @org.ordered_high_profile_groups
-                                             &.sort_by { |key| key["base_path"] }
-
-      alphabetical_high_profile_groups&.map! do |group|
-        {
-          text: group["title"],
-          path: group["base_path"],
-        }
-      end
+      high_profile_groups = @org.ordered_high_profile_groups
+        &.filter { |org| %w[live exempt transitioning].include?(org["details"]["organisation_govuk_status"]["status"]) }
+        &.sort_by { |key| key["base_path"] }
+        &.map do |group|
+          {
+            text: group["title"],
+            path: group["base_path"],
+          }
+        end
 
       {
         title: I18n.t("organisations.high_profile_groups", title: acronym),
         brand: @org.brand,
-        items: alphabetical_high_profile_groups,
+        items: high_profile_groups,
       }
     end
 

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -84,10 +84,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
           {
             base_path: "/government/organisations/attorney-generals-office-1",
             title: "High Profile Group 1",
+            details: { organisation_govuk_status: { status: "live" } },
           },
           {
             base_path: "/government/organisations/attorney-generals-office-2",
             title: "High Profile Group 2",
+            details: { organisation_govuk_status: { status: "live" } },
           },
         ],
         ordered_roles: [
@@ -296,10 +298,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
           {
             base_path: "/government/organisations/attorney-generals-office-1",
             title: "High Profile Group 1",
+            details: { organisation_govuk_status: { status: "live" } },
           },
           {
             base_path: "/government/organisations/attorney-generals-office-2",
             title: "High Profile Group 2",
+            details: { organisation_govuk_status: { status: "live" } },
           },
         ],
       },

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -426,10 +426,17 @@ module OrganisationHelpers
           {
             base_path: "/government/organisations/rural-development-programme-for-england-network",
             title: "Rural Development Programme for England Network",
+            details: { organisation_govuk_status: { status: "live" } },
           },
           {
             base_path: "/government/organisations/another-rural-development-programme-for-england-network",
             title: "Another Rural Development Programme for England Network",
+            details: { organisation_govuk_status: { status: "live" } },
+          },
+          {
+            base_path: "/government/organisations/yet-another-rural-development-programme-for-england-network",
+            title: "Yet another Rural Development Programme for England Network",
+            details: { organisation_govuk_status: { status: "closed" } },
           },
         ],
       },


### PR DESCRIPTION
Currently we show all high profile groups, but we'd prefer to only show those that are live (including exempt and transitioning).

[Trello Card](https://trello.com/c/v5hehBfZ/2004-3-amend-the-organisation-home-page-view-in-collections-to-only-display-high-priority-groups-that-are-not-closed)