### PR TITLE
Transition: Add missing transcript sections

### DIFF
--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -56,6 +56,10 @@
   border-left-color: govuk-colour('white');
 }
 
+.govuk-details__list {
+  color: govuk-colour('white');
+}
+
 .govuk-details__summary-text {
   &:hover {
     color: govuk-colour('white');

--- a/app/views/transition_landing_page/_comms.html.erb
+++ b/app/views/transition_landing_page/_comms.html.erb
@@ -9,7 +9,7 @@
 
 <div class="landing-page__section landing-page__section--border-top">
   <h2 class="govuk-heading-l"><%= I18n.t('transition_landing_page.comms_header') %></h2>
-  <div class="<%= grid_class %>">
+  <div class="<%= grid_class %>" lang="en">
 
     <% if comms_links %>
       <div class="<%= links_grid_class %> landing-page__comms-links" data-module="track-click">

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -100,7 +100,7 @@ cy:
     email_mailto_subject: "Get%20ready%20for%202021%20-%20GOV.UK"
     share_links: "Rhannu’r dudalen hon"
     sections:
-      aria_string_suffix: related to the transition period
+      aria_string_suffix: ""
       services: Gwasanaethau
       guidance_and_regulation: Canllawiau a rheoliadau
       news_and_communications: Newyddion a chyfathrebu

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -27,7 +27,7 @@ en:
       <p>For businesses this includes preparing for a new approach to trade with our partners in the European Union.</p>
       <p>For individuals this may include registering your residency rights.</p>
       <p>The government will ensure:</p>
-      <ul>
+      <ul class="govuk-list govuk-list--bullet govuk-details__list">
         <li>exporters can take advantage of new trade agreements</li>
         <li>industry regulation allows small businesses to thrive</li>
         <li>our immigration system suits the needs of our economy</li>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -26,6 +26,15 @@ en:
       <p>Citizens and business can check what they need to do, to prepare for the changes and opportunities ahead as a sovereign nation.</p>
       <p>For businesses this includes preparing for a new approach to trade with our partners in the European Union.</p>
       <p>For individuals this may include registering your residency rights.</p>
+      <p>The government will ensure:</p>
+      <ul>
+        <li>exporters can take advantage of new trade agreements</li>
+        <li>industry regulation allows small businesses to thrive</li>
+        <li>our immigration system suits the needs of our economy</li>
+        <li>the UK fishing industry takes back control of UK waters</li>
+      </ul>
+      <p>Now is the time to unleash the productive power of every corner of the UK.</p>
+      <p>UK's new start: let's get going</p>
     no_cookies:
       icon_text: VIDEO
       change_settings_text: Change your cookie settings


### PR DESCRIPTION
These words are shown in the video, but are not in our transcript yet.

Picked up in an [accessibility audit](https://docs.google.com/presentation/d/1yDr23ID0BB8BhCBW4QpWfjPPZ1ti0u6oXCe_GTLj8_I/edit#slide=id.g8cb4049982_0_4)

https://trello.com/c/P9rMz4eW/354-round-one-of-accessibility-fixes

https://govuk-collec-en-transcr-vbq9bn.herokuapp.com/transition