### PR TITLE
Content changes

### DIFF
--- a/app/views/transition_landing_page/_brexit_finders.html.erb
+++ b/app/views/transition_landing_page/_brexit_finders.html.erb
@@ -10,6 +10,8 @@
     } %>
   </div>
 </div>
+
+<% unless I18n.t("transition_landing_page.email_intro", default: "").empty? %>
 <%= render partial: 'components/signup-link', locals: {
   link_href: "/email-signup/?topic=#{email_path}",
   link_text: t("transition_landing_page.email"),
@@ -21,3 +23,4 @@
   },
   background: true
 } %>
+<% end %>

--- a/app/views/transition_landing_page/_brexit_finders.html.erb
+++ b/app/views/transition_landing_page/_brexit_finders.html.erb
@@ -10,17 +10,3 @@
     } %>
   </div>
 </div>
-
-<% unless I18n.t("transition_landing_page.email_intro", default: "").empty? %>
-<%= render partial: 'components/signup-link', locals: {
-  link_href: "/email-signup/?topic=#{email_path}",
-  link_text: t("transition_landing_page.email"),
-  heading: t("transition_landing_page.email_intro"),
-  data: {
-    "module": "track-click",
-    "track-category": "emailAlertLinkClicked",
-    "track-action": email_path
-  },
-  background: true
-} %>
-<% end %>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -8,7 +8,7 @@ en:
     explainer_text: |
       <p>The UK has left the EU and is now in a transition period, before new rules come into place from 1 January 2021. </p>
       <p>There will be new rules in many areas. For example, if you have a business, travel to Europe or sell your goods abroad. Use this service to answer some questions and get a personalised list of the changes that might affect you.</p>
-      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Check how to get ready for new rules in 2021" data-module="track-click">Check how to get ready for new rules in 2021</a></p>
+      <p><a class="govuk-!-font-weight-bold" href="/transition-check" data-track-category="transition-landing-page" data-track-action="/transition-check" data-track-label="Check what’s changing and sign up for email alerts" data-module="track-click">Check what’s changing and sign up for email alerts</a></p>
     guidance_header: "Actions you can take now"
     guidance_subheader: "Actions you can take now that do not depend on negotiations."
     campaign_buckets:

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -73,9 +73,6 @@ en:
           document_type: "Policy Paper"
     topic_section_header: All transition period information
     topic_section_subheading: Browse all information related to the transition period
-    email_intro: "Stay up to date"
-    email: Sign up for email updates about the transition period
-    email_mailto_subject: "Get%20ready%20for%202021%20-%20GOV.UK"
     share_links: "Share this page"
     sections:
       aria_string_suffix: related to the transition period

--- a/test/integration/transition_landing_page_test.rb
+++ b/test/integration/transition_landing_page_test.rb
@@ -16,13 +16,6 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
       and_i_can_see_the_explore_topics_section
     end
 
-    it "renders an email subscription section on Welsh version" do
-      given_there_is_a_transition_taxon
-      when_i_visit_the_welsh_transition_landing_page
-      then_i_can_see_an_email_subscription_link
-      and_the_email_link_is_tracked
-    end
-
     it "has tracking on all links" do
       given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page

--- a/test/integration/transition_landing_page_test.rb
+++ b/test/integration/transition_landing_page_test.rb
@@ -14,14 +14,19 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_what_happens_next_section
       then_i_can_see_the_share_links_section
       and_i_can_see_the_explore_topics_section
-      and_i_can_see_an_email_subscription_link
+    end
+
+    it "renders an email subscription section on Welsh version" do
+      given_there_is_a_transition_taxon
+      when_i_visit_the_welsh_transition_landing_page
+      then_i_can_see_an_email_subscription_link
+      and_the_email_link_is_tracked
     end
 
     it "has tracking on all links" do
       given_there_is_a_transition_taxon
       when_i_visit_the_transition_landing_page
       then_all_finder_links_have_tracking_data
-      and_the_email_link_is_tracked
       and_ecommerce_tracking_is_setup
     end
 

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -8,13 +8,19 @@ module TransitionLandingPageSteps
 
   TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
   TRANSITION_TAXON_PATH = "/transition".freeze
+  TRANSITION_TAXON_PATH_WELSH = "/transition.cy".freeze
 
   def given_there_is_a_transition_taxon
     stub_content_store_has_item(TRANSITION_TAXON_PATH, content_item)
+    stub_content_store_has_item(TRANSITION_TAXON_PATH_WELSH, content_item)
   end
 
   def when_i_visit_the_transition_landing_page
     visit TRANSITION_TAXON_PATH
+  end
+
+  def when_i_visit_the_welsh_transition_landing_page
+    visit TRANSITION_TAXON_PATH_WELSH
   end
 
   def then_i_can_see_the_title_section
@@ -45,9 +51,9 @@ module TransitionLandingPageSteps
     assert page.has_selector?("h2.govuk-heading-l", text: "Get ready for 2021")
   end
 
-  def and_i_can_see_an_email_subscription_link
+  def then_i_can_see_an_email_subscription_link
     assert page.has_selector?('a[href="/email-signup/?topic=' + TRANSITION_TAXON_PATH + '"]')
-    assert page.has_text?("Sign up for email updates about the transition period")
+    assert page.has_text?("Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio")
   end
 
   def and_i_can_see_the_explore_topics_section
@@ -87,13 +93,13 @@ module TransitionLandingPageSteps
       "Transparency and freedom of information releases",
     ].each do |section|
       assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: section)
-      assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: section)
+      assert page.has_css?("a[data-track-action=\"#{TRANSITION_TAXON_PATH}\"]", text: section)
     end
   end
 
   def and_the_email_link_is_tracked
     assert page.has_css?("a[data-track-category='emailAlertLinkClicked']")
-    assert page.has_css?("a[data-track-action=\"#{current_path}\"]")
+    assert page.has_css?("a[data-track-action=\"#{TRANSITION_TAXON_PATH}\"]")
   end
 
   def then_the_page_is_not_noindexed

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -8,19 +8,13 @@ module TransitionLandingPageSteps
 
   TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
   TRANSITION_TAXON_PATH = "/transition".freeze
-  TRANSITION_TAXON_PATH_WELSH = "/transition.cy".freeze
 
   def given_there_is_a_transition_taxon
     stub_content_store_has_item(TRANSITION_TAXON_PATH, content_item)
-    stub_content_store_has_item(TRANSITION_TAXON_PATH_WELSH, content_item)
   end
 
   def when_i_visit_the_transition_landing_page
     visit TRANSITION_TAXON_PATH
-  end
-
-  def when_i_visit_the_welsh_transition_landing_page
-    visit TRANSITION_TAXON_PATH_WELSH
   end
 
   def then_i_can_see_the_title_section
@@ -49,11 +43,6 @@ module TransitionLandingPageSteps
 
   def then_i_can_see_the_buckets_section
     assert page.has_selector?("h2.govuk-heading-l", text: "Get ready for 2021")
-  end
-
-  def then_i_can_see_an_email_subscription_link
-    assert page.has_selector?('a[href="/email-signup/?topic=' + TRANSITION_TAXON_PATH + '"]')
-    assert page.has_text?("Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio")
   end
 
   def and_i_can_see_the_explore_topics_section
@@ -95,11 +84,6 @@ module TransitionLandingPageSteps
       assert page.has_css?("a[data-track-category='SeeAllLinkClicked']", text: section)
       assert page.has_css?("a[data-track-action=\"#{TRANSITION_TAXON_PATH}\"]", text: section)
     end
-  end
-
-  def and_the_email_link_is_tracked
-    assert page.has_css?("a[data-track-category='emailAlertLinkClicked']")
-    assert page.has_css?("a[data-track-action=\"#{TRANSITION_TAXON_PATH}\"]")
   end
 
   def then_the_page_is_not_noindexed


### PR DESCRIPTION
Content changes and removal of email signup to https://www.gov.uk/transition and
https://www.gov.uk/transition.cy.

Screenshot:
![english](https://user-images.githubusercontent.com/5111927/85132705-3a54d080-b231-11ea-8d15-387b2a1aea2c.png)

Trello: https://trello.com/c/yemuGsYE/2032-updates-to-transition-landing-page