### PR TITLE
Add lang to person data object

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -81,6 +81,7 @@ module Organisations
         description: nil,
         metadata: roles.map { |role| role["details"]["role_payment_type"] }.compact.first,
         heading_text: person["title"],
+        lang: person["locale"],
         heading_level: 0,
         extra_links_no_indent: true,
       }

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -22,6 +22,7 @@ describe Organisations::PeoplePresenter do
           description: nil,
           metadata: nil,
           heading_text: "Oliver Dowden CBE MP",
+          lang: "en",
           heading_level: 0,
           extra_links_no_indent: true,
           extra_links: [
@@ -48,6 +49,7 @@ describe Organisations::PeoplePresenter do
           description: nil,
           metadata: nil,
           heading_text: "The Rt Hon Theresa May MP",
+          lang: "en",
           heading_level: 0,
           extra_links_no_indent: true,
           extra_links: [
@@ -76,6 +78,7 @@ describe Organisations::PeoplePresenter do
           description: nil,
           metadata: nil,
           heading_text: "Stuart Andrew MP",
+          lang: "en",
           heading_level: 0,
           extra_links_no_indent: true,
           extra_links: [
@@ -168,6 +171,7 @@ describe Organisations::PeoplePresenter do
         description: "Cabinet Secretary",
         metadata: "Unpaid",
         heading_text: "Sir Jeremy Heywood",
+        lang: "en",
         heading_level: 0,
         extra_links_no_indent: true,
         image_src: "/photo/jeremy-heywood",
@@ -180,6 +184,7 @@ describe Organisations::PeoplePresenter do
         description: "Chief Executive of the Civil Service",
         metadata: nil,
         heading_text: "John Manzoni",
+        lang: "en",
         heading_level: 0,
         extra_links_no_indent: true,
       }

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -140,6 +140,7 @@ module OrganisationHelpers
         ordered_ministers: [
           {
             title: "Oliver Dowden CBE MP",
+            locale: "en",
             base_path: "/government/people/oliver-dowden",
             details: {
               image: {
@@ -160,6 +161,7 @@ module OrganisationHelpers
           },
           {
             title: "Stuart Andrew MP",
+            locale: "en",
             base_path: "/government/people/stuart-andrew",
             details: {},
             links: {
@@ -175,6 +177,7 @@ module OrganisationHelpers
           },
           {
             title: "The Rt Hon Theresa May MP",
+            locale: "en",
             base_path: "/government/people/theresa-may",
             details: {
               image: {
@@ -223,6 +226,7 @@ module OrganisationHelpers
         ordered_board_members: [
           {
             title: "Sir Jeremy Heywood",
+            locale: "en",
             base_path: "/government/people/jeremy-heywood",
             details: {
               image: {
@@ -242,6 +246,7 @@ module OrganisationHelpers
           },
           {
             title: "John Manzoni",
+            locale: "en",
             base_path: "/government/people/john-manzoni",
             details: {
               image: {
@@ -288,6 +293,7 @@ module OrganisationHelpers
         ordered_board_members: [
           {
             title: "Sir Jeremy Heywood",
+            locale: "en",
             base_path: "/government/people/jeremy-heywood",
             details: {
               image: {
@@ -308,6 +314,7 @@ module OrganisationHelpers
           },
           {
             title: "John Manzoni",
+            locale: "en",
             base_path: "/government/people/john-manzoni",
             details: {
               image: {


### PR DESCRIPTION
## Why

There are instances on the site where a page will be in Welsh, but certain components on the page will display data in English as there is no Welsh translation for those parts of the page.

One of those instances is on the organisations pages rendered by the collections project. Some of the organisations pages will include a list of people/ministers which often are not translated ([example](https://www.gov.uk/government/organisations/nuclear-decommissioning-authority.cy)). 
So even when the document itself is in Welsh, some of the ministers information is still in English (and not indicated as such). This is a WCAG fail.

## What
Add lang to the person object in people presenter. This supports the work to fix mixed languages on people/minister information on the organisation pages. Lang will now be included with the data we are passing to the `image_card` component, which renders the markup for each person in the people lists. 


Dependent on https://github.com/alphagov/govuk_publishing_components/pull/1634


https://trello.com/c/4znXL1Bn/78-fix-mixed-languages-on-people-minister-information