### PR TITLE
Add show and hide flag for webinar tables

### DIFF
--- a/app/presenters/table_presenter.rb
+++ b/app/presenters/table_presenter.rb
@@ -3,6 +3,12 @@ class TablePresenter
     @table = table
   end
 
+  def show?
+    return unless valid_input?
+
+    table[:show]
+  end
+
   def rows
     return unless valid_input?
 
@@ -26,7 +32,7 @@ private
   attr_reader :table
 
   def valid_input?
-    return unless %i[headings rows].sort == table.keys.sort
+    return unless %i[show headings rows].sort == table.keys.sort
 
     table[:rows].all? { |e| e.is_a? Array }
   end

--- a/app/views/dit_landing_page/_training.html.erb
+++ b/app/views/dit_landing_page/_training.html.erb
@@ -6,6 +6,9 @@
           <%= t("dit_landing_page.training_section_title") %>
         </h2>
         <p class="govuk-body"><%= t("dit_landing_page.training_section_description") %></p>
+        <% if table.show? %>
+          <%= render "govuk_publishing_components/components/table", {  head: table.headings, rows: table.rows } %>
+        <% end %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= image_tag 'DIT-small-image.png', class: "dit-landing-page__training-image", alt: "", loading: "lazy" %>

--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -59,6 +59,7 @@ en:
     training_section_description: |
       Online events will help you understand the UK border requirements if you’re a trader in the EU, and what you need to do to prepare for the end of the transition period. Dates for these events are currently being scheduled and will be published on this page once they’re available.
     training_section_table:
+      show: false
       headings:
         - "Date"
         - "Country"

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -26,5 +26,6 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
 
   def then_i_can_see_the_training_section
     assert page.has_selector?("h2", text: "Additional help and support")
+    # assert page.has_selector?(".govuk-table__row", text: "Date")
   end
 end

--- a/test/presenters/table_presenter_spec.rb
+++ b/test/presenters/table_presenter_spec.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe TablePresenter do
   let(:table_data) do
     {
+      show: true,
       headings: %w[
         Date
         Country
@@ -62,6 +63,19 @@ describe TablePresenter do
       presenter = described_class.new(table_data)
       assert_nil(presenter.headings)
       assert_nil(presenter.rows)
+    end
+  end
+
+  describe "#show" do
+    it "returns true when table is set to be shown" do
+      presenter = described_class.new(table_data)
+      assert_equal presenter.show, true
+    end
+
+    it "returns false when table is set to be hidden" do
+      table_data[:show] = false
+      presenter = described_class.new(table_data)
+      assert_equal presenter.show, false
     end
   end
 end


### PR DESCRIPTION
# What

DIT have requested to remove reference to webinars from the EU business landing page. The webinars were scheduled to start on Monday but are being rescheduled
It's the section starting with "Additional help and support"

https://www.gov.uk/eubusiness

Reference to the webinar schedule has been removed, something has been put in its place that doesn't confuse users.

Reference https://trello.com/c/T68H7Gc7/464-remove-reference-to-webinars-on-eu-business-page