### PR TITLE
Fix translations for documents on organisations pages

### DIFF
--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -17,6 +17,7 @@ module Organisations
         link: {
           text: @raw_document["title"],
           path: @raw_document["link"],
+          locale: "en",
         },
       }.merge(present_metadata)
     end

--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -44,7 +44,7 @@ module Organisations
     def document_type
       return if document_translation.blank?
 
-      document_type = I18n.t(document_translation, default: cleaned_document_type)
+      document_type = I18n.t(document_translation, default: cleaned_document_type.titleize.gsub("_", " "))
 
       # Handle document types with acronyms
       document_acronyms = %w[Foi Dfid Aaib Cma Esi Hmrc Html Maib Raib Utaac]

--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -20,7 +20,7 @@ module Organisations
       }.merge(present_metadata)
     end
 
-    def present_metadata
+    def present_metadata      
       if include_metadata
         {
           metadata: {
@@ -40,7 +40,7 @@ module Organisations
 
       return if type.blank?
 
-      document_type = type.capitalize.tr("_", " ")
+      document_type = I18n.t("organisations.content_item.schema_name.#{type}.one")
 
       # Handle document types with acronyms
       document_acronyms = %w[Foi Dfid Aaib Cma Esi Hmrc Html Maib Raib Utaac]

--- a/test/presenters/organisations/document_presenter_test.rb
+++ b/test/presenters/organisations/document_presenter_test.rb
@@ -7,10 +7,15 @@ describe Organisations::DocumentPresenter do
         link: {
           text: "Quiddich World Cup 2022 begins",
           path: "/government/news/its-coming-home",
+          locale: "en",
         },
         metadata: {
           public_updated_at: Date.parse("2022-11-21T12:00:00.000+01:00"),
           document_type: "News story",
+          locale: {
+            public_updated_at: false,
+            document_type: false,
+          },
         },
       }
 
@@ -22,7 +27,7 @@ describe Organisations::DocumentPresenter do
     it "transforms the acronym in the doc type" do
       expected = presenter("content_store_document_type" => "Aaib_report")
 
-      assert_equal expected.present[:metadata][:document_type], "AAIB report"
+      assert_equal expected.present[:metadata][:document_type], "Air Accidents Investigation Branch report"
     end
   end
 
@@ -32,6 +37,7 @@ describe Organisations::DocumentPresenter do
         link: {
           text: "Quiddich World Cup 2022 begins",
           path: "/government/news/its-coming-home",
+          locale: "en",
         },
       }
 

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -68,10 +68,15 @@ describe Organisations::DocumentsPresenter do
               link: {
                 text: "Rapist has sentence increased after Solicitor General’s referral",
                 path: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
+                locale: "en",
               },
               metadata: {
                 document_type: "Press release",
                 public_updated_at: Date.parse("2018-06-18T17:39:34.000+01:00"),
+                locale: {
+                  document_type: false,
+                  public_updated_at: false,
+                },
               },
             },
           ],
@@ -85,7 +90,7 @@ describe Organisations::DocumentsPresenter do
       # This only applies to types containing "FOI" and "DFID"
       stub_rummager_latest_content_with_acronym("attorney-generals-office")
 
-      expected = "DFID research output"
+      expected = "Research for Development Output"
       actual = @documents_presenter.latest_documents[:items].first[:metadata][:document_type]
 
       assert_equal expected, actual

--- a/test/presenters/organisations/supergroups_presenter_test.rb
+++ b/test/presenters/organisations/supergroups_presenter_test.rb
@@ -59,7 +59,7 @@ describe Organisations::SupergroupsPresenter do
       assert_equal "Content item 1", document[:link][:text]
       assert_equal "/content-item-1", document[:link][:path]
       assert_equal Date.parse(1.hour.ago.iso8601), document[:metadata][:public_updated_at]
-      assert_equal "Transparency", document[:metadata][:document_type]
+      assert_equal "Transparency data", document[:metadata][:document_type]
 
       assert_equal "/search/transparency-and-freedom-of-information-releases?organisations[]=attorney-generals-office&parent=attorney-generals-office", transparency[:finder_link][:path]
       assert_equal "See all transparency and freedom of information releases", transparency[:finder_link][:text]

--- a/test/unit/organisation_helper_test.rb
+++ b/test/unit/organisation_helper_test.rb
@@ -39,10 +39,15 @@ describe OrganisationHelper do
         link: {
           text: "demo",
           path: "/demo",
+          locale: "en",
         },
         metadata: {
           public_updated_at: nil,
           document_type: nil,
+          locale: {
+            public_updated_at: false,
+            document_type: :en,
+          },
         },
       }
     end


### PR DESCRIPTION
## What
Adds several features to the documents presenter:

- Explicitly passes `locale: "en"` with the document link title to the documents list component
- Passes a `locale` object with the document metadata to the documents list component, including fallback locales for both the document type and document publish time
- Checks for an existing translation of the document type

Related to this PR for govuk_publishing_components <https://github.com/alphagov/govuk_publishing_components/pull/1643>

## Why
This is part of the wider work to fix i18n issues across govuk, which itself is part of the work to make govuk WCAG 2.1 compliant. As the scope of this work is limited and we don't have time to translate everything, passing the locale code as a `lang` html attribute will be enough for these language discrepancies to pass WCAG 2.1. Some more explicit reasoning behind my choices:

- Some research suggests that the govuk search API, where the documents are being pulled from, only return English results currently. I've therefore made the choice to confidently pass an "en" locale code.
- Translations for the vast majority of document types already existed in collections. The code however was being cleaned and passed directly to the frontend instead of via rails' i18n translate method. I've reimplemented this and added both a fallback to pass the locale attribute and if the translation for a particular document type doesn't exist anywhere in collections.

### Before
<img width="664" alt="Screenshot 2020-08-13 at 16 49 54" src="https://user-images.githubusercontent.com/64783893/90157529-bed15480-dd85-11ea-9ac1-0116947c19ba.png">

### After
<img width="913" alt="Screenshot 2020-08-13 at 16 54 52" src="https://user-images.githubusercontent.com/64783893/90157564-c7c22600-dd85-11ea-8985-21c093124771.png">

**Card:** https://trello.com/c/HT0lvX7v/77-fix-part-language-mixed-languages-on-document-lists