### PR TITLE
Add healthcheck for memcached

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,11 @@ Rails.application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  get "/healthcheck",
+      to: GovukHealthcheck.rack_response(
+        GovukHealthcheck::RailsCache,
+      )
+
   ["/coronavirus-taxon", "/coronavirus-taxon/*slug"].each do |path|
     get path, to: "taxons_redirection#redirect"
   end


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Previously this repo had a very basic healthcheck. This extends it
with a more thorough check of the infrastructure it needs to run:
Memcached [1] [2]. Since the caching can fail silently, there is
even more motivation for us to know about it.

[1]: https://github.com/alphagov/collections/blob/4cd256225bba8dcba7df282c78e5919f248aea31/app/lib/services.rb#L18
[2]: https://github.com/alphagov/collections/blob/4cd256225bba8dcba7df282c78e5919f248aea31/config/environments/production.rb#L58


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.