### PR TITLE
Allow html entities in page header

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -23,7 +23,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: header["title"],
+            text: sanitize(header["title"]),
             font_size: 19,
             margin_bottom: 6,
             inverse: true


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

Sanitizing the content passed allows HTML entities too, which gives us a way to deal with orphans.

The content change is already made in https://github.com/alphagov/govuk-coronavirus-content/pull/402

Before
<img width="602" alt="Screenshot 2020-09-09 at 16 34 21" src="https://user-images.githubusercontent.com/788096/92620523-a720b980-f2ba-11ea-8c40-0460599d7201.png">

After
<img width="611" alt="Screenshot 2020-09-09 at 16 34 09" src="https://user-images.githubusercontent.com/788096/92620552-ab4cd700-f2ba-11ea-8cd9-3fdb6e8b1ae1.png">
