### PR TITLE
Brexit countdown clock

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,6 +44,7 @@ $covid-yellow: #fff500;
 
 @import "views/browse";
 @import "views/transition-landing-page";
+@import "views/transition-countdown";
 @import "views/dit-landing-page";
 @import "views/latest-changes";
 @import "views/topics";

--- a/app/assets/stylesheets/views/_transition-countdown.scss
+++ b/app/assets/stylesheets/views/_transition-countdown.scss
@@ -1,0 +1,85 @@
+$dark-blue-2: #003078;
+$desktop-breakpoint-override: 1000px;
+
+.transition-countdown {
+  border: govuk-spacing(1) solid $dark-blue-2;
+  margin: 0;
+
+  .transition-countdown__countdown {
+    padding: govuk-spacing(3);
+    color: $dark-blue-2;
+    text-align: center;
+    width: 100%;
+
+    @include govuk-media-query($from: $desktop-breakpoint-override) {
+      padding: govuk-spacing(4);
+      width: 50%;
+    }
+  }
+
+  .transition-countdown__countdown-days-left {
+    @include govuk-font(80, $weight: bold);
+    display: inline-block;
+    vertical-align: middle;
+
+    @include govuk-media-query($from: tablet) {
+      @include govuk-font(48, $weight: bold);
+    }
+
+    @include govuk-media-query($from: $desktop-breakpoint-override) {
+      @include govuk-font(80, $weight: bold);
+      display: block;
+    }
+  }
+
+  .transition-countdown__countdown-days-text {
+    @include govuk-font($size: 24, $line-height: 1.5);
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0 govuk-spacing(1) govuk-spacing(1);
+
+    @include govuk-media-query($from: $desktop-breakpoint-override) {
+      @include govuk-font(19);
+      display: block;
+      margin: 0;
+    }
+  }
+
+  .transition-countdown__traffic-lights {
+    background-color: $dark-blue-2;
+    padding: govuk-spacing(3) govuk-spacing(2) govuk-spacing(2);
+    width: 100%;
+
+    @include govuk-media-query($from: $desktop-breakpoint-override) {
+      padding: govuk-spacing(2) govuk-spacing(3);
+      width: 50%;
+    }
+
+    .landing-page__take-action-traffic-lights {
+      margin-bottom: 0;
+      margin-top: 0;
+
+      @include govuk-media-query($from: tablet) {
+        margin: govuk-spacing(3) 0;
+      }
+    }
+
+    .landing-page__take-action-traffic-lists-icon {
+      vertical-align: middle;
+      margin-top: -5px;
+      width: 18px;
+    
+      @include govuk-media-query($from: tablet) {
+        width: 23px;
+      }
+    }
+
+    .landing-page__take-action-traffic-lists-text {
+      color: govuk-colour('white');
+
+      @include govuk-media-query($from: tablet) {
+        @include govuk-font($size: 24, $weight: bold);
+      }
+    }
+  }
+}

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -11,6 +11,7 @@ class TransitionLandingPageController < ApplicationController
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
       show_comms: show_comms?,
+      show_countdown: show_countdown?,
     }
   end
 
@@ -35,6 +36,10 @@ private
 
   def show_comms?
     true
+  end
+
+  def show_countdown?
+    false
   end
 
   def switch_locale(&action)

--- a/app/lib/countdown_clock.rb
+++ b/app/lib/countdown_clock.rb
@@ -5,15 +5,17 @@ class CountdownClock
     (END_OF_TRANSITION_PERIOD - today_in_london).to_i
   end
 
-  def today_in_london
-    Time.zone.now.utc.to_date
-  end
-
   def show?
     days_left.positive?
   end
 
   def days_text
     days_left == 1 ? "day" : "days"
+  end
+
+private
+
+  def today_in_london
+    Time.zone.now.utc.to_date
   end
 end

--- a/app/lib/countdown_clock.rb
+++ b/app/lib/countdown_clock.rb
@@ -1,0 +1,19 @@
+class CountdownClock
+  END_OF_TRANSITION_PERIOD = Date.new(2021, 1, 1)
+
+  def days_left
+    (END_OF_TRANSITION_PERIOD - today_in_london).to_i
+  end
+
+  def today_in_london
+    Time.zone.now.utc.to_date
+  end
+
+  def show?
+    days_left.positive?
+  end
+
+  def days_text
+    days_left == 1 ? "day" : "days"
+  end
+end

--- a/app/views/components/_countdown.html.erb
+++ b/app/views/components/_countdown.html.erb
@@ -1,3 +1,0 @@
-<% if clock.show? %>
-  <%= clock.days_left %><%= clock.days_text %> to go
-<% end %>

--- a/app/views/components/_countdown.html.erb
+++ b/app/views/components/_countdown.html.erb
@@ -1,0 +1,3 @@
+<% if clock.show? %>
+  <%= clock.days_left %><%= clock.days_text %> to go
+<% end %>

--- a/app/views/transition_landing_page/_countdown.html.erb
+++ b/app/views/transition_landing_page/_countdown.html.erb
@@ -1,0 +1,11 @@
+<div class="transition-countdown govuk-grid-row">
+  <div class="govuk-grid-column-one-half transition-countdown__countdown">
+    <p>
+      <span class="transition-countdown__countdown-days-left"><%= clock.days_left %></span>
+      <span class="transition-countdown__countdown-days-text"><%= clock.days_text %> to go</span>
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-half transition-countdown__traffic-lights">
+    <%= render partial: 'transition_landing_page/take-action-traffic-lights' %>
+  </div>
+</div>

--- a/app/views/transition_landing_page/_take-action-traffic-lights.html.erb
+++ b/app/views/transition_landing_page/_take-action-traffic-lights.html.erb
@@ -1,0 +1,20 @@
+<ul class="govuk-list landing-page__take-action-traffic-lights">
+  <li>
+    <%= image_tag 'take-action-red.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.red") } %>
+    <span class="landing-page__take-action-traffic-lists-text">
+      <%= t("transition_landing_page.take_action_list.red") %>
+    </span>
+  </li>
+  <li>
+    <%= image_tag 'take-action-amber.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.amber") }  %>
+    <span class="landing-page__take-action-traffic-lists-text">
+      <%= t("transition_landing_page.take_action_list.amber") %>
+    </span>
+  </li>
+  <li>
+    <%= image_tag 'take-action-green.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.green") }  %>
+    <span class="landing-page__take-action-traffic-lists-text">
+      <%= t("transition_landing_page.take_action_list.green") %>
+    </span>
+  </li>
+</ul>

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -28,6 +28,9 @@
           } %>
         </div>
       </div>
+      <% if show_countdown %>
+        <%= render partial: 'components/countdown', locals: { clock: CountdownClock.new } %>
+      <% end %>
       <div class="govuk-grid-column-one-third" data-module="track-click">
         <ul class="govuk-list landing-page__take-action-traffic-lights">
           <li>

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -1,58 +1,42 @@
 <div class="landing-page__section landing-page__section--light-grey">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="<%= show_countdown ? "govuk-grid-column-two-thirds" : "govuk-grid-column-full" %>">
         <h2 class="govuk-heading-l">
           <%= t("transition_landing_page.take_action_title") %>
         </h2>
-      </div>
-    </div>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/govspeak", {
-        } do %>
-          <%= t("transition_landing_page.take_action_text").html_safe() %>
-        <% end %>
-          <div class="landing-page__take-action-button">
-          <%= render "govuk_publishing_components/components/button", {
-            text: t("transition_landing_page.take_action_start_now"),
-            href: t("transition_landing_page.take_action_start_now_link"),
-            start: true,
-            margin_bottom: true,
-            data_attributes: {
-              "module": "track-click",
-              "track-action": t("transition_landing_page.take_action_start_now_link"),
-              "track-category": "transition-landing-page",
-              "track-label": t("transition_landing_page.take_action_start_now")
-            }
-          } %>
+        <div class="govuk-grid-row">
+          <div class="<%= show_countdown ? "govuk-grid-column-full" : "govuk-grid-column-two-thirds" %>">
+            <%= render "govuk_publishing_components/components/govspeak", {} do %>
+              <%= t("transition_landing_page.take_action_text").html_safe() %>
+            <% end %>
+            <div class="landing-page__take-action-button">
+              <%= render "govuk_publishing_components/components/button", {
+                text: t("transition_landing_page.take_action_start_now"),
+                href: t("transition_landing_page.take_action_start_now_link"),
+                start: true,
+                margin_bottom: true,
+                data_attributes: {
+                  "module": "track-click",
+                  "track-action": t("transition_landing_page.take_action_start_now_link"),
+                  "track-category": "transition-landing-page",
+                  "track-label": t("transition_landing_page.take_action_start_now")
+                }
+              } %>
+            </div>
+          </div>
+          <% unless show_countdown %>
+            <div class="govuk-grid-column-one-third">
+              <%= render partial: 'transition_landing_page/take-action-traffic-lights' %>
+            </div>
+          <% end %>
         </div>
       </div>
       <% if show_countdown %>
-        <%= render partial: 'components/countdown', locals: { clock: CountdownClock.new } %>
+        <div class="govuk-grid-column-one-third">
+            <%= render partial: 'transition_landing_page/countdown', locals: { clock: CountdownClock.new } %>
+        </div>
       <% end %>
-      <div class="govuk-grid-column-one-third" data-module="track-click">
-        <ul class="govuk-list landing-page__take-action-traffic-lights">
-          <li>
-            <%= image_tag 'take-action-red.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.red") } %>
-            <span class="landing-page__take-action-traffic-lists-text">
-              <%= t("transition_landing_page.take_action_list.red") %>
-            </span>
-          </li>
-          <li>
-            <%= image_tag 'take-action-amber.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.amber") }  %>
-            <span class="landing-page__take-action-traffic-lists-text">
-              <%= t("transition_landing_page.take_action_list.amber") %>
-            </span>
-          </li>
-          <li>
-            <%= image_tag 'take-action-green.svg', class: "landing-page__take-action-traffic-lists-icon", alt: "", data: { "track-action": "imageClick", "track-category": "pageElementInteraction", "track-label": t("transition_landing_page.take_action_list.green") }  %>
-            <span class="landing-page__take-action-traffic-lists-text">
-              <%= t("transition_landing_page.take_action_list.green") %>
-            </span>
-          </li>
-        </ul>
-      </div>
     </div>
   </div>
 </div>

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -10,7 +10,7 @@
   )
 %>
 
-<%= render partial: 'take_action' %>
+<%= render partial: 'take_action', locals: { show_countdown: show_countdown } %>
 
 <%= render partial: 'video_section' %>
 

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -17,9 +17,14 @@ describe TransitionLandingPageController do
 
       it "renders the page for the #{locale} locale" do
         get :show, params: params
-
         assert_response :success
       end
+    end
+
+    it "does not render the countdown partial" do
+      get :show
+      assert_template :show
+      assert_template partial: "_countdown", count: 0
     end
   end
 end

--- a/test/lib/countdown_clock_test.rb
+++ b/test/lib/countdown_clock_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class CountdownClockTest < ActiveSupport::TestCase
+  def clock
+    CountdownClock.new
+  end
+
+  describe "#days_left" do
+    it "gives the days left until end of transition period" do
+      day_before_transition_period_ends = Date.new(2020, 12, 31)
+      travel_to day_before_transition_period_ends
+      assert_equal(1, clock.days_left)
+    end
+  end
+
+  describe "#show?" do
+    it "returns false on the day the transition period ends" do
+      day_transition_period_ends = Date.new(2021, 1, 1)
+      travel_to day_transition_period_ends
+      assert_equal(false, clock.show?)
+    end
+  end
+
+  describe "#days_left" do
+    it "pluralizes day if necessary" do
+      one_day_left = Date.new(2020, 12, 31)
+      travel_to one_day_left
+      assert_equal("day", clock.days_text)
+
+      two_days_left = Date.new(2020, 12, 30)
+      travel_to two_days_left
+      assert_equal("days", clock.days_text)
+    end
+  end
+end


### PR DESCRIPTION
## What

We want to run an AB test to see if adding a countdown clock to the transition landing page increases engagement. As a first step we are adding the component, but hiding it behind a flag. The component can be switched on via the AB test as required.

Related PR: https://github.com/alphagov/collections/pull/1932

### show_countdown? = true

<img width="1100" alt="Screenshot 2020-10-05 at 10 40 13" src="https://user-images.githubusercontent.com/17908089/95064177-43da4980-06f7-11eb-9a6a-cd9fffaa5511.png">

### show_countdown? = false

<img width="1034" alt="Screenshot 2020-10-05 at 10 40 26" src="https://user-images.githubusercontent.com/17908089/95064164-4046c280-06f7-11eb-813b-80a9ab89d0fc.png">


Trello: https://trello.com/c/2xjWj2WN/481-a-b-test-for-urgency-phase-1

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
