### PR TITLE
Add rubocop Ruby linting to Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,7 @@
 
 require File.expand_path("config/application", __dir__)
 Collections::Application.load_tasks
+
+unless Rails.env.production?
+  task default: %w[lint]
+end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
Rubocop will now run as part of `bundle exec rake`.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
