### PR TITLE
Add new links to Covid landing page header

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -48,18 +48,48 @@
 
       <div class="govuk-grid-row covid__action-link-wrapper">
         <div class="govuk-grid-column-two-thirds">
-          <%= render 'govuk_publishing_components/components/action_link', {
-            light_text: true,
-            href: header["link"]["href"],
-            text: header["link"]["link_text"],
-            nowrap_text: header["link"]["link_nowrap_text"],
-            data: {
-              module: "track-click",
-              track_category: "pageElementInteraction",
-              track_action: "Announcements",
-              track_label: header["link"]["href"]
-            }
-          } %>
+          <% if header["link2"] && header["link3"] %>
+            <%= render 'govuk_publishing_components/components/action_link', {
+              light_text: true,
+              small_icon: true,
+              href: header["link2"]["href"],
+              text: header["link2"]["link_text"],
+              nowrap_text: header["link2"]["link_nowrap_text"],
+              margin_bottom: 2,
+              data: {
+                module: "track-click",
+                track_category: "pageElementInteraction",
+                track_action: "Announcements",
+                track_label: header["link2"]["href"]
+              }
+            } %>
+            <%= render 'govuk_publishing_components/components/action_link', {
+              light_text: true,
+              small_icon: true,
+              href: header["link3"]["href"],
+              text: header["link3"]["link_text"],
+              nowrap_text: header["link3"]["link_nowrap_text"],
+              data: {
+                module: "track-click",
+                track_category: "pageElementInteraction",
+                track_action: "Announcements",
+                track_label: header["link3"]["href"]
+              }
+            } %>
+          <% else %>
+            <%= render 'govuk_publishing_components/components/action_link', {
+              light_text: true,
+              href: header["link"]["href"],
+              text: header["link"]["link_text"],
+              nowrap_text: header["link"]["link_nowrap_text"],
+              data: {
+                module: "track-click",
+                track_category: "pageElementInteraction",
+                track_action: "Announcements",
+                track_label: header["link"]["href"]
+              }
+            } %>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What
There are now 2 versions of 'What you can and cannot do' one for before 4 July one for after 4 July.

Add code to support these new links being added to the coronavirus landing page header.

## Why 
For users planning to do things in July we need to let them know what will be possible before and after the rules change.

Content for these links has been added here https://github.com/alphagov/govuk-coronavirus-content/pull/309



https://trello.com/c/oB87oGqD