### PR TITLE
Add logic to handle bold instructions on the coronavirus landing page

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -36,7 +36,13 @@
           </p>
           <ul class="covid__list covid__list--header">
             <% header["list"].each do | item | %>
-              <li class="covid__list-item"><%= item %></li>
+              <li class="covid__list-item">
+                <% if item.is_a?(Hash) %>
+                  <strong><%= item["instruction"] %></strong> - <%= item["detail"] %>
+                <% else %>
+                  <%= item %>
+                <% end %>
+              </li>
             <% end %>
           </ul>
 


### PR DESCRIPTION
https://github.com/alphagov/govuk-coronavirus-content/pull/384 makes changes to the copy. It's been asked that the first instructions in the heading box are in bold. This allows this to happen while keeping backwards compatibility for the old way while this is deployed.