### PR TITLE
[DO NOT MERGE] Add information on travelling between areas

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -39,5 +39,6 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/travel_level_one" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -39,5 +39,6 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/travel_level_three" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -39,5 +39,6 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/travel_level_two" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_travel_level_one.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_one.html.erb
@@ -1,0 +1,28 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.heading"),
+  font_size: "m",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.body")) %>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @location_lookup.lower_tier_area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.body.level_one", area: @location_lookup.lower_tier_area_name)) %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.heading", area: @location_lookup.lower_tier_area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.body.level_one", area: @location_lookup.lower_tier_area_name)) %>

--- a/app/views/coronavirus_local_restrictions/_travel_level_one.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_one.html.erb
@@ -11,6 +11,8 @@
   items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
 } %>
 
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.extra_information")) %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @location_lookup.lower_tier_area_name),
   font_size: "s",

--- a/app/views/coronavirus_local_restrictions/_travel_level_three.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_three.html.erb
@@ -1,0 +1,28 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.level_three.heading"),
+  font_size: "m",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.level_three.body")) %>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @restriction.area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.body.level_three", area: @restriction.area_name)) %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.heading", area: @restriction.area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.body.level_three", area: @restriction.area_name)) %>

--- a/app/views/coronavirus_local_restrictions/_travel_level_three.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_three.html.erb
@@ -11,6 +11,8 @@
   items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
 } %>
 
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.extra_information")) %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @restriction.area_name),
   font_size: "s",

--- a/app/views/coronavirus_local_restrictions/_travel_level_two.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_two.html.erb
@@ -1,0 +1,28 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.heading"),
+  font_size: "m",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.body")) %>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @restriction.area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.body.level_two", area: @restriction.area_name)) %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.heading", area: @restriction.area_name),
+  font_size: "s",
+  margin_bottom: 4
+} %>
+
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.travel_from.body.level_two", area: @restriction.area_name)) %>

--- a/app/views/coronavirus_local_restrictions/_travel_level_two.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_level_two.html.erb
@@ -11,6 +11,8 @@
   items: t("coronavirus_local_restrictions.results.travelling_between_levels.reasons")
 } %>
 
+<%= sanitize(t("coronavirus_local_restrictions.results.travelling_between_levels.extra_information")) %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("coronavirus_local_restrictions.results.travelling_between_levels.travel_to.heading", area: @restriction.area_name),
   font_size: "s",

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -84,3 +84,47 @@ en:
           alert_level: "From %{date} this area will be in tier 2."
         level_three:
           alert_level: "From %{date} this area will be in tier 3."
+      travelling_between_levels:
+        levels_one_and_two:
+          heading: Travelling between areas
+          body: |
+            <p class="govuk-body">You can travel between areas which are in tier 1 or tier 2.</p>
+            <p class="govuk-body">You should only travel into or out of a tier 3 area if you need to travel for:</p>
+        level_three:
+          heading: Travelling in or out of the area
+          body: |
+            <p class="govuk-body">You should only travel into or out of a tier 3 area if you need to travel for:</p>
+        reasons:
+           - work
+           - education
+           - youth services
+           - caring responsibilities
+           - Medical treatment
+        extra_information: |
+          <p class="govuk-body">You can travel through a tier 3 area as part of a longer journey.</p>
+        travel_to:
+          heading: Travelling to %{area}
+          body:
+            level_one: |
+              <p class="govuk-body">If you’re going to %{area} from another tier 1 area, the guidance is the same.</p>
+              <p class="govuk-body">If you’re going to %{area} from a tier 2 or tier 3 area, you must follow the guidance for the place you’re coming from.</p>
+            level_two: |
+              <p class="govuk-body">If you’re going to %{area} from another tier 2 area, the guidance is the same.</p>
+              <p class="govuk-body">If you’re going to %{area} from a tier 1 area, you must follow the guidance for %{area}, which is tier 2.</p>
+              <p class="govuk-body">If you’re going to %{area} from a tier 3 area, you must follow the guidance for the area you’re coming from.</p>
+            level_three: |
+              <p class="govuk-body">If you’re going to %{area} from another tier 3 area, the guidance is the same.</p>
+              <p class="govuk-body">If you’re going to %{area} from a tier 1 or tier 2 area, you must follow the guidance for %{area}, which is tier 3.</p>
+        travel_from:
+          heading: Travelling from %{area}
+          body:
+            level_one: |
+              <p class="govuk-body">If you’re going from %{area} to another tier 1 area, the guidance is the same.</p>
+              <p class="govuk-body">If you're going from %{area} to a tier 2 or tier 3 area you must follow the guidance for the area you’re going to.</p>
+            level_two: |
+              <p class="govuk-body">If you’re going from %{area} to another tier 2 area, the guidance is the same.</p>
+              <p class="govuk-body">If you’re going from %{area} to a tier 1 area you must follow the guidance for %{area}, which is tier 2.</p>
+              <p class="govuk-body">If you’re going from %{area} to a tier 3 area you must follow the guidance for the area you’re going to.</p>
+            level_three: |
+              <p class="govuk-body">If you’re going from %{area} to another Very High area, the guidance is the same.</p>
+              <p class="govuk-body">If you’re going from %{area} to a tier 1 or tier 2 area you must follow the guidance for %{area}, which is tier 3.</p>

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -268,6 +268,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     area = "Tatooine"
     assert page.has_text?(area)
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.alert_level", area: area))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.heading"))
   end
 
   def then_i_see_the_results_page_for_level_two

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -280,6 +280,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     area = "Mandalore"
     assert page.has_text?(area)
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.alert_level", area: area))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.travelling_between_levels.level_three.heading"))
   end
 
   def then_i_see_details_of_national_restrictions

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -274,6 +274,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     area = "Coruscant Planetary Council"
     assert page.has_text?(area)
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level", area: area))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.travelling_between_levels.levels_one_and_two.heading"))
   end
 
   def then_i_see_the_results_page_for_level_three


### PR DESCRIPTION
Trello: https://trello.com/c/tAMjwmrV

# What?
We know users are confused about travelling between areas. This is a theme in feedback as well as the user research - rationale in the doc

We should update the postcode checker to show people information about travelling in to and out of this area

# Why?
There is no clear guidance on this anywhere on GOV.UK, currently people are breaking the law because they don't know what to do.

# Expected changes
## Tier 3
![screenshot-collections dev gov uk-2020 11 25-14_15_36](https://user-images.githubusercontent.com/5793815/100239648-8c5cf900-2f29-11eb-94ec-45024991144a.png)

## Tier 2
![screenshot-collections dev gov uk-2020 11 25-14_17_08](https://user-images.githubusercontent.com/5793815/100239434-4d2ea800-2f29-11eb-8091-861cc4881822.png)

## Tier 1
![screenshot-collections dev gov uk-2020 11 25-14_19_04](https://user-images.githubusercontent.com/5793815/100239428-4c961180-2f29-11eb-9aaa-ff538a5ee63d.png)


