### PR TITLE
Transition landing page AB Test 4

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -7,6 +7,8 @@ class TransitionLandingPageController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
+    ab_test_variant.configure_response(response) if page_under_test?
+
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
@@ -34,11 +36,32 @@ private
   end
 
   def show_comms?
-    true
+    !show_variant?
   end
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
+  end
+
+  helper_method :ab_test_variant, :page_under_test?, :show_variant?
+  def ab_test_variant
+    @ab_test_variant ||= begin
+      ab_test = GovukAbTesting::AbTest.new(
+        "TransitionUrgency4",
+        dimension: 44,
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      ab_test.requested_variant(request.headers)
+    end
+  end
+
+  def page_under_test?
+    request.path == "/transition"
+  end
+
+  def show_variant?
+    page_under_test? && ab_test_variant.variant?("B")
   end
 end

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -1,5 +1,7 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :meta_tags %>
+<% content_for :meta_tags do %>
+  <%= ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
+<% end %>
 
 <%=
   render(
@@ -13,7 +15,9 @@
 
 <%= render partial: 'take_action' %>
 
-<%= render partial: 'video_section' %>
+<% unless show_variant? %>
+  <%= render partial: 'video_section' %>
+<% end %>
 
 <div class="govuk-width-container">
   <div class="landing-page__buckets">

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -20,5 +20,38 @@ describe TransitionLandingPageController do
         assert_response :success
       end
     end
+
+    describe "TransitionUrgency4 AB test" do
+      context "In the en locale" do
+        %w[A Z].each do |variant|
+          it "Variant #{variant} shows the default (video and announcements visible)" do
+            with_variant TransitionUrgency4: variant do
+              get :show
+              assert_template partial: "_video_section", count: 1
+              assert_template partial: "_comms", count: 1
+            end
+          end
+        end
+
+        it "Variant B hides the video and announcements" do
+          with_variant TransitionUrgency4: "B" do
+            get :show
+            assert_template partial: "_video_section", count: 0
+            assert_template partial: "_comms", count: 0
+          end
+        end
+      end
+
+      context "In the cy locale" do
+        %w[A B Z].each do |variant|
+          it "All variants shows the default (video and announcements visible)" do
+            setup_ab_variant("TransitionUrgency4", variant)
+            get :show, params: { locale: "cy" }
+            assert_template partial: "_video_section", count: 1
+            assert_template partial: "_comms", count: 1
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What

Hide the video and announcement sections for users in variant B.

## Default

<img width="796" alt="Screenshot 2020-10-16 at 18 00 41" src="https://user-images.githubusercontent.com/17908089/96287238-86decb80-0fd9-11eb-9e2b-f4dcaf1135ca.png">


## Variant B
<img width="1067" alt="Screenshot 2020-10-16 at 18 01 13" src="https://user-images.githubusercontent.com/17908089/96287273-98c06e80-0fd9-11eb-829e-2a5c9c48cf19.png">




:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
