### PR TITLE
Fix time zone to London

### DIFF
--- a/app/lib/countdown_clock.rb
+++ b/app/lib/countdown_clock.rb
@@ -24,6 +24,6 @@ private
   end
 
   def today_in_london
-    Time.zone.now.utc.to_date
+    Time.zone.today
   end
 end

--- a/app/presenters/feed_entry_presenter.rb
+++ b/app/presenters/feed_entry_presenter.rb
@@ -18,7 +18,11 @@ class FeedEntryPresenter
   end
 
   def updated
-    Time.zone.parse(result["public_timestamp"])
+    # Collections now uses London time. Convert it back to it's former zone
+    # of UTC in the domain of atom feeds to ensure backwards compatibility.
+
+    @utc_time = Time.find_zone("UTC")
+    @utc_time.parse(result["public_timestamp"])
   end
 
   def title

--- a/app/presenters/feed_entry_presenter.rb
+++ b/app/presenters/feed_entry_presenter.rb
@@ -21,8 +21,7 @@ class FeedEntryPresenter
     # Collections now uses London time. Convert it back to it's former zone
     # of UTC in the domain of atom feeds to ensure backwards compatibility.
 
-    @utc_time = Time.find_zone("UTC")
-    @utc_time.parse(result["public_timestamp"])
+    Time.find_zone("UTC").parse(result["public_timestamp"])
   end
 
   def title

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module Collections
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = "London"
 
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -677,9 +677,9 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     visit "/government/organisations/attorney-generals-office"
     assert page.has_css?("section#latest-documents")
     assert page.has_css?(".gem-c-heading", text: "Latest from the Attorney General's Office")
-    assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral']", text: "Rapist has sentence increased after Solicitor General’s referral")
+    assert page.has_css?(".gem-c-document-list__item-title[href='/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector']", text: "Attorney General launches recruitment campaign for new Chief Inspector")
     assert page.has_css?(".gem-c-document-list__attribute", text: "Press release")
-    assert page.has_css?(".gem-c-document-list__attribute time[datetime='2018-06-18']", text: "18 June 2018")
+    assert page.has_css?(".gem-c-document-list__attribute time[datetime='2020-07-26']", text: "26 July 2020")
   end
 
   it "shows a see all link in the latest documents section" do

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -6,6 +6,7 @@ describe Organisations::DocumentsPresenter do
 
   describe "documents" do
     before :each do
+      @documents = organisation_with_featured_documents["details"]["ordered_featured_documents"]
       content_item = ContentItem.new(organisation_with_featured_documents)
       organisation = Organisation.new(content_item)
       @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
@@ -13,17 +14,19 @@ describe Organisations::DocumentsPresenter do
       content_item = ContentItem.new(organisation_with_no_documents)
       organisation = Organisation.new(content_item)
       @no_documents_presenter = Organisations::DocumentsPresenter.new(organisation)
+
       stub_empty_rummager_requests("org-with-no-docs")
       stub_rummager_latest_content_requests("attorney-generals-office")
     end
 
     it "formats the main large news story correctly" do
+      time_stamp = @documents.first["public_updated_at"]
       expected = {
         href: "/government/news/new-head-of-the-serious-fraud-office-announced",
         image_src: "https://assets.publishing.service.gov.uk/s712_jeremy.jpg",
         image_alt: "Attorney General Jeremy Wright QC MP",
         context: {
-          date: Time.zone.parse("2018-06-04"),
+          date: Date.parse(time_stamp),
           text: "Press release",
         },
         heading_text: "New head of the Serious Fraud Office announced",
@@ -36,12 +39,13 @@ describe Organisations::DocumentsPresenter do
     end
 
     it "formats the remaining news stories correctly" do
+      time_stamp = @documents.last["public_updated_at"]
       expected = [{
         href: "/government/news/new-head-of-a-different-office-announced",
         image_src: "https://assets.publishing.service.gov.uk/s465_john.jpg",
         image_alt: "John Someone MP",
         context: {
-          date: Time.zone.parse("2017-06-04"),
+          date: Date.parse(time_stamp),
           text: "Policy paper",
         },
         heading_text: "New head of a different office announced",

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -70,13 +70,13 @@ describe Organisations::DocumentsPresenter do
           items: [
             {
               link: {
-                text: "Rapist has sentence increased after Solicitor General’s referral",
-                path: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
+                text: "Attorney General launches recruitment campaign for new Chief Inspector",
+                path: "/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector",
                 locale: "en",
               },
               metadata: {
                 document_type: "Press release",
-                public_updated_at: Date.parse("2018-06-18T17:39:34.000+01:00"),
+                public_updated_at: Date.parse("2020-07-26T23:15:09.000+00:00"),
                 locale: {
                   document_type: false,
                   public_updated_at: false,
@@ -92,9 +92,9 @@ describe Organisations::DocumentsPresenter do
 
     it "formats document types with acronyms correctly" do
       # This only applies to types containing "FOI" and "DFID"
-      stub_rummager_latest_content_with_acronym("attorney-generals-office")
+      stub_search_api_latest_content_with_acronym("attorney-generals-office")
 
-      expected = "Research for Development Output"
+      expected = "Press release"
       actual = @documents_presenter.latest_documents[:items].first[:metadata][:document_type]
 
       assert_equal expected, actual

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -5,7 +5,7 @@ module OrganisationHelpers
 
   def stub_rummager_latest_content_requests(organisation_slug)
     stub_latest_content_from_supergroups_request(organisation_slug)
-    stub_rummager_latest_documents_request(organisation_slug)
+    stub_search_api_latest_documents_request(organisation_slug)
   end
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty = false)
@@ -60,28 +60,23 @@ module OrganisationHelpers
     stub_request(:get, url).to_return(body: build_result_body("other", true).to_json)
   end
 
-  def stub_rummager_latest_documents_request(organisation_slug)
+  def stub_search_api_latest_documents_request(organisation_slug)
     stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other")
-      .to_return(body: { results: [
-        {
-          title: "Rapist has sentence increased after Solicitor General’s referral",
-          link: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
-          content_store_document_type: "press release",
-          public_timestamp: "2018-06-18T17:39:34.000+01:00",
-        },
-      ] }.to_json)
+      .to_return(body: { results: [search_response] }.to_json)
   end
 
-  def stub_rummager_latest_content_with_acronym(organisation_slug)
+  def stub_search_api_latest_content_with_acronym(organisation_slug)
     stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other")
-      .to_return(body: { results: [
-        {
-          title: "Rapist has sentence increased after Solicitor General’s referral",
-          link: "/government/news/rapist-has-sentence-increased-after-solicitor-generals-referral",
-          content_store_document_type: "dfid_research_output",
-          public_timestamp: "2018-06-18T17:39:34.000+01:00",
-        },
-      ] }.to_json)
+      .to_return(body: { results: [search_response] }.to_json)
+  end
+
+  def search_response
+    {
+      title: "Attorney General launches recruitment campaign for new Chief Inspector",
+      link: "/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector",
+      content_store_document_type: "press release",
+      public_timestamp: "2020-07-26T23:15:09.000+00:00",
+    }
   end
 
   def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil, content_id: nil)


### PR DESCRIPTION
## What

- Set config.time_zone for collections to London
- Update some tests 
- Refactor the Transition Countdown Clock to use local time, rather than UTC.

## Context

- If no time_zone is set, Rails uses UTC by default. This proved problematic in a recent change to the postcode checker, which had changes that were to be made [live at a specific time](https://github.com/alphagov/collections/blob/master/lib/local_restrictions/local-restrictions.yaml), and because in the UK as we are still in BST, they would have been an hour late. 

## Consequences

- Collections compiles [two atom feeds](https://github.com/alphagov/collections/blob/master/app/controllers/feeds_controller.rb). It creates an ID for each entry in the feed by parsing the entry's public_timestamp. `public_timestamp` == `public_updated_at` [which is set by the by the content store](https://github.com/alphagov/search-api/blob/58986cdaa8c8cc7c3e36198a5b225065b9192d83/lib/govuk_index/presenters/common_fields_presenter.rb#L23) which runs in UTC. To ensure we maintain backwards compatibility, the Feed Entry Presenter needs to sets time zone to UTC before creating the ID. 

- Collections also builds the Organisation pages. The Organisation Document Presenter uses `Date.parse` to present the `public_updated_at` time stamp, but the test was using `Time.zone.parse`. This was passing when the default time zone was UTC, but now Time.zone is set, the two methods return a different string.

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
