### PR TITLE
Fix traffic lights list item wrapping

### DIFF
--- a/app/assets/stylesheets/views/_transition-landing-page.scss
+++ b/app/assets/stylesheets/views/_transition-landing-page.scss
@@ -114,6 +114,7 @@ $green: #00703C;
 
 .landing-page__take-action-traffic-lights > li {
   margin-bottom: govuk-spacing(1);
+  white-space: nowrap;
 
   @include govuk-media-query($until: tablet) {
     display: inline;


### PR DESCRIPTION
## What

Traffic lights list items contain two elements: icon and text. Setting `nowrap` at the list item level will force these two child elements to stay in the same line.

## Why

Wrapping these two elements causes issues at various breaking points, as flagged in https://github.com/alphagov/collections/pull/1983#issuecomment-710146819

[Trello card](https://trello.com/c/ANNuX6M7)

## Visual changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3070_transition cy](https://user-images.githubusercontent.com/788096/97590255-55f99000-19f6-11eb-95b9-16d306912909.png)

</td><td valign="top">

![localhost_3070_transition cy (1)](https://user-images.githubusercontent.com/788096/97590295-5f82f800-19f6-11eb-8a17-3fff636e7963.png)


</td></tr>
<tr><td valign="top">

![localhost_3070_transition cy (3)](https://user-images.githubusercontent.com/788096/97590332-66116f80-19f6-11eb-939d-eeae35c2cec8.png)


</td><td valign="top">

![localhost_3070_transition cy (2)](https://user-images.githubusercontent.com/788096/97590350-690c6000-19f6-11eb-8e7b-e6b654510354.png)

</td></tr>
</table>




----

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
