### PR TITLE
Add lang to featured links

### DIFF
--- a/app/views/components/_topic-list.html.erb
+++ b/app/views/components/_topic-list.html.erb
@@ -10,7 +10,7 @@
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 %>
 <% if items.any? %>
-  <%= tag.ul(class: ["app-c-topic-list", component_size, brand_helper.brand_class, margin_bottom_class]) do %>
+  <%= tag.ul(class: ["app-c-topic-list", component_size, brand_helper.brand_class, margin_bottom_class], lang: "en") do %>
     <% items.each do |item| %>
       <li class="app-c-topic-list__item">
         <%=


### PR DESCRIPTION
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

---

- featured links are always in English (you can't set an alternative set of featured links for a different language version of the page) (unless someone were to add featured links in another language, which would be unlikely)
- when the organisation page is in another language, the page language is set but these links are still in English, so adding a lang="en" to them to correctly indicate the language used

<img width="813" alt="Screenshot 2020-09-22 at 14 44 05" src="https://user-images.githubusercontent.com/861310/93890346-2a420680-fce2-11ea-8d11-19aebb5cbbe3.png">


No visual changes. Example page: https://www.gov.uk/government/organisations/companies-house.cy

Trello card: https://trello.com/c/BGIwj7un/403-update-language-attribute-on-featured-links-on-organisation-pages
