### PR TITLE
Swap the news and actions to take sections on the landing page

### DIFF
--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -12,13 +12,13 @@
 <div class="govuk-width-container">
   <%= render partial: 'explainer' %>
 
-  <% if show_comms %>
-    <%= render partial: 'comms', locals: { comms: presented_taxon.comms } %>
-  <% end %>
-
   <div class="landing-page__buckets">
     <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
   </div>
+
+  <% if show_comms %>
+    <%= render partial: 'comms', locals: { comms: presented_taxon.comms } %>
+  <% end %>
 
   <div class="landing-page__section">
     <%= render partial: 'brexit_finders', locals: { supergroups: presented_taxon.supergroup_sections, email_path: presented_taxon.email_path } %>


### PR DESCRIPTION
This is in order to make the actions to take section easier to see.

Trello - https://trello.com/c/mt205Cge/233-update-transition-landing-page-change-text-and-order-of-page-segments