### PR TITLE
Add route constraint to redirect postcode checker to guidance page in production

### DIFF
--- a/app/lib/coronavirus_local_restrictions_constraint.rb
+++ b/app/lib/coronavirus_local_restrictions_constraint.rb
@@ -1,0 +1,7 @@
+class CoronavirusLocalRestrictionsConstraint
+  def matches?(*)
+    return false if Rails.env.production?
+
+    true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,14 @@ Rails.application.routes.draw do
   end
 
   # Routes for local restrictions postcode lookup
-  get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
-  post "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#results"
+  constraints CoronavirusLocalRestrictionsConstraint.new do
+    get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
+    post "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#results"
+  end
+
+  # Will redirect for the production environment.
+  # This is because the postcode checker will not be in use during November national lockdown!
+  get "/find-coronavirus-local-restrictions", to: redirect("https://www.gov.uk/guidance/new-national-restrictions-from-5-november")
 
   # TODO: this redirect causes the request to be routed to Whitehall where
   # the country A-Z currently lives. This needs to be removed when the world index

--- a/test/lib/coronavirus_local_restrictions_constraint_test.rb
+++ b/test/lib/coronavirus_local_restrictions_constraint_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "mocha"
+
+class CoronavirusLocalRestrictionsConstraintTest < ActiveSupport::TestCase
+  describe "#matches?" do
+    it "returns false when the environment is production" do
+      Rails.stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      assert_equal described_class.new.matches?, false
+    end
+
+    it "returns true if the environment is not production" do
+      assert_equal described_class.new.matches?, true
+    end
+  end
+end


### PR DESCRIPTION
**DO NOT MERGE/DEPLOY until 00:00 05/11/2020**

- From 05/11/2020 - 02/12/2020 England will go into a national lockdown.
- As a result we will redirect from the postcode checker to the guidance.
- We have added the constraint depending on ENV so that we can bring the postcode checker back towards the end of the national lockdown.
- We still want to be able to continue development work, without users being to access the postcode checker.

[Original constraint adding PR!](https://github.com/alphagov/collections/pull/1952/files)

**DO NOT MERGE/DEPLOY until 00:00 05/11/2020**

**Will need to be merged after [this PR](https://github.com/alphagov/smokey/pull/736) to remove the smoke test has been deployed!**




:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
