### PR TITLE
Fix grouped links spacing

### DIFF
--- a/app/views/services_and_information/_grouped_links.html.erb
+++ b/app/views/services_and_information/_grouped_links.html.erb
@@ -1,6 +1,6 @@
 <% grouped_links.each_with_index do |group, group_index| -%>
-  <div class="govuk-grid-row" aria-labelledby="<%= group.title.parameterize %>">
-    <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-row govuk-!-margin-bottom-7" aria-labelledby="<%= group.title.parameterize %>">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
       <%= render "govuk_publishing_components/components/heading", {
         font_size: "m",
         heading_level: 2,
@@ -8,7 +8,7 @@
         text: group.title,
       } %>
     </div>
-    
+
     <div class="govuk-grid-column-two-thirds">
       <%
         list_item_count = group.see_more_link ? group.examples.count + 1 : group.examples.count

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
 
-    <div class="govuk-grid-column-one-third add-title-margin">
+    <div class="govuk-grid-column-one-third add-title-margin govuk-!-margin-bottom-3">
       <%= render "govuk_publishing_components/components/subscription-links", {
         email_signup_link: "/email-signup?topic=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
         email_signup_link_text: "Subscribe to email alerts",

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -25,9 +25,13 @@
     link_to_latest_feed: true,
   }) do %>
   <% subtopic.lists.each_with_index do |list, list_index| -%>
-    <div class="govuk-grid-row govuk-!-margin-bottom-5">
-      <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-m"><%= list.title %></h2>
+    <div class="govuk-grid-row govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-one-third  govuk-!-margin-bottom-2">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "m",
+          heading_level: 2,
+          text: list.title,
+        } %>
       </div>
       <div class="govuk-grid-column-two-thirds">
         <%= render 'components/topic-list', topic_list_params(list.contents, list_index: list_index, category: 'navSubtopicContentItemLinkClicked') %>


### PR DESCRIPTION
A [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4275226) was raised flagging that the content looks cluttered on a HMRC topic browse page.

[This](https://webarchive.nationalarchives.gov.uk/20200915190640/https://www.gov.uk/government/organisations/hm-revenue-customs/services-information) was provided as an example of what the page is supposed to look like. 
On the other hand [this](https://webarchive.nationalarchives.gov.uk/20201006190116/https://www.gov.uk/government/organisations/hm-revenue-customs/services-information) is what the page now looks like – note the lack of spacing between the link sections.

This PR aims to fix this problem as well as adjusting some of the styling on subtopic browse pages which have been affected similarly.


-----

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
