### PR TITLE
Make organisation search more accessible

### DIFF
--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -9,6 +9,13 @@
       // Form should only appear if the JS is working
       $('[data-filter="form"]').addClass('filter-organisations-list__form--active');
 
+      this.results = document.createElement('div')
+      this.results.classList.add('filter-organisations-list__results', 'govuk-heading-m', 'js-search-results')
+      this.results.setAttribute('aria-live', 'polite')
+      this.results.innerHTML = window.GOVUK.filter.countInitialDepartments() + ' results found'
+
+      $('#organisations_search_results').prepend(this.results)
+
       // We don't want the form to submit/refresh the page on enter key
       $('[data-filter="form"]').on('submit', function() { return false; })
 
@@ -54,6 +61,10 @@
       }
     },
 
+    countInitialDepartments: function () {
+      return document.querySelectorAll('[data-filter="item"]').length;
+    },
+
     updateDepartmentCount: function(listsToFilter) {
       var totalMatchingOrgs = 0;
 
@@ -74,7 +85,11 @@
         totalMatchingOrgs += matchingOrgCount;
       });
 
-      $('.js-no-filter-matches').toggleClass('js-hidden', totalMatchingOrgs > 0);
+      var text = ' results found'
+      if (totalMatchingOrgs === 1) {
+        text = ' result found'
+      }
+      this.results.innerHTML = totalMatchingOrgs + text
     }
   };
 

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -68,39 +68,12 @@
       float: right;
     }
   }
-
-  .organisations__no-filter-match {
-    display: none;
-
-    .js-enabled & {
-      @include govuk-font(19);
-      display: block;
-      text-align: center;
-      margin-bottom: govuk-spacing(9);
-    }
-  }
 }
 
 .filter-organisations-list__form {
   display: none;
-
-  .filter-organisations-list__label {
-    @include govuk-font(36, $weight: bold);
-    margin-right: govuk-spacing(2);
-  }
-
-  .filter-organisations-list__input {
-    @include govuk-font(16);
-    width: 30%;
-    min-width: 150px;
-    vertical-align: text-bottom;
-    padding: 5px;
-    border: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
-    margin: 0 5px 5px 0;
-  }
 }
 
 .filter-organisations-list__form--active {
   display: block;
-  margin-bottom: 45px;
 }

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -9,21 +9,24 @@
     <%= render "govuk_publishing_components/components/title", {
         title: @presented_organisations.title
     } %>
+
+    <form class="filter-organisations-list__form" data-filter="form">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Search for a department, agency or public body"
+        },
+        name: "search-box",
+        id: "filter-organisations-list",
+        controls: "organisations_search_results"
+      } %>
+    </form>
   </div>
 </div>
 
-<form class="filter-organisations-list__form" data-filter="form">
-  <label class="filter-organisations-list__label" for="filter-organisations-list">What’s the latest<br />from</label>
-  <input class="filter-organisations-list__input govuk-input" type="text" id="filter-organisations-list" placeholder="For example, Home Office">
-  <span class="filter-organisations-list__label" aria-hidden="true">?</span>
-</form>
-
-<div class="organisations">
+<div class="organisations" id="organisations_search_results">
   <%= render partial: 'organisations_list', locals: {
     all_organisations: @presented_organisations.all_organisations
   } %>
-
-  <p class="organisations__no-filter-match js-hidden js-no-filter-matches">No departments match that filter.</p>
 </div>
 
 <p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -10,7 +10,7 @@
         title: @presented_organisations.title
     } %>
 
-    <form class="filter-organisations-list__form" data-filter="form">
+    <form class="filter-organisations-list__form" data-filter="form" role="search" aria-label="Departments, agencies and public bodies">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Search for a department, agency or public body"
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<div class="organisations" id="organisations_search_results">
+<div class="organisations" id="organisations_search_results" role="region" aria-label="List of departments, agencies and public bodies">
   <%= render partial: 'organisations_list', locals: {
     all_organisations: @presented_organisations.all_organisations
   } %>

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -18,36 +18,37 @@ describe('organisation-list-filter.js', function() {
   ';
 
   var organisations = '\
-    <div data-filter="block">\
-      <div data-filter="count" class="count-for-logos">\
-        <h2>Ministerial Departments</h2>\
-        <p>There are <span class="js-accessible-department-count">2</span> Ministerial Departments</p>\
-        <span class="js-department-count">2</span>\
+    <div id="organisations_search_results">\
+      <div data-filter="block">\
+        <div data-filter="count" class="count-for-logos">\
+          <h2>Ministerial Departments</h2>\
+          <p>There are <span class="js-accessible-department-count">2</span> Ministerial Departments</p>\
+          <span class="js-department-count">2</span>\
+        </div>\
+        <ol data-filter="list">\
+          <li data-filter="item" class="org-logo-1">\
+            <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
+          </li>\
+          <li data-filter="item" class="org-logo-2">\
+            <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
+          </li>\
+        </ol>\
       </div>\
-      <ol data-filter="list">\
-        <li data-filter="item" class="org-logo-1">\
-          <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
-        </li>\
-        <li data-filter="item" class="org-logo-2">\
-          <div class="gem-c-organisation-logo__name">Cabinet Office</div>\
-        </li>\
-      </ol>\
-    </div>\
-    <div data-filter="block">\
-      <div data-filter="count" class="count-for-no-logos">\
-        <h2>Non Ministerial Departments</h2>\
-        <p>There are <span class="js-accessible-department-count">2</span> Non Ministerial Departments</p>\
-        <span class="js-department-count">2</span>\
+      <div data-filter="block">\
+        <div data-filter="count" class="count-for-no-logos">\
+          <h2>Non Ministerial Departments</h2>\
+          <p>There are <span class="js-accessible-department-count">2</span> Non Ministerial Departments</p>\
+          <span class="js-department-count">2</span>\
+        </div>\
+        <ol data-filter="list">\
+          <li data-filter="item" class="org-no-logo-1">\
+            <a class="organisation-list__item-title">Advisory Committee on Releases to the Environment</a>\
+          </li>\
+          <li data-filter="item" class="org-no-logo-2">\
+            <a class="organisation-list__item-title">Advisory Council on the Misuse of Drugs</a>\
+          </li>\
+        </ol>\
       </div>\
-      <ol data-filter="list">\
-        <li data-filter="item" class="org-no-logo-1">\
-          <a class="organisation-list__item-title">Advisory Committee on Releases to the Environment</a>\
-        </li>\
-        <li data-filter="item" class="org-no-logo-2">\
-          <a class="organisation-list__item-title">Advisory Council on the Misuse of Drugs</a>\
-        </li>\
-      </ol>\
-      <p class="js-hidden js-no-filter-matches">No departments match that filter.</p>\
     </div>\
   ';
 
@@ -74,6 +75,7 @@ describe('organisation-list-filter.js', function() {
       expect($('.org-logo-1')).toHaveClass("js-hidden");
       expect($('.org-logo-2')).toHaveClass("js-hidden");
       expect($('.org-no-logo-1')).toHaveClass("js-hidden");
+      expect($('.js-search-results')).toHaveText("1 result found");
       done();
     }, timeout);
   });
@@ -84,6 +86,7 @@ describe('organisation-list-filter.js', function() {
 
     setTimeout(function () {
       expect($('.org-no-logo-2')).not.toHaveClass("js-hidden");
+      expect($('.js-search-results')).toHaveText("1 result found");
       done();
     }, timeout);
   });
@@ -94,6 +97,7 @@ describe('organisation-list-filter.js', function() {
 
     setTimeout(function () {
       expect($('.count-for-logos')).toHaveClass("js-hidden");
+      expect($('.js-search-results')).toHaveText("1 result found");
       done();
     }, timeout);
   });
@@ -106,6 +110,7 @@ describe('organisation-list-filter.js', function() {
       expect($('.count-for-no-logos')).not.toHaveClass("js-hidden");
       expect($('.count-for-no-logos .js-accessible-department-count')).toHaveText(1);
       expect($('.count-for-no-logos .js-department-count')).toHaveText(1);
+      expect($('.js-search-results')).toHaveText("1 result found");
       done();
     }, timeout);
   });
@@ -115,7 +120,7 @@ describe('organisation-list-filter.js', function() {
     $('[data-filter="form"] input').trigger('keyup');
 
     setTimeout(function () {
-      expect($('.js-no-filter-matches')).not.toHaveClass("js-hidden");
+      expect($('.js-search-results')).toHaveText("0 results found");
       done();
     }, timeout);
   });

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -24,8 +24,7 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
 
   it "renders organisation filter" do
     assert page.has_css?(".filter-organisations-list__form")
-    assert page.has_css?(".filter-organisations-list__label", text: "What’s the latestfrom")
-    assert page.has_css?(".filter-organisations-list__input")
+    assert page.has_css?("label", text: "Search for a department, agency or public body")
   end
 
   it "renders an organisation_type heading" do


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

---

## What

Changes the search on https://www.gov.uk/government/organisations to be visually clearer and more accessible. Specifically:

- replaces the existing label that looks like a heading with inline search input with a standard input component
- updates the JS to add a result count and include `aria-live` attribute so screen readers hear the results of their search and know that something is happening
- adds landmarks to the search and results to aid navigation

Before | After
------- | ------
<img width="811" alt="Screenshot 2020-09-10 at 09 37 26" src="https://user-images.githubusercontent.com/861310/92702870-9bc89f00-f349-11ea-9ad1-7e85f0adcdba.png"> | <img width="861" alt="Screenshot 2020-09-10 at 09 37 06" src="https://user-images.githubusercontent.com/861310/92702891-a2571680-f349-11ea-97e3-63f4c6fc8ad8.png">


## Why

The existing search failed accessibility criteria.

Related to: https://github.com/alphagov/whitehall/pull/5788

Trello card: https://trello.com/c/XyOr5lMm/334-in-page-search-unclear-search-functionality-and-text-that-looks-like-headings
