### PR TITLE
Remove redundant start button wrapper (transition)

### DIFF
--- a/app/assets/stylesheets/views/_transition-landing-page.scss
+++ b/app/assets/stylesheets/views/_transition-landing-page.scss
@@ -105,13 +105,6 @@ $green: #00703C;
   }
 }
 
-.landing-page__take-action-button {
-  .govuk-button {
-    background-color: $green;
-    box-shadow: 0 2px 0 $dark-blue-shadow;
-  }
-}
-
 .landing-page__take-action-traffic-lights {
   @include govuk-media-query($until: tablet) {
     margin-top: govuk-spacing(4);

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -12,20 +12,18 @@
                 <%= t("transition_landing_page.take_action_text") %>
               </p>
             <% end %>
-            <div class="landing-page__take-action-button">
-              <%= render "govuk_publishing_components/components/button", {
-                text: t("transition_landing_page.take_action_start_now"),
-                href: t("transition_landing_page.take_action_start_now_link"),
-                start: true,
-                margin_bottom: true,
-                data_attributes: {
-                  "module": "track-click",
-                  "track-action": t("transition_landing_page.take_action_start_now_link"),
-                  "track-category": "transition-landing-page",
-                  "track-label": t("transition_landing_page.take_action_start_now")
-                }
-              } %>
-            </div>
+            <%= render "govuk_publishing_components/components/button", {
+              text: t("transition_landing_page.take_action_start_now"),
+              href: t("transition_landing_page.take_action_start_now_link"),
+              start: true,
+              margin_bottom: true,
+              data_attributes: {
+                "module": "track-click",
+                "track-action": t("transition_landing_page.take_action_start_now_link"),
+                "track-category": "transition-landing-page",
+                "track-label": t("transition_landing_page.take_action_start_now")
+              }
+            } %>
           </div>
           <div class="govuk-grid-column-one-third">
             <%= render partial: 'transition_landing_page/take-action-traffic-lights' %>


### PR DESCRIPTION
The start button wrapper on the transition page seems to change the button colour to a green. 
The default state of this button already has a green background, making this extra wrapper redundant.

**Before**
<img width="409" alt="Screenshot 2020-10-16 at 17 43 02" src="https://user-images.githubusercontent.com/7116819/96285764-454d2100-0fd7-11eb-9df8-8961150d11d7.png">
**After**
<img width="408" alt="Screenshot 2020-10-16 at 17 43 25" src="https://user-images.githubusercontent.com/7116819/96285767-467e4e00-0fd7-11eb-8eb8-0d7a70c48a0e.png">





:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
