### PR TITLE
Label social media links as English

### DIFF
--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -36,7 +36,9 @@
           font_size: 19,
           lang: t_fallback('organisations.follow_us')
         } %>
-        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
+        <div lang="en">
+          <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
https://trello.com/c/Nl2OpZDU/79-fix-mixed-languages-on-social-media-links

Example pages: 
/government/organisations/attorney-generals-office, 
/government/organisations/office-of-the-secretary-of-state-for-wales

The overwhelming majority of social media links are written in English or are proper nouns, and all links for an org are displayed on all language variants of their page. This tiny change labels that area of the page as being English to aid assistive tech in interpreting it.

There are cases we know of where the links are input in another language such as Welsh but there is no method to signify this on input so we can't determine this in the front end. We will highlight these edge cases in the accessibility statement.

There are no visual changes. The component is not set up to expect a language parameter, so I've wrapped it in a div to label it.