### PR TITLE
Show previous role holders section when historical accounts are enabled

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -87,7 +87,7 @@ class Role
 
   def past_holders_url
     if slug == "prime-minister"
-      "/government/history/past-prime-minister"
+      "/government/history/past-prime-ministers"
     elsif slug == "chancellor-of-the-exchequer"
       "/government/history/past-chancellors"
     elsif slug == "secretary-of-state-for-foreign-commonwealth-and-development-affairs"

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -86,7 +86,15 @@ class Role
   end
 
   def past_holders_url
-    "/government/history/past-#{slug.pluralize}"
+    if slug == "prime-minister"
+      "/government/history/past-prime-minister"
+    elsif slug == "chancellor-of-the-exchequer"
+      "/government/history/past-chancellors"
+    elsif slug == "secretary-of-state-for-foreign-commonwealth-and-development-affairs"
+      "/government/history/past-foreign-secretaries"
+    elsif slug == "foreign-secretary"
+      "/government/history/past-foreign-secretaries"
+    end
   end
 
 private

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -11,7 +11,7 @@
         href: "#current-role-holder"
       } : nil,
 
-      role.past_holders.present? ? {
+      role.past_holders.present? || role.supports_historical_accounts? ? {
         text: t("roles.headings.previous_holders"),
         href: "#past-role-holders"
       } : nil,

--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -1,23 +1,25 @@
-<% unless role.past_holders.empty? %>
+<% if role.supports_historical_accounts? %>
   <section id="past-role-holders" class="govuk-!-padding-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Previous holders of this role",
     } %>
-
-    <% if role.supports_historical_accounts? %>
-      <p class="govuk-body" lang="en">
-        Find out more about previous holders of this role in our <%= link_to "past #{role.title.pluralize}", role.past_holders_url, class: "govuk-link" %> section.
-      </p>
-    <% elsif role.past_holders.present? %>
-      <%= render "components/taxon-list", {
-        items: role.past_holders.map do |rh|
-          {
-            text: rh['title'],
-            path: rh['base_path'],
-            description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
-          }
-        end
-      } %>
-    <% end %>
+    <p class="govuk-body" lang="en">
+      Find out more about previous holders of this role in our <%= link_to "past #{role.title.pluralize}", role.past_holders_url, class: "govuk-link" %> section.
+    </p>
+  </section>
+<% elsif role.past_holders.present? %>
+  <section id="past-role-holders" class="govuk-!-padding-bottom-9">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Previous holders of this role",
+    } %>
+    <%= render "components/taxon-list", {
+      items: role.past_holders.map do |rh|
+        {
+          text: rh['title'],
+          path: rh['base_path'],
+          description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
+        }
+      end
+    } %>
   </section>
 <% end %>

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -164,10 +164,7 @@ describe Role do
     context "when applied to a chancellor" do
       setup do
         @api_data["title"] = "Chancellor of the Exchequer"
-        @api_data["base_path"] = "/government/ministers/chancellor"
-      end
-      it "pluralises correctly" do
-        assert @role.title.pluralize == "Chancellors of the Exchequer"
+        @api_data["base_path"] = "/government/ministers/chancellor-of-the-exchequer"
       end
 
       it "points to the correct historical account page" do
@@ -176,12 +173,8 @@ describe Role do
     end
     context "when applied to a foreign secretary" do
       setup do
-        @api_data["title"] = "Secretary of State for Foreign and Commonwealth Affairs"
-        @api_data["base_path"] = "/government/ministers/foreign-secretary"
-      end
-
-      it "pluralises correctly" do
-        assert @role.title.pluralize == "Secretaries of State for Foreign and Commonwealth Affairs"
+        @api_data["title"] = "Secretary of State for Foreign, Commonwealth and Development Affairs"
+        @api_data["base_path"] = "/government/ministers/secretary-of-state-for-foreign-commonwealth-and-development-affairs"
       end
 
       it "points to the correct historical account page" do


### PR DESCRIPTION
When a role has historical accounts enabled, it doesn't matter if it has
any past holders since we only show a paragraph linking to another page.

This change is necessary so that the previous holders paragraph will
show on the Secretary of State for Foreign, Commonwealth and Development
Affairs page: (https://www.gov.uk/government/ministers/secretary-of-state-for-foreign-commonwealth-and-development-affairs)

[Trello](https://trello.com/c/fhyWfybo/2164-3-add-historical-accounts-and-past-role-holders-to-new-fcdo-sos-role)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
