### PR TITLE
Test to ensure local restriction hash is empty

### DIFF
--- a/test/models/local_restriction_test.rb
+++ b/test/models/local_restriction_test.rb
@@ -1,3 +1,5 @@
+require "test_helper"
+
 describe LocalRestriction do
   let(:restriction) { described_class.new("E08000001") }
 

--- a/test/models/local_restriction_test.rb
+++ b/test/models/local_restriction_test.rb
@@ -16,7 +16,8 @@ describe LocalRestriction do
   end
 
   it "returns nil values if the gss code doesn't exist" do
-    restriction = described_class.new("fake code")
-    assert_nil restriction.area_name
+    local_restriction = described_class.new("fake code")
+    assert_empty local_restriction.restriction
+    assert_nil local_restriction.area_name
   end
 end


### PR DESCRIPTION
## What?

Add assertion to ensure the local restriction hash is empty

## Why?

The intent of this test is to ensure we return `nil` values for our properties when the gss code does not exist in our data structure.

Currently, the test will pass if the gss code exists, but has no "name" field.

For example, a YAML structure such as:

```
---
fake code:
  alert_level: 3
```

would still pass the test.

I think what we are trying to ensure is that we create an empty hash when calling `LocalRestriction#restriction` when the supplied gss code is not contained in the YAML/data source.

Asserting that `#restriction` is empty tests this, leaving in the `assert_nil` on `#area_name` gives us an extra level of 
confidence that we have instantiated an empty hash (as opposed to something like an empty array), though we could arguably achieve this by testing the type instead.

I initially thought `#restriction` might be better off as a private method, and to me it feels a bit clumsy to reach into the class and query it directly. I did consider refactoring and exposing something like a `#where` or `#empty?` directly on the class, but I noticed the initial implementation in finder frontend some discussion was had around this [potentially needing to be
public](alphagov/finder-frontend#2222 (comment)), so I've left it as is.

Also rename the local variable `restriction` to `local_restriction` to provide an extra bit of clarity and because `restriction.restriction` just looked wrong.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
