### PR TITLE
Amend link url on DIT landing page

### DIFF
--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -55,7 +55,7 @@ en:
 
       The EU importer must notify the Border Control Post that the consignment is arriving.
 
-      [Find out more about importing animal products from Great Britain to the EU.](/guidance/importing-animals-animal-products-and-high-risk-food-and-feed-not-of-animal-origin-from-1-january-2021)
+      [Find out more about importing animal products from Great Britain to the EU.](/guidance/exporting-animals-and-animal-products-to-the-eu-from-1-january-2021)
 
       ### Exporting plants and plant products
 


### PR DESCRIPTION
Amend URL on the DIT landing page as per email thread from DIT 21st October:

```
Importing animals and animal products

Please could you change the link from: 
https://www.gov.uk/guidance/importing-animals-animal-products-and-high-risk-food-and-feed-not-of-animal-origin-from-1-january-2021

To: https://www.gov.uk/guidance/exporting-animals-and-animal-products-to-the-eu-from-1-january-2021
(Keep the same hyperlinked copy please)

```




---
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
