### PR TITLE
Blank image alt text for people images

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -48,10 +48,6 @@ class Person
     details.dig("image", "url")
   end
 
-  def image_alt_text
-    details.dig("image", "alt_text")
-  end
-
   def biography
     details["body"]
   end

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -95,7 +95,6 @@ module Organisations
 
       if (image = person["details"]["image"])
         data[:image_src] = image["url"]
-        data[:image_alt] = image["alt_text"]
       end
 
       data

--- a/app/views/people/_image.html.erb
+++ b/app/views/people/_image.html.erb
@@ -2,6 +2,5 @@
   <%= render "govuk_publishing_components/components/image_card", {
     href: "#",
     image_src: person.image_url,
-    image_alt: person.image_alt_text,
   } %>
 <% end %>

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -18,7 +18,6 @@ describe Organisations::PeoplePresenter do
           brand: "attorney-generals-office",
           href: "/government/people/oliver-dowden",
           image_src: "/photo/oliver-dowden",
-          image_alt: "Oliver Dowden CBE MP",
           description: nil,
           metadata: nil,
           heading_text: "Oliver Dowden CBE MP",
@@ -45,7 +44,6 @@ describe Organisations::PeoplePresenter do
           brand: "attorney-generals-office",
           href: "/government/people/theresa-may",
           image_src: "/photo/theresa-may",
-          image_alt: "Theresa May MP",
           description: nil,
           metadata: nil,
           heading_text: "The Rt Hon Theresa May MP",
@@ -175,7 +173,6 @@ describe Organisations::PeoplePresenter do
         heading_level: 0,
         extra_links_no_indent: true,
         image_src: "/photo/jeremy-heywood",
-        image_alt: "Sir Jeremy Heywood",
       }
 
       expected_non_important = {


### PR DESCRIPTION
# What
Ensure people images have blank alt text on pages rendered by `collections`.
Namely pages under` /government/organisations/` and `/government/people/`.

The alt text still exists in the API. This change simply ensures that `collections` is no longer consuming it.


https://trello.com/c/x6g49fLo

# Why
This is to align with our current guidance on `alt` text for decorative images. 
Leaving alt text blank ensures screen readers can skip it, reducing noise and repetition for people using AT.

---------

### Before on `/government/organisations/planning-inspectorate` – has alt
<img width="1068" alt="Screenshot 2020-10-27 at 17 26 19" src="https://user-images.githubusercontent.com/7116819/97338874-c9c25e00-1879-11eb-842a-5e67bb77bd91.png">

### After on `/government/organisations/planning-inspectorate` – empty alt
<img width="1073" alt="Screenshot 2020-10-27 at 17 26 47" src="https://user-images.githubusercontent.com/7116819/97338875-ca5af480-1879-11eb-8ef8-f9f57ea2ce71.png">

### Before on `/government/people/sarah-richards` –  has alt
<img width="860" alt="Screenshot 2020-10-27 at 17 25 03" src="https://user-images.githubusercontent.com/7116819/97338860-c5964080-1879-11eb-9809-2e75d1208888.png">

### After on `/government/people/sarah-richards` – empty alt
<img width="901" alt="Screenshot 2020-10-27 at 17 25 36" src="https://user-images.githubusercontent.com/7116819/97338870-c8913100-1879-11eb-9d06-6a5159055a5c.png">



 
-----
:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
