### PR TITLE
Remove 'is_taxon_with_subtopics' option

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -6,12 +6,6 @@
   }
 }
 
-
-
-.taxon-feedback-wrapper {
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
-}
-
 .taxon-page__email-link-wrapper {
   background-color: govuk-colour("light-grey", $legacy: "grey-4");
   margin-top: -(govuk-spacing(6));

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,11 +27,7 @@
     <%= yield %>
     </main>
 
-    <% if content_for(:is_taxon_with_subtopics) %>
-      <div class="taxon-feedback-wrapper">
-        <%= render 'govuk_publishing_components/components/feedback', margin_top: 0 %>
-      </div>
-    <% elsif content_for(:is_full_width_header) %>
+    <% if content_for(:is_full_width_header) %>
       <div class="govuk-width-container">
         <%= render 'govuk_publishing_components/components/feedback' %>
       </div>


### PR DESCRIPTION
The code that used this was part of an AB test that was [removed in 2019.](https://github.com/alphagov/collections/commit/071d9792f64e7b86d36a2a06866b4437c5bf0c6b)

There are no other references to `:is_taxon_with_subtopics` in this repo.