### PR TITLE
Hide documents for joining organisations

### DIFF
--- a/app/views/organisations/separate_website.html.erb
+++ b/app/views/organisations/separate_website.html.erb
@@ -19,4 +19,6 @@
   </div>
 </div>
 
-<%= render partial: 'latest_documents_by_supergroup' %>
+<% unless @organisation.is_joining? %>
+  <%= render partial: 'latest_documents_by_supergroup' %>
+<% end %>

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -275,6 +275,11 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     assert_not page.has_css?(".gem-c-notice a")
     assert page.has_css?(".gem-c-govspeak")
     assert page.has_content?(/This organisation has a status of joining./i)
+    assert_not page.has_css?(".gem-c-heading", text: "Documents")
+    assert_not page.has_css?(".gem-c-heading", text: "News and communications")
+    assert_not page.has_css?(".gem-c-document-list__item-title[href='/content-item-1']", text: "Content item 1")
+    assert_not page.has_css?(".gem-c-heading", text: "Transparency")
+    assert_not page.has_css?(".gem-c-heading", text: "Guidance and regulation")
   end
 
   it "displays a left_gov organisation page correctly" do


### PR DESCRIPTION
Organisations that are just joining GOV.UK (created as "Coming soon" in [Whitehall](https://github.com/alphagov/whitehall/blob/52aff8f61a29b3999054b5b5c94875a5534eaf9a/app/views/admin/organisations/_form.html.erb#L42) ) currently display all associated documents on their organisation .

This change will prevent these documents from rendering on the organisation page until the organisation is live.

[Trello](https://trello.com/c/7FQYL0w8/2073-investigate-making-content-lists-not-display-on-organisation-pages-with-status-coming-soon)