### PR TITLE
Update headings to add context

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, page.title %>
+<% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <meta name='govuk:navigation-page-type' content='First Level Browse'>
@@ -10,7 +10,7 @@
 <div class="browse-panes section" data-state="section" data-module="track-click">
   <div id="section" class="section-pane pane with-sort">
     <%= render 'second_level_browse_page/second_level_browse_pages',
-          title: page.title,
+          title: yield(:title),
           second_level_browse_pages: page.second_level_browse_pages,
           curated_order: page.second_level_pages_curated? %>
   </div>

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,5 +1,5 @@
 <div class="pane-inner <%= page.lists.curated? ? 'curated-list' : 'a-to-z' %>">
-  <h2 tabindex="-1" class="js-heading"><%= page.title %></h2>
+  <h2 tabindex="-1" class="js-heading"><%= t("shared.browse.prefix") %> <%= page.title %></h2>
 
   <% page.lists.each_with_index do |list, section_index| %>
     <% if page.lists.curated? %>

--- a/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_second_level_browse_pages.html.erb
@@ -1,5 +1,5 @@
 <div class="pane-inner <%= curated_order ? "curated" : "alphabetical" %>">
-  <h2 tabindex="-1" class="js-heading"><%= title %></h2>
+  <h2 tabindex="-1" class="js-heading"><%= t("shared.browse.prefix") %> <%= title.sub(t("shared.browse.prefix"), "") %></h2>
   <% unless curated_order %>
     <h3 class="sort-order"><%= "A to Z" %></h3>
   <% end %>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, page.title %>
+<% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
+<% top_level_title = "#{t("shared.browse.prefix")} #{page.active_top_level_browse_page.title}" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
   <meta name='govuk:navigation-page-type' content='Second Level Browse'>
@@ -15,7 +16,7 @@
 
   <div id="section" class="section-pane pane">
     <%= render 'second_level_browse_pages',
-      title: page.active_top_level_browse_page.title,
+      title: top_level_title,
       second_level_browse_pages: page.second_level_browse_pages,
       curated_order: page.second_level_pages_curated? %>
   </div>

--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -2,6 +2,7 @@ en:
   shared:
     browse:
       title: "Browse GOV.UK"
+      prefix: "Browse:"
     language_names:
       ar: العربية
       az: Azərbaycanca


### PR DESCRIPTION
https://trello.com/c/selPnJ7y/379-update-title-and-heading-pattern-for-mainstream-browse-pages

This updates the title and headings on browse pages. Currently the pattern for determining titles and headings means that they sometimes match the title of another page. By prefixing with "Browse" we remove the duplication and contextualise this page. This makes it easier to differentiate in search results and clearer for users of assistive technology. This fulfills the WCAG advice that all page titles on a site be unique and that headings be descriptive.

Example pages:
https://www.gov.uk/browse/benefits/entitlement
https://www.gov.uk/browse/business/finance-support
https://www.gov.uk/browse/business

### Screenshots

#### Before

![Screenshot 2020-09-10 at 08 43 40](https://user-images.githubusercontent.com/31649453/92696607-0544af80-f342-11ea-91da-a2e9c2171d19.png)

#### After
![Screenshot 2020-09-10 at 11 53 10](https://user-images.githubusercontent.com/31649453/92720242-3f22af80-f35c-11ea-81e6-f71a60126666.png)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
