### PR TITLE
Change description font to match header

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -167,7 +167,7 @@
 }
 
 .covid__list-item-description {
-  @include govuk-font(16);
+  @include govuk-font(19);
   padding-left: govuk-spacing(6);
 }
 


### PR DESCRIPTION
# What
Update the description font size to 19 to match the size of the header

# Why
Styling updates to make the description more visible

https://trello.com/c/mNuWA1DC/689-change-description-font-to-match-header

# Before
![Screenshot 2020-07-15 at 12 31 02](https://user-images.githubusercontent.com/4599889/87540144-100efb00-c697-11ea-9b40-9cb08198aa92.png)

# After
![Screenshot 2020-07-15 at 12 21 01](https://user-images.githubusercontent.com/4599889/87540115-01c0df00-c697-11ea-94ed-91ee1289b6d2.png)
