### PR TITLE
Organisations page hidden headings

### DIFF
--- a/app/views/organisations/_expanded_works_with_organisations.html.erb
+++ b/app/views/organisations/_expanded_works_with_organisations.html.erb
@@ -4,7 +4,7 @@
 
 <div class="organisation-list__works-with js-hidden" id="toggle_<%= current_organisation.parameterize %>">
   <% works_with_organisations.each do |type, work_with_organisations| %>
-    <p class="organisation-list__works-with-title"><%=  t('organisations.type.' + type) %></p>
+    <h4 class="organisation-list__works-with-title"><%=  t('organisations.type.' + type) %></h4>
     <ul class="organisation-list__works-with-list">
       <% work_with_organisations.each do |work_with_organisation| %>
         <li class="organisation-list__works-with-list-item">
@@ -14,4 +14,3 @@
     </ul>
   <% end %>
 </div>
-

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -26,7 +26,8 @@
                   url: organisation["href"],
                   brand: organisation["brand"],
                   crest: organisation["logo"]["crest"]
-                }
+                },
+                heading_level: 3
               } %>
             <% else %>
               <%= link_to(organisation["title"], organisation["href"], class: "govuk-link organisation-list__item-title") %>


### PR DESCRIPTION
## What 

Use the appropriate heading tags so that the semantics of the content on the https://www.gov.uk/government/organisations page  matches the visual presentation.

https://trello.com/c/VhrxWh8O

## Why

The bold text in the hidden sections on the government organisations page looks like it should be a heading but is not marked up as one.  This is a WCAG fail.

**Text that should be a heading but uses a `<p>` tag instead:**
![image](https://user-images.githubusercontent.com/7116819/91981824-4d037f80-ed21-11ea-8d57-8b216267be60.png)

In addition to marking up the text in the screenshot above as a heading, this also makes the organisation logos/titles into headings as well. This was done in order to represent content hierarchy accurately.

<img width="1022" alt="Screenshot 2020-09-03 at 11 55 19" src="https://user-images.githubusercontent.com/7116819/92106509-674e6380-eddc-11ea-81cf-b737a3856610.png">





------

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
