### PR TITLE
Update coronavirus education hub page

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -35,13 +35,13 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: details.header_section["pretext"],
+            text: header["pretext"],
             font_size: 19,
             margin_bottom: 3,
             inverse: true
           } %>
           <ul class="covid__list covid__list--header">
-            <% details.header_section["list"].each do | item | %>
+            <% header["list"].each do | item | %>
               <li class="covid__list-item"><%= item %></li>
             <% end %>
           </ul>
@@ -49,5 +49,5 @@
       </div>
     </div>
   </div>
-  <%= render 'coronavirus_landing_page/components/hub/guidance_section', guidance: details.guidance_section, email_signup: details.notifications %>
+  <%= render 'coronavirus_landing_page/components/hub/guidance_section', guidance: guidance, email_signup: notifications %>
 </header>

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -34,40 +34,17 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <% if params[:hub_slug] == "education-and-childcare" %>
-            <%= render "govuk_publishing_components/components/heading", {
-              text: "Guidance for teachers, school leaders, carers, parents and students",
-              font_size: 19,
-              margin_bottom: 3,
-              inverse: true
-            } %>
-            <p class="govuk-body covid__inverse">
-              In England:
-            </p>
-            <ul class="covid__list covid__list--header">
-              <li class="covid__list-item">children in nursery, reception, year 1 and year 6 can return to school</li>
-              <li class="covid__list-item">schools remain closed for other year groups, except for children of key workers and vulnerable children</li>
-              <li class="covid__list-item">childminders can return to work</li>
-            </ul>
-            <p class="govuk-body covid__inverse">
-              Find out when schools are expected to reopen in
-              <%= link_to "Scotland","https://www.gov.scot/news/schools-to-re-open-in-august/", class: "covid__page-header-link govuk-link"%>,
-              <%= link_to "Wales","https://gov.wales/how-schools-will-work-during-coronavirus-pandemic#section-38402", class: "covid__page-header-link govuk-link"%> and
-              <%= link_to "Northern Ireland","https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities", class: "covid__page-header-link govuk-link"%>.
-            </p>
-          <% else %>
-            <%= render "govuk_publishing_components/components/heading", {
-              text: details.header_section["pretext"],
-              font_size: 19,
-              margin_bottom: 3,
-              inverse: true
-            } %>
-            <ul class="covid__list covid__list--header">
-              <% details.header_section["list"].each do | item | %>
-                <li class="covid__list-item"><%= item %></li>
-              <% end %>
-            </ul>
-          <% end %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: details.header_section["pretext"],
+            font_size: 19,
+            margin_bottom: 3,
+            inverse: true
+          } %>
+          <ul class="covid__list covid__list--header">
+            <% details.header_section["list"].each do | item | %>
+              <li class="covid__list-item"><%= item %></li>
+            <% end %>
+          </ul>
         </div>
       </div>
     </div>

--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -40,11 +40,24 @@
             margin_bottom: 3,
             inverse: true
           } %>
+          <% if header["list_heading"].present? %>
+            <p class="govuk-body covid__inverse">
+              <%= header["list_heading"] %>
+            </p>
+          <% end %>
           <ul class="covid__list covid__list--header">
             <% header["list"].each do | item | %>
               <li class="covid__list-item"><%= item %></li>
             <% end %>
           </ul>
+          <% if header["education-pretext"].present? %>
+            <p class="govuk-body covid__inverse">
+              <%= header["education-pretext"]["text"] %>
+              <% countries = header["education-pretext"]["countries"].map do |country| %>
+                <% link_to country["label"], country["url"], class: "covid__page-header-link govuk-link" %>
+              <% end %>
+              <%= countries.to_sentence(last_word_connector: ' and ').html_safe %>.
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/coronavirus_landing_page/hub.html.erb
+++ b/app/views/coronavirus_landing_page/hub.html.erb
@@ -1,7 +1,9 @@
 <%= render partial: "coronavirus_landing_page/components/shared/meta_tags" %>
 
 <%= render partial: "coronavirus_landing_page/components/hub/page_header", locals: {
-  details: details,
+  header: details.header_section,
+  guidance: details.guidance_section,
+  notifications: details.notifications,
   title: title,
   breadcrumbs: breadcrumbs
 } %>

--- a/test/fixtures/content_store/coronavirus_education_page.json
+++ b/test/fixtures/content_store/coronavirus_education_page.json
@@ -143,13 +143,30 @@
       "header": "All coronavirus education and childcare information on GOV.UK"
     },
     "header_section": {
+      "list_heading": "In England:",
       "list": [
         "Schools and nurseries remain closed to all pupils except children of keyworkers and vulnerable children",
         "Exams are cancelled and grades will be assessed differently",
         "Free school meals or food vouchers will be available for pupils not attending school"
       ],
-      "pretext": "How nurseries, schools, colleges and universities are working during coronavirus (COVID-19)"
-    },
-    "live_stream_enabled": false
+      "pretext": "How nurseries, schools, colleges and universities are working during coronavirus (COVID-19)",
+      "education-pretext": {
+        "text": "Find out when schools are expected to reopen in",
+        "countries": [
+          {
+            "label": "Scotland",
+            "url": "https://www.gov.scot/news/schools-to-re-open-in-august/"
+          },
+          {
+            "label": "Wales",
+            "url": "https://gov.wales/how-schools-will-work-during-coronavirus-pandemic#section-38402"
+          },
+          {
+            "label": "Northern Ireland",
+            "url": "https://www.nidirect.gov.uk/articles/coronavirus-covid-19-advice-schools-colleges-and-universities"
+          }
+        ]
+      }
+    }
   }
 }

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -73,6 +73,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_business_content_item
       when_i_visit_the_business_hub_page
       then_i_can_see_the_business_page
+      then_i_cannot_see_the_education_header_section
       then_i_can_see_the_business_accordions
       and_i_can_see_business_links_to_search
     end
@@ -83,6 +84,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_an_education_content_item
       when_i_visit_the_education_hub_page
       then_i_can_see_the_page_title("Education and Childcare")
+      then_i_can_see_the_education_header_section
       then_i_can_see_the_education_accordions
     end
   end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -99,6 +99,14 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: "Coronavirus (COVID-19)")
   end
 
+  def then_i_can_see_the_education_header_section
+    assert page.has_text?("Find out when schools are expected to reopen in Scotland, Wales and Northern Ireland")
+  end
+
+  def then_i_cannot_see_the_education_header_section
+    assert page.has_no_text?("Find out when schools are expected to reopen in Scotland, Wales and Northern Ireland")
+  end
+
   def then_i_can_see_the_business_page
     assert page.has_title?("Coronavirus (COVID-19): Business support")
     then_i_can_see_the_page_title("Business support")


### PR DESCRIPTION
## What 
Read from new keys added to the education header in [govuk-coronavirus-content](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_education_page.yml#L7-L16)

There is no visible frontend change, as the current version of collections has the same content hardcoded. 

This PR reverts this [commit](https://github.com/alphagov/collections/commit/6e83383a1f8bd76d3fd360d91b6004b50bb40258) 