### PR TITLE
makes content item variable accessible in view

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -2,6 +2,8 @@ class CoronavirusLocalRestrictionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:results]
 
   def show
+    @content_item = content_item.to_hash
+
     render :show,
            locals: {
              breadcrumbs: breadcrumbs,

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -7,6 +7,8 @@ describe CoronavirusLocalRestrictionsController do
 
   describe "GET show" do
     it "correctly renders the local restrictions page" do
+      stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
+
       get :show
 
       assert_response :success


### PR DESCRIPTION
This allows the meta tags component to pick up the correct content item and return the appropiate tracking tags for GA

## What

Dimension 2,3 and 53-57 isn't passed on the first page view to analytics

## Why

This will cause a problem for insights team if they need to group data together using taxon or other dimensions

https://trello.com/c/ozd8CUpf/867-make-sure-right-taxon-information-is-passed-to-ga-on-start-results-page

# Before
<img width="859" alt="Screenshot 2020-10-29 at 11 10 31" src="https://user-images.githubusercontent.com/4599889/97572539-5424d200-19e0-11eb-8a68-b02060b2299e.png">


# After
<img width="940" alt="Screenshot 2020-10-29 at 11 09 35" src="https://user-images.githubusercontent.com/4599889/97572546-571fc280-19e0-11eb-9dea-edd11af512bd.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
