### PR TITLE
Use Local Authority name from Mapit

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -17,7 +17,7 @@
   } %>
 
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
+    <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
   </p>
 
   <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -17,7 +17,7 @@
   } %>
 
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
+    <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
   </p>
 
   <%= render "govuk_publishing_components/components/heading", {

--- a/docs/update-covid-local-restriction-data.md
+++ b/docs/update-covid-local-restriction-data.md
@@ -58,18 +58,7 @@ This should look similar to the `Wigan Borough Council` example above (aka as a 
 
 If the GSS code **does not already exist** in the file then you will need to add it.
 
-To get the `name:` you will need to query Mapit using:
-
-```
-GdsApi.mapit.area_for_code("gss", "E06000006").to_h["name"]
-```
-
-Example of `area_for_code` response:
-
-```
-irb(main):002:0> GdsApi.mapit.area_for_code("gss", "E06000006").to_h
-=> {"generation_low"=>1, "name"=>"Halton Borough Council", "country_name"=>"England", "type"=>"UTA", "parent_area"=>nil, "id"=>1758, "type_name"=>"Unitary Authority", "country"=>"E", "generation_high"=>1, "all_names"=>{"M"=>["Override name", "Halton Borough Council"], "O"=>["Ordnance Survey", "Halton (B)"]}, "codes"=>{"ons"=>"00ET", "govuk_slug"=>"halton", "gss"=>"E06000006", "unit_id"=>"38848"}}
-```
+The `name` is just a human-readble description to make it easier to find existing entries in the YAML file. It is not displayed to users. 
 
 ### Test and deploy
 


### PR DESCRIPTION
When the restrictions data in "lib/local_restrictions/local-restrictions.yaml" is updated,
a developer is calling Mapit manually to get the name of the local authority to populate
the "name" field.

This seems pointless as we are already get the local authority name
when we do the lookup:

https://github.com/alphagov/collections/blob/master/app/services/location_lookup_service.rb#L37-L40

Asking people to call mapit like this, makes the restrictions data harder to update. Instead we should use
the "name" field in the YAML file as something human-readable for the person updating to look as gss codes are
hard to read, but not something that is used in the code.
