### PR TITLE
Adding guidance link

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -1,5 +1,10 @@
 <% guidance ||= nil %>
 
+<% if guidance.present? && guidance["intro"].present? %>
+  <p class="govuk-body">
+    <%= render_govspeak(guidance["intro"]) %>
+  <p>
+<% end %>
 <% if guidance.present? && guidance["links"].present? %>
   <%
     guidance_links = guidance["links"].map do | link |


### PR DESCRIPTION
## What?

- Adding new guidance link to landing page

## Why

[Trello Ticket](https://trello.com/c/K3hxtZTr)

## Visual Before 

![Screenshot 2020-10-13 at 14 27 27](https://user-images.githubusercontent.com/71266765/95866786-41639980-0d60-11eb-859b-a63a8473b786.png)

## Visual After

![Screenshot 2020-10-13 at 14 22 14](https://user-images.githubusercontent.com/71266765/95866746-33157d80-0d60-11eb-87bc-bcf6a85aa834.png)

## Anything else?

Content was updated [here](https://github.com/alphagov/govuk-coronavirus-content/pull/436) (& [here](
https://github.com/alphagov/govuk-coronavirus-content/pull/437)) as a precursor.  

Actual link directs:
`/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=most-viewed`

----

:warning: This application is Continuously Deployed: :warning: