### PR TITLE
Replace p tags with line breaks

### DIFF
--- a/app/views/transition_landing_page/components/_youtube_player.html.erb
+++ b/app/views/transition_landing_page/components/_youtube_player.html.erb
@@ -16,11 +16,11 @@
         <a href="<%= no_cookies_change_settings_link %>" class="govuk-link youtube__page-header-link youtube__bold">
           <%= no_cookies_change_settings_text %>
         </a>
-      </p>
-      <p class="govuk-body youtube__bold">
-        <%= no_cookies_to_watch_text %>
-      </p>
-      <p class="govuk-body">
+        <br>
+        <span class="youtube__bold">
+          <%= no_cookies_to_watch_text %>
+        </span>
+        <br>
         <%= no_cookies_or_text %>
       </p>
       <a


### PR DESCRIPTION
This is the text that is shown in place of the video if cookies are not accepted

The text is all part of one sentence. Using `p` tags to do the line breaks makes screen readers insert inappropriate pauses.

https://trello.com/c/P9rMz4eW/354-round-one-of-accessibility-fixes

## Before 
![Screenshot 2020-08-03 at 16 53 53](https://user-images.githubusercontent.com/773037/89201822-faac3300-d5a9-11ea-850b-5441e422635d.png)
