### PR TITLE
Tweaks to the Royal Mail postcode finder link

### DIFF
--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -22,8 +22,8 @@ en:
       meta_title: Find out the coronavirus restrictions in a local area
       meta_description: Use the postcode checker to find out the Local COVID Alert Level for an area.
     royal_mail_lookup:
-      link_text: Find a postcode on Royal Mail's postcode finder
-      href: http://www.royalmail.com/find-a-postcode
+      link_text: Find a postcode on Royal Mail’s postcode finder
+      href: https://www.royalmail.com/find-a-postcode
     results:
       travel_heading: Find information about somewhere else
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>


### PR DESCRIPTION
- Change the link to the HTTPS version of the Royal Mail postcode finder (the HTTP version redirects to it already so it just saves a network request and reduces the risk of the end user being victim to a MITM attack)

 - Change “Royal Mail's” to “Royal Mail’s” — that is, change the straight apostrophe to a curly right single quotation mark (because it was annoying me)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
