### PR TITLE
Removes redundant route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,9 +32,6 @@ Rails.application.routes.draw do
       to: "latest_changes#index",
       as: :latest_changes
 
-  # Collections used to have an interstitial signup screen. This was removed in https://github.com/alphagov/collections/pull/1749
-  get "/topic/:topic_slug/:subtopic_slug/email-signup", to: redirect("/email-signup?topic=/topic/%{topic_slug}/%{subtopic_slug}")
-
   get "/government/feed" => "feeds#all", defaults: { format: "atom" }
 
   get "/government/organisations",


### PR DESCRIPTION
Depends on:
https://github.com/alphagov/collections-publisher/pull/1102 & https://github.com/alphagov/collections-publisher/pull/1104

---

Trello:
https://trello.com/c/Fi2Z2zDy/399-redirect-and-remove-legacy-email-signup-routes-for-collections