### PR TITLE
Get Lower tier local authority name for postcode

### DIFF
--- a/app/models/mapit_postcode_response.rb
+++ b/app/models/mapit_postcode_response.rb
@@ -17,6 +17,10 @@ class MapitPostcodeResponse
     location["country_name"]
   end
 
+  def area_type
+    location["type"]
+  end
+
   def england?
     country == "England"
   end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -1,6 +1,8 @@
 class LocationLookupService
   attr_reader :postcode
 
+  LOWER_TIER_AREA_CODES = %w[COI LBO LGD MTD UTA DIS].freeze
+
   def initialize(postcode)
     @postcode = postcode
   end
@@ -26,6 +28,11 @@ class LocationLookupService
 
   def error
     response[:error]
+  end
+
+  def lower_tier_area_name
+    lower_tier = data.select { |d| d.area_type.in?(LOWER_TIER_AREA_CODES) }
+    lower_tier.first.area_name
   end
 
 private

--- a/test/models/mapit_postcode_response_test.rb
+++ b/test/models/mapit_postcode_response_test.rb
@@ -26,6 +26,10 @@ describe MapitPostcodeResponse do
     assert_equal("England", described_class.new(mapit_location).country)
   end
 
+  it "returns the area type" do
+    assert_equal("LBO", described_class.new(mapit_location).area_type)
+  end
+
   describe "#england?" do
     it "returns true if the country is England" do
       assert(described_class.new(mapit_location).england?)

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -81,5 +81,30 @@ describe LocationLookupService do
       assert_match(invalid_postcode, described_class.new(invalid_postcode).error[:message])
       assert(described_class.new(invalid_postcode).invalid_postcode?)
     end
+
+    it "returns the lowest tier area code" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "ons" => "01",
+          "gss" => "E01000123",
+          "govuk_slug" => "test-one",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+          "country_name" => "England",
+        },
+        {
+          "ons" => "02",
+          "gss" => "E02000456",
+          "govuk_slug" => "test-two",
+          "name" => "Galactic Empire",
+          "type" => "GLA",
+          "country_name" => "England",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      assert_equal("Coruscant Planetary Council", described_class.new(postcode).lower_tier_area_name)
+    end
   end
 end


### PR DESCRIPTION
We need to display the name of the area that a postcode is in if we
can't find any local coronavirus restrictions for the area.
Unfortunately there isn't any consistency in the "type" code for lower
tier areas

The "/find-local-council" service had the same problem, and uses a list
of "known" lower tier codes, that we have borrowed and are reusing.
See: https://github.com/alphagov/frontend/blob/8dbe0f0f6ca0f5a777a0d6ca77b858fe5adc2494/app/controllers/find_local_council_controller.rb#L8-L10

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
