### PR TITLE
Tweaks to description on the coronavirus lookup page

### DIFF
--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -13,6 +13,7 @@
   <meta property="og:url" content="<%= request.base_url + request.path %>">
   <meta property="og:title" content="<%= t("coronavirus_local_restrictions.lookup.meta_title") %>">
   <meta property="og:description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
+  <meta name="description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
 <% end %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -20,7 +20,7 @@ en:
         <p class="govuk-body">Each area has a <a class="govuk-link" href="/guidance/local-covid-alert-levels-what-you-need-to-know">Local COVID Alert Level</a>. There are 3 Local COVID Alert Levels. Sometimes this is known as a ‘local lockdown’.</p>
         <p class="govuk-body">You can find out what you can or cannot do.</p>
       meta_title: Find out the coronavirus restrictions in a local area
-      meta_description: Find out the Local COVID Alert Level for an area. Search by postcode.
+      meta_description: Use the postcode checker to find out the Local COVID Alert Level for an area.
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail's postcode finder
       href: http://www.royalmail.com/find-a-postcode


### PR DESCRIPTION
## Include standard meta description for SEO

The og:description field is mainly used in social media for sharing links. We should add the description tag too, as this is more commonly used by search engines.

## Update meta description

This will match [the description field in the content item](alphagov/special-route-publisher#123).

The main reason for this change is to include the word "checker" in the text, as we've noted that this is commonly used by people searching for this page. (Suggested by Tara and Hannah)