### PR TITLE
add support for links in NHS box

### DIFF
--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -25,7 +25,13 @@
     <% if list.any? %>
       <ul class="app-c-header-notice__list govuk-list govuk-list--bullet">
         <% list.each do |item| %>
-          <li><%= item %></li>
+          <li>
+            <% if item.is_a?(Hash) %>
+              <%= link_to(item["label"], item["href"], class: "app-c-header-notice__call-to-action-link govuk-link") %>
+            <% else %>
+              <%= item %>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     <% end %>

--- a/test/components/header_notice_test.rb
+++ b/test/components/header_notice_test.rb
@@ -30,6 +30,18 @@ class HeaderNoticeTest < ComponentTestCase
     }
   end
 
+  def list_with_links
+    {
+      title: "this is a title",
+      heading: "This is a header",
+      list: ["blah", "blah2", { "label" => "blahWithLink", "href" => "/blah" }],
+      call_to_action: {
+        href: "/this-is-a-link",
+        title: "Click me!",
+      },
+    }
+  end
+
   test "renders nothing without passed content" do
     assert_empty render_component({})
   end
@@ -85,7 +97,27 @@ class HeaderNoticeTest < ComponentTestCase
     assert_select ".app-c-header-notice__list li", count: branded_notice[:list].count
     assert_select ".app-c-header-notice__list li" do |items|
       items.each_with_index do |item, index|
-        assert_equal item.text, branded_notice[:list][index]
+        assert_equal item.text.strip, branded_notice[:list][index]
+      end
+    end
+  end
+
+  test "renders a list with links if list with links is passed in" do
+    render_component(list_with_links)
+    assert_select ".app-c-header-notice__list"
+    assert_select ".app-c-header-notice__list li", count: list_with_links[:list].count
+    assert_select ".app-c-header-notice__list li a", count: 1
+    assert_select ".app-c-header-notice__list li" do |items|
+      items.each_with_index do |item, index|
+        if list_with_links[:list][index].is_a?(Hash)
+          assert_select "a[href=?]", list_with_links[:list][index]["href"],
+                        {
+                          count: 1,
+                          text: list_with_links[:list][index]["label"],
+                        }
+        else
+          assert_equal item.text.strip, list_with_links[:list][index]
+        end
       end
     end
   end


### PR DESCRIPTION
# What
Allows links on NHS box

# Why
We want to start adding links instead of plain text to the list

# Visual diffs
![Screenshot 2020-07-16 at 16 47 12](https://user-images.githubusercontent.com/4599889/87692852-22b32e00-c784-11ea-8469-e87c64e64736.png)

https://trello.com/c/eeSbyTSU/683-rework-nhs-box