### PR TITLE
Add service to get Mapit data for postcode

### DIFF
--- a/app/models/mapit_postcode_response.rb
+++ b/app/models/mapit_postcode_response.rb
@@ -1,0 +1,35 @@
+class MapitPostcodeResponse
+  attr_reader :location
+
+  def initialize(location)
+    @location = location
+  end
+
+  def gss
+    location["codes"]["gss"]
+  end
+
+  def area_name
+    location["name"]
+  end
+
+  def country
+    location["country_name"]
+  end
+
+  def england?
+    country == "England"
+  end
+
+  def scotland?
+    country == "Scotland"
+  end
+
+  def wales?
+    country == "Wales"
+  end
+
+  def northern_ireland?
+    country == "Northern Ireland"
+  end
+end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -22,10 +22,14 @@ class LocationLookupService
 private
 
   def areas
+    return [] if response.blank?
+
     response["response"].select { |data| data.first == "areas" }.first.last
   end
 
   def response
     JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+  rescue GdsApi::HTTPNotFound
+    []
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -28,8 +28,10 @@ private
   end
 
   def response
-    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
-  rescue GdsApi::HTTPNotFound
-    []
+    @response ||= begin
+                    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+                  rescue GdsApi::HTTPNotFound
+                    []
+                  end
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -6,12 +6,18 @@ class LocationLookupService
   end
 
   def data
+    return [] if error
+
     location_data = areas.map do |_, area|
       location = MapitPostcodeResponse.new(area)
       location if location.gss
     end
 
     location_data.compact
+  end
+
+  def error
+    response[:error]
   end
 
 private
@@ -25,8 +31,8 @@ private
   def response
     @response ||= begin
                     JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
-                  rescue GdsApi::HTTPNotFound
-                    []
+                  rescue GdsApi::HTTPNotFound, GdsApi::HTTPClientError => e
+                    { error: e.error_details["error"] }
                   end
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -7,13 +7,8 @@ class LocationLookupService
 
   def data
     location_data = areas.map do |_, area|
-      next if area["codes"]["gss"].blank?
-
-      {
-        gss: area["codes"]["gss"],
-        area_name: area["name"],
-        country: area["country_name"],
-      }
+      location = MapitPostcodeResponse.new(area)
+      location if location.gss
     end
 
     location_data.compact

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -1,0 +1,31 @@
+class LocationLookupService
+  attr_reader :postcode
+
+  def initialize(postcode)
+    @postcode = postcode
+  end
+
+  def data
+    location_data = areas.map do |_, area|
+      next if area["codes"]["gss"].blank?
+
+      {
+        gss: area["codes"]["gss"],
+        area_name: area["name"],
+        country: area["country_name"],
+      }
+    end
+
+    location_data.compact
+  end
+
+private
+
+  def areas
+    response["response"].select { |data| data.first == "areas" }.first.last
+  end
+
+  def response
+    JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
+  end
+end

--- a/test/models/mapit_postcode_response_test.rb
+++ b/test/models/mapit_postcode_response_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+describe MapitPostcodeResponse do
+  let(:mapit_location) do
+    {
+      "codes" => {
+        "ons" => "01",
+        "gss" => "E01000123",
+        "govuk_slug" => "test-one",
+      },
+      "name" => "Coruscant Planetary Council",
+      "type" => "LBO",
+      "country_name" => "England",
+    }
+  end
+
+  it "returns the gss code" do
+    assert_equal("E01000123", described_class.new(mapit_location).gss)
+  end
+
+  it "returns the area name" do
+    assert_equal("Coruscant Planetary Council", described_class.new(mapit_location).area_name)
+  end
+
+  it "returns the country" do
+    assert_equal("England", described_class.new(mapit_location).country)
+  end
+
+  describe "#england?" do
+    it "returns true if the country is England" do
+      assert(described_class.new(mapit_location).england?)
+    end
+  end
+
+  describe "#scotland?" do
+    it "returns true if the country is Scotland" do
+      mapit_location["country_name"] = "Scotland"
+
+      assert(described_class.new(mapit_location).scotland?)
+    end
+  end
+
+  describe "#wales?" do
+    it "returns true if the country is Wales" do
+      mapit_location["country_name"] = "Wales"
+
+      assert(described_class.new(mapit_location).wales?)
+    end
+  end
+
+  describe "#northern_ireland?" do
+    it "returns true if the country is Northern Ireland" do
+      mapit_location["country_name"] = "Northern Ireland"
+
+      assert(described_class.new(mapit_location).northern_ireland?)
+    end
+  end
+end

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -64,11 +64,20 @@ describe LocationLookupService do
       assert_equal("E01000123", data.first.gss)
     end
 
-    it "returns nothing if the postcode isn't found" do
+    it "returns an error if the postcode isn't found" do
       postcode = "E18QS"
       stub_mapit_does_not_have_a_postcode(postcode)
 
       assert_equal([], described_class.new(postcode).data)
+      assert_not_nil(described_class.new(postcode).error)
+    end
+
+    it "returns an error if the postcode is not valid" do
+      invalid_postcode = "hello"
+      stub_mapit_does_not_have_a_bad_postcode(invalid_postcode)
+
+      assert_equal([], described_class.new(invalid_postcode).data)
+      assert_match(invalid_postcode, described_class.new(invalid_postcode).error)
     end
   end
 end

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -73,5 +73,12 @@ describe LocationLookupService do
 
       assert_equal(described_class.new(postcode).data, expected_data)
     end
+
+    it "returns nothing if the postcode isn't found" do
+      postcode = "E18QS"
+      stub_mapit_does_not_have_a_postcode(postcode)
+
+      assert_equal([], described_class.new(postcode).data)
+    end
   end
 end

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -27,20 +27,14 @@ describe LocationLookupService do
       ]
       stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-      expected_data = [
-        {
-          gss: "E01000123",
-          area_name: "Coruscant Planetary Council",
-          country: "England",
-        },
-        {
-          gss: "E02000456",
-          area_name: "Galactic Empire",
-          country: "England",
-        },
-      ]
+      data = described_class.new(postcode).data
 
-      assert_equal(described_class.new(postcode).data, expected_data)
+      assert_equal(2, data.size)
+      assert_instance_of(MapitPostcodeResponse, data.first)
+      assert_equal("E01000123", data.first.gss)
+
+      assert_instance_of(MapitPostcodeResponse, data.second)
+      assert_equal("E02000456", data.second.gss)
     end
 
     it "only returns locations with a gss code" do
@@ -63,15 +57,11 @@ describe LocationLookupService do
       ]
       stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-      expected_data = [
-        {
-          gss: "E01000123",
-          area_name: "Coruscant Planetary Council",
-          country: "England",
-        },
-      ]
+      data = described_class.new(postcode).data
 
-      assert_equal(described_class.new(postcode).data, expected_data)
+      assert_equal(1, data.size)
+      assert_instance_of(MapitPostcodeResponse, data.first)
+      assert_equal("E01000123", data.first.gss)
     end
 
     it "returns nothing if the postcode isn't found" do

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+require "gds_api/test_helpers/mapit"
+
+describe LocationLookupService do
+  include GdsApi::TestHelpers::Mapit
+
+  describe "#data" do
+    it "returns location data" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "ons" => "01",
+          "gss" => "E01000123",
+          "govuk_slug" => "test-one",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+          "country_name" => "England",
+        },
+        {
+          "ons" => "02",
+          "gss" => "E02000456",
+          "govuk_slug" => "test-two",
+          "name" => "Galactic Empire",
+          "type" => "GLA",
+          "country_name" => "England",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      expected_data = [
+        {
+          gss: "E01000123",
+          area_name: "Coruscant Planetary Council",
+          country: "England",
+        },
+        {
+          gss: "E02000456",
+          area_name: "Galactic Empire",
+          country: "England",
+        },
+      ]
+
+      assert_equal(described_class.new(postcode).data, expected_data)
+    end
+
+    it "only returns locations with a gss code" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "ons" => "01",
+          "gss" => "E01000123",
+          "govuk_slug" => "test-one",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+          "country_name" => "England",
+        },
+        {
+          "govuk_slug" => "test-two",
+          "name" => "Galactic Empire",
+          "type" => "GLA",
+          "country_name" => "England",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      expected_data = [
+        {
+          gss: "E01000123",
+          area_name: "Coruscant Planetary Council",
+          country: "England",
+        },
+      ]
+
+      assert_equal(described_class.new(postcode).data, expected_data)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/XzjJRItp
Replaces: https://github.com/alphagov/finder-frontend/pull/2219

# What?
Adds a service that takes a postcode as an input and gets location data from Mapit.

The service return the following for each "area" (local authority, ward etc) that the postcode is in:
- The "gss" code
- The area name, E.g "Maldon District Council"
- The country the postcode is in.

# Why?
A local restrictions postcode lookup is being built to help users find local restrictions in their area. The local restrictions will be LTLA (Lower Tier Local Authority) and will use GSS codes to match users to their area. People don't know which GSS codes they are in, so we need be able to find it for them from their postcode.

# How to test the changes

Mapit data isn't available locally unless you download all of the data (not recommended) so the best way to test this is to deploy a branch to integration and run the following in a console:

```
LocationLookupService.new("E1 8QS").data
```

or to see any errors:

```
LocationLookupService.new("E1 8QS").error
```

## Results from testing

```
irb(main):001:0> LocationLookupService.new("E1 8QS").data
=> [#<MapitPostcodeResponse:0x00007f069b3c23c0 @location={"codes"=>{"ons"=>"A26", "unit_id"=>"25070", "gss"=>"E14000555"}, "generation_low"=>1, "type"=>"WMC", "name"=>"Bethnal Green and Bow", "parent_area"=>nil, "all_names"=>{}, "type_name"=>"UK Parliament constituency", "country_name"=>"England", "country"=>"E", "id"=>10675, "generation_high"=>1}>, #<MapitPostcodeResponse:0x00007f069b3c2348 @location={"codes"=>{"ons"=>"", "unit_id"=>"41444", "gss"=>"E32000004"}, "generation_low"=>1, "type"=>"LAC", "name"=>"City and East", "parent_area"=>1684, "all_names"=>{}, "type_name"=>"London Assembly constituency", "country_name"=>"England", "country"=>"E", "id"=>9221, "generation_high"=>1}>, #<MapitPostcodeResponse:0x00007f069b3c22f8 @location={"codes"=>{"ons"=>"07", "unit_id"=>"41428", "gss"=>"E15000007"}, "generation_low"=>1, "type"=>"EUR", "name"=>"London", "parent_area"=>nil, "all_names"=>{}, "type_name"=>"European region", "country_name"=>"England", "country"=>"E", "id"=>9209, "generation_high"=>1}>, #<MapitPostcodeResponse:0x00007f069b3c22d0 @location={"codes"=>{"unit_id"=>"11192", "gss"=>"E05009336"}, "generation_low"=>1, "type"=>"LBW", "name"=>"Whitechapel", "parent_area"=>2004, "all_names"=>{}, "type_name"=>"London borough ward", "country_name"=>"England", "country"=>"E", "id"=>5082, "generation_high"=>1}>, #<MapitPostcodeResponse:0x00007f069b3c2280 @location={"codes"=>{"ons"=>"00BG", "govuk_slug"=>"tower-hamlets", "unit_id"=>"11185", "gss"=>"E09000030"}, "generation_low"=>1, "type"=>"LBO", "name"=>"London Borough of Tower Hamlets", "parent_area"=>nil, "all_names"=>{}, "type_name"=>"London borough", "country_name"=>"England", "country"=>"E", "id"=>2004, "generation_high"=>1}>]
irb(main):002:0> LocationLookupService.new("E1 8QS").error
=> nil
irb(main):003:0> LocationLookupService.new("E1").data
{"request_uri":"https://mapit.integration.govuk-internal.digital/postcode/E1.json","start_time":1602062609.2601116,"status":400,"end_time":1602062609.2688737,"body":"{\"error\": \"Postcode 'E1' is not valid.\", \"code\": 400}"}
=> []
irb(main):004:0> LocationLookupService.new("E1").error
{"request_uri":"https://mapit.integration.govuk-internal.digital/postcode/E1.json","start_time":1602062613.2754903,"status":400,"end_time":1602062613.2846563,"body":"{\"code\": 400, \"error\": \"Postcode 'E1' is not valid.\"}"}
=> "Postcode 'E1' is not valid."
```

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
