### PR TITLE
Add model for local restriction data

### DIFF
--- a/app/models/local_restriction.rb
+++ b/app/models/local_restriction.rb
@@ -1,0 +1,43 @@
+class LocalRestriction
+  attr_reader :gss_code
+
+  def initialize(gss_code)
+    @gss_code = gss_code
+  end
+
+  def all_restrictions
+    @all_restrictions ||= YAML.load_file(file_name)
+  end
+
+  def restriction
+    all_restrictions[gss_code] || {}
+  end
+
+  def file_name
+    "lib/local_restrictions/local-restrictions.yaml"
+  end
+
+  def area_name
+    restriction["name"]
+  end
+
+  def alert_level
+    restriction["alert_level"]
+  end
+
+  def guidance
+    restriction["guidance"]
+  end
+
+  def extra_restrictions
+    restriction["extra_restrictions"]
+  end
+
+  def start_date
+    restriction["start_date"]&.to_date
+  end
+
+  def end_date
+    restriction["end_date"]&.to_date
+  end
+end

--- a/test/fixtures/local-restrictions.yaml
+++ b/test/fixtures/local-restrictions.yaml
@@ -1,0 +1,13 @@
+---
+E08000001:
+  alert_level: 4
+  name: Tatooine
+  start_date: "01 October 2020"
+  end_date: "02 October 2020"
+  guidance:
+    label: These are not the restrictions you are looking for
+    link: "guidance/tatooine-local-restrictions"
+  extra_restrictions:
+E08000002:
+  start_date:
+  end_date:

--- a/test/models/local_restriction_test.rb
+++ b/test/models/local_restriction_test.rb
@@ -1,0 +1,53 @@
+describe LocalRestriction do
+  let(:restriction) { described_class.new("E08000001") }
+
+  before do
+    LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
+  end
+
+  it "returns the area name" do
+    assert_equal "Tatooine", restriction.area_name
+  end
+
+  it "returns the alert level" do
+    assert_equal 4, restriction.alert_level
+  end
+
+  it "returns the guidance" do
+    guidance = restriction.guidance
+    assert_equal "These are not the restrictions you are looking for", guidance["label"]
+    assert_equal "guidance/tatooine-local-restrictions", guidance["link"]
+  end
+
+  it "returns the extra restrictions" do
+    assert_nil restriction.extra_restrictions
+  end
+
+  it "returns nil values if the gss code doesn't exist" do
+    restriction = described_class.new("fake code")
+    assert_nil restriction.area_name
+    assert_nil restriction.guidance
+  end
+
+  describe "#start_date" do
+    it "returns the start date" do
+      assert_equal "01 October 2020".to_date, restriction.start_date
+    end
+
+    it "allows the start date to be nil" do
+      restriction = described_class.new("E08000002")
+      assert_nil restriction.start_date
+    end
+  end
+
+  describe "#end_date" do
+    it "returns the end date" do
+      assert_equal "02 October 2020".to_date, restriction.end_date
+    end
+
+    it "allows the end date to be nil" do
+      restriction = described_class.new("E08000002")
+      assert_nil restriction.end_date
+    end
+  end
+end


### PR DESCRIPTION
This is a port of a previous commit to finder frontend - https://github.com/alphagov/finder-frontend/pull/2222

It is designed to provide a way to query the data added in https://github.com/alphagov/collections/pull/1934. There are some changes between the PR in finder-frontend and here because of the differences between rspec and minitest.

Trello - https://trello.com/c/743PCdEy/843-add-mapping-service-to-get-lockdown-data-from-gss-code-in-collections

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
