### PR TITLE
Amend Transition page metadescription

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -1,7 +1,7 @@
 en:
   transition_landing_page:
     meta_title: The transition period
-    meta_description: The UK has left the EU. Find out what this means for you.
+    meta_description: The UK’s transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.
     page_header: The UK has left the EU
     page_header_explainer: Find out what this means for you.
     explainer_title: Get ready for 2021


### PR DESCRIPTION
I'm going to check why this isn't read from the content item. Will make a new story to sort this (and the search index entry) out if they can be.

https://trello.com/c/zYugZiMJ/288-update-meta-description-for-transition-landing-page-for-site-search-purposes