### PR TITLE
Add GA tracking to transition landing page

### DIFF
--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -16,9 +16,15 @@
         <div class="landing-page__take-action-button">
           <%= render "govuk_publishing_components/components/button", {
             text: t("transition_landing_page.take_action_start_now"),
-            href: "/transition-check/questions",
+            href: t("transition_landing_page.take_action_start_now_link"),
             start: true,
-            margin_bottom: true
+            margin_bottom: true,
+            data_attributes: {
+              "module": "track-click",
+              "track-action": t("transition_landing_page.take_action_start_now_link"),
+              "track-category": "transition-landing-page",
+              "track-label": t("transition_landing_page.take_action_start_now")
+            }
           } %>
         </div>
       </div>

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -9,6 +9,7 @@ cy:
     take_action_text: |
       <p>Atebwch rywfaint o gwestiynau er mwyn cael rhestr bersonol o gamau gweithredu ar eich cyfer chi, eich teulu a’ch busnes. Yna, cofrestrwch i gael yr wybodaeth ddiweddaraf dros yr e-bost pan fydd pethau’n newid.</p>
     take_action_start_now: Dechrau nawr
+    take_action_start_now_link: "/transition-check/questions"
     take_action_list:
       red: Gwirio
       amber: Newid

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -9,6 +9,7 @@ en:
     take_action_text: |
       <p>Answer a few questions to get a personalised list of actions for you, your family, and your business. Then sign up for emails to get updates when things change.</p>
     take_action_start_now: Start now
+    take_action_start_now_link: "/transition-check/questions"
     take_action_list:
       red: Check
       amber: Change


### PR DESCRIPTION
## What

When the new landing page design was created, we lost some GA tracking. We used to track clicks that lead users to the brexit checker:

<img width="1100" alt="before" src="https://user-images.githubusercontent.com/17908089/87324755-76294000-c528-11ea-8425-91e94660befa.png">


This PR reinstates it by adding tracking to clicks of the start now button.

<img width="977" alt="New" src="https://user-images.githubusercontent.com/17908089/87325141-fbacf000-c528-11ea-889d-0be757a9713b.png">
trello: https://trello.com/c/jH2DdJOl/318-add-tracking-to-start-now-button-on-transition-landing-page