### PR TITLE
Adjusting fallback copy

### DIFF
--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -5,15 +5,6 @@
   border: solid 2px govuk-colour("black");
   text-align: center;
   margin-bottom: govuk-spacing(2);
-
-  .govuk-body {
-    margin: 0;
-    color: govuk-colour("black");
-  }
-
-  .youtube__bold {
-    font-weight: bold;
-  }
 }
 
 .youtube__video-logo {
@@ -42,6 +33,10 @@
 }
 
 .youtube__video-wrapper--inverse {
+  .youtube__video-placeholder {
+    color: govuk-colour("black");
+  }
+
   .govuk-details__summary {
     color: govuk-colour('white');
 

--- a/app/views/shared/_youtube_player.html.erb
+++ b/app/views/shared/_youtube_player.html.erb
@@ -12,27 +12,28 @@
 <%= tag.div class: css_classes do %>
   <%= render "govuk_publishing_components/components/govspeak", {
   } do %>
-    <div class="youtube__video-placeholder">
-      <div class="youtube__video-logo"><%= no_cookies_icon_text %></div>
-      <p class="govuk-body">
-        <a href="<%= no_cookies_change_settings_link %>" class="govuk-link youtube__page-header-link youtube__bold">
+    <p class="youtube__video-placeholder">
+      <span class="youtube__video-logo">
+        <%= no_cookies_icon_text %>
+      </span>
+      <strong>
+        <a href="<%= no_cookies_change_settings_link %>" class="govuk-link">
           <%= no_cookies_change_settings_text %>
-        </a>
-        <br>
-        <span class="youtube__bold">
+          <br aria-hidden="true">
           <%= no_cookies_to_watch_text %>
-        </span>
-        <br>
-        <%= no_cookies_or_text %>
-      </p>
+        </a>
+      </strong>
+      <br aria-hidden="true">
+      <%= no_cookies_or_text %>
+      <br aria-hidden="true">
       <a
-        href="<%= youtube_video_url %>"
-        class="govuk-body govuk-link"
-        data-youtube-player-analytics="true"
-        data-youtube-player-analytics-category="EmbeddedYoutube">
+          href="<%= youtube_video_url %>"
+          class="govuk-body govuk-link"
+          data-youtube-player-analytics="true"
+          data-youtube-player-analytics-category="EmbeddedYoutube">
         <%= no_cookies_watch_link_text %>
       </a>
-    </div>
+    </p>
   <% end %>
   <%= render "govuk_publishing_components/components/details", { title: transcription_summary} do %>
     <%= transcription_text.html_safe %>


### PR DESCRIPTION
## What?

When cookies are not accepted, adjusting Content to ensure that screen-readers do not read the _YouTube_ fallback Content in a disjointed manner. Partially, maintaining existing Design.  

`govspeak` replaces code when a video is detected inside a `p` tag to render a video. There is also an update to improve the use of bold copy to be semantic

Change impacting the [coronavirus](https://www.gov.uk/coronavirus) and [transition](https://www.gov.uk/transition) page only.

## Why? 

([Ticket](https://trello.com/c/xZaPl0v7)) - A user has to accept cookies to view a _YouTube_ video, if they don't consent the video cannot be displayed as _YouTube_ will track the user, therefore breaching GPDR.  The fallback Content currently doesn't read in a coherent manner for screen readers.

_Screen reader and user style users will not see the text as one sentence. Screen reader users might get confused by the incomplete heading and not understand it out of context._

`[P]Change your cookie settings[/P] [P]to watch the video[/P] [P]or[/P] Watch on YouTube`

 **Fail of WCAG SC 1.3.1**
present on [coronavirus](https://www.gov.uk/coronavirus) and [transition](https://www.gov.uk/transition) page.

## Anything else?

 - The [original PR](https://github.com/alphagov/collections/pull/1987) was [reverted](https://github.com/alphagov/collections/pull/2017/files) after a visual issue went live, this led to some deeper investigation:

- Testing reveals that `br` [tags are problematic for VoiceOver](https://axesslab.com/text-splitting/) they cause disjointed text splitting when being read out.  

- [A similar PR using `br` as solution was previously created](https://github.com/alphagov/collections/pull/1849)

 - There is a [similar issue](https://github.com/alphagov/govuk_publishing_components/issues/1256) that references this fallback within the publishing components.

- There is no dedicated video component, `govspeak` has a feature to include _YouTube_ video which is then enhanced, to increase its level of accessibility.

- the Design System have [explored various considerations to add video ](https://github.com/alphagov/govuk-design-system-backlog/issues/107)

- [Coronavirus](https://www.gov.uk/coronavirus) and [transition](https://www.gov.uk/transition) pages are seemingly the only pages that build upon the `govspeak` component to provide this fallback Design / Content

- Pragmatic fix to resolve issue however, aware this does introduce tech debt as additional development diverges from _component gem_ based architecture. 

A visual representation of how the text now sounds can be seen below:

```
Link, Change your cookie settings to watch the video

or 

Link, Watch on YouTube
```

## Visuals

Fallback **before**
![Screenshot 2020-10-26 at 12 59 12](https://user-images.githubusercontent.com/71266765/97176782-59d6a980-178d-11eb-8cf2-7be8881f05f7.png)

Fallback **after**
![Screenshot 2020-10-29 at 11 44 57](https://user-images.githubusercontent.com/71266765/97575689-078fc580-19e5-11eb-9dac-c8fd34de88aa.png)

 
Cookies Accepted

![Screenshot 2020-10-26 at 10 52 13](https://user-images.githubusercontent.com/71266765/97174940-ae2c5a00-178a-11eb-8bba-e955c825bbeb.png)

---

Fallback 

![Screenshot 2020-10-29 at 11 45 19](https://user-images.githubusercontent.com/71266765/97575709-0eb6d380-19e5-11eb-883f-b51399ebb1b8.png)

Cookies Accepted:

![Screenshot 2020-10-26 at 12 57 06](https://user-images.githubusercontent.com/71266765/97175064-d1efa000-178a-11eb-802a-7b6c5fd71d6f.png)

----
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
