### PR TITLE
Update transition landing page copy

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -41,11 +41,11 @@ en:
       watch_link_text: Watch on YouTube
     guidance_header: "Changes for businesses and citizens"
     campaign_links:
-      lead_in: "You need to take action now if you're:"
+      lead_in: "You need to act now if you’re"
       links:
-        - text: importing goods into the UK
+        - text: importing goods from the EU
           path: /prepare-to-import-to-great-britain-from-january-2021
-        - text: exporting goods from the UK
+        - text: exporting goods to the EU
           path: /prepare-to-export-from-great-britain-from-january-2021
         - text: travelling to the EU
           path: /visit-europe-1-january-2021


### PR DESCRIPTION
## What

Update transition landing page **Changes for businesses and citizens** section. We don't have a welsh translation yet, so this just updates the English version.

## Why

- The current text is inaccurate - it links to pages about importing and exporting to Great Britain, not the UK
- ‘Act now’ is shorter, plainer and more immediate than ‘take action now’

## Before:

<img width="796" alt="Screenshot 2020-11-09 at 12 35 56" src="https://user-images.githubusercontent.com/17908089/98541987-25341900-2288-11eb-91a8-f649e4273a49.png">


# After:

<img width="775" alt="Screenshot 2020-11-09 at 12 40 04" src="https://user-images.githubusercontent.com/17908089/98542372-b905e500-2288-11eb-80c8-93db62f2d096.png">


Trello: https://trello.com/c/lgMHTxJa/532-amend-wording-of-the-import-export-links-on-the-landing-page

Release app: http://govuk-collec-update-lan-lj77yc.herokuapp.com/transition

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
