### PR TITLE
Add lang to main element in application template

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 </head>
 
 <body <% if content_for(:is_full_width_header) %>class="full-width"<% end %>>
-  <div class="wrapper" id="wrapper" <%= "lang=#{@content_item["locale"]}" unless !@content_item["locale"] || @content_item["locale"].eql?("en") %>>
+  <div class="wrapper" id="wrapper">
     <% unless content_for(:is_full_width_header) %>
       <% if content_for?(:breadcrumbs) %>
         <%= yield :breadcrumbs %>
@@ -20,7 +20,7 @@
       <% end %>
     <% end %>
 
-    <main id="content" role="main" class="content <%= yield :page_class %>">
+    <main id="content" role="main" class="content <%= yield :page_class %>" <%= "lang=#{@content_item["locale"]}" unless !@content_item["locale"] || @content_item["locale"].eql?("en") %>>
       <%= yield %>
     </main>
 


### PR DESCRIPTION
The` <div id="wrapper">` element is a container for the application
breadcrumbs, for the feedback component, and for the `<main id="content">`
element.

Out of these three things, only the `<main>` element contains content that
might be translated into languages other than English. Seeing as at this
time both the breadcrumbs and the feedback component are in English, it
makes more sense to add a lang attribute to the `<main>` element instead
of the wrapper element.

This removes the need to override `lang` for feedback/breadcrumbs when a
page is being viewed in a language other than English.