### PR TITLE
Post code lookup partial

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/title';
 @import 'govuk_publishing_components/components/translation-nav';
+@import "govuk_publishing_components/components/error-alert";
 
 @import "helpers/layouts";
 @import "helpers/margins";

--- a/app/assets/stylesheets/views/_postcode-lookup.scss
+++ b/app/assets/stylesheets/views/_postcode-lookup.scss
@@ -1,0 +1,5 @@
+.postcode-lookup {
+  padding: govuk-spacing(3);
+  margin: govuk-spacing(6) 0;
+  background: govuk-colour("light-grey");
+}

--- a/app/views/coronavirus_landing_page/components/shared/_postcode-lookup.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_postcode-lookup.html.erb
@@ -1,0 +1,36 @@
+<%
+  input_label ||= "Enter your postcode"
+  input_value ||= nil
+  input_error ||= "We couldn’t find this postcode"
+  hint_text ||= "For example SW1A 2AA"
+  button_text ||= "Find"
+  error_message ||= "This isn't a valid postcode."
+  error_description ||= "Check it and enter it again."
+  link ||= { text: "Find a postcode on Royal Mail's postcode finder", href: "http://www.royalmail.com/find-a-postcode"}
+%>
+<% if error_message %>
+  <%= render "govuk_publishing_components/components/error_alert", {
+      message: error_message,
+      description: error_description,
+    } %>
+<% end %>
+<div class="postcode-lookup">
+    <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: input_label
+          },
+          heading_size: "s",
+          error_message: input_error,
+          value: input_value,
+          name: "postcode-lookup",
+          hint: hint_text,
+          invalid: error_message ? 'true' : 'false',
+          autocomplete: "postal-code",
+        } %>
+    <%= render "govuk_publishing_components/components/button", text: button_text, margin_bottom: true %>
+    <%= tag.p link_to(
+      link[:text],
+      link[:href],
+      class: "govuk-link covid__postcode-lookup--link"),
+      class: "govuk-body" %>
+</div>


### PR DESCRIPTION
## What?
Adding postcode lookup partial, as a user I want to lookup local restrictions for Corona Virus to see what rules apply to me, I can visit this page and input my postcode to get relevant information. 

## Why?

Adding a partial so this can be integrated into the wider page setup.

## How?

Creating a new a postcode lookup partial, initially _based_ to [find-my-council](https://www.gov.uk/find-local-council) on `finder-frontend` however as since been modified upon review.

## Testing?
Was initially included however this has since been removed as this is to be included at page not a partial level.

## Design & Prototype
https://www.figma.com/file/GuYNyaQkjKqhR87nqqqRTv/Local-restrictions?node-id=0%3A1
https://govuk-coronavirus-lockdown-v2.herokuapp.com/

![Screenshot 2020-10-07 at 21 54 39](https://user-images.githubusercontent.com/71266765/95452663-81daa600-0961-11eb-86b0-16f37c45e5d5.png)


##  Ticket
https://trello.com/c/6mYZd3HQ

##  Anything else?
**This PR includes a request for a commit to be removed.**

This commit exists so that the partial can render visually on the landing page for review, to give context and so can be shared and tested wider. Default values have been added to the partial which will be overwritten by Content values once included on the relevant page.  

----

## Draft PRs, discussion & code history
Moved from `frontend` to `finder-fronend` to `collections`
https://github.com/alphagov/finder-frontend/pull/2226 
Reviewed @DilwoarH  @andysellick 

https://github.com/alphagov/collections/pull/1936
Reviewed @leenagupte @Rosa-Fox @DilwoarH 

A [component](https://components.publishing.service.gov.uk/component-guide) is a shared reusable and tested UI element while a partial is a collection of components that live within particular apps ([atom > organisms](https://bradfrost.com/blog/post/atomic-web-design/)) 

There has been on-going discussion regarding conventions and definitions. Many centre about the difference between a component and partial in the context of the `collections` repo and within also the wider frontend definition and how this is defined by other disciplines.  Granular testing was initially included however this was since removed as this will happen at a page level not a partial level focusing on errors.  Translation setup has been advised will happen at a different stage and the `<form>` element has been removed being advised it will render at section of the page.

There is probably a wider conversation around the Frontend conventions & ideologies applied in the context of this `collections` app. 

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
