### PR TITLE
Change topic-list list type from ol to ul

### DIFF
--- a/app/views/components/_topic-list.html.erb
+++ b/app/views/components/_topic-list.html.erb
@@ -10,7 +10,7 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if items.any? %>
-  <ol class="app-c-topic-list <%= component_size %> <%= brand_helper.brand_class %> <%= margin_bottom_class %>">
+  <%= tag.ul(class: ["app-c-topic-list", component_size, brand_helper.brand_class, margin_bottom_class]) do %>
     <% items.each do |item| %>
       <li class="app-c-topic-list__item">
         <%=
@@ -36,5 +36,5 @@
         %>
       </li>
     <% end %>
-  </ol>
+  <% end %>
 <% end %>


### PR DESCRIPTION
I've inspected each use of the topic-list component in this app. There is no clear benefit as far as I can see to having any of these as an ordered list.

Org pages use it to present lists of corporate information links and high profile groups. They are not in any discernable order, and it would not make sense to number them.

Org and courts pages use it to present featured links. They are short lists of "useful" things, but there's no real order to them.

The same goes for [topic pages](gov.uk/topic/benefits-credits/child-benefit) and the finders list at the foot of the [transition landing page](https://www.gov.uk/transition).

These are failures of WCAG SC 1.3.1

https://trello.com/c/O3Mck5D5/441-transition-page-incorrect-list-type

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
