### PR TITLE
Change hub tracking label to be consistent with other pages

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -15,7 +15,7 @@
             data-module="track-click"
             data-track-category="breadcrumbClicked"
             data-track-action="superBreadcrumb"
-            data-track-label="<%= title[:context][:href] %>"
+            data-track-label="<%= request.path %>"
           >
             <%= title[:context][:text] %>
           </a>


### PR DESCRIPTION
The event label on the super breadcrumb on both of the hubs that takes the user back to /coronavirus is /coronavirus (rather than /coronavirus/business-support or /coronavirus/education-and-childcare).

Could we change it to /coronavirus/business-support & /coronavirus/education-and-childcare for it to be consistent with the other tagging.

https://trello.com/c/5FiUElVX/335-edit-super-breadcrumb-on-the-business-education-hub