### PR TITLE
Display localisations for news document type

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -93,6 +93,7 @@ module Organisations
 
       featured.each do |news|
         date = Date.parse(news["public_updated_at"]) if news["public_updated_at"]
+        text = I18n.t("organisations.content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]) if news["document_type"]
 
         news_stories << {
           href: news["href"],
@@ -100,7 +101,7 @@ module Organisations
           image_alt: news["image"]["alt_text"],
           context: {
             date: date,
-            text: I18n.t("content_item.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]),
+            text: text,
           },
           heading_text: news["title"],
           description: news["summary"].html_safe,


### PR DESCRIPTION
Ensure that image card component news stories are displaying the correct translation for document type. E.g displaying 'Stori newyddion' instead of 'News story'.

Don't call the I18n translation function if `document_type` is `null` as this leads to an error.

The original change [here](https://github.com/alphagov/collections/pull/1866) was reverted [here](https://github.com/alphagov/collections/pull/1871) due to causing [errors](https://sentry.io/organizations/govuk/issues/1846708045/events/ef64bf5ed5284790889c1bbf9bdd278b/#exception)  on this page https://www.gov.uk/government/organisations/hm-treasury


A brief investigation into the content item revealed that the **A Plan for Jobs 2020** document  had `"document_type": null` which was leading to an `I18n::InvalidPluralizationData`  error.


------------


## Context from original PR:

On the organisations pages, news stories using the image card component were always displaying the English translation as their document type even though translations existed in the config.

This changes the way document type data is pulled from the locale, to ensure that the localised terms are displayed when an organisation page is viewed in a certain language (e.g displaying 'Stori newyddion' instead of 'News story'

**Before**: the term "Press Release" is in English even though we are viewing the Welsh version of the page

<img width="967" alt="Screenshot 2020-08-13 at 16 50 39" src="https://user-images.githubusercontent.com/7116819/90157138-3eaaef00-dd85-11ea-86f0-6dd5cac1adea.png">


**After**: uses the Welsh version of "Press Release"

<img width="968" alt="Screenshot 2020-08-13 at 16 51 05" src="https://user-images.githubusercontent.com/7116819/90157149-436fa300-dd85-11ea-8337-68accf6380fc.png"> 


https://trello.com/c/uA7mDUvI 