### PR TITLE
Bug Fix: Remove special characters from postcode before calling Mapit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rinku", require: "rails_rinku"
 gem "sass-rails"
 gem "slimmer"
 gem "uglifier"
+gem "uk_postcode"
 
 group :test do
   gem "cucumber-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    uk_postcode (2.1.6)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
@@ -432,6 +433,7 @@ DEPENDENCIES
   slimmer
   timecop
   uglifier
+  uk_postcode
   webdrivers
   webmock
 

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -20,7 +20,7 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     if @postcode.blank?
       return render_no_postcode_error
-    elsif !postcode_validation
+    elsif !PostcodeService.new(@postcode).valid?
       return render_invalid_postcode_error
     end
 
@@ -86,10 +86,6 @@ private
         url: "/coronavirus",
       },
     ]
-  end
-
-  def postcode_validation
-    @postcode =~ /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/
   end
 
   def content_item

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -16,7 +16,7 @@ class CoronavirusLocalRestrictionsController < ApplicationController
       return render_no_postcode_error
     end
 
-    @postcode = params["postcode-lookup"].gsub(/\s+/, "").upcase
+    @postcode = PostcodeService.new(params["postcode-lookup"]).sanitize
 
     if @postcode.blank?
       return render_no_postcode_error

--- a/app/services/postcode_service.rb
+++ b/app/services/postcode_service.rb
@@ -8,4 +8,12 @@ class PostcodeService
   def valid?
     postcode =~ /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/
   end
+
+  def sanitize
+    if postcode.present?
+      # Strip trailing whitespace, non-alphanumerics, and use the
+      # uk_postcode gem to potentially transpose O/0 and I/1.
+      UKPostcode.parse(postcode.gsub(/[^a-z0-9 ]/i, "").strip).to_s
+    end
+  end
 end

--- a/app/services/postcode_service.rb
+++ b/app/services/postcode_service.rb
@@ -1,0 +1,11 @@
+class PostcodeService
+  attr_reader :postcode
+
+  def initialize(postcode)
+    @postcode = postcode
+  end
+
+  def valid?
+    postcode =~ /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/
+  end
+end

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -16,7 +16,7 @@ describe CoronavirusLocalRestrictionsController do
 
   describe "POST results" do
     it "renders the results page when given a real postcode" do
-      postcode = "E18QS"
+      postcode = "E1 8QS"
       areas = [
         {
           "gss" => "E01000123",

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -45,6 +45,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     then_i_see_the_no_information_page
   end
 
+  it "displays the right restrictions if the postcode is correct except for a special character" do
+    given_i_am_on_the_local_restrictions_page
+    then_i_can_see_the_postcode_lookup_form
+    then_i_enter_a_valid_english_postcode_with_an_extra_special_character
+    then_i_click_on_find
+    then_i_see_the_results_page_for_level_two_with_future_level_three_restrictions
+  end
+
   describe "future restrictions" do
     before do
       travel_to Time.zone.local(2020, 10, 12, 20, 10, 10)
@@ -74,7 +82,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_enter_a_valid_english_postcode
-    postcode = "E18QS"
+    postcode = "E1 8QS"
     areas = [
       {
         "gss" => "E01000123",
@@ -89,7 +97,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_restriction
-    postcode = "E18QS"
+    postcode = "E1 8QS"
     areas = [
       {
         "gss" => "E08000001",
@@ -104,8 +112,23 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     fill_in "Enter your postcode", with: postcode
   end
 
+  def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
+    areas = [
+      {
+        "gss" => "E08000001",
+        "name" => "Coruscant Planetary Council",
+        "type" => "LBO",
+        "country_name" => "England",
+      },
+    ]
+    stub_mapit_has_a_postcode_and_areas("E1 8QS", [], areas)
+    LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
+
+    fill_in "Enter your postcode", with: ".e18qs"
+  end
+
   def then_i_enter_a_valid_english_postcode_in_tier_two
-    postcode = "E18QS"
+    postcode = "E1 8QS"
     areas = [
       {
         "gss" => "E09000030",
@@ -120,7 +143,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_enter_a_valid_welsh_postcode
-    postcode = "LL110BY"
+    postcode = "LL11 0BY"
     areas = [
       {
         "gss" => "E01000123",
@@ -133,7 +156,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def when_i_enter_a_valid_postcode_that_returns_no_results
-    postcode = "IM11AF"
+    postcode = "IM1 1AF"
     mapit_endpoint = Plek.current.find("mapit")
 
     stub_request(:get, "#{mapit_endpoint}/postcode/" + postcode.tr(" ", "+") + ".json")

--- a/test/services/postcode_service_test.rb
+++ b/test/services/postcode_service_test.rb
@@ -17,4 +17,30 @@ describe PostcodeService do
       assert_not(described_class.new(postcode).valid?)
     end
   end
+
+  describe "#sanitize" do
+    it "strips trailing spaces from entered postcodes" do
+      assert_equal "WC2B 6NH", described_class.new("WC2B 6NH ").sanitize
+    end
+
+    it "transposes O/0 and I/1 if necessary" do
+      assert_equal "W1A 0AA", described_class.new("WIA OAA").sanitize
+    end
+
+    it "returns nil if the postcode parameter is nil or an empty string" do
+      assert_nil described_class.new("").sanitize
+    end
+
+    it "removes special characters from the start of the postcode" do
+      assert_equal "WC2B 6NH", described_class.new(".WC2B6NH").sanitize
+    end
+
+    it "converts the postcode to uppercase" do
+      assert_equal "WC2B 6NH", described_class.new("wc2b6nh").sanitize
+    end
+
+    it "removes non-breaking spaces from the postcode" do
+      assert_equal "WC1A 1AA", described_class.new("\u00A0WC1A1AA").sanitize
+    end
+  end
 end

--- a/test/services/postcode_service_test.rb
+++ b/test/services/postcode_service_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+describe PostcodeService do
+  describe "#valid?" do
+    it "returns true if postcode is valid" do
+      postcode = "E1 8QS"
+      assert(described_class.new(postcode).valid?)
+    end
+
+    it "returns false if the postcode is not valid" do
+      postcode = "invalid postcode"
+      assert_not(described_class.new(postcode).valid?)
+    end
+
+    it "returns false for partial postcodes" do
+      postcode = "SW1A"
+      assert_not(described_class.new(postcode).valid?)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Sw0IjxOP

# What?

Sanitise the postcode entered by the user to remove all special characters.

# Why?
If you add a "." to the beginning of the postcode, e.g. ".CH89RS" the lookup throws a "500" error. This is not being caught be the postcode validation regex,  although "." by itself is being caught correctly.

https://sentry.io/organizations/govuk/issues/1954296277/?project=202213&referrer=slack

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
