### PR TITLE
Change misleading travel heading

### DIFF
--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -25,8 +25,8 @@ en:
       link_text: Find a postcode on Royal Mail's postcode finder
       href: http://www.royalmail.com/find-a-postcode
     results:
-      travel_heading: If you travel to other areas
-      travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode</a> to find out what restrictions there are.
+      travel_heading: Find information about somewhere else
+      travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>
       current_level_heading: Current Local COVID Alert Level
       changing_levels_title: The Local COVID Alert Level is changing soon
       level_one:


### PR DESCRIPTION
Change 'if you travel to other areas'
Not necessarily correct, this is about finding information about somewhere else

Part of this https://trello.com/c/Dl6yR3Tn/866-explore-journey-of-people-looking-up-postcodes-for-different-areas-where-they-live-travel-to-work

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
