### PR TITLE
Make requested changes to header notice

### DIFF
--- a/app/assets/stylesheets/components/_header-notice.scss
+++ b/app/assets/stylesheets/components/_header-notice.scss
@@ -51,3 +51,8 @@
 .app-c-header-notice__call-to-action {
   @include govuk-font(16, $weight: bold);
 }
+
+.app-c-header-notice__call-to-action-description {
+  @include govuk-font(19);
+  padding-top: govuk-spacing(3)
+}

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -41,7 +41,7 @@
         <%= link_to(call_to_action[:title], call_to_action[:href], class: "app-c-header-notice__call-to-action-link govuk-link") %>
       </p>
       <% if call_to_action[:description].present? %>
-        <p class="govuk-body-s"><%= call_to_action[:description] %></p>
+        <p class="app-c-header-notice__call-to-action-description"><%= call_to_action[:description] %></p>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
This makes some changes to how the header notice looks. It slightly increases font size for the description and adds a small amount of padding above the text.

## Before 
<img width="962" alt="Screenshot 2020-09-01 at 14 09 58" src="https://user-images.githubusercontent.com/24547207/91855294-e452cf00-ec5c-11ea-9de5-364c2b40b0ee.png">

## After
<img width="961" alt="Screenshot 2020-09-01 at 14 07 06" src="https://user-images.githubusercontent.com/24547207/91855308-e87eec80-ec5c-11ea-82c2-55def7498074.png">
