### PR TITLE
Improve enter postcode box

### DIFF
--- a/app/assets/stylesheets/shared/_postcode-lookup.scss
+++ b/app/assets/stylesheets/shared/_postcode-lookup.scss
@@ -2,4 +2,8 @@
   padding: govuk-spacing(3);
   margin: govuk-spacing(6) 0;
   background: govuk-colour("light-grey");
+
+  .govuk-hint .gem-c-govspeak {
+    color: $govuk-secondary-text-colour;
+  }
 }

--- a/app/views/shared/_postcode-lookup.html.erb
+++ b/app/views/shared/_postcode-lookup.html.erb
@@ -2,7 +2,7 @@
   input_label ||= t("coronavirus_local_restrictions.lookup.input_label")
   input_value ||= nil
   input_error ||= nil
-  hint_text ||= t("coronavirus_local_restrictions.lookup.hint_text")
+  hint_text ||= render_govspeak(t("coronavirus_local_restrictions.lookup.hint_text"))
   button_text ||= t("coronavirus_local_restrictions.lookup.button_text")
   link ||= { text: t("coronavirus_local_restrictions.royal_mail_lookup.link_text"), href: t("coronavirus_local_restrictions.royal_mail_lookup.href")}
 %>
@@ -12,6 +12,7 @@
           label: {
             text: input_label
           },
+          heading_level: 2,
           heading_size: "s",
           error_message: input_error,
           value: input_value,

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -10,8 +10,11 @@ en:
         input_error: Enter a valid postcode
         error_description: Enter a valid postcode
     lookup:
-      input_label: Enter your postcode
-      hint_text: For example LS1 1UR
+      input_label: Enter a full postcode 
+      hint_text: |
+        For example, LS1 1UR
+
+        We use this to give you more accurate information about the area. 
       button_text: Find
       title: Find out the coronavirus restrictions in a local area
       inset_text: |

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -153,7 +153,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
@@ -168,7 +168,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
@@ -183,20 +183,20 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
     stub_mapit_has_a_postcode_and_areas("E1 8QS", [], [level_two_area])
 
-    fill_in "Enter your postcode", with: ".e18qs"
+    fill_in "Enter a full postcode", with: ".e18qs"
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_two
     postcode = "E1 8QS"
     stub_mapit_has_a_postcode_and_areas(postcode, [], [level_two_area])
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_three
@@ -211,7 +211,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_welsh_postcode
@@ -224,7 +224,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_scottish_postcode
@@ -237,7 +237,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def then_i_enter_a_valid_northern_ireland_postcode
@@ -250,7 +250,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     ]
     stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def when_i_enter_a_valid_postcode_that_returns_no_results
@@ -260,11 +260,11 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     stub_request(:get, "#{mapit_endpoint}/postcode/" + postcode.tr(" ", "+") + ".json")
         .to_return(body: { "postcode" => postcode.to_s, "areas" => {} }.to_json, status: 200)
 
-    fill_in "Enter your postcode", with: postcode
+    fill_in "Enter a full postcode", with: postcode
   end
 
   def when_i_enter_an_invalid_postcode
-    fill_in "Enter your postcode", with: "Hello"
+    fill_in "Enter a full postcode", with: "Hello"
   end
 
   def then_i_click_on_find


### PR DESCRIPTION
This content change should make it clearer to users what is required of them, for the postcode input, by making the heading and hints less ambiguous.

It also adds a h2 tag to the input label to improve the accessibility for users of screen readers.

**BEFORE**

<img width="421" alt="Screenshot 2020-10-23 at 12 47 19" src="https://user-images.githubusercontent.com/41922771/96999919-e97e1d00-152d-11eb-9e14-699d547cf9b7.png">


**AFTER**

<img width="518" alt="Screenshot 2020-11-12 at 10 42 48" src="https://user-images.githubusercontent.com/41922771/98930157-25285900-24d4-11eb-9212-892181b86348.png">


[Trello card](https://trello.com/c/2MANqkBI/880-improve-enter-postcode-box)