### PR TITLE
Greater Manchester moves to very high on Friday.

### DIFF
--- a/lib/local_restrictions/local-restrictions.yaml
+++ b/lib/local_restrictions/local-restrictions.yaml
@@ -59,11 +59,17 @@ E08000003:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
+      start_time: "00:01"
 E08000001:
   name: Bolton Borough Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
       start_time: "00:01"
 E08000002:
   name: Bury Borough Council
@@ -71,11 +77,17 @@ E08000002:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
+      start_time: "00:01"
 E08000007:
   name: Stockport Borough Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
       start_time: "00:01"
 E08000008:
   name: Tameside Borough Council
@@ -83,11 +95,17 @@ E08000008:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
+      start_time: "00:01"
 E08000009:
   name: Trafford Borough Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
       start_time: "00:01"
 E08000010:
   name: Wigan Borough Council
@@ -95,11 +113,17 @@ E08000010:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
+      start_time: "00:01"
 E08000006:
   name: Salford City Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
       start_time: "00:01"
 E08000005:
   name: Rochdale Borough Council
@@ -107,11 +131,17 @@ E08000005:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
+      start_time: "00:01"
 E08000004:
   name: Oldham Borough Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+    - alert_level: 3
+      start_date: 2020-10-23
       start_time: "00:01"
 E07000117:
   name: Burnley Borough Council

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -105,12 +105,12 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_two
-    postcode = "M11AD"
+    postcode = "B24QA"
     areas = [
       {
-        "gss" => "E08000001",
-        "name" => "Bolton",
-        "type" => "LBO",
+        "gss" => "E08000025",
+        "name" => "Birmingham",
+        "type" => "MTD",
         "country_name" => "England",
       },
     ]
@@ -152,7 +152,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_see_the_results_page_for_level_two
-    assert page.has_text?("Bolton")
+    assert page.has_text?("Birmingham")
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level"))
   end
 


### PR DESCRIPTION
As a resident who has just heard the news about Greater Manchester,
I want the government's postcode site to be immediately up-to-date,
so that I can look up my postcode to confirm what is going to happen and see the new guidance that will apply to me.

(Thanks for providing this tool and your work; I do hope one day you are able to update it alongside the announcements because there are a lot of confused people.)