### PR TITLE
Use default time zone in postcode checker

### DIFF
--- a/app/models/local_restriction.rb
+++ b/app/models/local_restriction.rb
@@ -3,7 +3,6 @@ class LocalRestriction
 
   def initialize(gss_code)
     @gss_code = gss_code
-    @time_zone = Time.find_zone("London")
   end
 
   def all_restrictions
@@ -33,7 +32,7 @@ class LocalRestriction
   def current
     restrictions = restriction["restrictions"]
     current_restrictions = restrictions.select do |rest|
-      start_date = @time_zone.parse("#{rest['start_date']} #{rest['start_time']}")
+      start_date = Time.zone.parse("#{rest['start_date']} #{rest['start_time']}")
       start_date.past?
     end
 
@@ -43,7 +42,7 @@ class LocalRestriction
   def future
     restrictions = restriction["restrictions"]
     future_restrictions = restrictions.select do |rest|
-      start_date = @time_zone.parse("#{rest['start_date']} #{rest['start_time']}")
+      start_date = Time.zone.parse("#{rest['start_date']} #{rest['start_time']}")
       start_date.future?
     end
 


### PR DESCRIPTION
In this commit: https://github.com/alphagov/collections/pull/1985/commits/35e3cb4850ea72b43f64dd5b207d4f3c4369ad74
we had to manually set the time zone to London, so that the future COVID restrictions would
update in the postcode checker at one minute past midnight as expected and not at 1:01am.

Ideally at the time, we would have set the default time zone to "London" for the whole app, but too many unrelated
tests needed to be fixed.  However,  that has all been fixed in https://github.com/alphagov/collections/pull/1997
so we can remove our work around.

Results from testing on Production server:
```
$ date
Fri Oct 23 11:11:00 UTC 2020
$ govuk_app_console collections
Loading production environment (Rails 6.0.3.4)
irb(main):001:0> Time.zone.now
=> Fri, 23 Oct 2020 12:11:17 BST +01:00
```

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
