### PR TITLE
Adjusting fallback copy

### DIFF
--- a/app/views/shared/_youtube_player.html.erb
+++ b/app/views/shared/_youtube_player.html.erb
@@ -9,7 +9,6 @@
   css_classes = %w(youtube__video-wrapper)
   css_classes << "youtube__video-wrapper--inverse" if inverse
 %>
-
 <%= tag.div class: css_classes do %>
   <%= render "govuk_publishing_components/components/govspeak", {
   } do %>
@@ -25,15 +24,15 @@
         </span>
         <br>
         <%= no_cookies_or_text %>
+        <br>
+        <a
+          href="<%= youtube_video_url %>"
+          class="govuk-body govuk-link"
+          data-youtube-player-analytics="true"
+          data-youtube-player-analytics-category="EmbeddedYoutube">
+          <%= no_cookies_watch_link_text %>
+        </a>
       </p>
-      <a
-        href="<%= youtube_video_url %>"
-        class="govuk-body govuk-link"
-        data-youtube-player-analytics="true"
-        data-youtube-player-analytics-category="EmbeddedYoutube"
-      >
-        <%= no_cookies_watch_link_text %>
-      </a>
     </div>
   <% end %>
   <%= render "govuk_publishing_components/components/details", { title: transcription_summary} do %>


### PR DESCRIPTION
## What?
Adjusting copy so it reads within one sentence

## Why?
Fail of WCAG SC 1.3.1
_Screen reader and user style users will not see the text as one sentence. Screen reader users might get confused by the incomplete heading and not understand it out of context._

[Ticket](https://trello.com/c/xZaPl0v7)

## Visuals
No visual change
![Screenshot 2020-10-16 at 14 26 08](https://user-images.githubusercontent.com/71266765/96263985-9e0ec080-0fbb-11eb-8cec-7c92b657a655.png)



-----
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
