### PR TITLE
Add related content to the 'Find local restrictions' page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/organisation-logo';
 @import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/related-navigation';
 @import 'govuk_publishing_components/components/share-links';
 @import 'govuk_publishing_components/components/step-by-step-nav';
 @import 'govuk_publishing_components/components/subscription-links';

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -50,4 +50,21 @@
       } %>
     <% end %>
   </div>
+  <% if t("coronavirus_local_restrictions.related_navigation").is_a?(Array) %>
+    <div class="govuk-grid-column-one-third">
+      <%= render 'govuk_publishing_components/components/related_navigation', {
+        "content_item": {
+          "links" => {
+            "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map do | item |
+              {
+                "title" => item[:title],
+                "base_path" => item[:base_path]
+              }
+            end
+          }
+        },
+        context: :sidebar
+      } %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -50,21 +50,14 @@
       } %>
     <% end %>
   </div>
-  <% if t("coronavirus_local_restrictions.related_navigation").is_a?(Array) %>
-    <div class="govuk-grid-column-one-third">
-      <%= render 'govuk_publishing_components/components/related_navigation', {
-        "content_item": {
-          "links" => {
-            "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map do | item |
-              {
-                "title" => item[:title],
-                "base_path" => item[:base_path]
-              }
-            end
-          }
-        },
-        context: :sidebar
-      } %>
-    </div>
-  <% end %>
+  <div class="govuk-grid-column-one-third">
+    <%= render 'govuk_publishing_components/components/related_navigation', {
+      "content_item": {
+        "links" => {
+          "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map(&:with_indifferent_access)
+        }
+      },
+      context: :sidebar
+    } %>
+  </div>
 </div>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -24,6 +24,13 @@ en:
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail’s postcode finder
       href: https://www.royalmail.com/find-a-postcode
+    related_navigation:
+      - title: "Coronavirus (COVID-19): guidance and support"
+        base_path: /coronavirus
+      - title: Find out what support you can get if you’re affected by coronavirus
+        base_path: /find-coronavirus-support
+      - title: Making a support bubble with another household
+        base_path: /guidance/making-a-support-bubble-with-another-household
     results:
       travel_heading: Find information about somewhere else
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -120,6 +120,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe "related links" do
+    it "renders related links" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_see_the_related_links_for_coronavirus
+    end
+  end
+
   def given_i_am_on_the_local_restrictions_page
     stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
 
@@ -326,5 +333,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       "type" => "LBO",
       "country_name" => "England",
     }
+  end
+
+  def then_i_see_the_related_links_for_coronavirus
+    within ".gem-c-related-navigation" do
+      I18n.t("coronavirus_local_restrictions.related_navigation").each do |link|
+        assert page.has_link?(link[:title], href: link[:base_path])
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Add related content to the first page of the postcode lookup - we don't need to show it on the results page as it distracts from the main call to action

Related content should be:
gov.uk/coronavirus
gov.uk/find-coronavirus-support
https://www.gov.uk/guidance/making-a-support-bubble-with-another-household

## Why

To help users who can't find what they need on the page

<img width="1013" alt="Screenshot 2020-10-28 at 09 44 42" src="https://user-images.githubusercontent.com/41922771/97419678-3f720c80-1902-11eb-8661-6898df3ee4fa.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.

[Trello](https://trello.com/c/CXVGa7zY/861-add-related-content-to-the-find-local-restrictions-page)