### PR TITLE
Third level browse links underlines

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -277,7 +277,6 @@
       ul li a {
         @include govuk-font(19, $weight: bold);
         display: block;
-        text-decoration: none;
         padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
       }
 


### PR DESCRIPTION
The "third level" browse links on pages such as this one can only be distinguished through colour: www.gov.uk/browse/benefits/entitlement

This is a problem as people with certain visual impairments could experience issues distinguishing between a link and regular text.

This removes the `text-decoration: none` rule that removed the underlines from the links in question.

### Before

<img width="1311" alt="Screenshot 2020-09-08 at 16 15 12" src="https://user-images.githubusercontent.com/7116819/92495238-94d94980-f1ee-11ea-806f-554f6b6c1d27.png">

### After

<img width="1321" alt="Screenshot 2020-09-08 at 16 14 55" src="https://user-images.githubusercontent.com/7116819/92495226-9145c280-f1ee-11ea-8686-92f11b1a1329.png">

https://trello.com/c/iRP9fAYw


------ 
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
