### PR TITLE
Remove 2020-11-02 changes to local restrictions

### DIFF
--- a/lib/local_restrictions/local-restrictions.yaml
+++ b/lib/local_restrictions/local-restrictions.yaml
@@ -248,17 +248,11 @@ E08000035:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
-    - alert_level: 3
-      start_date: 2020-11-02
-      start_time: "00:01"
 E08000032:
   name: City of Bradford Metropolitan District Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
-      start_time: "00:01"
-    - alert_level: 3
-      start_date: 2020-11-02
       start_time: "00:01"
 E08000034:
   name: Kirklees Council
@@ -266,26 +260,17 @@ E08000034:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
-    - alert_level: 3
-      start_date: 2020-11-02
-      start_time: "00:01"
 E08000033:
   name: Calderdale Metropolitan Borough Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
       start_time: "00:01"
-    - alert_level: 3
-      start_date: 2020-11-02
-      start_time: "00:01"
 E08000036:
   name: Wakefield Metropolitan District Council
   restrictions:
     - alert_level: 2
       start_date: 2020-10-12
-      start_time: "00:01"
-    - alert_level: 3
-      start_date: 2020-11-02
       start_time: "00:01"
 E08000016:
   name: Barnsley Metropolitan Borough Council


### PR DESCRIPTION
These are superseded by the national restrictions which come into force
on 2020-11-05.

For example, Leeds postcode should only mention the new national restrictions on the 5th, not the local restrictions which were due to come into force on the 2nd.

| This branch, deployed to integration | Production |
|----|----|
| ![image](https://user-images.githubusercontent.com/1696784/97790467-b76d5a80-1bc0-11eb-9cbf-3df73da0b462.png) | ![image](https://user-images.githubusercontent.com/1696784/97790478-ce13b180-1bc0-11eb-80d2-2023bad7284d.png) |


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
