### PR TITLE
Revert "Display localised terms for news document type on org pages"

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -100,7 +100,7 @@ module Organisations
           image_alt: news["image"]["alt_text"],
           context: {
             date: date,
-            text: I18n.t("organisations.content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
+            text: I18n.t("content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
           },
           heading_text: news["title"],
           description: news["summary"].html_safe,


### PR DESCRIPTION
Reverts alphagov/collections#1866

This change is causing a number of errors in sentry at the moment: https://sentry.io/organizations/govuk/issues/1846708045/?project=202213&referrer=slack

Running the master branch locally the same errors can be replicated, and fixed by undoing the change. So reverting for now to give time to find a solution.