### PR TITLE
Remove custom header for contents-list on taxon pages

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -11,9 +11,7 @@
 <div class="full-page-width-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third content-list__sticky">
-      <h2><%= t('taxons.in_page_nav_title') %></h2>
       <%= render "govuk_publishing_components/components/contents_list", {
-          hide_title: true,
           contents: @presentable_section_items
       } %>
     </div>


### PR DESCRIPTION
To improve accessibility we are making the implementation of the contents-list
component consistently use the same heading and removing the ability to hide it.
This updates the page ahead of that to avoid having a double heading.

https://trello.com/c/LbVmpaK6/441-inconsistent-naming-of-table-of-contents

Sample url: https://www.gov.uk/education

### Before
![Screenshot 2020-10-14 at 15 55 26](https://user-images.githubusercontent.com/31649453/96008707-bf46a400-0e37-11eb-8b36-38d13373fd85.png)


### After
![Screenshot 2020-10-14 at 15 55 10](https://user-images.githubusercontent.com/31649453/96008677-b655d280-0e37-11eb-9f5a-384862d14036.png)


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
