### PR TITLE
Set up the TransitionChecker3 AB test

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -48,7 +48,7 @@ private
   def ab_test_variant
     @ab_test_variant ||= begin
       ab_test = GovukAbTesting::AbTest.new(
-        "TransitionChecker2",
+        "TransitionChecker3",
         dimension: 44,
         allowed_variants: %w[A B Z],
         control_variant: "Z",

--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -6,14 +6,14 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-l">
-        <%= t("transition_landing_page.guidance_header") %>
-      </h2>
-       <p class="landing-page__guidance_subheader" data-module="track-click">
         <% if show_variant? %>
-          <%= raw t("transition_landing_page.guidance_subheader_variant_b") %>
+          <%= raw t("transition_landing_page.guidance_header_variant_b") %>
         <% else %>
-          <%= t("transition_landing_page.guidance_subheader") %>
+          <%= t("transition_landing_page.guidance_header") %>
         <% end %>
+      </h2>
+      <p class="landing-page__guidance_subheader" data-module="track-click">
+        <%= raw t("transition_landing_page.guidance_subheader") %>
       </p>
     </div>
   </div>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -41,8 +41,8 @@ en:
       or_text: or
       watch_link_text: Watch on YouTube
     guidance_header: "Actions you can take now"
-    guidance_subheader: "Actions you can take now that do not depend on negotiations."
-    guidance_subheader_variant_b: "These are some of the new rules from January 2021. For a complete list of actions <a href='/transition-check/questions' class='govuk-link' data-track-category='transition-landing-page' data-track-action='/transition-check/questions' data-track-label='answer a few questions' >answer a few questions</a> about you, your family or business."
+    guidance_header_variant_b: "Some of the new rules for 2021"
+    guidance_subheader: "These are some of the new rules from January 2021. For a complete list of actions <a href='/transition-check/questions' class='govuk-link' data-track-category='transition-landing-page' data-track-action='/transition-check/questions' data-track-label='answer a few questions' >answer a few questions</a> about you, your family or business."
     campaign_buckets:
       - row_title: "Travelling to the EU"
         list_block: |

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -24,31 +24,31 @@ describe TransitionLandingPageController do
 
     %w[A INVALID_VARIANT].each do |variant|
       it "displays the default text for the #{variant} variant in the en locale" do
-        with_variant TransitionChecker2: "A" do
+        with_variant TransitionChecker3: "A" do
           get :show
-          assert_select ".landing-page__guidance_subheader", text: "Actions you can take now that do not depend on negotiations."
-          assert_select ".landing-page__guidance_subheader", text: "These are some of the new rules from January 2021. For a complete list of actions answer a few questions about you, your family or business.", count: 0
+          assert_select "h2", text: "Actions you can take now"
+          assert_select "h2", text: "Some of the new rules for 2021", count: 0
         end
       end
     end
 
     it "shows the alternate text for the B variant in the en locale" do
-      with_variant TransitionChecker2: "B" do
+      with_variant TransitionChecker3: "B" do
         get :show
-        assert_select ".landing-page__guidance_subheader", text: "These are some of the new rules from January 2021. For a complete list of actions answer a few questions about you, your family or business."
-        assert_select ".landing-page__guidance_subheader", text: "Actions you can take now that do not depend on negotiations.", count: 0
+        assert_select "h2", text: "Some of the new rules for 2021"
+        assert_select "h2", text: "Actions you can take now", count: 0
       end
     end
 
     %w[A B INVALID_VARIANT].each do |variant|
       it "displays the default text for the #{variant} variant in the cy locale" do
-        setup_ab_variant("TransitionChecker2", variant)
+        setup_ab_variant("TransitionChecker3", variant)
 
         get :show, params: { locale: "cy" }
 
-        assert_response_not_modified_for_ab_test("TransitionChecker1")
-        assert_select ".landing-page__guidance_subheader", text: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
-        assert_select ".landing-page__guidance_subheader", text: "These are some of the new rules from January 2021. For a complete list of actions answer a few questions about you, your family or business.", count: 0
+        assert_response_not_modified_for_ab_test("TransitionChecker3")
+        assert_select "h2", text: "Camau y gallwch eu cymryd nawr"
+        assert_select "h2", text: "Some of the new rules for 2021", count: 0
       end
     end
   end


### PR DESCRIPTION
### What
Stop[ TransitionChecker2 AB test](https://github.com/alphagov/collections/pull/1865), and start TransitionChecker3 AB test.

### Details
TransitionChecker2 changed subheading text in the "Actions you can take now section", but it did not lead to a significant improvement in clicks through to the tracker. So in test 3 we we are leaving that subheading text in place, but amending the heading text. **Control**: Actions you can take now. **B**: Some of the new rules for 2021

### Testing
It's possible to test this in the [review app](https://govuk-collec-ab-test-3-haxl1yp.herokuapp.com/transition) by using a browser extension such as "ModHeader" to include custom http headers with your request. You'd need to configure it to send:
GOVUK-ABTEST-TRANSITIONCHECKER3 with a value of A or B

Trello: https://trello.com/c/HT54mSlR/387-hypothesis-test-3-actions-you-can-take-now-section-title-change

### Control (variants A and Z)

<img width="1030" alt="Screenshot 2020-08-19 at 12 08 04" src="https://user-images.githubusercontent.com/17908089/90628274-3f280780-e215-11ea-9442-25b263b7db5f.png">


### B variant

<img width="1068" alt="Screenshot 2020-08-19 at 12 07 42" src="https://user-images.githubusercontent.com/17908089/90628244-30d9eb80-e215-11ea-97fd-48b5d636ebe2.png">

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
