### PR TITLE
Add border to covid 19 find support block

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -123,6 +123,8 @@
   @include govuk-responsive-margin(9, "bottom");
   background-color: $covid-grey;
   padding: govuk-spacing(6) govuk-spacing(5);
+  border-left: 10px solid;
+  border-image: repeating-linear-gradient(25deg, transparent 0, $covid-yellow 1px, $covid-yellow 10px, transparent 11px, transparent 20px) 25;
 }
 
 .covid__list {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -123,7 +123,7 @@
   @include govuk-responsive-margin(9, "bottom");
   background-color: $covid-grey;
   padding: govuk-spacing(6) govuk-spacing(5);
-  border-left: 10px solid;
+  border-left: 10px solid $covid-yellow;
   border-image: repeating-linear-gradient(25deg, transparent 0, $covid-yellow 1px, $covid-yellow 10px, transparent 11px, transparent 20px) 25;
 }
 


### PR DESCRIPTION
# What
We need to look at updating the content, and possibly the design, of the 'Find support if you're struggling' box. The content needs to more accurately reflect the service. 

Update the box with this final design (in cover) and attached 'Final support design'

# Why
Research has shown that some users are either not noticing, or not understanding the content in the 'Find support if you're struggling' box on the landing page.

# Demo
https://govuk-collec-add-border-3uwnln.herokuapp.com/coronavirus

# Before
![Screenshot 2020-07-14 at 15 40 00](https://user-images.githubusercontent.com/4599889/87439130-50637000-c5e8-11ea-9c75-44051cc773fb.png)

# After
![Screenshot 2020-07-16 at 15 30 11](https://user-images.githubusercontent.com/4599889/87683795-65233d80-c779-11ea-8c26-5523ae44601d.png)

# IE10 and below
![Screenshot 2020-07-16 at 15 29 48](https://user-images.githubusercontent.com/4599889/87683872-79ffd100-c779-11ea-898c-1cb9488a1993.png)



https://trello.com/c/UzmUWkvX/674-update-the-find-support-if-youre-struggling-box