### PR TITLE
Remove webinar table from DIT landing page

### DIFF
--- a/app/views/dit_landing_page/_training.html.erb
+++ b/app/views/dit_landing_page/_training.html.erb
@@ -6,7 +6,6 @@
           <%= t("dit_landing_page.training_section_title") %>
         </h2>
         <p class="govuk-body"><%= t("dit_landing_page.training_section_description") %></p>
-        <%= render "govuk_publishing_components/components/table", {  head: table.headings, rows: table.rows } %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= image_tag 'DIT-small-image.png', class: "dit-landing-page__training-image", alt: "", loading: "lazy" %>

--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -56,7 +56,8 @@ en:
       - you or your employees provide services in a UK regulated profession
     services_list_end: <p>Check the regulations for the UK, including visa requirements, and understand how changes could affect your business.</p>
     training_section_title: Additional help and support
-    training_section_description: These online events will help you understand the UK border requirements if you're a trader in the EU, and what you need to do to prepare for the end of the transition period. More information will be added soon, but provisional dates and times are listed below.
+    training_section_description: |
+      Online events will help you understand the UK border requirements if you’re a trader in the EU, and what you need to do to prepare for the end of the transition period. Dates for these events are currently being scheduled and will be published on this page once they’re available.
     training_section_table:
       headings:
         - "Date"

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -26,6 +26,5 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
 
   def then_i_can_see_the_training_section
     assert page.has_selector?("h2", text: "Additional help and support")
-    assert page.has_selector?(".govuk-table__row", text: "Date")
   end
 end


### PR DESCRIPTION
DIT have requested to remove reference to webinars from the EU business landing page. The webinars were scheduled to start on Monday but are being rescheduled
It's the section starting with "Additional help and support"

https://www.gov.uk/eubusiness

Reference to the webinar schedule has been removed, something has been put in its place that doesn't confuse users.

Reference https://trello.com/c/T68H7Gc7/464-remove-reference-to-webinars-on-eu-business-page