### PR TITLE
Finish one AB test and start the next

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -48,7 +48,7 @@ private
   def ab_test_variant
     @ab_test_variant ||= begin
       ab_test = GovukAbTesting::AbTest.new(
-        "TransitionUrgency2",
+        "TransitionUrgency3",
         dimension: 44,
         allowed_variants: %w[A B Z],
         control_variant: "Z",

--- a/app/presenters/transition_landing_page_presenter.rb
+++ b/app/presenters/transition_landing_page_presenter.rb
@@ -2,7 +2,7 @@ require "yaml"
 require "govspeak"
 
 class TransitionLandingPagePresenter
-  attr_reader :taxon, :comms
+  attr_reader :taxon, :comms, :buckets
   delegate(
     :title,
     :base_path,
@@ -12,6 +12,7 @@ class TransitionLandingPagePresenter
   def initialize(taxon)
     @taxon = taxon
     @comms = fetch_comms
+    @buckets = fetch_buckets
   end
 
   def supergroup_sections
@@ -50,17 +51,10 @@ class TransitionLandingPagePresenter
     links.sort_by { |t| t[:locale] == I18n.default_locale.to_s ? "" : t[:locale] }
   end
 
-  def buckets(show_variant = false)
-    @buckets ||= begin
-      bucket_translation_key = show_variant ? "transition_landing_page.campaign_buckets_variant_B" : "transition_landing_page.campaign_buckets"
-      fetch_buckets(bucket_translation_key)
-    end
-  end
-
 private
 
-  def fetch_buckets(bucket_translation_key)
-    buckets = I18n.t(bucket_translation_key)
+  def fetch_buckets
+    buckets = I18n.t("transition_landing_page.campaign_buckets")
     buckets.each do |bucket|
       bucket[:list_block] = convert_to_govspeak(bucket[:list_block])
     end

--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -10,28 +10,43 @@
       <h2 class="govuk-heading-l">
         <%= guidance_header %>
       </h2>
-      <p class="landing-page__guidance_subheader" data-module="track-click">
-        <%= raw t("transition_landing_page.guidance_subheader") %>
-      </p>
+      <% unless show_variant? %>
+        <p class="landing-page__guidance_subheader" data-module="track-click">
+          <%= raw t("transition_landing_page.guidance_subheader") %>
+        </p>
+      <% end %>
     </div>
   </div>
 
-  <% buckets.each do |bucket| %>
-    <div class="govuk-grid-row landing-page__section-list-wrapper">
-      <div class="govuk-grid-column-one-third">
-        <% if bucket[:row_title] %>
-          <h3 class="govuk-heading-m">
-            <%= bucket[:row_title] %>
-          </h3>
-        <% end %>
-      </div>
+  <% if show_variant? %>
+    <% variant_b_section = I18n.t("transition_landing_page.campaign_links") %>
+    <% links = variant_b_section[:links].map{ |link| "<a href='#{link[:path]}'>#{link[:text]}</a>"} %>
+    <p class='govuk-body'><%= variant_b_section[:lead_in] %>
+      <%= render "govuk_publishing_components/components/list", {
+        extra_spacing: true,
+        visible_counters: true,
+        items: links
+      } %>
+    </p>
+    <p class="govuk-body govuk-!-padding-top-2"><%= variant_b_section[:lead_out].html_safe %></p>
+  <% else %>
+    <% buckets.each do |bucket| %>
+      <div class="govuk-grid-row landing-page__section-list-wrapper">
+        <div class="govuk-grid-column-one-third">
+          <% if bucket[:row_title] %>
+            <h3 class="govuk-heading-m">
+              <%= bucket[:row_title] %>
+            </h3>
+          <% end %>
+        </div>
 
-      <div class="govuk-grid-column-two-thirds" data-module="track-click">
-        <%= render "govuk_publishing_components/components/govspeak", {
-          } do %>
-          <%= bucket[:list_block] %>
-        <% end %>
+        <div class="govuk-grid-column-two-thirds" data-module="track-click">
+          <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
+            <%= bucket[:list_block] %>
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -1,4 +1,4 @@
-<% guidance_header = show_variant? ? t("transition_landing_page.guidance_header_variant_B") : t("transition_landing_page.guidance_header")%>
+<% guidance_header = t("transition_landing_page.guidance_header") %>
 
 <div class="landing-page__section"
   data-analytics-ecommerce

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -18,7 +18,7 @@
 
 <div class="govuk-width-container">
   <div class="landing-page__buckets">
-    <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets(show_variant?) } %>
+    <%= render partial: 'buckets', locals: { buckets: presented_taxon.buckets } %>
   </div>
 
   <% if show_comms %>

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -40,39 +40,9 @@ en:
       to_watch_text: to watch the video
       or_text: or
       watch_link_text: Watch on YouTube
-    guidance_header: "Actions you can take now"
-    guidance_header_variant_B: "Changes for businesses and citizens"
+    guidance_header: "Changes for businesses and citizens"
     guidance_subheader: "These are some of the new rules from January 2021. For a complete list of actions <a href='/transition-check/questions' class='govuk-link' data-track-category='transition-landing-page' data-track-action='/transition-check/questions' data-track-label='answer a few questions' >answer a few questions</a> about you, your family or business."
     campaign_buckets:
-      - row_title: "Travelling to the EU"
-        list_block: |
-          You can continue to travel to the EU as usual during the transition period.
-
-          From 1 January 2021 there will be new rules to travel to the EU, or to Switzerland, Norway, Iceland or Liechtenstein.
-
-          <a class="govuk-!-font-weight-bold" href="/visit-europe-1-january-2021" data-track-category="transition-landing-page" data-track-action="/visit-europe-1-january-2021" data-track-label="What you can do now">Check what you need to do to travel to Europe from 2021</a>
-      - row_title: "Staying in the UK if you’re an EU citizen"
-        list_block: |
-          Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
-
-          <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="What you can do now">Check what you need to do to stay in the UK</a>
-      - row_title: "Continue living and working in the EU"
-        list_block: |
-          Living and working in an EU country depends on the rules in that country.
-
-          You may need to register or apply for residency. You should check that you’re covered for healthcare.
-
-          You may also need to exchange your UK driving licence for a licence issued by the EU country where you live.
-
-          <a class="govuk-!-font-weight-bold" href="/uk-nationals-living-eu" data-track-category="transition-landing-page" data-track-action="/uk-nationals-living-eu" data-track-label="What you can do now">Check what you must do in the country where you live</a>
-      - row_title: "Businesses that import and export goods"
-        list_block: |
-          From 1 January 2021 the process for importing and exporting goods will change. Find out what you need to do to continue to:
-          <ul>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-to-import-to-great-britain-from-january-2021" data-track-category="transition-landing-page" data-track-action="/prepare-to-import-to-great-britain-from-january-2021" data-track-label="What you can do now">import goods from the EU</a></li>
-            <li><a class="govuk-!-font-weight-bold" href="/prepare-to-export-from-great-britain-from-january-2021" data-track-category="transition-landing-page" data-track-action="/prepare-to-export-from-great-britain-from-january-2021" data-track-label="What you can do now">export goods to the EU</a></li>
-          </ul>
-    campaign_buckets_variant_B:
       - row_title: "Businesses that import and export goods"
         list_block: |
           From 1 January 2021 the process for importing and exporting goods will change. Find out what you need to do to continue to:

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -71,6 +71,20 @@ en:
           Check if you need to apply to the settlement scheme if you or your family are from the EU, or from Switzerland, Norway, Iceland or Liechtenstein.
 
           <a class="govuk-!-font-weight-bold" href="/staying-uk-eu-citizen" data-track-category="transition-landing-page" data-track-action="/staying-uk-eu-citizen" data-track-label="What you can do now">Check what you need to do to stay in the UK</a>
+    campaign_links:
+      lead_in: "You need to take action now if you're:"
+      links:
+        - text: importing goods into the UK
+          path: /prepare-to-import-to-great-britain-from-january-2021
+        - text: exporting goods from the UK
+          path: /prepare-to-export-from-great-britain-from-january-2021
+        - text: travelling to the EU
+          path: /visit-europe-1-january-2021
+        - text: living and working in the EU
+          path: /uk-nationals-living-eu
+        - text: staying in the UK if you're an EU citizen
+          path: /staying-uk-eu-citizen
+      lead_out: <a href="/transition-check/questions">Get the complete list</a> of what you need to do for you, your business and your family.
     comms_header: "Announcements"
     comms:
       links:

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -21,14 +21,23 @@ describe TransitionLandingPageController do
       end
     end
 
-    describe "TransitionUrgency2 AB test" do
-      context "Bucket section header test in the en locale" do
-        %w[A B Z].each do |variant|
-          it "displays the winning text for the #{variant} variant" do
-            with_variant TransitionUrgency2: variant do
+    describe "TransitionUrgency3 AB test" do
+      context "Changes to bucket display in the en locale" do
+        %w[A Z].each do |variant|
+          it "#{variant} shows the default" do
+            with_variant TransitionUrgency3: variant do
               get :show
-              assert_select ".govuk-heading-l", text: "Changes for businesses and citizens"
+              assert_select ".govuk-heading-m", text: "Businesses that import and export goods"
             end
+          end
+        end
+
+        it "A shows the default" do
+          with_variant TransitionUrgency3: "B" do
+            get :show
+            assert_select ".landing-page__buckets .govuk-body", text: "You need to take action now if you're:"
+            assert_select ".landing-page__buckets li a", href: "/prepare-to-import-to-great-britain-from-january-2021", text: "importing goods into the UK"
+            assert_select ".landing-page__buckets a", href: "/transition-check/questions", text: "Get the complete list"
           end
         end
       end
@@ -36,16 +45,13 @@ describe TransitionLandingPageController do
       context "In the cy locale" do
         %w[A B Z].each do |variant|
           it "displays the control text for the #{variant} variant" do
-            setup_ab_variant("TransitionUrgency2", variant)
+            setup_ab_variant("TransitionUrgency3", variant)
 
             get :show, params: { locale: "cy" }
 
             assert_response_not_modified_for_ab_test("TransitionUrgency2")
-            assert_select "h1", text: "Pontio’r DU"
-            assert_select "h1", text: "The transition period ends in December", count: 0
-
-            assert_select "h2", text: "Cymrwch y camau a chofrestru ar gyfer negeseuon e-bost"
-            assert_select "h2", text: "Make sure you're ready", count: 0
+            assert_select ".govuk-heading-m", text: "Teithio i’r UE"
+            assert_select ".landing-page__buckets .govuk-body", text: "You need to take action now if you're:", count: 0
           end
         end
       end

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -23,49 +23,12 @@ describe TransitionLandingPageController do
 
     describe "TransitionUrgency2 AB test" do
       context "Bucket section header test in the en locale" do
-        it "A" do
-          with_variant TransitionUrgency2: "A" do
-            get :show
-            assert_select ".govuk-heading-l", text: "Actions you can take now"
-            assert_select ".govuk-heading-l", text: "Changes for businesses and citizens", count: 0
-          end
-        end
-
-        it "B" do
-          with_variant TransitionUrgency2: "B" do
-            get :show
-            assert_select ".govuk-heading-l", text: "Changes for businesses and citizens"
-            assert_select ".govuk-heading-l", text: "Actions you can take now", count: 0
-          end
-        end
-
-        it "Z" do
-          with_variant TransitionUrgency2: "Z" do
-            get :show
-            assert_select ".govuk-heading-l", text: "Actions you can take now"
-          end
-        end
-      end
-
-      context "Make sure that buckets appear in the expected order in the en locale" do
-        it "A" do
-          with_variant TransitionUrgency2: "A" do
-            get :show
-            assert_select ".landing-page__section-list-wrapper h3:first-of-type", text: "Travelling to the EU"
-          end
-        end
-
-        it "B" do
-          with_variant TransitionUrgency2: "B" do
-            get :show
-            assert_select ".landing-page__section-list-wrapper h3:first-of-type", text: "Businesses that import and export goods"
-          end
-        end
-
-        it "Z" do
-          with_variant TransitionUrgency2: "Z" do
-            get :show
-            assert_select ".landing-page__section-list-wrapper h3:first-of-type", text: "Travelling to the EU"
+        %w[A B Z].each do |variant|
+          it "displays the winning text for the #{variant} variant" do
+            with_variant TransitionUrgency2: variant do
+              get :show
+              assert_select ".govuk-heading-l", text: "Changes for businesses and citizens"
+            end
           end
         end
       end


### PR DESCRIPTION
We're finishing TransitionUrgency2 and keeping the changes we made.

In the next test, we're changing the display of the "things you can do now" links to play them down a bit. It's a tricky balance: making sure people know they're there, but also doing the checker as a higher priority.

This replaces the bucket section (which is quite large, bold and contains multiple sections) with a simple list of links.

This test is English only, so the Welsh page should be unaffected.

## A variant (partial screenshot of the section as it's very long)

<img width="1058" alt="Screenshot 2020-10-13 at 12 21 43" src="https://user-images.githubusercontent.com/773037/95854336-b75f0500-0d4e-11eb-8152-cd1e4872dc88.png">

## B variant (entire section)

<img width="1132" alt="Screenshot 2020-10-13 at 12 20 54" src="https://user-images.githubusercontent.com/773037/95854396-d067b600-0d4e-11eb-93b5-d5b2fdb4a591.png">


https://trello.com/c/3XR9BeaI/511-ab-test-for-urgency-phase-3