### PR TITLE
Turn off transition urgency AB test 4

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -7,8 +7,6 @@ class TransitionLandingPageController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
-    ab_test_variant.configure_response(response) if page_under_test?
-
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
@@ -36,32 +34,11 @@ private
   end
 
   def show_comms?
-    !show_variant?
+    true
   end
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
-  end
-
-  helper_method :ab_test_variant, :page_under_test?, :show_variant?
-  def ab_test_variant
-    @ab_test_variant ||= begin
-      ab_test = GovukAbTesting::AbTest.new(
-        "TransitionUrgency4",
-        dimension: 44,
-        allowed_variants: %w[A B Z],
-        control_variant: "Z",
-      )
-      ab_test.requested_variant(request.headers)
-    end
-  end
-
-  def page_under_test?
-    request.path == "/transition"
-  end
-
-  def show_variant?
-    page_under_test? && ab_test_variant.variant?("B")
   end
 end

--- a/app/views/transition_landing_page/show.html.erb
+++ b/app/views/transition_landing_page/show.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :meta_tags do %>
-  <%= ab_test_variant.analytics_meta_tag.html_safe if page_under_test? %>
-<% end %>
+<% content_for :meta_tags %>
 
 <%=
   render(
@@ -15,9 +13,7 @@
 
 <%= render partial: 'take_action' %>
 
-<% unless show_variant? %>
-  <%= render partial: 'video_section' %>
-<% end %>
+<%= render partial: 'video_section' %>
 
 <div class="govuk-width-container">
   <div class="landing-page__buckets">

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -20,38 +20,5 @@ describe TransitionLandingPageController do
         assert_response :success
       end
     end
-
-    describe "TransitionUrgency4 AB test" do
-      context "In the en locale" do
-        %w[A Z].each do |variant|
-          it "Variant #{variant} shows the default (video and announcements visible)" do
-            with_variant TransitionUrgency4: variant do
-              get :show
-              assert_template partial: "_video_section", count: 1
-              assert_template partial: "_comms", count: 1
-            end
-          end
-        end
-
-        it "Variant B hides the video and announcements" do
-          with_variant TransitionUrgency4: "B" do
-            get :show
-            assert_template partial: "_video_section", count: 0
-            assert_template partial: "_comms", count: 0
-          end
-        end
-      end
-
-      context "In the cy locale" do
-        %w[A B Z].each do |variant|
-          it "All variants shows the default (video and announcements visible)" do
-            setup_ab_variant("TransitionUrgency4", variant)
-            get :show, params: { locale: "cy" }
-            assert_template partial: "_video_section", count: 1
-            assert_template partial: "_comms", count: 1
-          end
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Turn off transition landing page AB test 4

- Checker engagement dropped for variant B, so we are reinstating the control which is displaying both the video and the announcements sections.

Trello: https://trello.com/c/I1FS8yqy/543-phase-4-ab-test-results-and-test-switch-off

---

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
