### PR TITLE
Update Essex line

### DIFF
--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -26,7 +26,7 @@ en:
         <li>Chesterfield</li>
         <li>Elmbridge</li>
         <li>Erewash</li>
-        <li>Essex</li>
+        <li>Essex (county council, so excluding Southend-on-Sea and Thurrock)</li>
         <li>London – all boroughs</li>
         <li>North East Derbyshire</li>
         <li>York</li>


### PR DESCRIPTION
The word "Essex" on its own is unclear, so explicitly state it is the county council area, and not the ceremonial county.