### PR TITLE
Add tracking to links in B variant

### DIFF
--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -20,15 +20,30 @@
 
   <% if show_variant? %>
     <% variant_b_section = I18n.t("transition_landing_page.campaign_links") %>
-    <% links = variant_b_section[:links].map{ |link| "<a href='#{link[:path]}'>#{link[:text]}</a>"} %>
-    <p class='govuk-body'><%= variant_b_section[:lead_in] %>
-      <%= render "govuk_publishing_components/components/list", {
-        extra_spacing: true,
-        visible_counters: true,
-        items: links
-      } %>
-    </p>
-    <p class="govuk-body govuk-!-padding-top-2"><%= variant_b_section[:lead_out].html_safe %></p>
+    <%
+      links = variant_b_section[:links].map do |link|
+        link_to(link[:text], link[:path], data: {
+          track_action: link[:path],
+          track_category: "transition-landing-page",
+          track_label: "What you can do now"
+        })
+      end
+    %>
+    <div class="govuk-grid-row landing-page__section-list-wrapper">
+      <div class="govuk-grid-column-two-thirds" data-module="track-click">
+        <p class='govuk-body'><%= variant_b_section[:lead_in] %></p>
+
+        <%= tag.ul class: %w[govuk-list govuk-list--bullet govuk-list--spaced] do %>
+          <% links.each do |link| %>
+            <%= tag.li do %>
+              <%= link %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <p class="govuk-body govuk-!-padding-top-2"><%= variant_b_section[:lead_out].html_safe %></p>
+      </div>
+    </div>
   <% else %>
     <% buckets.each do |bucket| %>
       <div class="govuk-grid-row landing-page__section-list-wrapper">


### PR DESCRIPTION
Adds the same tracking attributes to the B variant as those in defined in the [translated list blocks](https://github.com/alphagov/collections/blob/929ca08d377956ea7d64d997c426c13c34d3a493/config/locales/en/transition_landing_page.yml#L50) used in the default variant.

I've had to move away from using the list component because it [sanitizes the items passed into it](https://github.com/alphagov/govuk_publishing_components/blob/bf6ab59747f3287d75456e6aeee6d99476342864/app/views/govuk_publishing_components/components/_list.html.erb#L23) which unfortunately strips off any data attributes. 

If we end up keeping this version, then I'll look at [adding `data` to the allowed attributes](https://github.com/rails/rails-html-sanitizer) in the component, but as this is just for an initial four day period, we'll skip it for now.
