### PR TITLE
Turn off compatibility mode with GOV.UK Elements and remove legacy colour declarations

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,4 @@
 $govuk-compatibility-govuktemplate: true;
-$govuk-compatibility-govukelements: true;
 $govuk-use-legacy-palette: false;
 $covid-grey: #272828;
 $covid-yellow: #fff500;

--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -15,7 +15,7 @@
     cursor: pointer;
 
     &:hover {
-      background: govuk-colour("light-grey", $legacy: "grey-3");
+      background: govuk-colour("light-grey");
     }
   }
 }

--- a/app/assets/stylesheets/components/_signup-link.scss
+++ b/app/assets/stylesheets/components/_signup-link.scss
@@ -21,7 +21,7 @@
 
 .app-c-signup-link--with-background-and-border {
   padding: govuk-spacing(6);
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   border: 1px solid $govuk-border-colour;
 }
 

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -132,7 +132,7 @@
         }
 
         &:hover {
-          background: govuk-colour("light-grey", $legacy: "grey-3");
+          background: govuk-colour("light-grey");
           color: $govuk-link-colour;
 
           p {

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -76,7 +76,7 @@
 }
 
 .organisation__contact-section--border-top {
-  border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+  border-top: 1px solid govuk-colour("mid-grey");
   margin-bottom: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -11,7 +11,7 @@
     list-style-type: none;
     padding-bottom: govuk-spacing(3);
     margin-bottom: govuk-spacing(3);
-    border-bottom: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+    border-bottom: 1px solid govuk-colour("mid-grey");
   }
 
   .organisation-list__item-title {
@@ -20,7 +20,7 @@
   }
 
   .organisation-list__item-context {
-    color: govuk-colour("dark-grey", $legacy: "grey-1");
+    color: govuk-colour("dark-grey");
     white-space: nowrap;
   }
 
@@ -45,7 +45,7 @@
   }
 
   .organisation-list__works-with {
-    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+    background-color: govuk-colour("light-grey");
     margin-top: govuk-spacing(2);
     padding: govuk-spacing(2);
   }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -7,7 +7,7 @@
 }
 
 .taxon-page__email-link-wrapper {
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   margin-top: -(govuk-spacing(6));
   margin-bottom: govuk-spacing(6);
   border-bottom: 1px solid $govuk-border-colour;
@@ -77,7 +77,7 @@
 }
 
 .taxon-page__grid {
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   padding-top: govuk-spacing(6);
   margin-top: 60px;
 

--- a/app/assets/stylesheets/views/_transition-landing-page.scss
+++ b/app/assets/stylesheets/views/_transition-landing-page.scss
@@ -231,7 +231,7 @@ $green: #00703C;
   margin-bottom: govuk-spacing(6);
 
   &:before {
-    border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+    border-top: 1px solid govuk-colour("mid-grey");
     content: "";
     display: block;
     margin-right: govuk-spacing(3);


### PR DESCRIPTION
Turn off compatibility mode with GOV.UK Elements and remove legacy colour declarations.