### PR TITLE
TransitionChecker1 AB test

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -7,6 +7,8 @@ class TransitionLandingPageController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
+    ab_test_variant.configure_response(response) if page_under_test?
+
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
@@ -40,5 +42,26 @@ private
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
+  end
+
+  helper_method :ab_test_variant, :page_under_test?, :show_variant?
+  def ab_test_variant
+    @ab_test_variant ||= begin
+      ab_test = GovukAbTesting::AbTest.new(
+        "TransitionChecker1",
+        dimension: 44,
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      ab_test.requested_variant(request.headers)
+    end
+  end
+
+  def page_under_test?
+    request.path == "/transition"
+  end
+
+  def show_variant?
+    page_under_test? && ab_test_variant.variant?("B")
   end
 end

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -3,7 +3,11 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">
-          <%= t("transition_landing_page.take_action_title") %>
+          <% if show_variant? %>
+            <%= t("transition_landing_page.take_action_title_variant_B") %>
+          <% else %>
+            <%= t("transition_landing_page.take_action_title") %>
+          <% end %>
         </h2>
       </div>
     </div>

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
+<% content_for :meta_tags do %>
+  <%= ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
+<% end %>
 
 <%=
   render(

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -6,6 +6,7 @@ en:
     page_header_explainer: |
       The UK has left the EU, and the transition period after Brexit comes to an end this year. Check the new rules from January 2021 and take action now.
     take_action_title: Take action and sign up for emails
+    take_action_title_variant_B: Take action
     take_action_text: |
       <p>Answer a few questions to get a personalised list of actions for you, your family, and your business. Then sign up for emails to get updates when things change.</p>
     take_action_start_now: Start now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,6 @@ Rails.application.routes.draw do
   end
 
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
-  get "/brexit(.:locale)", to: "transition_landing_page#show"
   get "/transition(.:locale)", to: "transition_landing_page#show"
 
   # We get requests for URLs like

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -2,18 +2,54 @@ require "test_helper"
 
 describe TransitionLandingPageController do
   include TaxonHelpers
+  include GovukAbTesting::MinitestHelpers
 
   describe "GET show" do
     before do
       brexit_taxon = taxon
-      brexit_taxon["base_path"] = "/brexit"
+      brexit_taxon["base_path"] = "/transition"
       stub_content_store_has_item(brexit_taxon["base_path"], brexit_taxon)
+      stub_content_store_has_item(brexit_taxon["base_path"] + ".cy", brexit_taxon)
     end
 
-    it "renders the page" do
-      get :show
+    %w[cy en].each do |locale|
+      params = locale == "en" ? {} : { locale: locale }
 
-      assert_response :success
+      it "renders the page for the #{locale} locale" do
+        get :show, params: params
+
+        assert_response :success
+      end
+    end
+
+    %w[A INVALID_VARIANT].each do |variant|
+      it "displays the default text for the #{variant} variant in the en locale" do
+        with_variant TransitionChecker1: "A" do
+          get :show
+          assert_select "h2", text: "Take action and sign up for emails"
+          assert_select "h2", text: "Take action", count: 0
+        end
+      end
+    end
+
+    it "shows the alternate text for the B variant in the en locale" do
+      with_variant TransitionChecker1: "B" do
+        get :show
+        assert_select "h2", text: "Take action"
+        assert_select "h2", text: "Take action and sign up for emails", count: 0
+      end
+    end
+
+    %w[A B INVALID_VARIANT].each do |variant|
+      it "displays the default text for the #{variant} variant in the cy locale" do
+        setup_ab_variant("TransitionChecker1", variant)
+
+        get :show, params: { locale: "cy" }
+
+        assert_response_not_modified_for_ab_test("TransitionChecker1")
+        assert_select "h2", text: "Cymrwch y camau a chofrestru ar gyfer negeseuon e-bost"
+        assert_select "h2", text: "Take action", count: 0
+      end
     end
   end
 end


### PR DESCRIPTION
## What
We want to test whether the mention of email signups is putting people off using the checker, so we're running a test where some users will see (the default) title of: 
> Take action and sign up for emails

and some will see

> Take action

This is only on the `/transition` page, and not `/transition.cy` for now. The proportion of traffic on the Welsh version is not sufficient to produce quick statistically significant results.

We add a Z variant to capture traffic that has not been assigned an A/B bucket from Fastly. Users in this variant will be shown the standard text, but will not be included in the test results.

It's possible to test this in the review app by using a browser extension such as "ModHeader" to include custom http headers with your request. You'd need to configure it to send:
`GOVUK-ABTEST-TRANSITIONCHECKER1` with a value of `A`, `B` or `AnYtHiNg YoU lIkE`.

Once it's on a GOV.UK environment, the standard GOV.UK browser extension comes into play.

https://govuk-collec-transtion--u3zg6y.herokuapp.com/transition

trello https://trello.com/c/K2JvlULI/356-hypothesis-test-1-remove-and-sign-up-for-email-from-checker-cta-title-on-transition-landing-page

## A variant (and anything else that is not B)

![Screenshot 2020-08-03 at 15 16 39](https://user-images.githubusercontent.com/773037/89192487-6ab3bc80-d59c-11ea-8132-78575ed5d89e.png)

## B variant 

![Screenshot 2020-08-03 at 15 16 27](https://user-images.githubusercontent.com/773037/89192496-70a99d80-d59c-11ea-9adc-185b7c611a32.png)
