### PR TITLE
Fix focus states on transition page

### DIFF
--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       <% end %>
 
-      <p class="govuk-body govuk-!-padding-top-2"><%= campaign_links[:lead_out].html_safe %></p>
+      <p class="govuk-body govuk-!-padding-top-2"><%= sanitize(campaign_links[:lead_out]) %></p>
     </div>
   </div>
 </div>

--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -16,7 +16,7 @@
   <% campaign_links = I18n.t("transition_landing_page.campaign_links") %>
   <%
     links = campaign_links[:links].map do |link|
-      link_to(link[:text], link[:path], data: {
+      link_to(link[:text], link[:path], class: "govuk-link", data: {
         track_action: link[:path],
         track_category: "transition-landing-page",
         track_label: "What you can do now"

--- a/app/views/transition_landing_page/_document_list.html.erb
+++ b/app/views/transition_landing_page/_document_list.html.erb
@@ -27,6 +27,6 @@
   <% end %>
 
   <% if see_all_link && see_all_text %>
-    <%= link_to(see_all_text, see_all_link, class: "landing-page__section-see-all") %>
+    <%= link_to(see_all_text, see_all_link, class: "landing-page__section-see-all govuk-link") %>
   <% end %>
 </div>

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -85,7 +85,7 @@ cy:
           path: /uk-nationals-living-eu
         - text: aros yn y DU os ydych chi’n ddinesydd o’r UE
           path: /staying-uk-eu-citizen
-      lead_out: <a href="/transition-check/questions">Cael y rhestr gyflawn</a> o'r hyn y mae angen i chi ei wneud ar eich cyfer chi, eich busnes a'ch teulu.
+      lead_out: <a href="/transition-check/questions" class="govuk-link">Cael y rhestr gyflawn</a> o'r hyn y mae angen i chi ei wneud ar eich cyfer chi, eich busnes a'ch teulu.
     topic_section_header: Yr holl wybodaeth am y cyfnod pontio
     topic_section_subheading: Pori’r holl wybodaeth sy’n berthnasol i’r cyfnod pontio
     email_intro: "I gael y manylion diweddaraf"

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -53,7 +53,7 @@ en:
           path: /uk-nationals-living-eu
         - text: staying in the UK if you're an EU citizen
           path: /staying-uk-eu-citizen
-      lead_out: <a href="/transition-check/questions">Get the complete list</a> of what you need to do for you, your business and your family.
+      lead_out: <a href="/transition-check/questions" class="govuk-link">Get the complete list</a> of what you need to do for you, your business and your family.
     comms_header: "Announcements"
     comms:
       links:


### PR DESCRIPTION
Links in various parts of the transition page are missing the core `govuk-link` hence not providing the more accessible focus state.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1012" alt="Screenshot 2020-11-09 at 17 09 24" src="https://user-images.githubusercontent.com/788096/98573559-ea91a700-22ae-11eb-98e5-e4b047688b83.png">


</td><td valign="top">

<img width="1012" alt="Screenshot 2020-11-09 at 17 07 06" src="https://user-images.githubusercontent.com/788096/98573576-ec5b6a80-22ae-11eb-893c-e3b1a4698518.png">

</td></tr>
</table>


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
