### PR TITLE
Reintroduce "ask a question" and FAQ link section

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_live_stream_section.html.erb
@@ -26,6 +26,20 @@
         <%= live_stream["previous_videos"]["previous_videos_text"] %>
       </a>
     </li>
+    <% if live_stream["ask_a_question_visible"] == true %>
+      <li class="covid__topic-list-item">
+        <a href="<%= live_stream["ask_a_question_link"] %>" class="covid__topic-list-link govuk-link">
+          <%= live_stream["ask_a_question_text"] %>
+        </a>
+      </li>
+    <% end %>
+    <% if live_stream["popular_questions_link_visible"] == true %>
+      <li class="covid__topic-list-item">
+        <a href="<%= live_stream["see_popular_questions_link"] %>" class="covid__topic-list-link govuk-link">
+          <%= live_stream["see_popular_questions_text"] %>
+        </a>
+      </li>
+    <% end %>
   </ul>
 </section>
 <% end %>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -396,6 +396,12 @@
         "previous_videos_text": "Watch all press conferences on YouTube",
         "next_conference_text": "The next live press conference will be shown here"
       },
+      "ask_a_question_visible" : true,
+      "ask_a_question_text": "Ask a question at the next press conference",
+      "ask_a_question_link": "https://www.gov.uk",
+      "popular_questions_link_visible": true,
+      "see_popular_questions_text": "See the types of questions submitted by the public",
+      "see_popular_questions_link": "https://www.gov.uk",
       "show_live_stream": true
     },
     "special_announcement_schema": {

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -27,6 +27,8 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_streamed_date
+      then_i_can_see_the_ask_a_question_section
+      then_i_can_see_the_popular_questions_link
     end
 
     it "can hide the livestream section" do
@@ -39,6 +41,18 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       given_there_is_a_content_item_with_live_stream_time
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_live_stream_section_with_date_and_time
+    end
+
+    it "optionally hides the ask a question link" do
+      given_there_is_a_content_item_with_ask_a_question_disabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_cannot_see_the_ask_a_question_section
+    end
+
+    it "optionally hides the popular questions link" do
+      given_there_is_a_content_item_with_popular_questions_link_disabled
+      when_i_visit_the_coronavirus_landing_page
+      then_i_cannot_see_the_popular_questions_link
     end
 
     it "shows COVID-19 risk level when risk level is enabled" do

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -134,6 +134,26 @@ module CoronavirusLandingPageSteps
     assert page.has_text?("19 April at 5:00pm")
   end
 
+  def then_i_can_see_the_ask_a_question_section
+    assert page.has_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
+  end
+
+  def then_i_cannot_see_the_ask_a_question_section
+    assert page.has_no_link?("Ask a question at the next press conference", href: "https://www.gov.uk")
+  end
+
+  def then_i_can_see_the_popular_questions_link
+    assert page.has_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
+  end
+
+  def then_i_cannot_see_the_popular_questions_link
+    assert page.has_no_link?("See the types of questions submitted by the public", href: "https://www.gov.uk")
+  end
+
+  def and_there_is_no_ask_a_question_section
+    assert page.has_no_link?("Ask a question at the next press conference")
+  end
+
   def then_i_can_see_the_live_stream_section
     assert page.has_selector?(".covid__topic-wrapper h2", text: "Press conferences and speeches")
     assert page.has_selector?(".covid__video-wrapper")


### PR DESCRIPTION
This reverts commit 92db1da72bfc0a18791b41c1ce92c280f74a58b4.

We want to show the /ask link. The FAQ link is toggled to be off at the moment (and I can certainly see someone wanting to reintroduce it, so let's just bring it all back for the moment).