### PR TITLE
Add lang attribute to translation links

### DIFF
--- a/app/views/dit_landing_page/_guidance.html.erb
+++ b/app/views/dit_landing_page/_guidance.html.erb
@@ -17,7 +17,7 @@
           <%= t("dit_landing_page.guidance_text").html_safe %>
           <ul class="govuk-list govuk-list">
             <% t("dit_landing_page.countries").each do |country| %>
-              <li><%= link_to country[:label], country[:url]  %></li>
+              <li lang='<%= country[:lang] %>'><%= link_to country[:label], country[:url]  %></li>
             <% end %>
           </ul>
         <% end %>

--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -14,14 +14,19 @@ en:
       <p>This information is also available in the following languages:</p>
     countries:
       - label: Deutsch
+        lang: de
         url: government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/handel-mit-dem-vereinigten-konigreich-ab-1-januar-2021-fur-unternehmen-mit-sitz-in-der-eu
       - label: Español
+        lang: es
         url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/como-hacer-negocios-con-el-reino-unido-a-partir-del-1-de-enero-de-2021-en-caso-de-ser-una-empresa-con-sede-en-la-ue
       - label: Français
+        lang: fr
         url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/travailler-avec-le-royaume-uni-a-partir-du-1er-janvier-2021-en-tant-quentreprise-basee-dans-lue
       - label: Italiano
+        lang: it
         url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/come-le-aziende-presenti-nellunione-europea-potranno-effettuare-scambi-commerciali-con-il-regno-unito-a-partire-dal-01012021
       - label: Polski
+        lang: pl
         url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/handel-z-wielka-brytania-od-1-stycznia-2021-roku-informacje-dla-firm-z-unii-europejskiej
     goods_title: Buying or selling goods
     goods_text: |

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -7,6 +7,7 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
     it "renders" do
       when_i_visit_the_dit_landing_page
       then_i_can_see_the_header_section
+      and_i_can_see_the_translation_links
       then_i_can_see_the_training_section
     end
   end
@@ -17,6 +18,10 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
 
   def then_i_can_see_the_header_section
     assert page.has_title? "Trade with the UK from 1 January 2021 as a business based in the EU"
+  end
+
+  def and_i_can_see_the_translation_links
+    assert page.has_selector?("li[lang='de']", text: "Deutsch")
   end
 
   def then_i_can_see_the_training_section


### PR DESCRIPTION
These links are in a different language. We should mark them up as such.

https://trello.com/c/6S1h2UYf/446-fix-lang-attributes-on-eubusiness-page

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
