### PR TITLE
Lower the related content box

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,6 +55,7 @@ $covid-yellow: #fff500;
 @import "views/organisations";
 @import "views/organisation";
 @import "views/covid";
+@import "views/coronavirus-local-restriction";
 
 @import "modules/full-page-width";
 

--- a/app/assets/stylesheets/views/_coronavirus-local-restriction.scss
+++ b/app/assets/stylesheets/views/_coronavirus-local-restriction.scss
@@ -1,0 +1,3 @@
+.coronavirus-local-restriction__related-navigation {
+  margin-top: govuk-spacing(8);
+}

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -51,13 +51,15 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">
-    <%= render 'govuk_publishing_components/components/related_navigation', {
-      "content_item": {
-        "links" => {
-          "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map(&:with_indifferent_access)
-        }
-      },
-      context: :sidebar
-    } %>
+    <div class="coronavirus-local-restriction__related-navigation">
+      <%= render 'govuk_publishing_components/components/related_navigation', {
+        "content_item": {
+          "links" => {
+            "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map(&:with_indifferent_access)
+          }
+        },
+        context: :sidebar
+      } %>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This moves the box to be in line with the title as per the design. In an ideal world I'd do this by passing a margin top parameter to the component but it doesn't support that

## Before
<img width="1440" alt="Screenshot 2020-10-29 at 12 31 49" src="https://user-images.githubusercontent.com/24547207/97574409-1aa19600-19e3-11eb-8de3-da41f0cdf032.png">

## After
<img width="1440" alt="Screenshot 2020-10-29 at 12 31 27" src="https://user-images.githubusercontent.com/24547207/97574421-1f664a00-19e3-11eb-89a1-67f7af9fa25f.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
