### PR TITLE
Update subtopic semantics to no longer denote sections as navigation

### DIFF
--- a/app/assets/stylesheets/views/_topics.scss
+++ b/app/assets/stylesheets/views/_topics.scss
@@ -23,32 +23,9 @@
     min-height: 500px;
     padding: 0 0 45px 0;
 
-    h2,
-    h3 {
-      @include govuk-font(19, $weight: bold);
-      margin-bottom: 0;
-    }
-
     @include govuk-media-query($from: mobile) {
       padding: 0 0 30px 0;
       min-height: auto;
-    }
-  }
-
-  nav {
-    padding-top: 1em;
-    padding-bottom: 1em;
-    overflow: auto;
-
-    h1 {
-      @include govuk-font(24, $weight: bold);
-
-      margin-bottom: govuk-spacing(2);
-
-      @include govuk-media-query($from: desktop) {
-        float: left;
-        max-width: 12.5em;
-      }
     }
   }
 }

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -2,7 +2,7 @@
 
 <header class="page-header group">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="subtopic-metadata">
       <%= yield :page_title %>
       <% if organisations.any? %>
         <%= render "govuk_publishing_components/components/metadata", from: organisations.array_of_links %>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -25,13 +25,13 @@
     link_to_latest_feed: true,
   }) do %>
   <% subtopic.lists.each_with_index do |list, list_index| -%>
-    <nav class="govuk-grid-row" aria-labelledby="<%= list.title.parameterize %>">
+    <div class="govuk-grid-row govuk-!-margin-bottom-5">
       <div class="govuk-grid-column-one-third">
-        <h1 id="<%= list.title.parameterize %>"><%= list.title %></h1>
+        <h2 class="govuk-heading-m"><%= list.title %></h1>
       </div>
       <div class="govuk-grid-column-two-thirds">
         <%= render 'components/topic-list', topic_list_params(list.contents, list_index: list_index, category: 'navSubtopicContentItemLinkClicked') %>
       </div>
-    </nav>
+    </div>
   <% end -%>
 <% end %>

--- a/features/step_definitions/browsing_topics_steps.rb
+++ b/features/step_definitions/browsing_topics_steps.rb
@@ -7,7 +7,7 @@ When(/^I view the browse page for that subtopic$/) do
 end
 
 Then(/^I see a list of organisations associated with content in the subtopic$/) do
-  within ".gem-c-metadata" do
+  within "#subtopic-metadata" do
     assert page.has_text?("Department of Energy & Climate Change")
   end
 end

--- a/features/step_definitions/curated_lists_steps.rb
+++ b/features/step_definitions/curated_lists_steps.rb
@@ -3,6 +3,6 @@ Given(/^there is curated content for a subtopic$/) do
 end
 
 Then(/^I see a curated list of content$/) do
-  assert page.has_selector?("h1", text: "Oil rigs")
-  assert page.has_selector?("h1", text: "Piping")
+  assert page.has_selector?("h2", text: "Oil rigs")
+  assert page.has_selector?("h2", text: "Piping")
 end


### PR DESCRIPTION
## What
Removes the `nav` tag surrounding subtopic lists and changes `h1`s within subtopics to `h2`s. Additionally removes some now redundant styling.

## Why
These sections being navigation elements can be confusing to screen readers as they aren't technically navigational items within and what were `h1`s look smaller than `h1`s seen across govuk. This fails WCAG SC 2.4.1 (navigations) and 1.3.1 (headings).

No visual changes.

**Card:** https://trello.com/c/qiAWvH0i/342-unsemantic-topic-pages 

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
