### PR TITLE
Turn off Transition Checker AB Test 4

### DIFF
--- a/app/assets/stylesheets/views/_transition-landing-page.scss
+++ b/app/assets/stylesheets/views/_transition-landing-page.scss
@@ -108,13 +108,6 @@ $green: #00703C;
 
 .landing-page__take-action-button {
   .govuk-button {
-    background-color: $dark-blue;
-    box-shadow: 0 2px 0 $dark-blue-shadow;
-  }
-}
-
-.landing-page__take-action-button_variantB {
-  .govuk-button {
     background-color: $green;
     box-shadow: 0 2px 0 $dark-blue-shadow;
   }

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -7,8 +7,6 @@ class TransitionLandingPageController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
-    ab_test_variant.configure_response(response) if page_under_test?
-
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
@@ -42,26 +40,5 @@ private
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
-  end
-
-  helper_method :ab_test_variant, :page_under_test?, :show_variant?
-  def ab_test_variant
-    @ab_test_variant ||= begin
-      ab_test = GovukAbTesting::AbTest.new(
-        "TransitionChecker4",
-        dimension: 44,
-        allowed_variants: %w[A B Z],
-        control_variant: "Z",
-      )
-      ab_test.requested_variant(request.headers)
-    end
-  end
-
-  def page_under_test?
-    request.path == "/transition"
-  end
-
-  def show_variant?
-    page_under_test? && ab_test_variant.variant?("B")
   end
 end

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -13,11 +13,7 @@
         } do %>
           <%= t("transition_landing_page.take_action_text").html_safe() %>
         <% end %>
-        <% if show_variant? %>
-          <div class="landing-page__take-action-button_variantB">
-        <% else %>
           <div class="landing-page__take-action-button">
-        <% end %>
           <%= render "govuk_publishing_components/components/button", {
             text: t("transition_landing_page.take_action_start_now"),
             href: t("transition_landing_page.take_action_start_now_link"),

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :meta_tags do %>
-  <%= ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
-<% end %>
+<% content_for :meta_tags %>
 
 <%=
   render(

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -21,35 +21,5 @@ describe TransitionLandingPageController do
         assert_response :success
       end
     end
-
-    %w[A INVALID_VARIANT].each do |variant|
-      it "displays the default blue button for the #{variant} variant in the en locale" do
-        with_variant TransitionChecker4: "A" do
-          get :show
-          assert_select "div.landing-page__take-action-button"
-          assert_select "div.landing-page__take-action-button_variantB", count: 0
-        end
-      end
-    end
-
-    it "displays a red button for the B variant in the en locale" do
-      with_variant TransitionChecker4: "B" do
-        get :show
-        assert_select "div.landing-page__take-action-button_variantB"
-        assert_select "div.landing-page__take-action-button", count: 0
-      end
-    end
-
-    %w[A B INVALID_VARIANT].each do |variant|
-      it "displays the default blue button for the #{variant} variant in the cy locale" do
-        setup_ab_variant("TransitionChecker4", variant)
-
-        get :show, params: { locale: "cy" }
-
-        assert_response_not_modified_for_ab_test("TransitionChecker3")
-        assert_select "div.landing-page__take-action-button"
-        assert_select "div.landing-page__take-action-button_variantB", count: 0
-      end
-    end
   end
 end


### PR DESCRIPTION
## What

- Turn of the AB test
- Make the start now button on the transition landing page green, instead of blue, as that variant won.

## Before
<img width="817" alt="Screenshot 2020-09-08 at 16 14 01" src="https://user-images.githubusercontent.com/17908089/92495042-580d5280-f1ee-11ea-98db-9552995bf825.png">

## After
<img width="754" alt="Screenshot 2020-09-08 at 16 12 02" src="https://user-images.githubusercontent.com/17908089/92494815-0fee3000-f1ee-11ea-9532-07e25e3c8dd4.png">

trello: https://trello.com/c/dCnm694O/435-a-b-test-4-results

related: https://github.com/alphagov/govuk-cdn-config/pull/288
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
