### PR TITLE
Include missing chief scientific advisor title for board member

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -52,6 +52,7 @@ module Organisations
     def expected_document_type(type)
       return "ministerial_role" if type == :ministers
       return "military_role" if type == :military_personnel
+      return %w[board_member_role chief_scientific_advisor_role] if type == :board_members
 
       # for example: board_members -> board_member_role
       type.to_s.delete_suffix("s") + "_role"
@@ -62,7 +63,7 @@ module Organisations
         .select { |ra| ra["details"]["current"] }
         .map { |ra| ra["links"]["role"].first }
         .select { |role| allowed_role_content_ids.include?(role["content_id"]) }
-        .select { |role| role["document_type"] == expected_document_type(type) }
+        .select { |role| expected_document_type(type).include?(role["document_type"]) }
     end
 
     def formatted_role_link(role)


### PR DESCRIPTION
This a quick fix to solve an issue where the title of chief_scientific_advisor people wasn't being shown when the person was on the org page in the board members.

This is because each person was expected to have a role of board_member
in order to be displayed.

This is a quick fix where we add the chief_scientific_advisor role as
one of the expected document types returned for board_members.

Before:
![image](https://user-images.githubusercontent.com/17481621/93793174-6156e000-fc2e-11ea-9bb2-0e59274af272.png)

After:
![Screenshot 2020-09-21 at 17 19 35](https://user-images.githubusercontent.com/17481621/93793372-a549e500-fc2e-11ea-9380-eee0090f6aeb.png)
