### PR TITLE
Add canonical URL to landing pages

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
@@ -5,9 +5,10 @@
 <% content_for :is_full_width_header, true %>
 <% content_for :title, @content_item["title"] %>
 <% content_for :meta_tags do %>
+  <% page_url = File.join(request.base_url, request.path) %>
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="GOV.UK">
-  <meta property="og:url" content="<%= request.base_url + request.path %>">
+  <meta property="og:url" content="<%= page_url %>">
   <meta property="og:title" content="<%= @content_item["title"] %>">
   <meta property="og:description" content="<%= @content_item["description"] %>">
   <meta name="description" content="<%= @content_item["description"] %>">
@@ -18,4 +19,5 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="<%= image_url("corona-share-image.png") %>">
   <% end %>
+  <link rel="canonical" href="<%= page_url %>">
 <% end %>

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -13,6 +13,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_accordions
       then_i_can_see_the_live_stream_section
       and_i_can_see_links_to_search
+      and_there_are_metatags
     end
 
     it "has sections that can be clicked" do

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -207,6 +207,11 @@ module CoronavirusLandingPageSteps
     assert_nil(special_announcement_schema["gettingTestedInfo"])
   end
 
+  def and_there_are_metatags
+    assert page.has_selector? "meta[name='description'][content='Find out about the government response to coronavirus (COVID-19) and what you need to do.']", visible: false
+    assert page.has_selector?("link[rel='canonical'][href='http://www.example.com/coronavirus']", visible: false)
+  end
+
   def and_the_faqpage_schema_is_rendered
     special_announcement_schema = find_schema("FAQPage")
     assert_equal(special_announcement_schema["name"], "Coronavirus (COVID-19): what you need to do")


### PR DESCRIPTION
We get this by default on pages that use the machine_readable component, but we've got a custom set up on these pages that doesn't lend itself to that.

We need to add this because these pages are often linked to with campaign or marketing query strings. This causes Google et al to believe that they might behave differently at times. (They don't)

https://trello.com/c/nF93uexi/388-put-canonical-url-on-landing-pages