### PR TITLE
Update tests for postcode checker to use fixture data

### DIFF
--- a/test/fixtures/local-restrictions.yaml
+++ b/test/fixtures/local-restrictions.yaml
@@ -1,5 +1,5 @@
 ---
-E08000001:
+E08000123:
   name: Tatooine
   restrictions:
     - alert_level: 2
@@ -14,8 +14,8 @@ E08000001:
     - alert_level: 3
       start_date: 2021-10-12
       start_time: "00:01"
-E08000002:
-  name: Tatooine
+E08000456:
+  name: Coruscant Planetary Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
@@ -23,12 +23,9 @@ E08000002:
     - alert_level: 3
       start_date: 2019-10-12
       start_time: "00:01"
-E08000003:
-  name: Tatooine
+E08000789:
+  name: Naboo
   restrictions:
-    - alert_level: 4
+    - alert_level: 2
       start_date: 2021-10-12
-      start_time: "00:01"
-    - alert_level: 4
-      start_date: 2022-10-12
       start_time: "00:01"

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -5,6 +5,10 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::Mapit
   include GdsApi::TestHelpers::ContentStore
 
+  before do
+    LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
+  end
+
   it "displays the tier one restrictions" do
     given_i_am_on_the_local_restrictions_page
     then_i_can_see_the_postcode_lookup_form
@@ -50,12 +54,12 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     then_i_can_see_the_postcode_lookup_form
     then_i_enter_a_valid_english_postcode_with_an_extra_special_character
     then_i_click_on_find
-    then_i_see_the_results_page_for_level_two_with_future_level_three_restrictions
+    then_i_see_the_results_page_for_level_two
   end
 
   describe "future restrictions" do
     before do
-      travel_to Time.zone.local(2020, 10, 12, 20, 10, 10)
+      travel_to Time.zone.local(2020, 10, 11, 10, 10, 10)
     end
 
     after do
@@ -66,7 +70,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       given_i_am_on_the_local_restrictions_page
       then_i_enter_a_valid_english_postcode_with_a_future_restriction
       then_i_click_on_find
-      then_i_see_the_results_page_for_level_two_with_future_level_three_restrictions
+      then_i_see_the_results_page_for_changing_restriction_levels
     end
   end
 
@@ -86,7 +90,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     areas = [
       {
         "gss" => "E01000123",
-        "name" => "Coruscant Planetary Council",
+        "name" => "Tatooine",
         "type" => "LBO",
         "country_name" => "England",
       },
@@ -100,14 +104,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     areas = [
       {
-        "gss" => "E08000001",
+        "gss" => "E08000456",
         "name" => "Coruscant Planetary Council",
         "type" => "LBO",
         "country_name" => "England",
       },
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
-    LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
 
     fill_in "Enter your postcode", with: postcode
   end
@@ -115,14 +118,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
     areas = [
       {
-        "gss" => "E08000001",
+        "gss" => "E08000456",
         "name" => "Coruscant Planetary Council",
         "type" => "LBO",
         "country_name" => "England",
       },
     ]
     stub_mapit_has_a_postcode_and_areas("E1 8QS", [], areas)
-    LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
 
     fill_in "Enter your postcode", with: ".e18qs"
   end
@@ -131,8 +133,8 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     areas = [
       {
-        "gss" => "E09000030",
-        "name" => "London Borough of Tower Hamlets",
+        "gss" => "E08000456",
+        "name" => "Coruscant Planetary Council",
         "type" => "LBO",
         "country_name" => "England",
       },
@@ -170,12 +172,12 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_see_the_results_page_for_level_one
-    assert page.has_text?("Coruscant Planetary Council")
+    assert page.has_text?("Tatooine")
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.heading"))
   end
 
   def then_i_see_the_results_page_for_level_two
-    assert page.has_text?("London Borough of Tower Hamlets")
+    assert page.has_text?("Coruscant Planetary Council")
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level"))
   end
 
@@ -191,11 +193,11 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.no_information.heading"))
   end
 
-  def then_i_see_the_results_page_for_level_two_with_future_level_three_restrictions
-    date = "2021-10-12".to_date.strftime("%-d %B")
+  def then_i_see_the_results_page_for_changing_restriction_levels
+    date = "2020-10-12".to_date.strftime("%-d %B")
 
-    assert page.has_text?("Tatooine")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.changing_alert_level"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.future.level_three.alert_level", date: date))
+    assert page.has_text?("Coruscant Planetary Council")
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.changing_alert_level"))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.future.level_two.alert_level", date: date))
   end
 end

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -102,44 +102,20 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_enter_a_valid_english_postcode_with_a_future_restriction
     postcode = "E1 8QS"
-    areas = [
-      {
-        "gss" => "E08000456",
-        "name" => "Coruscant Planetary Council",
-        "type" => "LBO",
-        "country_name" => "England",
-      },
-    ]
-    stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+    stub_mapit_has_a_postcode_and_areas(postcode, [], [level_two_area])
 
     fill_in "Enter your postcode", with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
-    areas = [
-      {
-        "gss" => "E08000456",
-        "name" => "Coruscant Planetary Council",
-        "type" => "LBO",
-        "country_name" => "England",
-      },
-    ]
-    stub_mapit_has_a_postcode_and_areas("E1 8QS", [], areas)
+    stub_mapit_has_a_postcode_and_areas("E1 8QS", [], [level_two_area])
 
     fill_in "Enter your postcode", with: ".e18qs"
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_two
     postcode = "E1 8QS"
-    areas = [
-      {
-        "gss" => "E08000456",
-        "name" => "Coruscant Planetary Council",
-        "type" => "LBO",
-        "country_name" => "England",
-      },
-    ]
-    stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
+    stub_mapit_has_a_postcode_and_areas(postcode, [], [level_two_area])
 
     fill_in "Enter your postcode", with: postcode
   end
@@ -199,5 +175,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     assert page.has_text?("Coruscant Planetary Council")
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.changing_alert_level"))
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.future.level_two.alert_level", date: date))
+  end
+
+  def level_two_area
+    {
+      "gss" => "E08000456",
+      "name" => "Coruscant Planetary Council",
+      "type" => "LBO",
+      "country_name" => "England",
+    }
   end
 end

--- a/test/models/local_restriction_test.rb
+++ b/test/models/local_restriction_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe LocalRestriction do
-  let(:restriction) { described_class.new("E08000001") }
+  let(:restriction) { described_class.new("E08000123") }
 
   before do
     LocalRestriction.any_instance.stubs(:file_name).returns("test/fixtures/local-restrictions.yaml")
@@ -69,14 +69,14 @@ describe LocalRestriction do
 
   it "returns nil when there are no future restrictions" do
     travel_to Time.zone.local(2020, 10, 15, 10, 10, 10)
-    restriction = described_class.new("E08000002")
+    restriction = described_class.new("E08000456")
     assert_nil restriction.future
     travel_back
   end
 
   it "returns nil when there are no current restrictions" do
     travel_to Time.zone.local(2020, 10, 15, 10, 10, 10)
-    restriction = described_class.new("E08000003")
+    restriction = described_class.new("E08000789")
     assert_nil restriction.current
     travel_back
   end


### PR DESCRIPTION
Trello: https://trello.com/c/QpdrksCQ

# What?

Update tests for the postcode checker to use stubbed data and/or data from a fixture file.

# Why?

At the moment we're using the data in the live files for our tests and that data is constantly subject to change. If we don't change to using stubbed data, it means that we might need to update the tests when areas change restriction levels. This makes it harder for non-tech people to update the levels.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
