### PR TITLE
Add events to local restrictions

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require components/accordion
 //= require modules/coronavirus-landing-page
 //= require modules/coronavirus-track-local-restrictions
+//= require modules/coronavirus-track-local-restriction-results
 //= require modules/track-timeline-links
 
 $(document).on('ready', function(){

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require modules/toggle-attribute
 //= require components/accordion
 //= require modules/coronavirus-landing-page
+//= require modules/coronavirus-track-local-restrictions
 //= require modules/track-timeline-links
 
 $(document).on('ready', function(){

--- a/app/assets/javascripts/modules/coronavirus-track-local-restriction-results.js
+++ b/app/assets/javascripts/modules/coronavirus-track-local-restriction-results.js
@@ -1,0 +1,23 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CoronavirusTrackLocalRestrictionResults () {}
+
+  CoronavirusTrackLocalRestrictionResults.prototype.start = function (element) {
+    this.addRiskLevelEvent(element[0])
+  }
+
+  CoronavirusTrackLocalRestrictionResults.prototype.addRiskLevelEvent = function (element) {
+    var label = element.getAttribute('data-tracking-label')
+
+    var options = {
+      transport: "beacon",
+      label: label
+    }
+
+    GOVUK.analytics.trackEvent("postcodeSearch:local_lockdown", "postcodeResultShown", options)
+  }
+
+  Modules.CoronavirusTrackLocalRestrictionResults = CoronavirusTrackLocalRestrictionResults
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/modules/coronavirus-track-local-restrictions.js
+++ b/app/assets/javascripts/modules/coronavirus-track-local-restrictions.js
@@ -1,0 +1,37 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function CoronavirusTrackLocalRestrictions () {}
+
+  CoronavirusTrackLocalRestrictions.prototype.start = function (element) {
+    this.addPostcodeFormSubmitListener(element[0])
+    this.addErrorMessageEvent(element[0])
+  }
+
+  CoronavirusTrackLocalRestrictions.prototype.addPostcodeFormSubmitListener = function (element) {
+    element.querySelector('.coronavirus-local-restrictions__postcode-form')
+      .addEventListener('submit', function(event){
+        var options = {
+          transport: "beacon"
+        }
+
+        GOVUK.analytics.trackEvent("postcodeSearch:local_lockdown", "postcodeSearchStarted", options)
+      })
+  }
+
+  CoronavirusTrackLocalRestrictions.prototype.addErrorMessageEvent = function (element) {
+    var errorMessage = element.querySelector('[data-tracking=local-restrictions-postcode-error]')
+
+    if (errorMessage) {
+      var options = {
+        transport: "beacon",
+        label: errorMessage.textContent.trim()
+      }
+
+      GOVUK.analytics.trackEvent("userAlerts:local_lockdown", "postcodeErrorShown: invalidPostcodeFormat", options)
+    }
+  }
+
+  Modules.CoronavirusTrackLocalRestrictions = CoronavirusTrackLocalRestrictions
+})(window.GOVUK.Modules)

--- a/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
+++ b/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
@@ -1,18 +1,23 @@
-<%= render "govuk_publishing_components/components/title", {
-  title: t("coronavirus_local_restrictions.results.devolved_nations.heading")
-} %>
-<% if @location_lookup.data.first.scotland? %>
-  <p class="govuk-body">
-    <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance")) %>
-  </p>
-<% elsif @location_lookup.data.first.northern_ireland? %>
-  <p class="govuk-body">
-    <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.northern_ireland.guidance")) %>
-  </p>
-<% elsif @location_lookup.data.first.wales? %>
-  <p class="govuk-body">
-    <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.wales.guidance")) %>
-  </p>
-<% end %>
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => "Devolved nation: #{@location_lookup.data.first.country}"
+} do %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.devolved_nations.heading")
+  } %>
+  <% if @location_lookup.data.first.scotland? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance")) %>
+    </p>
+  <% elsif @location_lookup.data.first.northern_ireland? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.northern_ireland.guidance")) %>
+    </p>
+  <% elsif @location_lookup.data.first.wales? %>
+    <p class="govuk-body">
+      <%= sanitize(t("coronavirus_local_restrictions.results.devolved_nations.wales.guidance")) %>
+    </p>
+  <% end %>
 
-<%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.devolved_nations.travel_heading") } %>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.devolved_nations.travel_heading") } %>
+<% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -1,37 +1,42 @@
-<% if @restriction.present? && @restriction.future.present? %>
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => "Tier one: #{@location_lookup.lower_tier_area_name}"
+} do %>
+  <% if @restriction.present? && @restriction.future.present? %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("coronavirus_local_restrictions.results.changing_levels_title")
+    } %>
+  <% else %>
   <%= render "govuk_publishing_components/components/title", {
-    title: t("coronavirus_local_restrictions.results.changing_levels_title")
+    title: t("coronavirus_local_restrictions.results.level_one.heading")
   } %>
-<% else %>
-<%= render "govuk_publishing_components/components/title", {
-  title: t("coronavirus_local_restrictions.results.level_one.heading")
-} %>
-<% end %>
+  <% end %>
 
-<p class="govuk-body">
-  <%= t("coronavirus_local_restrictions.results.level_one.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
-</p>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_local_restrictions.results.current_level_heading"),
-  font_size: "m",
-  margin_bottom: 4
-} %>
-
-<% if @restriction.present? && @restriction.future.present? %>
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_one.changing_alert_level") %>
+    <%= t("coronavirus_local_restrictions.results.level_one.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
   </p>
-<% else %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("coronavirus_local_restrictions.results.current_level_heading"),
+    font_size: "m",
+    margin_bottom: 4
+  } %>
+
+  <% if @restriction.present? && @restriction.future.present? %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_one.changing_alert_level") %>
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_one.alert_level") %>
+    </p>
+  <% end %>
+
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_one.alert_level") %>
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_one.guidance")) %>
   </p>
+
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
+
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>
-
-<p class="govuk-body">
-  <%= sanitize(t("coronavirus_local_restrictions.results.level_one.guidance")) %>
-</p>
-
-<%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-<%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -1,37 +1,42 @@
-<% if @restriction.present? && @restriction.future.present? %>
-  <%= render "govuk_publishing_components/components/title", {
-    title: t("coronavirus_local_restrictions.results.changing_levels_title")
-  } %>
-<% else %>
-  <%= render "govuk_publishing_components/components/title", {
-    title: t("coronavirus_local_restrictions.results.level_three.heading")
-  } %>
-<% end %>
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => "Tier three: #{@restriction.area_name}"
+} do %>
+  <% if @restriction.present? && @restriction.future.present? %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("coronavirus_local_restrictions.results.changing_levels_title")
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("coronavirus_local_restrictions.results.level_three.heading")
+    } %>
+  <% end %>
 
-<p class="govuk-body">
-  <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
-</p>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_local_restrictions.results.current_level_heading"),
-  font_size: "m",
-  margin_bottom: 4
-} %>
-
-<% if @restriction.present? && @restriction.future.present? %>
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_three.changing_alert_level") %>
+    <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
   </p>
-<% else %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("coronavirus_local_restrictions.results.current_level_heading"),
+    font_size: "m",
+    margin_bottom: 4
+  } %>
+
+  <% if @restriction.present? && @restriction.future.present? %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_three.changing_alert_level") %>
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_three.alert_level") %>
+    </p>
+  <% end %>
+
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_three.alert_level") %>
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_three.guidance")) %>
   </p>
+
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
+
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>
-
-<p class="govuk-body">
-  <%= sanitize(t("coronavirus_local_restrictions.results.level_three.guidance")) %>
-</p>
-
-<%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-<%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -1,37 +1,42 @@
-<% if @restriction.present? && @restriction.future.present? %>
-  <%= render "govuk_publishing_components/components/title", {
-    title: t("coronavirus_local_restrictions.results.changing_levels_title")
-  } %>
-<% else %>
-  <%= render "govuk_publishing_components/components/title", {
-    title: t("coronavirus_local_restrictions.results.level_two.heading")
-  } %>
-<% end %>
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => "Tier two: #{@restriction.area_name}"
+} do %>
+  <% if @restriction.present? && @restriction.future.present? %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("coronavirus_local_restrictions.results.changing_levels_title")
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("coronavirus_local_restrictions.results.level_two.heading")
+    } %>
+  <% end %>
 
-<p class="govuk-body">
-  <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
-</p>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_local_restrictions.results.current_level_heading"),
-  font_size: "m",
-  margin_bottom: 4
-} %>
-
-<% if @restriction.present? && @restriction.future.present? %>
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_two.changing_alert_level") %>
+    <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
   </p>
-<% else %>
+
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("coronavirus_local_restrictions.results.current_level_heading"),
+    font_size: "m",
+    margin_bottom: 4
+  } %>
+
+  <% if @restriction.present? && @restriction.future.present? %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_two.changing_alert_level") %>
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_two.alert_level") %>
+    </p>
+  <% end %>
+
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_two.alert_level") %>
+    <%= sanitize(t("coronavirus_local_restrictions.results.level_two.guidance")) %>
   </p>
+
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
+
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>
-
-<p class="govuk-body">
-  <%= sanitize(t("coronavirus_local_restrictions.results.level_two.guidance")) %>
-</p>
-
-<%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-<%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>

--- a/app/views/coronavirus_local_restrictions/no_information.html.erb
+++ b/app/views/coronavirus_local_restrictions/no_information.html.erb
@@ -1,10 +1,15 @@
 <% content_for :title, t("coronavirus_local_restrictions.results.no_information.heading") %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: t("coronavirus_local_restrictions.results.no_information.heading")
-} %>
-<p class="govuk-body">
-  <%= sanitize(t("coronavirus_local_restrictions.results.no_information.guidance")) %>
-</p>
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => t("coronavirus_local_restrictions.results.no_information.heading")
+} do %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: t("coronavirus_local_restrictions.results.no_information.heading")
+  } %>
+  <p class="govuk-body">
+    <%= sanitize(t("coronavirus_local_restrictions.results.no_information.guidance")) %>
+  </p>
 
-<%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
+<% end %>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -16,7 +16,7 @@
   <meta name="description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-module="coronavirus-track-local-restrictions">
   <div class="govuk-grid-column-two-thirds">
     <% if error_message %>
       <%= render "govuk_publishing_components/components/error_summary", {
@@ -24,7 +24,10 @@
         items: [
           {
             text: error_description,
-            href: "#postcodeLookup"
+            href: "#postcodeLookup",
+            data_attributes: {
+              tracking: "local-restrictions-postcode-error"
+            }
           }
         ]
       } %>
@@ -36,7 +39,7 @@
 
     <%= sanitize(t("coronavirus_local_restrictions.lookup.body_content")) %>
 
-    <%= form_for :postcode_lookup, :url => find_coronavirus_local_restrictions_path do |f| %>
+    <%= form_for :postcode_lookup, :url => find_coronavirus_local_restrictions_path, :html => {:class => "coronavirus-local-restrictions__postcode-form"} do |f| %>
       <%= render "shared/postcode-lookup", {
         input_error: input_error
       } %>

--- a/spec/javascripts/modules/coronavirus-track-local-restriction-results_spec.js
+++ b/spec/javascripts/modules/coronavirus-track-local-restriction-results_spec.js
@@ -1,0 +1,35 @@
+describe('Coronavirus local restriction results page', function () {
+  "use strict"
+
+  var coronavirusTrackLocalRestrictionResults;
+  var html = '<div id="element" data-module="coronavirus-track-local-restriction-results" data-tracking-label="Tier One: London"></div>'
+  var element
+
+  beforeEach(function () {
+    GOVUK.analytics = {
+      trackEvent: function () {
+      }
+    }
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    element = document.createElement('div');
+    element.innerHTML = html;
+    element = element.firstElementChild
+
+    coronavirusTrackLocalRestrictionResults = new GOVUK.Modules.CoronavirusTrackLocalRestrictionResults()
+    coronavirusTrackLocalRestrictionResults.start([element])
+  })
+
+  afterEach(function () {
+    GOVUK.analytics.trackEvent.calls.reset()
+  })
+
+  it("sends event on load", function () {
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      "postcodeSearch:local_lockdown", "postcodeResultShown", {
+        transport: "beacon",
+        label: "Tier One: London"
+      }
+    )
+  })
+});

--- a/spec/javascripts/modules/coronavirus-track-local-restrictions_spec.js
+++ b/spec/javascripts/modules/coronavirus-track-local-restrictions_spec.js
@@ -1,0 +1,80 @@
+describe('Coronavirus local restrictions landing page', function () {
+  "use strict"
+
+  var coronavirusTrackLocalRestrictions;
+  var element
+
+
+  describe('landing page without errors', function () {
+    var html = '<div data-module="coronavirus-track-local-restrictions">\
+      <form class="coronavirus-local-restrictions__postcode-form"></form>\
+    </div>'
+
+    beforeEach(function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      element = document.createElement('div');
+      element.innerHTML = html;
+      element = element.firstElementChild
+
+      coronavirusTrackLocalRestrictions = new GOVUK.Modules.CoronavirusTrackLocalRestrictions()
+      coronavirusTrackLocalRestrictions.start([element])
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it("track submit event", function () {
+      element.querySelector('form').dispatchEvent(new Event('submit'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'postcodeSearch:local_lockdown', 'postcodeSearchStarted', { transport: 'beacon' }
+      )
+    })
+  })
+
+
+  describe('landing page with errors', function () {
+    var html = '<div data-module="coronavirus-track-local-restrictions">\
+      <div class="gem-c-error-summary govuk-error-summary" data-module="govuk-error-summary"> \
+        <h2 class="govuk-error-summary__title">There is a problem</h2> \
+      <div class="govuk-error-summary__body"> \
+          <ul class="govuk-list govuk-error-summary__list"> \
+              <li class="gem-c-error-summary__list-item" data-tracking="local-restrictions-postcode-error"><a href="#postcodeLookup">Enter a postcode</a></li> \
+          </ul> \
+      </div> \
+      </div>\
+      <form class="coronavirus-local-restrictions__postcode-form"></form>\
+    </div>'
+
+    beforeEach(function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      element = document.createElement('div');
+      element.innerHTML = html;
+      element = element.firstElementChild
+
+      coronavirusTrackLocalRestrictions = new GOVUK.Modules.CoronavirusTrackLocalRestrictions()
+      coronavirusTrackLocalRestrictions.start([element])
+    })
+
+    afterEach(function () {
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+
+    it("track error event", function () {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'userAlerts:local_lockdown', 'postcodeErrorShown: invalidPostcodeFormat', { transport: 'beacon', label: "Enter a postcode" }
+      )
+    })
+  })
+})

--- a/spec/javascripts/modules/track-timeline-links_spec.js
+++ b/spec/javascripts/modules/track-timeline-links_spec.js
@@ -23,6 +23,10 @@ describe('Track timeline links', function () {
   var element;
   
   beforeEach(function () {
+    GOVUK.analytics = {
+      trackEvent: function () {
+      }
+    }
     spyOn(GOVUK.analytics, 'trackEvent')
 
     element = document.createElement('div');


### PR DESCRIPTION
## What

We track certain things on pages on GOV.UK but there are certain elements  which won't be tracked unless we set it up.

We use Google Analytics across GOV.UK so we should use the same. 

https://www.gov.uk/find-local-council use events with naming convention so let's copy this.

*Proposal attached but this could change depending on how final design or results page looks*

We should probably capture:

- When the postcode checker is started
- Whether an error message was shown 
- What results are shown to the user: local level alert and local area (?)

Less important but may be something to consider

- What links user clicks on in text 
- Whether user clicks 'check another postcode'

## Why

Without extra tracking we won't know
- How many users saw an error message
- What results are shown to users (Local council and alert level)
- How many users engaged with links on the results page

*Caveat: since December 2019 we do not count everyone that comes to GOV.UK with Google Analytics. We only count users if they have consented to it. That means any figures that we collect is not representative to an unknown degree*


https://trello.com/c/UlXBmBcR/848-add-ga-tracking-to-local-postcode-lookup


## How to test

1. Go to https://www.gov.uk/find-coronavirus-local-restrictions
2. Open console (with OmniBug or something similar to track analytics)
3. Submit the form without any input to test error event
4. Submit the form with a valid postcode to test result event

----
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

