### PR TITLE
Enable open/close all accordion tracking

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -5,11 +5,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function CoronavirusLandingPage () {}
 
   CoronavirusLandingPage.prototype.start = function ($element) {
+    var $this = this
     // Confirm the user is on the coronavirus landing page
     if (this.checkOnLandingPage()) {
       this.globarBarSeen()
     }
-    this.addAccordionOpenAllTracking($element)
+
+    // Ensure that the "Open/Close all" element exists when attaching the event listeners for tracking
+    $(document).ready(function() {
+      $this.addAccordionOpenAllTracking($element)
+    })
   }
 
   CoronavirusLandingPage.prototype.checkOnLandingPage = function () {


### PR DESCRIPTION
Event tracking for open/close all accordions does not currently work. This is because at the time we attach the event listener for tracking, the Open all element does not yet exist in the DOM.

This ensures that the event is attached after the element is in place.