### PR TITLE
Transition metadata updates

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_schema.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_schema.html.erb
@@ -1,7 +1,7 @@
 <script type="application/ld+json">
-  <%= (presenter.faq_schema(@content_item).to_json).html_safe %>
+  <%= raw JSON.pretty_generate(presenter.faq_schema(@content_item)) %>
 </script>
 
 <script type="application/ld+json">
-  <%= (special_announcement.payload.to_json).html_safe %>
+  <%= raw JSON.pretty_generate(special_announcement.payload) %>
 </script>

--- a/app/views/step_nav/_structured_data.html.erb
+++ b/app/views/step_nav/_structured_data.html.erb
@@ -1,3 +1,4 @@
 <script type="application/ld+json">
-  <%= raw Schemas::HowTo.new(step_by_step, self).structured_data.to_json %>
+  <% structured_data = Schemas::HowTo.new(step_by_step, self).structured_data %>
+  <%= raw JSON.pretty_generate(structured_data) %>
 </script>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -56,7 +56,7 @@
           "type": "controller",
           "class": "PeopleController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/people_controller.rb",
           "rendered": {
             "name": "people/show",
@@ -66,7 +66,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 13,
+          "line": 17,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_current_roles",
@@ -130,7 +130,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/people/_current_roles.html.erb",
-      "line": 20,
+      "line": 24,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "(Unresolved Model).new[\"links\"].fetch(\"ordered_parent_organisations\", []).map do\n link_to(parent[\"title\"], parent[\"base_path\"], :class => \"govuk-link\")\n end.to_sentence",
       "render_path": [
@@ -138,7 +138,7 @@
           "type": "controller",
           "class": "PeopleController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/people_controller.rb",
           "rendered": {
             "name": "people/show",
@@ -148,7 +148,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 13,
+          "line": 17,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_current_roles",
@@ -171,7 +171,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/roles/_responsibilities.html.erb",
-      "line": 9,
+      "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Role.find!(request.path).responsibilities",
       "render_path": [
@@ -179,7 +179,7 @@
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -207,6 +207,36 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "83c75781847c3bb2bb1f9d24934b22722d8f340da3401b6697fc5d160fbd6155",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/step_nav/_structured_data.html.erb",
+      "line": 3,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "JSON.pretty_generate(Schemas::HowTo.new(step_by_step, self).structured_data)",
+      "render_path": [
+        {
+          "type": "template",
+          "name": "step_nav/show",
+          "line": 3,
+          "file": "app/views/step_nav/show.html.erb",
+          "rendered": {
+            "name": "step_nav/_structured_data",
+            "file": "app/views/step_nav/_structured_data.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "step_nav/_structured_data"
+      },
+      "user_input": "Schemas::HowTo.new(step_by_step, self).structured_data",
+      "confidence": "Weak",
+      "note": "This comes from the content store and we trust the data there"
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 84,
       "fingerprint": "840e07ce0072ce08b8e6875bde330c91ba40ac3cd6545a95952a567008a3aa83",
       "check_name": "RenderInline",
@@ -220,7 +250,7 @@
           "type": "controller",
           "class": "PeopleController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/people_controller.rb",
           "rendered": {
             "name": "people/show",
@@ -230,7 +260,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 13,
+          "line": 17,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_current_roles",
@@ -253,7 +283,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
-      "line": 14,
+      "line": 15,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Role.find!(request.path).current_holder_biography",
       "render_path": [
@@ -261,7 +291,7 @@
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -294,7 +324,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/people/_biography.html.erb",
-      "line": 9,
+      "line": 10,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "Person.find!(request.path).biography",
       "render_path": [
@@ -302,7 +332,7 @@
           "type": "controller",
           "class": "PeopleController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/people_controller.rb",
           "rendered": {
             "name": "people/show",
@@ -312,7 +342,7 @@
         {
           "type": "template",
           "name": "people/show",
-          "line": 12,
+          "line": 16,
           "file": "app/views/people/show.html.erb",
           "rendered": {
             "name": "people/_biography",
@@ -335,7 +365,7 @@
       "check_name": "RenderInline",
       "message": "Unescaped model attribute rendered inline",
       "file": "app/views/roles/_current_role_holder_with_biography.html.erb",
-      "line": 8,
+      "line": 9,
       "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
       "code": "render(text => Role.find!(request.path).current_holder[\"title\"], { :margin_bottom => 2 })",
       "render_path": [
@@ -343,7 +373,7 @@
           "type": "controller",
           "class": "RolesController",
           "method": "show",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/roles_controller.rb",
           "rendered": {
             "name": "roles/show",
@@ -370,6 +400,6 @@
       "note": "This comes from the content store and we trust the data there."
     }
   ],
-  "updated": "2019-12-10 12:38:36 +0000",
-  "brakeman_version": "4.7.1"
+  "updated": "2020-07-21 17:06:24 +0100",
+  "brakeman_version": "4.8.2"
 }

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -1,6 +1,6 @@
 cy:
   transition_landing_page:
-    meta_title: "Y cyfnod pontio"
+    meta_title: Cymrwch y camau
     meta_description: "Mae’r DU wedi gadael yr UE. Ewch i weld beth mae’n ei olygu i chi."
     page_header: Cymrwch y camau
     page_header_explainer: |

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -1,7 +1,7 @@
 en:
   transition_landing_page:
     meta_title: The UK transition
-    meta_description: The UK has left the EU. Find out what this means for you.
+    meta_description: The UK's transition period after Brexit comes to an end this year. Find out how to get ready for new rules from January 2021.
     page_header: The UK transition
     page_header_explainer: |
       The UK has left the EU, and the transition period after Brexit comes to an end this year. Take action now to get ready for new rules from January 2021.

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -1,6 +1,6 @@
 en:
   transition_landing_page:
-    meta_title: The transition period
+    meta_title: The UK transition
     meta_description: The UK has left the EU. Find out what this means for you.
     page_header: The UK transition
     page_header_explainer: |

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -18,7 +18,7 @@ module TransitionLandingPageSteps
   end
 
   def then_i_can_see_the_title_section
-    assert page.has_selector?("title", text: "The transition period", visible: false)
+    assert page.has_selector?("title", text: "The UK transition", visible: false)
   end
 
   def then_i_can_see_the_header_section


### PR DESCRIPTION
- Sets the transition page titles to the same as the agreed h1 text
- Fixes the inadvertently overwritten meta-description
- Makes structured data (more) humanly readable

See individual commits for details