### PR TITLE
Headings on grouped links

### DIFF
--- a/app/views/services_and_information/_grouped_links.html.erb
+++ b/app/views/services_and_information/_grouped_links.html.erb
@@ -1,8 +1,14 @@
 <% grouped_links.each_with_index do |group, group_index| -%>
-  <nav class="govuk-grid-row" aria-labelledby="<%= group.title.parameterize %>">
+  <div class="govuk-grid-row" aria-labelledby="<%= group.title.parameterize %>">
     <div class="govuk-grid-column-one-third">
-      <h1 id="<%= group.title.parameterize %>"><%= group.title %></h1>
+      <%= render "govuk_publishing_components/components/heading", {
+        font_size: "m",
+        heading_level: 2,
+        id: group.title.parameterize,
+        text: group.title,
+      } %>
     </div>
+    
     <div class="govuk-grid-column-two-thirds">
       <%
         list_item_count = group.see_more_link ? group.examples.count + 1 : group.examples.count
@@ -17,5 +23,5 @@
       %>
       <%= render 'components/topic-list', topic_list_component_params %>
     </div>
-  </nav>
+  </div>
 <% end -%>

--- a/test/integration/services_and_information_browsing_test.rb
+++ b/test/integration/services_and_information_browsing_test.rb
@@ -18,11 +18,11 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Services and information")
     end
 
-    within "nav.govuk-grid-row:nth-child(1) h1" do
+    within ".govuk-grid-row:nth-child(1) h2" do
       assert page.has_content?("Environmental permits")
     end
 
-    within "nav.govuk-grid-row:nth-child(2) h1" do
+    within ".govuk-grid-row:nth-child(2) h2" do
       assert page.has_content?("Waste")
     end
 
@@ -34,7 +34,7 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
 
     assert page.has_selector?('.browse-container[data-module="track-click"]')
 
-    within "nav.govuk-grid-row:first-child .app-c-topic-list" do
+    within ".govuk-grid-row:first-child .app-c-topic-list" do
       content_item_link = page.first("li a")
 
       assert_equal(
@@ -71,7 +71,7 @@ class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
       )
     end
 
-    within "nav.govuk-grid-row:nth-child(2) .app-c-topic-list" do
+    within ".govuk-grid-row:nth-child(2) .app-c-topic-list" do
       content_item_link = page.first("li a")
 
       assert_equal(


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

## What
Update the markup for grouped links on the services and information pages, specifically replacing h1s with h2s and nav blocks with plain divs.

## Why
This was missed in [this PR](https://github.com/alphagov/collections/pull/1909) which was done to address accessibility issues on govuk.

No visual changes.