### PR TITLE
Add Slough, Stoke-on-Trent and Coventry to HIGH

### DIFF
--- a/lib/local_restrictions/local-restrictions.yaml
+++ b/lib/local_restrictions/local-restrictions.yaml
@@ -41,6 +41,18 @@ E06000007:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
+E06000021:
+  name: Stoke-on-Trent City Council
+  restrictions:
+    - alert_level: 2
+      start_date: 2020-10-24
+      start_time: "00:01"
+E06000039:
+  name: Slough Borough Council
+  restrictions:
+    - alert_level: 2
+      start_date: 2020-10-24
+      start_time: "00:01"
 E06000050:
   name: Cheshire West and Chester Council
   restrictions:
@@ -322,6 +334,12 @@ E08000024:
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
+      start_time: "00:01"
+E08000026:
+  name: Coventry City Council
+  restrictions:
+    - alert_level: 2
+      start_date: 2020-10-24
       start_time: "00:01"
 E06000047:
   name: Durham County Council


### PR DESCRIPTION
Trello: https://trello.com/c/ldNrRDrU/891-update-postcode-data-for-slough-stoke-coventry

# What?

We hear that the following towns need to be added to the postcode checker from the following dates all at TIER 2 - HIGH LEVEL

E06000021	Stoke-on-Trent 24-10-20
E08000026	Coventry	24-10-20
E06000039	Slough	24-10-20

# Expected changes

<img width="1532" alt="Screenshot 2020-10-22 at 16 03 23" src="https://user-images.githubusercontent.com/5793815/96891179-4c18df80-1480-11eb-9f13-355f96afeab0.png">
<img width="1532" alt="Screenshot 2020-10-22 at 16 02 37" src="https://user-images.githubusercontent.com/5793815/96891182-4cb17600-1480-11eb-8a73-b98ca1c3e65d.png">
<img width="1532" alt="Screenshot 2020-10-22 at 16 01 52" src="https://user-images.githubusercontent.com/5793815/96891184-4d4a0c80-1480-11eb-829f-c81819ed98e8.png">



:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
