### PR TITLE
Load ActiveModel on Coronavirus landing page

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,3 +1,5 @@
+require "active_model"
+
 class CoronavirusLandingPageController < ApplicationController
   skip_before_action :set_expiry
   before_action -> { set_expiry(5.minutes) }


### PR DESCRIPTION
When run locally, the coronavirus landing page errored with:

`uninitialized constant #<Class:0x0000562f92d53730>::ActiveModel`

This was being caused by the following line in one of the live stream
views:

`<% if ActiveModel::Type::Boolean.new.cast(live_stream["show_live_stream"]) %>`

This line was added to make sure that the live stream would be correctly
toggled on of of even if the value of `show_live_stream` was set to
`"false"` rather than `false`.

The error doesn't occur in production because the dependencies are
front-loaded, but that's not the case locally.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
