### PR TITLE
Send errors to sentry to see why are users shown an error message

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -15,14 +15,29 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
   def results
     if params["postcode-lookup"].blank?
+      GovukError.notify(
+        "Postcode left blank",
+        extra: { error_message: "Postcode field left blank" },
+      )
+
       return render_no_postcode_error
     end
 
     @postcode = PostcodeService.new(params["postcode-lookup"]).sanitize
 
     if @postcode.blank?
+      GovukError.notify(
+        "Sanitized postcode is blank",
+        extra: { error_message: "Postcode is blank after being sanitized" },
+      )
+
       return render_no_postcode_error
     elsif !PostcodeService.new(@postcode).valid?
+      GovukError.notify(
+        "Postcode failed validation",
+        extra: { error_message: "Postcode #{@postcode} failed validation after being sanitized" },
+      )
+
       return render_invalid_postcode_error
     end
 
@@ -36,8 +51,18 @@ class CoronavirusLocalRestrictionsController < ApplicationController
                       breadcrumbs: breadcrumbs,
                     }
     elsif @location_lookup.invalid_postcode?
+      GovukError.notify(
+        "Postcode failed Mapit validation",
+        extra: { error_message: "Postcode #{@postcode} failed validation with Mapit" },
+      )
+
       return render_invalid_postcode_error
     elsif @location_lookup.postcode_not_found?
+      GovukError.notify(
+        "Mapit couldn't find postcode",
+        extra: { error_message: "Postcode #{@postcode} couldn't be found in Mapit" },
+      )
+
       return render_no_postcode_error
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/dZz2sedX

# What?

Send postcode errors the user is seeing to Sentry we can see if there are any common problems.

# Why?

We know that between 12 - 15% of users will see an error message when they enter their postcode. (Tracking began on 20 October)
We also receive a fair amount of feedback about this. This seems high.
However, we don't know why users are seeing these errors. 

# Results from testing in integration

## Submitting a blank postcode
<img width="603" alt="Screenshot 2020-11-11 at 12 21 28" src="https://user-images.githubusercontent.com/5793815/98812506-8b50a580-241a-11eb-964e-d7222b5de7f6.png">
<img width="506" alt="Screenshot 2020-11-11 at 12 22 15" src="https://user-images.githubusercontent.com/5793815/98812562-a02d3900-241a-11eb-8036-e6b9c03a531b.png">


## Submitting a postcode with a special character in it
<img width="542" alt="Screenshot 2020-11-11 at 12 24 03" src="https://user-images.githubusercontent.com/5793815/98812608-b509cc80-241a-11eb-991f-5dc41c9f07a1.png">
<img width="864" alt="Screenshot 2020-11-11 at 12 30 28" src="https://user-images.githubusercontent.com/5793815/98812682-d23e9b00-241a-11eb-9f05-a3c4d2635dc9.png">
