### PR TITLE
Fix raw HTML output for organisations

### DIFF
--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,6 +1,6 @@
 <% if role.organisations %>
   <div class="organisations-list <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <span lang="en">Organisations</span>:
-    <%= role.organisations.map { |organisation| link_to(organisation['title'], sanitize(organisation['base_path']), class: "govuk-link") }.to_sentence %>
+    <%= to_sentence(role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path'], class: "govuk-link") }) %>
   </div>
 <% end %>


### PR DESCRIPTION
In an attempt to fix a brakeman failure in https://github.com/alphagov/collections/commit/a8fb322737525b9468c89cea84bf53d8e85b1ad4 I did not realised that the organisation would end up rendered as HTML. This fixes the issue by applying the `to_sentence ` after generating the organisations array.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3070_government_ministers_prime-minister (1)](https://user-images.githubusercontent.com/788096/98587245-c7242780-22c1-11eb-8362-a5d0d9a85932.png)

</td><td valign="top">

![localhost_3070_government_ministers_prime-minister (2)](https://user-images.githubusercontent.com/788096/98587214-bd022900-22c1-11eb-8e6d-0535bb5f31c2.png)

</td></tr>
</table>

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
