### PR TITLE
Bump version of govuk_publishing_components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.8)
     govuk_document_types (0.9.2)
-    govuk_publishing_components (21.69.0)
+    govuk_publishing_components (23.2.0)
       govuk_app_config
       kramdown
       plek


### PR DESCRIPTION
This should have been triggered by dependabot, as with:
- https://github.com/alphagov/government-frontend/pull/1894
- https://github.com/alphagov/frontend/pull/2504

I'm hoping that bumping the gem manually will kick-start dependabot again.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
