### PR TITLE
Set A to Z element to be an h3

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,10 +7,6 @@ module ApplicationHelper
     request.path.starts_with?(section.base_path)
   end
 
-  def hairspace(string)
-    string.gsub(/\s/, "\u200A") # \u200A = unicode hairspace
-  end
-
   def current_path_without_query_string
     request.original_fullpath.split("?", 2).first
   end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -5,7 +5,7 @@
     <% if page.lists.curated? %>
       <h3 class='list-header'><%= list.title %></h3>
     <% else %>
-      <p class="sort-order"><%= hairspace list.title %></p>
+      <h3 class="sort-order"><%= list.title %></h3>
     <% end %>
 
     <ul>

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -1,7 +1,7 @@
 <div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
   <h2 tabindex="-1" class="js-heading"><%= title %></h2>
   <% unless curated_order %>
-    <p class="sort-order"><%= hairspace 'A to Z' %></p>
+    <h3 class="sort-order"><%= "A to Z" %></h3>
   <% end %>
   <ul>
     <% second_level_browse_pages.each_with_index do |browse_page, index| %>

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -78,11 +78,11 @@ Then(/^I should see the second level browse page$/) do
 end
 
 Then(/^the A to Z label should be present$/) do
-  assert page.has_content?("A\u200Ato\u200AZ")
+  assert page.has_content?("A to Z")
 end
 
 Then(/^the A to Z label should not be present$/) do
-  assert page.has_no_content?("A\u200Ato\u200AZ")
+  assert page.has_no_content?("A to Z")
 end
 
 When(/^I visit that browse page$/) do


### PR DESCRIPTION
## What
This PR achieves 2 things: 

1. Reworks the "A to Z" text seen on browse views ([example](https://www.gov.uk/browse/benefits/disability)) so that it now sits within an h3 tag.
2. Removes the `hairspace` helper method and all instances of it.

## Why
It was raised during the accessibility audit of govuk that there are several pages where there are elements that look like headings but aren't, failing WCAG criterion 1.3.1. The reason I've removed `hairspace` is because the hairspace unicode character isn't recognised by screen readers. In this example, the string "A to Z" with the spaces replaced with a hairspace get read out by screen readers as "ah-toz".

### Before
<img width="479" alt="Screenshot 2020-08-28 at 11 11 51" src="https://user-images.githubusercontent.com/64783893/91558239-e3086600-e92d-11ea-9f24-eb72c941d053.png">

### After
<img width="463" alt="Screenshot 2020-08-28 at 11 14 16" src="https://user-images.githubusercontent.com/64783893/91558267-edc2fb00-e92d-11ea-954f-05d44e91541c.png">

**Card:** https://trello.com/c/g7RVI9Mq/338-browse-pages-text-looks-like-heading-but-isnt-one

