### PR TITLE
Bug fix: POST route throws error when postcode is nil

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -13,17 +13,14 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
   def results
     if params["postcode-lookup"].blank?
-      @error = true
       return render_no_postcode_error
     end
 
     @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
 
     if @postcode.blank?
-      @error = true
       return render_no_postcode_error
     elsif !postcode_validation
-      @error = true
       return render_invalid_postcode_error
     end
 

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -12,6 +12,17 @@ class CoronavirusLocalRestrictionsController < ApplicationController
   end
 
   def results
+    if params["postcode-lookup"].blank?
+      @error = true
+      return render :show,
+                    locals: {
+                      breadcrumbs: breadcrumbs,
+                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
+                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
+                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
+                    }
+    end
+
     @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
 
     if @postcode.blank?

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -14,35 +14,17 @@ class CoronavirusLocalRestrictionsController < ApplicationController
   def results
     if params["postcode-lookup"].blank?
       @error = true
-      return render :show,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
-                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
-                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
-                    }
+      return render_no_postcode_error
     end
 
     @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
 
     if @postcode.blank?
       @error = true
-      return render :show,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
-                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
-                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
-                    }
+      return render_no_postcode_error
     elsif !postcode_validation
       @error = true
-      return render :show,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                      error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
-                      input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
-                      error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
-                    }
+      return render_invalid_postcode_error
     end
 
     @content_item = content_item.to_hash
@@ -55,21 +37,9 @@ class CoronavirusLocalRestrictionsController < ApplicationController
                       breadcrumbs: breadcrumbs,
                     }
     elsif @location_lookup.invalid_postcode?
-      return render :show,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                      error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
-                      input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
-                      error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
-                    }
+      return render_invalid_postcode_error
     elsif @location_lookup.postcode_not_found?
-      return render :show,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                      error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
-                      input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
-                      error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
-                    }
+      return render_no_postcode_error
     end
 
     if @location_lookup.data.present?
@@ -85,6 +55,26 @@ class CoronavirusLocalRestrictionsController < ApplicationController
   end
 
 private
+
+  def render_no_postcode_error
+    render :show,
+           locals: {
+             breadcrumbs: breadcrumbs,
+             error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
+             input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
+             error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
+           }
+  end
+
+  def render_invalid_postcode_error
+    render :show,
+           locals: {
+             breadcrumbs: breadcrumbs,
+             error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
+             input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
+             error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
+           }
+  end
 
   # Breadcrumbs for this page are hardcoded because it doesn't yet have a
   # content item with parents.

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -42,5 +42,13 @@ describe CoronavirusLocalRestrictionsController do
       assert_response :success
       assert_template :show
     end
+
+    it "renders the local restriction page when the postcode is blank" do
+      postcode = ""
+      post :results, params: { "postcode-lookup" => postcode }
+
+      assert_response :success
+      assert_template :show
+    end
   end
 end

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -50,5 +50,12 @@ describe CoronavirusLocalRestrictionsController do
       assert_response :success
       assert_template :show
     end
+
+    it "renders the local restriction page when the postcode param is not passed in" do
+      post :results
+
+      assert_response :success
+      assert_template :show
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/9DI7SFML

# What?

A 500 error is being thrown if the "results" controller method called is directly without any params. This is because we are not checking if `postcode` is nil before stripping the whitespace.  We should instead be redirecting users back to the show page.

Error in sentry:
https://sentry.io/organizations/govuk/issues/1954271093/?project=202213&query=is%3Aunresolved


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
