### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    brakeman (4.8.2)
+    brakeman (4.9.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.33.0)
@@ -101,12 +101,12 @@ GEM
     cucumber-create-meta (1.0.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
       sys-uname (~> 1.2, >= 1.2.1)
-    cucumber-cucumber-expressions (10.2.1)
-    cucumber-gherkin (14.0.1)
-      cucumber-messages (~> 12.2, >= 12.2.0)
-    cucumber-html-formatter (7.0.0)
-      cucumber-messages (~> 12.2, >= 12.2.0)
-    cucumber-messages (12.2.0)
+    cucumber-cucumber-expressions (10.3.0)
+    cucumber-gherkin (14.2.0)
+      cucumber-messages (~> 12.4, >= 12.4.0)
+    cucumber-html-formatter (7.2.0)
+      cucumber-messages (~> 12.4, >= 12.4.0)
+    cucumber-messages (12.4.0)
       protobuf-cucumber (~> 3.10, >= 3.10.8)
     cucumber-rails (2.1.0)
       capybara (>= 2.12, < 4)
@@ -180,12 +180,12 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jasmine (3.5.1)
-      jasmine-core (~> 3.5.0)
+    jasmine (3.6.0)
+      jasmine-core (~> 3.6.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (3.5.0)
+    jasmine-core (3.6.0)
     jasmine_selenium_runner (3.0.0)
       jasmine (~> 3.0)
       selenium-webdriver (~> 3.8)
@@ -246,8 +246,8 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.5)
-    puma (4.3.5)
+    public_suffix (4.0.6)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -305,8 +305,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.2.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     rubocop-govuk (3.17.0)
       rubocop (= 0.87.1)
       rubocop-rails (= 2.6.0)
@@ -342,7 +342,7 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (3.0.4)
       faraday (>= 1.0)
-    simplecov (0.18.5)
+    simplecov (0.19.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
@@ -431,9 +431,6 @@ DEPENDENCIES
   uglifier
   webdrivers
   webmock
-
-RUBY VERSION
-   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.3

--- a/test/presenters/organisations/document_presenter_test.rb
+++ b/test/presenters/organisations/document_presenter_test.rb
@@ -25,7 +25,7 @@ describe Organisations::DocumentPresenter do
 
   context "content_store_document_type has an acronym" do
     it "transforms the acronym in the doc type" do
-      expected = presenter("content_store_document_type" => "Aaib_report")
+      expected = presenter({ "content_store_document_type" => "Aaib_report" })
 
       assert_equal expected.present[:metadata][:document_type], "Air Accidents Investigation Branch report"
     end


### PR DESCRIPTION
These are the necessary changes to upgrade to Ruby 2.7

Since there is an automatic way of handling changing ruby versions across govuk apps, I updated it locally, made the changes, but then changed the version back before creating a PR. 

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.