### PR TITLE
Update page titles and headings for topic views

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -31,9 +31,9 @@ class Topic
 
   def combined_title
     if parent
-      "#{parent.title}: #{title}"
+      "#{parent.title}: #{title} - detailed information"
     else
-      title
+      "#{title}: detailed information"
     end
   end
 

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 <% content_for :page_title do %>
   <%
-    title_params = { title: subtopic.title }
+    title_params = { title: "#{subtopic.title}: detailed information" }
     if subtopic.parent
       title_params[:context] = {
         text: subtopic.parent.title,

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, topic.title %>
+<% title_with_suffix = "#{topic.title}: detailed information" %>
+<% content_for :title, title_with_suffix %>
 <%= render 'shared/tag_meta', tag: topic %>
 <% content_for :meta_tags do %>
   <meta name='govuk:navigation-page-type' content='<%= navigation_page_type %>'>
@@ -6,7 +7,7 @@
 <% content_for :page_class, "topics-page" %>
 
 <header class="page-header group">
-  <%= render "govuk_publishing_components/components/title", title: topic.title %>
+  <%= render "govuk_publishing_components/components/title", title: title_with_suffix %>
 </header>
 
 <div class="browse-container full-width topics-page" data-module="track-click">

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -69,10 +69,13 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
     # When I visit the subtopic page
     visit "/topic/oil-and-gas/offshore"
 
+    # Then it should have the correct page title
+    assert page.has_title?("Oil and Gas: Offshore - detailed information - GOV.UK")
+
     # Then I should see the subtopic metadata
     within ".page-header" do
       within ".gem-c-title" do
-        assert page.has_css?(".gem-c-title__text", text: "Offshore")
+        assert page.has_css?(".gem-c-title__text", text: "Offshore: detailed information")
         assert page.has_css?(".gem-c-title__context-link[href='/topic/oil-and-gas']", text: "Oil and Gas")
       end
 

--- a/test/integration/topic_browsing_test.rb
+++ b/test/integration/topic_browsing_test.rb
@@ -61,7 +61,7 @@ class TopicBrowsingTest < ActionDispatch::IntegrationTest
     )
 
     visit "/topic/oil-and-gas"
-    assert page.has_title?("Oil and gas - GOV.UK")
+    assert page.has_title?("Oil and gas: detailed information - GOV.UK")
 
     within "header.page-header" do
       assert page.has_content?("Oil and gas")

--- a/test/models/topic_test.rb
+++ b/test/models/topic_test.rb
@@ -49,7 +49,7 @@ describe Topic do
     end
 
     it "returns the combined_title" do
-      assert_equal "Business tax: PAYE", @topic.combined_title
+      assert_equal "Business tax: PAYE - detailed information", @topic.combined_title
     end
 
     describe "when parent details are missing" do
@@ -63,7 +63,7 @@ describe Topic do
       end
 
       it "returns the topic title in combined_title" do
-        assert_equal "PAYE", @topic.combined_title
+        assert_equal "PAYE: detailed information", @topic.combined_title
       end
 
       it "handles the links hash missing completely" do


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

## What
Updates page titles and h1's on subtopic pages and topic pages, to include the suffix "detailed information". This is organised like so:

- Topic page titles: `topic: detailed information - GOV.UK`
- Subtopic page titles: `topic: subtopic - detailed information - GOV.UK`
- Topic headings: `topic: detailed information`
- Subtopic headings: `subtopic: detailed information`

## Why
There are several instances of different pages that feature the same heading and page title in different parts of the site. This PR, using the detailed information title and heading suffix, will provide a clear differentiator between specialist topics and normal browse pages. Examples of specialist topic pages:

- [topic](https://www.gov.uk/topic/business-tax)
- [subtopic](https://www.gov.uk/topic/personal-tax/income-tax)

This was decided by the content support team during an accessibility content blast day.

## Visual changes
### Before
![Screenshot 2020-09-17 at 17 52 37](https://user-images.githubusercontent.com/64783893/93502715-001dcc80-f90f-11ea-9857-0b70c0fd3c36.png)

### After
![Screenshot 2020-09-17 at 17 52 05](https://user-images.githubusercontent.com/64783893/93502724-0318bd00-f90f-11ea-8b9f-2936a5d60ce2.png)

**Card:** https://trello.com/c/0ckzTB40/380-update-title-and-heading-pattern-for-specialist-topic-pages