### PR TITLE
Add a custom width 10 to postcode input

### DIFF
--- a/app/views/shared/_postcode-lookup.html.erb
+++ b/app/views/shared/_postcode-lookup.html.erb
@@ -19,6 +19,7 @@
           hint: hint_text,
           invalid: input_error ? 'true' : 'false',
           autocomplete: "postal-code",
+          width: 10,
         } %>
     <%= render "govuk_publishing_components/components/button", text: button_text, margin_bottom: true %>
     <%= tag.p link_to(


### PR DESCRIPTION
## What

Make the postcode input field smaller - see screenshot

## Why

Makes it clearer users should just enter a postcode rather than the place name


https://trello.com/c/PQvIF0If/859-make-postcode-input-field-smaller

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
