### PR TITLE
Add event tracking to timeline

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require modules/toggle-attribute
 //= require components/accordion
 //= require modules/coronavirus-landing-page
+//= require modules/track-timeline-links
 
 $(document).on('ready', function(){
   var toggleAttribute = new GOVUK.Modules.ToggleAttribute();

--- a/app/assets/javascripts/modules/track-timeline-links.js
+++ b/app/assets/javascripts/modules/track-timeline-links.js
@@ -1,0 +1,24 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  "use strict";
+
+  Modules.TrackTimelineLinks = function () {
+    this.start = function (element) {
+      var links = element[0].getElementsByTagName("a")
+      
+      for (var i = 0; i < links.length; i++) {
+        var link = links[i];
+        link.addEventListener("click", function(e) {
+          var options = {
+            transport: "beacon",
+            label: e.target.getAttribute('href')
+          }
+
+          GOVUK.analytics.trackEvent("pageElementInteraction", "Timeline", options)
+        })
+      }
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -1,4 +1,4 @@
-<div class="covid-timeline">
+<div class="covid-timeline" data-module="track-timeline-links">
   <%= render "govuk_publishing_components/components/heading", {
     text: timeline["heading"],
     padding: true,

--- a/spec/javascripts/modules/track-timeline-links_spec.js
+++ b/spec/javascripts/modules/track-timeline-links_spec.js
@@ -1,0 +1,61 @@
+GOVUK.analytics = GOVUK.analytics || {}
+GOVUK.analytics.trackEvent = function () {}
+
+describe('Track timeline links', function () {
+  "use strict"
+
+  var html = '<div class="covid-timeline" data-module="track-timeline-links"> \
+    <h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--padding   govuk-!-margin-bottom-4">Recent and upcoming changes</h2> \
+    <div class="covid-timeline__item"> \
+      <h3 class="covid-timeline__item-heading govuk-heading-s">24 September</h3> \
+      <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"> \
+        <p>Get the <a rel="external" href="https://covid19.nhs.uk/">NHS COVID-19 app</a> to help protect yourself and others</p> \
+      </div> \
+    </div> \
+      <div class="covid-timeline__item"> \
+        <h3 class="covid-timeline__item-heading govuk-heading-s">24 September</h3> \
+        <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak"> \
+        <p>Find out how the <a href="/government/news/chancellor-outlines-winter-economy-plan">Winter Economy Plan</a> will protect jobs and support businesses</p> \
+      </div> \
+    </div> \
+  </div>';
+
+  var element;
+  
+  beforeEach(function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    element = document.createElement('div');
+    element.innerHTML = html;
+    element = element.firstElementChild
+
+    var tracker = new GOVUK.Modules.TrackTimelineLinks()
+    tracker.start([element])
+  })
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset()
+  })
+
+  it('track events sends href as label', function () {
+    element.querySelector('a[href="/government/news/chancellor-outlines-winter-economy-plan"]').dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      "pageElementInteraction", "Timeline", {
+        transport: "beacon",
+        label: "/government/news/chancellor-outlines-winter-economy-plan"
+      }
+    )
+  })
+
+  it('track events sends external href', function () {
+    element.querySelector('a[href="https://covid19.nhs.uk/"]').dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      "pageElementInteraction", "Timeline", {
+        transport: "beacon",
+        label: "https://covid19.nhs.uk/"
+      }
+    )
+  })
+})


### PR DESCRIPTION
## What

Add Google Analytics event tracking to the links within timeline section of the landing page.

This should use the following:
Event Category: pageElementInteraction
Event Action: Timeline
Event Label: [Page URL of destination page]

## Why

So we can track engagement with the timeline element of the landing page.

Trello: https://trello.com/c/cwkmPkIN/822-add-event-tracking-to-timeline

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
