### PR TITLE
Add error helper methods to LocationLookupService

### DIFF
--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -16,6 +16,14 @@ class LocationLookupService
     location_data.compact
   end
 
+  def postcode_not_found?
+    error && error[:code] == 404
+  end
+
+  def invalid_postcode?
+    error && error[:code] == 400
+  end
+
   def error
     response[:error]
   end
@@ -32,7 +40,12 @@ private
     @response ||= begin
                     JSON.parse(GdsApi.mapit.location_for_postcode(postcode).to_json)
                   rescue GdsApi::HTTPNotFound, GdsApi::HTTPClientError => e
-                    { error: e.error_details["error"] }
+                    {
+                      error: {
+                        message: e.error_details["error"],
+                        code: e.code,
+                      },
+                    }
                   end
   end
 end

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -70,6 +70,7 @@ describe LocationLookupService do
 
       assert_equal([], described_class.new(postcode).data)
       assert_not_nil(described_class.new(postcode).error)
+      assert(described_class.new(postcode).postcode_not_found?)
     end
 
     it "returns an error if the postcode is not valid" do
@@ -77,7 +78,8 @@ describe LocationLookupService do
       stub_mapit_does_not_have_a_bad_postcode(invalid_postcode)
 
       assert_equal([], described_class.new(invalid_postcode).data)
-      assert_match(invalid_postcode, described_class.new(invalid_postcode).error)
+      assert_match(invalid_postcode, described_class.new(invalid_postcode).error[:message])
+      assert(described_class.new(invalid_postcode).invalid_postcode?)
     end
   end
 end


### PR DESCRIPTION
Add helper methods so that we can display a different error to the user
depending on whether they have entered a "bad" postcode (i.e. one in an
invalid format), or a postcode that Mapit does not know about yet (e.g.
for new builds).

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
