### PR TITLE
Add video transcription to transition landing page

### DIFF
--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -39,3 +39,11 @@
     border-radius: 100%;
   }
 }
+
+.govuk-details__summary {
+  color: govuk-colour('white');
+}
+
+.govuk-details__text {
+  color: govuk-colour('white');
+}

--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -42,8 +42,17 @@
 
 .govuk-details__summary {
   color: govuk-colour('white');
+  &:hover {
+    color: govuk-colour('white');
+  }
 }
 
 .govuk-details__text {
   color: govuk-colour('white');
+}
+
+.govuk-details__summary-text {
+  &:hover {
+    color: govuk-colour('white');
+  }
 }

--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -45,10 +45,15 @@
   &:hover {
     color: govuk-colour('white');
   }
+  &:hover:focus,
+  &:hover:focus .govuk-details__summary-text {
+    color: govuk-colour('black');
+  }
 }
 
 .govuk-details__text {
   color: govuk-colour('white');
+  border-left-color: govuk-colour('white');
 }
 
 .govuk-details__summary-text {

--- a/app/views/transition_landing_page/_video_section.html.erb
+++ b/app/views/transition_landing_page/_video_section.html.erb
@@ -11,13 +11,15 @@
         <% end %>
       </div>
       <div class="govuk-grid-column-one-half">
-        <%= render partial: 'transition_landing_page/components/youtube_player', locals: { 
+        <%= render partial: 'transition_landing_page/components/youtube_player', locals: {
           no_cookies_icon_text: t("transition_landing_page.no_cookies.icon_text"),
           no_cookies_change_settings_text: t("transition_landing_page.no_cookies.change_settings_text"),
           no_cookies_to_watch_text: t("transition_landing_page.no_cookies.to_watch_text"),
           no_cookies_or_text: t("transition_landing_page.no_cookies.or_text"),
           no_cookies_watch_link_text: t("transition_landing_page.no_cookies.watch_link_text"),
           youtube_video_url: t("transition_landing_page.video_section_link"),
+          transcription_summary: t("transition_landing_page.video_section_transcription_summary"),
+          transcription_text: t("transition_landing_page.video_section_transcription_text")
         } %>
       </div>
     </div>

--- a/app/views/transition_landing_page/components/_youtube_player.html.erb
+++ b/app/views/transition_landing_page/components/_youtube_player.html.erb
@@ -33,4 +33,7 @@
       </a>
     </div>
   <% end %>
+  <%= render "govuk_publishing_components/components/details", { title: transcription_summary} do %>
+    <%= transcription_text.html_safe %>
+  <% end %>
 </div>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -19,6 +19,12 @@ en:
       <p>The UK is leaving the EU single market and customs union, and the end of the transition period will affect citizens, businesses, as well as travel to and from the EU.</p>
       <p>Watch the video to find out what 2021 will mean for you.</p>
     video_section_link: https://www.youtube.com/watch?v=3ZHKjj-9WTk&rel=0
+    video_section_transcription_summary: View the video transcript
+    video_section_transcription_text: |
+      <p>On 1 January, the UK will regain its political and economic independence and can start new trading relationships with the EU and rest of the world.</p>
+      <p>Citizens and business can check what they need to do, to prepare for the changes and opportunities ahead as a sovereign nation.</p>
+      <p>For businesses this includes preparing for a new approach to trade with our partners in the European Union.</p>
+      <p>For individuals this may include registering your residency rights.</p>
     no_cookies:
       icon_text: VIDEO
       change_settings_text: Change your cookie settings


### PR DESCRIPTION
## What
Add transcription of the youtube video to the transition landing page. 

## Review app
https://govuk-collec-video-tran-ceuh41.herokuapp.com/transition

<img width="1043" alt="Screenshot 2020-07-21 at 14 23 27" src="https://user-images.githubusercontent.com/17908089/88060187-cc683580-cb5d-11ea-9d6d-9c5645bdaafe.png">
<img width="1100" alt="Screenshot 2020-07-21 at 14 23 37" src="https://user-images.githubusercontent.com/17908089/88060195-cffbbc80-cb5d-11ea-93e7-14bf32f1914a.png">


Trello: https://trello.com/c/qDJkX4wa/325-add-video-transcript-to-landing-page-english
