### PR TITLE
Fix promoted news

### DIFF
--- a/app/presenters/supergroups/news_and_communications.rb
+++ b/app/presenters/supergroups/news_and_communications.rb
@@ -16,6 +16,12 @@ module Supergroups
       format_document_data(items)
     end
 
+    def document_list_with_promoted(taxon_id)
+      items = tagged_content(taxon_id)
+
+      format_document_data(items)
+    end
+
     def promoted_content(taxon_id)
       items = tagged_content(taxon_id).shift(promoted_content_count)
       format_document_data(items, "FeaturedLinkClicked", true)

--- a/app/services/supergroup_sections/sections.rb
+++ b/app/services/supergroup_sections/sections.rb
@@ -14,6 +14,7 @@ module SupergroupSections
           title: supergroup.title,
           promoted_content: (supergroup.promoted_content(taxon_id) if supergroup.methods.include? :promoted_content),
           documents: supergroup.document_list(taxon_id),
+          documents_with_promoted: (supergroup.document_list_with_promoted(taxon_id) if supergroup.methods.include? :document_list_with_promoted),
           partial_template: supergroup.partial_template,
           see_more_link: supergroup.finder_link(base_path, taxon_id),
           show_section: supergroup.show_section?(taxon_id),

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -9,6 +9,7 @@
         href: featured_item[:link].fetch(:path),
         image_src: featured_item[:image][:url],
         heading_text: featured_item[:link].fetch(:text),
+        heading_level: 3,
         metadata: featured_item[:metadata][:organisations],
         context: {
           date: featured_item[:metadata][:public_updated_at],

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,15 +1,14 @@
 <%
   featured_item = section[:promoted_content].first
-  featured_item_layout_class = "taxon-page__featured-item--single" if section[:documents].empty?
 %>
 
-  <div class="taxon-page__featured-item <%= featured_item_layout_class %>">
+<% if section[:documents].empty? %>
+  <div class="taxon-page__featured-item taxon-page__featured-item--single">
     <%= render "govuk_publishing_components/components/image_card", {
         large: true,
         href: featured_item[:link].fetch(:path),
         image_src: featured_item[:image][:url],
         heading_text: featured_item[:link].fetch(:text),
-        heading_level: 3,
         metadata: featured_item[:metadata][:organisations],
         context: {
           date: featured_item[:metadata][:public_updated_at],
@@ -23,16 +22,18 @@
         }
     } %>
   </div>
-  <% if section[:documents].any? %>
-    <div>
-      <%= render 'govuk_publishing_components/components/document_list',
-        items: section[:documents],
-        margin_top: true,
-        margin_bottom: true
-      %>
-  <% else %>
-    <div class="taxon-page__featured-see-more">
-  <% end %>
-    <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+<% end %>
 
-  </div>
+<% if section[:documents].any? %>
+  <div>
+    <%= render 'govuk_publishing_components/components/document_list',
+      items: section[:documents_with_promoted],
+      margin_top: true,
+      margin_bottom: true
+    %>
+<% else %>
+  <div class="taxon-page__featured-see-more">
+<% end %>
+  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
+
+</div>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -145,8 +145,19 @@ private
   end
 
   def and_the_taxon_has_short_tagged_content
-    stub_content_for_taxon(content_id, tagged_content)
+    stub_document_types_for_supergroup("guidance_and_regulation")
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
+    stub_document_types_for_supergroup("services")
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
     stub_document_types_for_supergroup("news_and_communications")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: "news_and_communications")
+    stub_document_types_for_supergroup("policy_and_engagement")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
+    stub_document_types_for_supergroup("transparency")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
+    stub_document_types_for_supergroup("research_and_statistics")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
+    stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
   def when_i_visit_that_taxon

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -150,7 +150,7 @@ private
     stub_document_types_for_supergroup("services")
     stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
     stub_document_types_for_supergroup("news_and_communications")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: "news_and_communications")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications(number_of_docs: 1), filter_content_store_document_type: "news_and_communications")
     stub_document_types_for_supergroup("policy_and_engagement")
     stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
     stub_document_types_for_supergroup("transparency")
@@ -423,8 +423,8 @@ private
     @tagged_content_for_guidance_and_regulation ||= generate_search_results(2, "guidance_and_regulation")
   end
 
-  def tagged_content_for_news_and_communications
-    @tagged_content_for_news_and_communications ||= generate_search_results(2, "news_and_communications")
+  def tagged_content_for_news_and_communications(number_of_docs: 2)
+    @tagged_content_for_news_and_communications ||= generate_search_results(number_of_docs, "news_and_communications")
   end
 
   def tagged_content_for_policy_and_engagement

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -23,6 +23,14 @@ class TaxonBrowsingTest < ActionDispatch::IntegrationTest
     then_the_page_is_noindexed
   end
 
+  it "renders a promoted item when there is only 1 tagged news item" do
+    given_there_is_a_taxon_with_children
+    and_the_taxon_is_live
+    and_the_taxon_has_short_tagged_content
+    when_i_visit_that_taxon
+    then_i_can_see_the_short_news_and_communications_section
+  end
+
   it "renders a taxon page for a draft taxon" do
     given_there_is_a_taxon_with_children
     and_the_taxon_is_not_live
@@ -136,6 +144,11 @@ private
     stub_organisations_for_taxon(taxon_content_id, tagged_organisations)
   end
 
+  def and_the_taxon_has_short_tagged_content(taxon_content_id = content_id)
+    stub_content_for_taxon(taxon_content_id, tagged_content)
+    stub_document_types_for_supergroup("news_and_communications")
+  end
+
   def when_i_visit_that_taxon
     visit base_path
   end
@@ -199,11 +212,22 @@ private
 
   def and_i_can_see_the_news_and_communications_section
     assert page.has_selector?(".gem-c-heading", text: "News")
-    assert page.has_selector?(".taxon-page__featured-item")
 
     tagged_content_for_news_and_communications.each do |item|
       all_other_sections_list_item_test(item)
     end
+
+    expected_link = {
+      text: "See more news and communications in this topic",
+      url: "/search/news-and-communications?" + finder_query_string,
+    }
+
+    assert page.has_link?(expected_link[:text], href: expected_link[:url])
+  end
+
+  def then_i_can_see_the_short_news_and_communications_section
+    assert page.has_selector?(".gem-c-heading", text: "News")
+    assert page.has_selector?(".taxon-page__featured-item")
 
     expected_link = {
       text: "See more news and communications in this topic",

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -126,26 +126,26 @@ private
     stub_content_store_has_item(base_path, @content_item)
   end
 
-  def and_the_taxon_has_tagged_content(taxon_content_id = content_id)
+  def and_the_taxon_has_tagged_content
     # We still need to stub tagged content because it is used by the sub-topic grid
-    stub_content_for_taxon(taxon_content_id, tagged_content)
+    stub_content_for_taxon(content_id, tagged_content)
     stub_document_types_for_supergroup("guidance_and_regulation")
-    stub_most_popular_content_for_taxon(taxon_content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
     stub_document_types_for_supergroup("services")
-    stub_most_popular_content_for_taxon(taxon_content_id, tagged_content_for_services, filter_content_store_document_type: "services")
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
     stub_document_types_for_supergroup("news_and_communications")
-    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: "news_and_communications")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: "news_and_communications")
     stub_document_types_for_supergroup("policy_and_engagement")
-    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
     stub_document_types_for_supergroup("transparency")
-    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
     stub_document_types_for_supergroup("research_and_statistics")
-    stub_most_recent_content_for_taxon(taxon_content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
-    stub_organisations_for_taxon(taxon_content_id, tagged_organisations)
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
+    stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
-  def and_the_taxon_has_short_tagged_content(taxon_content_id = content_id)
-    stub_content_for_taxon(taxon_content_id, tagged_content)
+  def and_the_taxon_has_short_tagged_content
+    stub_content_for_taxon(content_id, tagged_content)
     stub_document_types_for_supergroup("news_and_communications")
   end
 

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -130,23 +130,23 @@ private
     # We still need to stub tagged content because it is used by the sub-topic grid
     stub_content_for_taxon(content_id, tagged_content)
     stub_supergroup_document_types
-    stub_guidance_and_regulation
-    stub_services
-    stub_news_and_communications
-    stub_policy_and_engagement
-    stub_transparency
-    stub_research_and_statistics
+    stub_content_for(content_type: "guidance_and_regulation", query_type: "most_popular")
+    stub_content_for(content_type: "services", query_type: "most_popular")
+    stub_content_for(content_type: "news_and_communications", query_type: "most_recent")
+    stub_content_for(content_type: "policy_and_engagement", query_type: "most_recent")
+    stub_content_for(content_type: "transparency", query_type: "most_recent")
+    stub_content_for(content_type: "research_and_statistics", query_type: "most_recent")
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
   def and_the_taxon_has_short_tagged_content
     stub_supergroup_document_types
-    stub_guidance_and_regulation
-    stub_services
-    stub_news_and_communications(number_of_docs: 1)
-    stub_policy_and_engagement
-    stub_transparency
-    stub_research_and_statistics
+    stub_content_for(content_type: "guidance_and_regulation", query_type: "most_popular")
+    stub_content_for(content_type: "services", query_type: "most_popular")
+    stub_content_for(content_type: "news_and_communications", query_type: "most_recent", number_of_docs: 1)
+    stub_content_for(content_type: "policy_and_engagement", query_type: "most_recent")
+    stub_content_for(content_type: "transparency", query_type: "most_recent")
+    stub_content_for(content_type: "research_and_statistics", query_type: "most_recent")
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
@@ -159,28 +159,10 @@ private
     stub_document_types_for_supergroup("research_and_statistics")
   end
 
-  def stub_guidance_and_regulation
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
-  end
-
-  def stub_services
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
-  end
-
-  def stub_news_and_communications(number_of_docs: 2)
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications(number_of_docs: number_of_docs), filter_content_store_document_type: "news_and_communications")
-  end
-
-  def stub_policy_and_engagement
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
-  end
-
-  def stub_transparency
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
-  end
-
-  def stub_research_and_statistics
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
+  def stub_content_for(content_type:, query_type:, number_of_docs: 2)
+    generated_content = generate_search_results(number_of_docs, content_type)
+    # can be stub_most_recent_content_for_taxon or stub_most_popular_content_for_taxon
+    send("stub_#{query_type}_content_for_taxon", content_id, generated_content, filter_content_store_document_type: content_type)
   end
 
   def when_i_visit_that_taxon
@@ -436,30 +418,6 @@ private
     GovukSchemas::Example.find("taxon", example_name: "taxon").tap do |content_item|
       content_item["phase"] = "live"
     end
-  end
-
-  def tagged_content_for_services
-    @tagged_content_for_services ||= generate_search_results(2, "services")
-  end
-
-  def tagged_content_for_guidance_and_regulation
-    @tagged_content_for_guidance_and_regulation ||= generate_search_results(2, "guidance_and_regulation")
-  end
-
-  def tagged_content_for_news_and_communications(number_of_docs: 2)
-    @tagged_content_for_news_and_communications ||= generate_search_results(number_of_docs, "news_and_communications")
-  end
-
-  def tagged_content_for_policy_and_engagement
-    @tagged_content_for_policy_and_engagement ||= generate_search_results(2, "policy_and_engagement")
-  end
-
-  def tagged_content_for_transparency
-    @tagged_content_for_transparency ||= generate_search_results(2, "transparency")
-  end
-
-  def tagged_content_for_research_and_statistics
-    @tagged_content_for_research_and_statistics ||= generate_search_results(2, "research_and_statistics")
   end
 
   def tagged_organisations

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -127,42 +127,48 @@ private
   end
 
   def and_the_taxon_has_tagged_content
-    # We still need to stub tagged content because it is used by the sub-topic grid
-    stub_content_for_taxon(content_id, tagged_content)
-    stub_supergroup_document_types
-    stub_content_for(content_type: "guidance_and_regulation", query_type: "most_popular")
-    stub_content_for(content_type: "services", query_type: "most_popular")
-    stub_content_for(content_type: "news_and_communications", query_type: "most_recent")
-    stub_content_for(content_type: "policy_and_engagement", query_type: "most_recent")
-    stub_content_for(content_type: "transparency", query_type: "most_recent")
-    stub_content_for(content_type: "research_and_statistics", query_type: "most_recent")
+    [
+      { content_type: "guidance_and_regulation", query_type: "most_popular" },
+      { content_type: "services", query_type: "most_popular" },
+      { content_type: "news_and_communications", query_type: "most_recent" },
+      { content_type: "policy_and_engagement", query_type: "most_recent" },
+      { content_type: "transparency", query_type: "most_recent" },
+      { content_type: "research_and_statistics", query_type: "most_recent" },
+    ].each do |config|
+      stub_document_types_for_supergroup(config[:content_type])
+
+      dummy_content = generate_dummy_search_content(config)
+      stub_search_api_response(dummy_content, config)
+    end
+
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
   def and_the_taxon_has_short_tagged_content
-    stub_supergroup_document_types
-    stub_content_for(content_type: "guidance_and_regulation", query_type: "most_popular")
-    stub_content_for(content_type: "services", query_type: "most_popular")
-    stub_content_for(content_type: "news_and_communications", query_type: "most_recent", number_of_docs: 1)
-    stub_content_for(content_type: "policy_and_engagement", query_type: "most_recent")
-    stub_content_for(content_type: "transparency", query_type: "most_recent")
-    stub_content_for(content_type: "research_and_statistics", query_type: "most_recent")
+    [
+      { content_type: "guidance_and_regulation", query_type: "most_popular" },
+      { content_type: "services", query_type: "most_popular" },
+      { content_type: "news_and_communications", query_type: "most_recent", number_of_docs: 1 },
+      { content_type: "policy_and_engagement", query_type: "most_recent" },
+      { content_type: "transparency", query_type: "most_recent" },
+      { content_type: "research_and_statistics", query_type: "most_recent" },
+    ].each do |config|
+      stub_document_types_for_supergroup(config[:content_type])
+
+      dummy_content = generate_dummy_search_content(config)
+      stub_search_api_response(dummy_content, config)
+    end
+
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
-  def stub_supergroup_document_types
-    stub_document_types_for_supergroup("guidance_and_regulation")
-    stub_document_types_for_supergroup("services")
-    stub_document_types_for_supergroup("news_and_communications")
-    stub_document_types_for_supergroup("policy_and_engagement")
-    stub_document_types_for_supergroup("transparency")
-    stub_document_types_for_supergroup("research_and_statistics")
+  def generate_dummy_search_content(content_type:, query_type:, number_of_docs: 2)
+    generate_search_results(number_of_docs, content_type)
   end
 
-  def stub_content_for(content_type:, query_type:, number_of_docs: 2)
-    generated_content = generate_search_results(number_of_docs, content_type)
+  def stub_search_api_response(dummy_content, content_type:, query_type:, number_of_docs: 2)
     # can be stub_most_recent_content_for_taxon or stub_most_popular_content_for_taxon
-    send("stub_#{query_type}_content_for_taxon", content_id, generated_content, filter_content_store_document_type: content_type)
+    send("stub_#{query_type}_content_for_taxon", content_id, dummy_content, filter_content_store_document_type: content_type)
   end
 
   def when_i_visit_that_taxon

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -129,35 +129,58 @@ private
   def and_the_taxon_has_tagged_content
     # We still need to stub tagged content because it is used by the sub-topic grid
     stub_content_for_taxon(content_id, tagged_content)
-    stub_document_types_for_supergroup("guidance_and_regulation")
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
-    stub_document_types_for_supergroup("services")
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
-    stub_document_types_for_supergroup("news_and_communications")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications, filter_content_store_document_type: "news_and_communications")
-    stub_document_types_for_supergroup("policy_and_engagement")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
-    stub_document_types_for_supergroup("transparency")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
-    stub_document_types_for_supergroup("research_and_statistics")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
+    stub_supergroup_document_types
+    stub_guidance_and_regulation
+    stub_services
+    stub_news_and_communications
+    stub_policy_and_engagement
+    stub_transparency
+    stub_research_and_statistics
     stub_organisations_for_taxon(content_id, tagged_organisations)
   end
 
   def and_the_taxon_has_short_tagged_content
-    stub_document_types_for_supergroup("guidance_and_regulation")
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
-    stub_document_types_for_supergroup("services")
-    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
-    stub_document_types_for_supergroup("news_and_communications")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications(number_of_docs: 1), filter_content_store_document_type: "news_and_communications")
-    stub_document_types_for_supergroup("policy_and_engagement")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
-    stub_document_types_for_supergroup("transparency")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
-    stub_document_types_for_supergroup("research_and_statistics")
-    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
+    stub_supergroup_document_types
+    stub_guidance_and_regulation
+    stub_services
+    stub_news_and_communications(number_of_docs: 1)
+    stub_policy_and_engagement
+    stub_transparency
+    stub_research_and_statistics
     stub_organisations_for_taxon(content_id, tagged_organisations)
+  end
+
+  def stub_supergroup_document_types
+    stub_document_types_for_supergroup("guidance_and_regulation")
+    stub_document_types_for_supergroup("services")
+    stub_document_types_for_supergroup("news_and_communications")
+    stub_document_types_for_supergroup("policy_and_engagement")
+    stub_document_types_for_supergroup("transparency")
+    stub_document_types_for_supergroup("research_and_statistics")
+  end
+
+  def stub_guidance_and_regulation
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_guidance_and_regulation, filter_content_store_document_type: "guidance_and_regulation")
+  end
+
+  def stub_services
+    stub_most_popular_content_for_taxon(content_id, tagged_content_for_services, filter_content_store_document_type: "services")
+  end
+
+  def stub_news_and_communications(number_of_docs: 2)
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_news_and_communications(number_of_docs: number_of_docs), filter_content_store_document_type: "news_and_communications")
+  end
+
+  def stub_policy_and_engagement
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_policy_and_engagement, filter_content_store_document_type: "policy_and_engagement")
+  end
+
+  def stub_transparency
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_transparency, filter_content_store_document_type: "transparency")
+  end
+
+  def stub_research_and_statistics
+    stub_most_recent_content_for_taxon(content_id, tagged_content_for_research_and_statistics, filter_content_store_document_type: "research_and_statistics")
   end
 
   def when_i_visit_that_taxon

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -29,6 +29,7 @@ describe SupergroupSections::Sections do
         title
         promoted_content
         documents
+        documents_with_promoted
         partial_template
         see_more_link
         show_section


### PR DESCRIPTION
This changes the news section of a taxon page to show all news & comms items in a document list, unless there is only 1 item, in which case it falls back to showing the image card for the promoted item. 

This is to improve the semantic integrity of the page. Currently we have a h2 for the News heading, followed by a h2 for the image card, which suggests "News" has no content and Item 1 is the heading for all subsequent content. Demoting the promoted item into the list fixes this, and reducing the image card header to a h3 when it does appear means it sits correctly in the hierarchy of the page.

This is an accessibility fix as the current semantic hierarchy of headings could be confusing for users with personalised styles applied or screenreader users.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
