### PR TITLE
Hide live stream section and remove /ask

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -1,3 +1,4 @@
+<% if ActiveModel::Type::Boolean.new.cast(live_stream["show_live_stream"]) %>
 <%
   list_css_classes = %w(govuk-list)
   list_css_classes << "covid__spaced-list" if live_stream["spaced_links"]
@@ -41,3 +42,4 @@
     <% end %>
   </ul>
 </section>
+<% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -26,20 +26,6 @@
         <%= live_stream["previous_videos"]["previous_videos_text"] %>
       </a>
     </li>
-    <% if live_stream["ask_a_question_visible"] == true %>
-      <li class="covid__topic-list-item">
-        <a href="<%= live_stream["ask_a_question_link"] %>" class="covid__topic-list-link govuk-link">
-          <%= live_stream["ask_a_question_text"] %>
-        </a>
-      </li>
-    <% end %>
-    <% if live_stream["popular_questions_link_visible"] == true %>
-      <li class="covid__topic-list-item">
-        <a href="<%= live_stream["see_popular_questions_link"] %>" class="covid__topic-list-link govuk-link">
-          <%= live_stream["see_popular_questions_text"] %>
-        </a>
-      </li>
-    <% end %>
   </ul>
 </section>
 <% end %>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -402,7 +402,7 @@
       "popular_questions_link_visible": true,
       "see_popular_questions_text": "See the types of questions submitted by the public",
       "see_popular_questions_link": "https://www.gov.uk",
-      "date_text": "Live streamed"
+      "show_live_stream": true
     },
     "special_announcement_schema": {
       "category": "https://www.wikidata.org/wiki/Q81068910",

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -396,12 +396,6 @@
         "previous_videos_text": "Watch all press conferences on YouTube",
         "next_conference_text": "The next live press conference will be shown here"
       },
-      "ask_a_question_visible" : true,
-      "ask_a_question_text": "Ask a question at the next press conference",
-      "ask_a_question_link": "https://www.gov.uk",
-      "popular_questions_link_visible": true,
-      "see_popular_questions_text": "See the types of questions submitted by the public",
-      "see_popular_questions_link": "https://www.gov.uk",
       "show_live_stream": true
     },
     "special_announcement_schema": {

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -26,8 +26,6 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_streamed_date
-      then_i_can_see_the_ask_a_question_section
-      then_i_can_see_the_popular_questions_link
     end
 
     it "can hide the livestream section" do
@@ -40,18 +38,6 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item_with_live_stream_time
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_date_and_time
-    end
-
-    it "optionally hides the ask a question link" do
-      given_there_is_a_content_item_with_ask_a_question_disabled
-      when_i_visit_the_coronavirus_landing_page
-      then_i_cannot_see_the_ask_a_question_section
-    end
-
-    it "optionally hides the popular questions link" do
-      given_there_is_a_content_item_with_popular_questions_link_disabled
-      when_i_visit_the_coronavirus_landing_page
-      then_i_cannot_see_the_popular_questions_link
     end
 
     it "shows COVID-19 risk level when risk level is enabled" do

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -30,6 +30,12 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_popular_questions_link
     end
 
+    it "can hide the livestream section" do
+      given_there_is_a_content_item_with_livestream_disabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_cannot_see_the_live_stream_section
+    end
+
     it "optionally shows the time of a livestream" do
       given_there_is_a_content_item_with_live_stream_time
       when_i_visit_the_coronavirus_landing_page

--- a/test/support/coronavirus_helper.rb
+++ b/test/support/coronavirus_helper.rb
@@ -31,6 +31,12 @@ def coronavirus_content_item
   end
 end
 
+def coronavirus_content_item_with_livestream_disabled
+  content_item = coronavirus_content_item
+  content_item["details"]["live_stream"].delete("show_live_stream")
+  content_item
+end
+
 def coronavirus_content_item_with_live_stream_time
   content_item = coronavirus_content_item
   content_item["details"]["live_stream"]["time"] = "5:00pm"

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -134,26 +134,6 @@ module CoronavirusLandingPageSteps
     assert page.has_text?("19 April at 5:00pm")
   end
 
-  def then_i_can_see_the_ask_a_question_section
-    assert page.has_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
-  end
-
-  def then_i_cannot_see_the_ask_a_question_section
-    assert page.has_no_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
-  end
-
-  def then_i_can_see_the_popular_questions_link
-    assert page.has_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
-  end
-
-  def then_i_cannot_see_the_popular_questions_link
-    assert page.has_no_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
-  end
-
-  def and_there_is_no_ask_a_question_section
-    assert page.has_no_link?("Ask a question at the next press conference")
-  end
-
   def then_i_can_see_the_live_stream_section
     assert page.has_selector?(".covid__topic-wrapper h2", text: "Press conferences and speeches")
     assert page.has_selector?(".covid__video-wrapper")

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -19,6 +19,10 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item)
   end
 
+  def given_there_is_a_content_item_with_livestream_disabled
+    stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_livestream_disabled)
+  end
+
   def given_there_is_a_content_item_with_live_stream_time
     stub_content_store_has_item(CORONAVIRUS_PATH, coronavirus_content_item_with_live_stream_time)
   end
@@ -116,7 +120,12 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".covid__page-header h1", text: title)
   end
 
+  def then_i_cannot_see_the_live_stream_section
+    assert page.has_no_text?("Press conferences and speeches")
+  end
+
   def then_i_can_see_the_live_stream_section_with_streamed_date
+    assert page.has_text?("Press conferences and speeches")
     assert page.has_text?("19 April")
     assert_not page.has_text?("19 April at")
   end


### PR DESCRIPTION
We may want to turn the livestream section back on again, so we'll use a toggle in the content item.

The /ask page and the FAQ page have already been taken down, and the links disabled, so it's safe to remove these.

https://trello.com/c/r5x97Fni/385-remove-the-press-conferences-and-speeches-section-of-the-landing-page