### PR TITLE
Add timeline of changes element

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -293,3 +293,15 @@ $c19-landing-page-header-background: #0843a1;
     margin-bottom: govuk-spacing(2);
   }
 }
+
+.covid-timeline {
+  padding-bottom: govuk-spacing(5);
+}
+
+.covid-timeline__item {
+  margin-bottom: govuk-spacing(5);
+}
+
+.covid-timeline__item-heading {
+  margin-bottom: govuk-spacing(1);
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,4 +51,10 @@ module ApplicationHelper
       false
     end
   end
+
+  def render_govspeak(content)
+    render "govuk_publishing_components/components/govspeak" do
+      raw(Govspeak::Document.new(content, sanitize: false).to_html)
+    end
+  end
 end

--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -1,5 +1,23 @@
 class CoronavirusLandingPagePresenter
-  COMPONENTS = %w[live_stream live_stream_enabled header_section announcements_label announcements risk_level see_all_announcements_link nhs_banner sections sections_heading additional_country_guidance topic_section statistics_section notifications find_help page_header].freeze
+  COMPONENTS = %w[
+    live_stream
+    live_stream_enabled
+    header_section
+    announcements_label
+    announcements
+    see_all_announcements_link
+    risk_level
+    nhs_banner
+    sections
+    sections_heading
+    additional_country_guidance
+    topic_section
+    statistics_section
+    notifications
+    find_help
+    page_header
+    timeline
+  ].freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -1,5 +1,7 @@
 <%
   heading ||= false
+  heading_padding ||= false
+  border_top ||= false
   country_guidance ||= false
   accordion_contents = []
   number_of_accordion_sections = accordions.length
@@ -34,7 +36,8 @@
 <% end %>
 <%= render "govuk_publishing_components/components/heading", {
   text: heading,
-  margin_bottom: 3,
+  padding: heading_padding,
+  border_top: border_top,
 } if heading %>
 <div data-module="track-click">
   <div data-module="toggle-attribute">

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -1,0 +1,14 @@
+<div class="covid-timeline">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: timeline["heading"],
+    padding: true,
+    margin_bottom: 4
+  } %>
+
+  <% timeline["list"].each do | item | %>
+    <div class="covid-timeline__item">
+      <h3 class="covid-timeline__item-heading govuk-heading-s"><%= item["heading"] %></h3>
+      <%= render_govspeak(item["paragraph"]) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -41,7 +41,13 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections, heading: details.sections_heading }%>
+      <%= render partial: 'coronavirus_landing_page/components/shared/timeline', locals: { timeline: details.timeline } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: {
+        accordions: details.sections,
+        heading: details.sections_heading,
+        heading_padding: true,
+        border_top: 2,
+      } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>

--- a/test/fixtures/content_store/coronavirus_landing_page.json
+++ b/test/fixtures/content_store/coronavirus_landing_page.json
@@ -371,6 +371,27 @@
         }
       ]
     },
+    "timeline": {
+      "list": [
+        {
+          "heading": "18 September",
+          "paragraph": "If you live, work or travel in the North East, you need to [follow different covid rules](/guidance/north-east-of-england-local-restrictions)\n"
+        },
+        {
+          "heading": "15 September",
+          "paragraph": "If you live, work or visit Bolton, you need to [follow different covid rules](/guidance/bolton-local-restrictions)\n"
+        },
+        {
+          "heading": "14 September",
+          "paragraph": "People must not meet in groups larger than 6 in England. There are [exceptions to this 'rule of 6'](/government/publications/coronavirus-covid-19-meeting-with-others-safely-social-distancing/coronavirus-covid-19-meeting-with-others-safely-social-distancing#seeing-friends-and-family)\n"
+        },
+        {
+          "heading": "24 July",
+          "paragraph": "[Face coverings are mandatory in shops](/government/publications/face-coverings-when-to-wear-one-and-how-to-make-your-own/face-coverings-when-to-wear-one-and-how-to-make-your-own)\n"
+        }
+      ],
+      "heading": "Recent and upcoming changes"
+    },
     "notifications": {
       "intro": "Stay up to date with GOV.UK",
       "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website",

--- a/test/integration/coronavirus_landing_page_test.rb
+++ b/test/integration/coronavirus_landing_page_test.rb
@@ -10,6 +10,7 @@ class CoronavirusLandingPageTest < ActionDispatch::IntegrationTest
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
       then_i_can_see_the_nhs_banner
+      then_i_can_see_the_timeline
       then_i_can_see_the_accordions
       then_i_can_see_the_live_stream_section
       and_i_can_see_links_to_search

--- a/test/presenters/coronavirus_landing_page_presenter_test.rb
+++ b/test/presenters/coronavirus_landing_page_presenter_test.rb
@@ -4,7 +4,25 @@ require_relative "../../test/support/coronavirus_helper"
 describe CoronavirusLandingPagePresenter do
   it "provides getter methods for all component keys" do
     presenter = described_class.new(coronavirus_landing_page_content_item)
-    %i[live_stream header_section announcements_label announcements see_all_announcements_link nhs_banner find_help sections sections_heading additional_country_guidance topic_section statistics_section notifications live_stream].each do |method|
+    %i[
+      live_stream
+      live_stream_enabled
+      header_section
+      announcements_label
+      announcements
+      see_all_announcements_link
+      risk_level
+      nhs_banner
+      sections
+      sections_heading
+      additional_country_guidance
+      topic_section
+      statistics_section
+      notifications
+      find_help
+      page_header
+      timeline
+    ].each do |method|
       assert_respond_to(presenter, method)
     end
   end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -163,6 +163,22 @@ module CoronavirusLandingPageSteps
     assert page.has_selector?(".app-c-header-notice__branding--nhs h2", text: "Do not leave home if you or someone you live with has either")
   end
 
+  def then_i_can_see_the_timeline
+    assert page.has_selector?("h2", text: "Recent and upcoming changes")
+
+    assert page.has_selector?(".covid-timeline__item-heading", text: "18 September")
+    assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "If you live, work or travel in the North East, you need to follow different covid rules")
+
+    assert page.has_selector?(".covid-timeline__item-heading", text: "15 September")
+    assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "If you live, work or visit Bolton, you need to follow different covid rules")
+
+    assert page.has_selector?(".covid-timeline__item-heading", text: "14 September")
+    assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "People must not meet in groups larger than 6 in England. There are exceptions to this ‘rule of 6’")
+
+    assert page.has_selector?(".covid-timeline__item-heading", text: "24 July")
+    assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "Face coverings are mandatory in shops")
+  end
+
   def then_i_can_see_the_accordions
     assert page.has_selector?("h2", text: "Guidance and support")
     assert page.has_selector?(".govuk-accordion__section-header", text: "How to protect yourself and others")


### PR DESCRIPTION
## What
Add a timeline of recent changes to the landing page to communicate to users what rules are changing or have recently changed, and what they need to do differently from what date.

## Why
We know that users are struggling to find out what has recently changed, and this impacts how likely they are to follow the rules, and how confident they feel that the landing page is up to date and relevant.

We hope that this timeline element will help users:

- understand what's changed
- feel confident that the information is up to date
- ultimately comply with new rules and help prevent the spread of covid

https://trello.com/c/XUyYJ8lt/813-24-sept-landing-page-add-timeline-of-changes-element