### PR TITLE
Add back button to results page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/title';
 @import 'govuk_publishing_components/components/translation-nav';
 @import "govuk_publishing_components/components/error-summary";
+@import "govuk_publishing_components/components/back-link";
 
 @import "helpers/layouts";
 @import "helpers/margins";

--- a/app/views/coronavirus_local_restrictions/no_information.html.erb
+++ b/app/views/coronavirus_local_restrictions/no_information.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, t("coronavirus_local_restrictions.results.no_information.heading") %>
 
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: find_coronavirus_local_restrictions_path
+  } %>
+<% end %>
+
 <%= tag.div :data => {
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => t("coronavirus_local_restrictions.results.no_information.heading")

--- a/app/views/coronavirus_local_restrictions/results.html.erb
+++ b/app/views/coronavirus_local_restrictions/results.html.erb
@@ -1,3 +1,9 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: find_coronavirus_local_restrictions_path
+  } %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if !@location_lookup.data.first.england? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,8 @@
 
 <body <% if content_for(:is_full_width_header) %>class="full-width"<% end %>>
   <div class="wrapper" id="wrapper">
-    <% unless content_for(:is_full_width_header) %>
+    <%= yield :back_link %>
+    <% unless (content_for(:is_full_width_header) || content_for(:back_link)) %>
       <% if content_for?(:breadcrumbs) %>
         <%= yield :breadcrumbs %>
       <% else %>


### PR DESCRIPTION
## What
 
Add back button to results page - when a user clicks it then they go back to the enter your postcode page

## Why

Standard navigation 

https://trello.com/c/ZiMAyVy1/858-add-back-button-to-results-page

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
