### PR TITLE
Display local restriction results

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -23,12 +23,29 @@ class CoronavirusLocalRestrictionsController < ApplicationController
                       input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
                       error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
                     }
+    elsif !postcode_validation
+      @error = true
+      return render :show,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                      error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
+                      input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
+                      error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
+                    }
     end
 
     @content_item = content_item.to_hash
 
     @location_lookup = LocationLookupService.new(@postcode)
 
+    elsif @location_lookup.invalid_postcode?
+      return render :show,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                      error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
+                      input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
+                      error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
+                    }
     elsif @location_lookup.postcode_not_found?
       return render :show,
                     locals: {
@@ -70,6 +87,10 @@ private
         url: "/coronavirus",
       },
     ]
+  end
+
+  def postcode_validation
+    @postcode =~ /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/
   end
 
   def content_item

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -38,6 +38,11 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     @location_lookup = LocationLookupService.new(@postcode)
 
+    if @location_lookup.no_information?
+      return render :no_information,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                    }
     elsif @location_lookup.invalid_postcode?
       return render :show,
                     locals: {

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -1,9 +1,15 @@
 class CoronavirusLocalRestrictionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:results]
+
   def show
     render :show,
            locals: {
              breadcrumbs: breadcrumbs,
            }
+  end
+
+  def results
+    @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
   end
 
   def error_404

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -5,15 +5,39 @@ class CoronavirusLocalRestrictionsController < ApplicationController
     render :show,
            locals: {
              breadcrumbs: breadcrumbs,
+             error_message: nil,
+             input_error: nil,
+             error_description: nil,
            }
   end
 
   def results
     @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
 
+    if @postcode.blank?
+      @error = true
+      return render :show,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
+                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
+                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
+                    }
+    end
+
     @content_item = content_item.to_hash
 
     @location_lookup = LocationLookupService.new(@postcode)
+
+    elsif @location_lookup.postcode_not_found?
+      return render :show,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
+                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
+                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
+                    }
+    end
 
     if @location_lookup.data.present?
       restrictions = @location_lookup.data.map do |area|

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -10,6 +10,21 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
   def results
     @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
+
+    @content_item = content_item.to_hash
+
+    @location_lookup = LocationLookupService.new(@postcode)
+
+    if @location_lookup.data.present?
+      restrictions = @location_lookup.data.map do |area|
+        restriction = LocalRestriction.new(area.gss)
+        restriction if restriction.area_name
+      end
+
+      @restriction = restrictions.compact.first
+
+      render
+    end
   end
 
   def error_404
@@ -31,5 +46,9 @@ private
         url: "/coronavirus",
       },
     ]
+  end
+
+  def content_item
+    @content_item ||= ContentItem.find!(request.path)
   end
 end

--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -19,11 +19,15 @@ class LocationLookupService
   end
 
   def postcode_not_found?
-    error && error[:code] == 404
+    (error && error[:code] == 404)
   end
 
   def invalid_postcode?
     error && error[:code] == 400
+  end
+
+  def no_information?
+    error.blank? && data.blank?
   end
 
   def error

--- a/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
+++ b/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
@@ -1,0 +1,19 @@
+<div class="covid-local-restrictions__devolved-nation-guidance">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.devolved_nations.heading")
+  } %>
+  <% if @location_lookup.data.first.scotland? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance")) %>
+    </p>
+  <% elsif @location_lookup.data.first.northern_ireland? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.northern_ireland.guidance")) %>
+    </p>
+  <% elsif @location_lookup.data.first.wales? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.wales.guidance")) %>
+    </p>
+  <% end %>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.devolved_nations.travel_heading") } %>
+</div>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -1,0 +1,17 @@
+<div class="covid-local-restrictions__no-restriction-guidance">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.level_one.heading")
+  } %>
+
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_one.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
+  </p>
+
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_one.alert_level") %>
+  </p>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_one.guidance")) %>
+  </p>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+</div>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -1,0 +1,15 @@
+<div class="covid-local-restrictions__local-alert-guidance">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.level_three.heading")
+  } %>
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
+  </p>
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_three.alert_level") %>
+  </p>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_three.guidance")) %>
+  </p>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+</div>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -1,0 +1,15 @@
+<div class="covid-local-restrictions__local-alert-guidance">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.level_two.heading")
+  } %>
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
+  </p>
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.level_two.alert_level") %>
+  </p>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_two.guidance")) %>
+  </p>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+</div>

--- a/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
@@ -1,0 +1,10 @@
+<div class="covid-local-restrictions__travel-gudiance">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: travel_heading,
+    font_size: "m",
+    margin_bottom: 3
+  } %>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.travel_text")) %>
+  </p>
+</div>

--- a/app/views/coronavirus_local_restrictions/no_information.html.erb
+++ b/app/views/coronavirus_local_restrictions/no_information.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t("coronavirus_local_restrictions.results.no_information.heading") %>
+
+<div class="covid-local-restrictions__local-alert-guidance">
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.no_information.heading")
+  } %>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.no_information.guidance")) %>
+  </p>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+</div>

--- a/app/views/coronavirus_local_restrictions/results.html.erb
+++ b/app/views/coronavirus_local_restrictions/results.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, t("coronavirus_local_restrictions.lookup.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if !@location_lookup.data.first.england? %>
+      <%= render partial: "coronavirus_local_restrictions/devolved_nation" %>
+    <% elsif @restriction.present? && @restriction.alert_level == 2 %>
+        <%= render partial: "coronavirus_local_restrictions/tier_two_restrictions" %>
+    <% elsif @restriction.present? && @restriction.alert_level == 3 %>
+        <%= render partial: "coronavirus_local_restrictions/tier_three_restrictions" %>
+    <% else %>
+      <%= render partial: "coronavirus_local_restrictions/tier_one_restrictions" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -7,6 +7,14 @@
 
 <% content_for :title, t("coronavirus_local_restrictions.lookup.title") %>
 
+<% content_for :meta_tags do %>
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="GOV.UK">
+  <meta property="og:url" content="<%= request.base_url + request.path %>">
+  <meta property="og:title" content="<%= t("coronavirus_local_restrictions.lookup.meta_title") %>">
+  <meta property="og:description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", title: t("coronavirus_local_restrictions.lookup.title") %>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -1,22 +1,25 @@
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% content_for :breadcrumbs do %>
-        <%= render 'govuk_publishing_components/components/breadcrumbs', {
-          breadcrumbs: breadcrumbs,
-          collapse_on_mobile: true
-        } %>
-      <% end %>
+<% content_for :breadcrumbs do %>
+  <%= render 'govuk_publishing_components/components/breadcrumbs', {
+    breadcrumbs: breadcrumbs,
+    collapse_on_mobile: true
+  } %>
+<% end %>
 
-      <% content_for :title, t("coronavirus_local_restrictions.lookup.title") %>
+<% content_for :title, t("coronavirus_local_restrictions.lookup.title") %>
 
-      <%= render "govuk_publishing_components/components/title", title: t("coronavirus_local_restrictions.lookup.title") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", title: t("coronavirus_local_restrictions.lookup.title") %>
 
-      <%= render "govuk_publishing_components/components/inset_text", text: t('coronavirus_local_restrictions.lookup.inset_text') %>
+    <%= render "govuk_publishing_components/components/inset_text", text: t('coronavirus_local_restrictions.lookup.inset_text') %>
 
-      <%= sanitize(t("coronavirus_local_restrictions.lookup.body_content")) %>
-
-      <%= render "shared/postcode-lookup" %>
-    </div>
+    <%= sanitize(t("coronavirus_local_restrictions.lookup.body_content")) %>
+    <%= form_for :postcode_lookup, :url => find_coronavirus_local_restrictions_path do |f| %>
+      <%= render "shared/postcode-lookup", {
+        error_message: error_message,
+        error_description: error_description,
+        input_error: input_error
+      } %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -19,6 +19,8 @@ en:
         <p class="govuk-body">Enter the postcode of the place you want to find information about. For example where you live, work, or visit.</p>
         <p class="govuk-body">Each area has a <a class="govuk-link" href="/guidance/local-covid-alert-levels-what-you-need-to-know">Local COVID Alert Level</a>. There are 3 Local COVID Alert Levels. Sometimes this is known as a ‘local lockdown’.</p>
         <p class="govuk-body">You can find out what you can or cannot do.</p>
+      meta_title: Find out the coronavirus restrictions in a local area
+      meta_description: Find out the Local COVID Alert Level for an area. Search by postcode.
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail's postcode finder
       href: http://www.royalmail.com/find-a-postcode

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -2,13 +2,13 @@ en:
   coronavirus_local_restrictions:
     errors:
       no_postcode:
-        error_message: There is a problem.
-        input_error: Enter a postcode.
-        error_description: Enter a postcode.
+        error_message: There is a problem
+        input_error: Enter a postcode
+        error_description: Enter a postcode
       invalid_postcode:
-        error_message: There is a problem.
-        input_error: Enter a valid postcode.
-        error_description: Enter a valid postcode.
+        error_message: There is a problem
+        input_error: Enter a valid postcode
+        error_description: Enter a valid postcode
     lookup:
       input_label: Enter your postcode
       hint_text: For example SW1A 2AA
@@ -17,8 +17,8 @@ en:
       inset_text: There are different restrictions in Scotland, Wales and Northern Ireland.
       body_content: |
         <p class="govuk-body">Enter the postcode of the place you want to find information about. For example where you live, work, or visit.</p>
-        <p class="govuk-body">You can find out what you can or cannot do. Sometimes this is known as a ‘local lockdown’.</p>
-        <p class="govuk-body">Each area has a local alert level. There are 3 alert levels. Level 1 areas have the least restrictions and level 3 areas have the most restrictions.</p>
+        <p class="govuk-body">Each area has a <a class="govuk-link" href="/guidance/local-covid-alert-levels-what-you-need-to-know">Local COVID Alert Level</a>. There are 3 Local COVID Alert Levels. Sometimes this is known as a ‘local lockdown’.</p>
+        <p class="govuk-body">You can find out what you can or cannot do.</p>
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail's postcode finder
       href: http://www.royalmail.com/find-a-postcode
@@ -51,4 +51,4 @@ en:
           guidance: <a class="govuk-link" href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-and-localised-restrictions">Find out what you can or cannot do from the Northern Ireland Government.</a>
       no_information:
         heading: There is no information about the restrictions in this area
-        guidance: <a class="govuk-link" href="/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19">All coronavirus information about what you can and cannot do.</a>
+        guidance: <a class="govuk-link" href="/coronavirus">All coronavirus information about what you can and cannot do.</a>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -1,5 +1,14 @@
 en:
   coronavirus_local_restrictions:
+    errors:
+      no_postcode:
+        error_message: There is a problem.
+        input_error: Enter a postcode.
+        error_description: Enter a postcode.
+      invalid_postcode:
+        error_message: There is a problem.
+        input_error: Enter a valid postcode.
+        error_description: Enter a valid postcode.
     lookup:
       input_label: Enter your postcode
       hint_text: For example SW1A 2AA
@@ -13,3 +22,33 @@ en:
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail's postcode finder
       href: http://www.royalmail.com/find-a-postcode
+    results:
+      travel_heading: If you travel to other areas
+      travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode</a> to find out what restrictions there are.
+      level_one:
+        heading: Local COVID Alert Level Medium
+        match: "We've matched the postcode"
+        alert_level: This area is in Local COVID Alert Level Medium.
+        guidance: <a class="govuk-link" href="/covid19app/localalertlevel1">What you can and cannot do.</a
+      level_two:
+        heading: Local COVID Alert Level High
+        alert_level: This area is in Local COVID Alert Level High.
+        guidance: <a class="govuk-link" href="/covid19app/localalertlevel2">What you can and cannot do.</a>
+        match: "We've matched the postcode"
+      level_three:
+        heading: Local COVID Alert Level Very High
+        alert_level: This area is in Local COVID Alert Level Very High.
+        guidance: <a class="govuk-link" href="/covid19app/localalertlevel3">What you can and cannot do.</a>
+        match: "We've matched the postcode"
+      devolved_nations:
+        heading: There might be restrictions in this area
+        travel_heading: If you travel to areas in England
+        scotland:
+          guidance: <a class="govuk-link" href="https://www.gov.scot/coronavirus-covid-19/">Find out what you can or cannot do from the Scottish Government.</a>
+        wales:
+          guidance: <a class="govuk-link" href="https://gov.wales/local-lockdown">Find out what you can or cannot do from the Welsh Government.</a>
+        northern_ireland:
+          guidance: <a class="govuk-link" href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-and-localised-restrictions">Find out what you can or cannot do from the Northern Ireland Government.</a>
+      no_information:
+        heading: There is no information about the restrictions in this area
+        guidance: <a class="govuk-link" href="/government/collections/local-restrictions-areas-with-an-outbreak-of-coronavirus-covid-19">All coronavirus information about what you can and cannot do.</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   # Routes for local restrictions postcode lookup
   constraints CoronavirusLocalRestrictionsConstraint.new do
     get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
+    post "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#results"
   end
 
   get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#error_404"

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -1,12 +1,37 @@
 require "test_helper"
+require "gds_api/test_helpers/mapit"
 
 describe CoronavirusLocalRestrictionsController do
+  include GdsApi::TestHelpers::Mapit
+  include GdsApi::TestHelpers::ContentStore
+
   describe "GET show" do
     it "correctly renders the local restrictions page" do
       get :show
 
       assert_response :success
       assert_template :show
+    end
+  end
+
+  describe "POST results" do
+    it "renders the results page when given a real postcode" do
+      postcode = "E18QS"
+      areas = [
+        {
+          "gss" => "E01000123",
+          "name" => "Coruscant Planetary Council",
+          "type" => "LBO",
+        },
+      ]
+      stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+      stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
+
+      post :results, params: { "postcode-lookup" => postcode }
+
+      assert_response :success
+      assert_template :results
     end
   end
 end

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -33,5 +33,14 @@ describe CoronavirusLocalRestrictionsController do
       assert_response :success
       assert_template :results
     end
+
+    it "renders the local restriction page when given an incorrect postcode" do
+      postcode = "invalid postcode"
+      stub_mapit_does_not_have_a_postcode(postcode)
+      post :results, params: { "postcode-lookup" => postcode }
+
+      assert_response :success
+      assert_template :show
+    end
   end
 end

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -1,17 +1,137 @@
 require "integration_test_helper"
+require "gds_api/test_helpers/mapit"
 
 class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
-  it "visits postcode lookup page" do
+  include GdsApi::TestHelpers::Mapit
+  include GdsApi::TestHelpers::ContentStore
+
+  it "displays the tier one restrictions" do
     given_i_am_on_the_local_restrictions_page
     then_i_can_see_the_postcode_lookup_form
+    then_i_enter_a_valid_english_postcode
+    then_i_click_on_find
+    then_i_see_the_results_page_for_level_one
+  end
+
+  it "displays the tier two restrictions" do
+    given_i_am_on_the_local_restrictions_page
+    then_i_can_see_the_postcode_lookup_form
+    then_i_enter_a_valid_english_postcode_in_tier_two
+    then_i_click_on_find
+    then_i_see_the_results_page_for_level_two
+  end
+
+  it "displays guidance for a devolved nation" do
+    given_i_am_on_the_local_restrictions_page
+    then_i_can_see_the_postcode_lookup_form
+    then_i_enter_a_valid_welsh_postcode
+    then_i_click_on_find
+    then_i_see_the_results_for_wales
+  end
+
+  it "errors gracefully if you don't enter a postcode" do
+    given_i_am_on_the_local_restrictions_page
+    then_i_can_see_the_postcode_lookup_form
+    then_i_click_on_find
+    then_i_can_see_the_postcode_lookup_form
+    then_i_see_an_error_message
+  end
+
+  it "displays no information found if the postcode is in a valid format, but there is no data" do
+    given_i_am_on_the_local_restrictions_page
+    then_i_can_see_the_postcode_lookup_form
+    when_i_enter_a_valid_postcode_that_returns_no_results
+    then_i_click_on_find
+    then_i_see_the_no_information_page
   end
 
   def given_i_am_on_the_local_restrictions_page
+    stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
+
     visit find_coronavirus_local_restrictions_path
   end
 
   def then_i_can_see_the_postcode_lookup_form
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.lookup.title"))
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.lookup.input_label"))
+  end
+
+  def then_i_enter_a_valid_english_postcode
+    postcode = "E18QS"
+    areas = [
+      {
+        "gss" => "E01000123",
+        "name" => "Coruscant Planetary Council",
+        "type" => "LBO",
+        "country_name" => "England",
+      },
+    ]
+    stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+    fill_in "Enter your postcode", with: postcode
+  end
+
+  def then_i_enter_a_valid_english_postcode_in_tier_two
+    postcode = "M11AD"
+    areas = [
+      {
+        "gss" => "E08000001",
+        "name" => "Bolton",
+        "type" => "LBO",
+        "country_name" => "England",
+      },
+    ]
+    stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+    fill_in "Enter your postcode", with: postcode
+  end
+
+  def then_i_enter_a_valid_welsh_postcode
+    postcode = "LL110BY"
+    areas = [
+      {
+        "gss" => "E01000123",
+        "country_name" => "Wales",
+      },
+    ]
+    stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+
+    fill_in "Enter your postcode", with: postcode
+  end
+
+  def when_i_enter_a_valid_postcode_that_returns_no_results
+    postcode = "IM11AF"
+    mapit_endpoint = Plek.current.find("mapit")
+
+    stub_request(:get, "#{mapit_endpoint}/postcode/" + postcode.tr(" ", "+") + ".json")
+        .to_return(body: { "postcode" => postcode.to_s, "areas" => {} }.to_json, status: 200)
+
+    fill_in "Enter your postcode", with: postcode
+  end
+
+  def then_i_click_on_find
+    click_on "Find"
+  end
+
+  def then_i_see_the_results_page_for_level_one
+    assert page.has_text?("Coruscant Planetary Council")
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.heading"))
+  end
+
+  def then_i_see_the_results_page_for_level_two
+    assert page.has_text?("Bolton")
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level"))
+  end
+
+  def then_i_see_the_results_for_wales
+    assert page.has_text?("Welsh Government")
+  end
+
+  def then_i_see_an_error_message
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"))
+  end
+
+  def then_i_see_the_no_information_page
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.no_information.heading"))
   end
 end

--- a/test/services/location_lookup_service_test.rb
+++ b/test/services/location_lookup_service_test.rb
@@ -106,5 +106,15 @@ describe LocationLookupService do
 
       assert_equal("Coruscant Planetary Council", described_class.new(postcode).lower_tier_area_name)
     end
+
+    it "returns no information if the postcode is in a valid format but there is no data" do
+      postcode = "IM11AF"
+      MAPIT_ENDPOINT = Plek.current.find("mapit")
+
+      stub_request(:get, "#{MAPIT_ENDPOINT}/postcode/" + postcode.tr(" ", "+") + ".json")
+          .to_return(body: { "postcode" => postcode.to_s, "areas" => {} }.to_json, status: 200)
+
+      assert(described_class.new(postcode).no_information?)
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/g3eVg2yg

# What?
Display the results of the postcode lookup.
The content will change depending on whether the area:

- Has local restrictions
 - Level: Medium (this will be the lowest level of restrictions and therefore the default)
 - Level: High
 - Level: Very High
- Is in Scotland
- Is in Wales
- Is in Northern Ireland
- there is no information or no result (this shouldn't really happen, but is like the error page) 

# Expected changes

<img width="1532" alt="Screenshot 2020-10-12 at 15 42 50" src="https://user-images.githubusercontent.com/5793815/95759781-14e94800-0ca2-11eb-9e09-61e27660972d.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 44 40" src="https://user-images.githubusercontent.com/5793815/95759784-161a7500-0ca2-11eb-936b-389fa7018feb.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 44 23" src="https://user-images.githubusercontent.com/5793815/95759785-16b30b80-0ca2-11eb-8445-d6769f28989e.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 43 56" src="https://user-images.githubusercontent.com/5793815/95759787-174ba200-0ca2-11eb-87cb-6b90e34e8d5a.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 43 24" src="https://user-images.githubusercontent.com/5793815/95759791-17e43880-0ca2-11eb-9b94-e73aead4bc5c.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 43 14" src="https://user-images.githubusercontent.com/5793815/95759796-187ccf00-0ca2-11eb-8dbb-ed87d82bb337.png">
<img width="1532" alt="Screenshot 2020-10-12 at 15 42 59" src="https://user-images.githubusercontent.com/5793815/95759798-19156580-0ca2-11eb-816d-0dc97ee4aacd.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
