### PR TITLE
Amend organisation list markup (taxon pages)

### DIFF
--- a/app/views/taxons/_organisation_logos_and_list.html.erb
+++ b/app/views/taxons/_organisation_logos_and_list.html.erb
@@ -1,5 +1,5 @@
 <div class="taxon-page__organisations">
-  <ol>
+  <ul>
     <% organisations_with_logos.each do |promoted_organisation| %>
       <li class="taxon-page__organisation">
         <%= render 'govuk_publishing_components/components/organisation_logo', {
@@ -8,7 +8,7 @@
         %>
       </li>
     <% end %>
-  </ol>
+  </ul>
 </div>
 
 <% if organisations_without_logos.any? %>


### PR DESCRIPTION
## What
This changes the markup for the organisations list on the taxon pages to use an unordered list instead of an ordered one. Example page: https://www.gov.uk/health-and-social-care/public-health 

## Why
It does not make semantic sense for the list of organisations to be ordered. Leaving ul in the markup is a WCAG fail.

No visual changes should occur as a result of this adjustment.

https://trello.com/c/C3KbVDJ7


-------

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
