### PR TITLE
Temporary hard code of header on education hub

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -30,22 +30,44 @@
       </div>
     </div>
   </div>
-
   <div class="covid__page-header-light covid__page-header-light--hub">
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: details.header_section["pretext"],
-            font_size: 19,
-            margin_bottom: 3,
-            inverse: true
-          } %>
-          <ul class="covid__list covid__list--header">
-            <% details.header_section["list"].each do | item | %>
-              <li class="covid__list-item"><%= item %></li>
-            <% end %>
-          </ul>
+          <% if params[:hub_slug] == "education-and-childcare" %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Guidance for teachers, school leaders, carers, parents and students",
+              font_size: 19,
+              margin_bottom: 3,
+              inverse: true
+            } %>
+            <p class="govuk-body covid__inverse">
+              In England:
+            </p>
+            <ul class="covid__list covid__list--header">
+              <li class="covid__list-item">children in nursery, reception, year 1 and year 6 can return to school</li>
+              <li class="covid__list-item">schools remain closed for other year groups, except for children of key workers and vulnerable children</li>
+              <li class="covid__list-item">childminders can return to work</li>
+            </ul>
+            <p class="govuk-body covid__inverse">
+              Find out when schools are expected to reopen in
+              <%= link_to "Scotland","https://www.gov.scot/news/schools-to-re-open-in-august/", class: "covid__page-header-link govuk-link"%>,
+              <%= link_to "Wales","https://gov.wales/how-schools-will-work-during-coronavirus-pandemic#section-38402", class: "covid__page-header-link govuk-link"%> and
+              <%= link_to "Northern Ireland","https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities", class: "covid__page-header-link govuk-link"%>.
+            </p>
+          <% else %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: details.header_section["pretext"],
+              font_size: 19,
+              margin_bottom: 3,
+              inverse: true
+            } %>
+            <ul class="covid__list covid__list--header">
+              <% details.header_section["list"].each do | item | %>
+                <li class="covid__list-item"><%= item %></li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- We need to add new links to the header, but also add new fields. Content changes in [this doc](https://docs.google.com/document/d/1hhFFRN8CWjWg5iAUoH1RTQfrztDpM-sATdpnwb9wckk/edit)
- Hardcoding the changes for now, then we can publish the new content item. 
  PR: https://github.com/alphagov/govuk-coronavirus-content/pull/277
- Then we can update collections to read from the new fields.

### Before:

<img width="705" alt="Screenshot 2020-06-08 at 13 11 30" src="https://user-images.githubusercontent.com/17908089/84029000-9b56eb80-a989-11ea-93ff-3512e719d98e.png">



### After:

<img width="758" alt="Screenshot 2020-06-08 at 13 34 28" src="https://user-images.githubusercontent.com/17908089/84030985-d3136280-a98c-11ea-89dd-3ddea208deed.png">
