### PR TITLE
Fix heading level on image card

### DIFF
--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -9,6 +9,7 @@
         href: featured_item[:link].fetch(:path),
         image_src: featured_item[:image][:url],
         heading_text: featured_item[:link].fetch(:text),
+        heading_level: 3,
         metadata: featured_item[:metadata][:organisations],
         context: {
           date: featured_item[:metadata][:public_updated_at],


### PR DESCRIPTION
On the taxons pages, eg https://www.gov.uk/health-and-social-care/public-health the image card currently displays with its default heading level of 2. Because it is followed by other items with heading levels of 3, this makes it look semantically as though it is a parent to the subsequent items. By passing in the desired heading level of 3 we demote it to being a sibling to the other items, making the page more accessible to people using screenreaders or custom CSS.

No visual changes are caused by this.

https://trello.com/c/gCs7k6OH/438-taxon-page-confusing-heading-structure

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
