### PR TITLE
Display localised terms for news document type on org pages

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -100,7 +100,7 @@ module Organisations
           image_alt: news["image"]["alt_text"],
           context: {
             date: date,
-            text: I18n.t("content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
+            text: I18n.t("organisations.content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
           },
           heading_text: news["title"],
           description: news["summary"].html_safe,


### PR DESCRIPTION
On the organisations pages, news stories using the image card component were always displaying the English translation as their document type even though translations existed in the config.

This changes the way document type data is pulled from the locale, to ensure that the localised terms are displayed when an organisation page is viewed in a certain language (e.g displaying 'Stori newyddion' instead of 'News story'

**Before**: the term "Press Release" is in English even though we are viewing the Welsh version of the page

<img width="967" alt="Screenshot 2020-08-13 at 16 50 39" src="https://user-images.githubusercontent.com/7116819/90157138-3eaaef00-dd85-11ea-86f0-6dd5cac1adea.png">


**After**: uses the Welsh version of "Press Release"

<img width="968" alt="Screenshot 2020-08-13 at 16 51 05" src="https://user-images.githubusercontent.com/7116819/90157149-436fa300-dd85-11ea-8337-68accf6380fc.png"> 






https://trello.com/c/uA7mDUvI

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
