### PR TITLE
Add lang to organisation contacts section

### DIFF
--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -32,6 +32,7 @@ module Organisations
     def format_contacts(contacts, foi: false)
       contacts.map do |contact|
         {
+          locale: contact["locale"] || "",
           title: foi_title(contact["details"]["title"], foi: foi),
           post_addresses: contact["details"]["post_addresses"]&.map do |post|
             contact_address(post)

--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -32,7 +32,7 @@ module Organisations
     def format_contacts(contacts, foi: false)
       contacts.map do |contact|
         {
-          locale: contact["locale"] || "",
+          locale: contact["locale"].presence,
           title: foi_title(contact["details"]["title"], foi: foi),
           post_addresses: contact["details"]["post_addresses"]&.map do |post|
             contact_address(post)

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -1,6 +1,6 @@
 <% if contacts.present? %>
 <% contacts.each do |contact| %>
-  <div class="organisation__contact-section <%= "organisation__contact-section--border-top" if local_assigns[:border] %>">
+  <div class="organisation__contact-section <%= "organisation__contact-section--border-top" if local_assigns[:border] %>" <%= "lang=#{contact[:locale]}" if contact[:locale] %>>
     <%= render "govuk_publishing_components/components/heading", {
       text: contact[:title],
       padding: true,

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -21,7 +21,7 @@
         <div class="<%= contact[:post_addresses].any? ? "govuk-grid-column-one-half" : "govuk-grid-column-two-thirds" %>">
           <% if contact[:email_addresses].any? %>
             <div class="organisation__margin-bottom">
-              <p><%= t('organisations.contact.email') %></p>
+              <p <%= "lang=en" if contact[:locale] != "en" %>><%= t('organisations.contact.email', locale: :en) %></p>
               <% contact[:email_addresses].each do |email| %>
                 <p><%= email.html_safe %></p>
               <% end %>

--- a/test/presenters/organisations/contacts_presenter_test.rb
+++ b/test/presenters/organisations/contacts_presenter_test.rb
@@ -14,6 +14,7 @@ describe Organisations::ContactsPresenter do
     it "formats foi contacts correctly" do
       expected = [
         {
+          locale: "en",
           title: "FOI stuff",
           post_addresses: [
             "Office of the Secretary of State for Wales<br/>Gwydyr House<br/>Whitehall<br/>SW1A 2NP<br/>UK<br/>",
@@ -30,6 +31,7 @@ describe Organisations::ContactsPresenter do
           description: "<p>FOI requests<br/><br/>are possible</p>",
         },
         {
+          locale: "en",
           title: "Freedom of Information requests",
           post_addresses: [
             "The Welsh Office<br/>Green House<br/>Bracknell<br/>B2 3ZZ<br/>",
@@ -44,6 +46,7 @@ describe Organisations::ContactsPresenter do
           description: "<p>Something here<br/><br/>Something there</p>",
         },
         {
+          locale: "en",
           title: "Freedom of Information requests",
           post_addresses: [],
           phone_numbers: [],
@@ -67,6 +70,7 @@ describe Organisations::ContactsPresenter do
     it "formats contact information correctly" do
       expected = [
         {
+          locale: "en",
           title: "Department for International Trade",
           post_addresses: [
             "King Charles Street<br/>Whitehall<br/>London<br/>SW1A 2AH<br/>United Kingdom<br/>",
@@ -97,6 +101,7 @@ describe Organisations::ContactsPresenter do
 
       expected = [
         {
+          locale: "en",
           title: "Department for International Trade",
           post_addresses: [nil],
           phone_numbers: [],

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -464,6 +464,7 @@ module OrganisationHelpers
       links: {
         ordered_foi_contacts: [
           {
+            locale: "en",
             withdrawn: false,
             details: {
               title: "FOI stuff",
@@ -499,6 +500,7 @@ module OrganisationHelpers
             },
           },
           {
+            locale: "en",
             withdrawn: false,
             details: {
               description: "Something here\r\n\r\nSomething there",
@@ -524,6 +526,7 @@ module OrganisationHelpers
             },
           },
           {
+            locale: "en",
             withdrawn: false,
             details: {
               description: "",
@@ -547,6 +550,7 @@ module OrganisationHelpers
       links: {
         ordered_contacts: [
           {
+            locale: "en",
             title: "Department for International Trade",
             details: {
               title: "Department for International Trade",
@@ -586,6 +590,7 @@ module OrganisationHelpers
       links: {
         ordered_contacts: [
           {
+            locale: "en",
             title: "Department for International Trade",
             details: {
               title: "Department for International Trade",


### PR DESCRIPTION
## What
Add `lang` attribute to FOI contacts section on organisation pages


## Why
Organisation pages can be translated (often into Welsh), but there are
parts of the page that are never translated and will fall back to the
English version.

The FOI contacts section is one of those areas that will sometimes fall
back to the default English version. This results in a WCAG fail as it
is not clearly indicated that part of the page is in a different
language than the rest of the page, which can be a problem for people
using assistive tech.

Adding lang to the areas that might be falling back to the English
language version will help resolve the problem.

-----

**BEFORE =  bad**: page is in Welsh, FOI contact is in English and not marked with `lang="en"`

<img width="1194" alt="Screenshot 2020-08-07 at 10 27 09" src="https://user-images.githubusercontent.com/7116819/89631466-b87c3d80-d898-11ea-95b0-af5861250c67.png">


**AFTER =  less bad**: page is in Welsh, FOI contact is in English, but marked as `lang="en"`

<img width="1198" alt="Screenshot 2020-08-07 at 10 27 50" src="https://user-images.githubusercontent.com/7116819/89631478-bc0fc480-d898-11ea-8641-d18eb70c3e8b.png">




https://trello.com/c/1sD18QyB