### PR TITLE
Render breadcrumbs dynamically

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -6,7 +6,6 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     render :show,
            locals: {
-             breadcrumbs: breadcrumbs,
              error_message: nil,
              input_error: nil,
              error_description: nil,
@@ -14,6 +13,8 @@ class CoronavirusLocalRestrictionsController < ApplicationController
   end
 
   def results
+    @content_item = content_item.to_hash
+
     if params["postcode-lookup"].blank?
       return render_no_postcode_error
     end
@@ -26,15 +27,10 @@ class CoronavirusLocalRestrictionsController < ApplicationController
       return render_invalid_postcode_error
     end
 
-    @content_item = content_item.to_hash
-
     @location_lookup = LocationLookupService.new(@postcode)
 
     if @location_lookup.no_information?
-      return render :no_information,
-                    locals: {
-                      breadcrumbs: breadcrumbs,
-                    }
+      return render :no_information
     elsif @location_lookup.invalid_postcode?
       return render_invalid_postcode_error
     elsif @location_lookup.postcode_not_found?
@@ -58,7 +54,6 @@ private
   def render_no_postcode_error
     render :show,
            locals: {
-             breadcrumbs: breadcrumbs,
              error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
              input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
              error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
@@ -68,26 +63,10 @@ private
   def render_invalid_postcode_error
     render :show,
            locals: {
-             breadcrumbs: breadcrumbs,
              error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
              input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
              error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
            }
-  end
-
-  # Breadcrumbs for this page are hardcoded because it doesn't yet have a
-  # content item with parents.
-  def breadcrumbs
-    [
-      {
-        title: "Home",
-        url: "/",
-      },
-      {
-        title: "Coronavirus (COVID-19)",
-        url: "/coronavirus",
-      },
-    ]
   end
 
   def content_item

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -4,10 +4,7 @@
 %>
 
 <% content_for :breadcrumbs do %>
-  <%= render 'govuk_publishing_components/components/breadcrumbs', {
-    breadcrumbs: breadcrumbs,
-    collapse_on_mobile: true
-  } %>
+  <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: @content_item %>
 <% end %>
 
 <% content_for :title, title %>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -49,14 +49,7 @@
   </div>
   <div class="govuk-grid-column-one-third">
     <div class="coronavirus-local-restriction__related-navigation">
-      <%= render 'govuk_publishing_components/components/related_navigation', {
-        "content_item": {
-          "links" => {
-            "ordered_related_items" => t("coronavirus_local_restrictions.related_navigation").map(&:with_indifferent_access)
-          }
-        },
-        context: :sidebar
-      } %>
+      <%= render 'govuk_publishing_components/components/contextual_sidebar', { "content_item": @content_item } %>
     </div>
   </div>
 </div>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -52,4 +52,7 @@
       <%= render 'govuk_publishing_components/components/contextual_sidebar', { "content_item": @content_item } %>
     </div>
   </div>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render 'govuk_publishing_components/components/contextual_footer', { content_item: @content_item } %>
+  </div>
 </div>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -26,13 +26,6 @@ en:
     royal_mail_lookup:
       link_text: Find a postcode on Royal Mail’s postcode finder
       href: https://www.royalmail.com/find-a-postcode
-    related_navigation:
-      - title: "Coronavirus (COVID-19): guidance and support"
-        base_path: /coronavirus
-      - title: Find out what support you can get if you’re affected by coronavirus
-        base_path: /find-coronavirus-support
-      - title: Making a support bubble with another household
-        base_path: /guidance/making-a-support-bubble-with-another-household
     results:
       travel_heading: Find information about somewhere else
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -5,10 +5,12 @@ describe CoronavirusLocalRestrictionsController do
   include GdsApi::TestHelpers::Mapit
   include GdsApi::TestHelpers::ContentStore
 
+  before do
+    stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
+  end
+
   describe "GET show" do
     it "correctly renders the local restrictions page" do
-      stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
-
       get :show
 
       assert_response :success
@@ -27,8 +29,6 @@ describe CoronavirusLocalRestrictionsController do
         },
       ]
       stub_mapit_has_a_postcode_and_areas(postcode, [], areas)
-
-      stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
 
       post :results, params: { "postcode-lookup" => postcode }
 

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -123,13 +123,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     end
   end
 
-  describe "related links" do
-    it "renders related links" do
-      given_i_am_on_the_local_restrictions_page
-      then_i_see_the_related_links_for_coronavirus
-    end
-  end
-
   def given_i_am_on_the_local_restrictions_page
     stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
 
@@ -341,13 +334,5 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       "type" => "LBO",
       "country_name" => "England",
     }
-  end
-
-  def then_i_see_the_related_links_for_coronavirus
-    within ".gem-c-related-navigation" do
-      I18n.t("coronavirus_local_restrictions.related_navigation").each do |link|
-        assert page.has_link?(link[:title], href: link[:base_path])
-      end
-    end
   end
 end


### PR DESCRIPTION
This removes the hardcoded breadcrumbs now that the `find-coronavirus-local-restrictions` page has a content item. There are some other code changes that are in place either to allow the tests to pass or to ensure that the landing page can be accessed without the hardcoded breadcrumbs.

The only visual difference is the addition of the footer. The breadcrumbs and the sidebar will remain the same
### Before
#### Computer
<img width="1105" alt="Screenshot 2020-11-12 at 12 01 39" src="https://user-images.githubusercontent.com/24547207/98938007-2b700280-24df-11eb-9595-427499894f2b.png">

#### Phone
<img width="399" alt="Screenshot 2020-11-12 at 12 01 46" src="https://user-images.githubusercontent.com/24547207/98938031-332fa700-24df-11eb-8247-78ad1773ec50.png">

### After
#### Computer
<img width="1424" alt="Screenshot 2020-11-12 at 12 00 43" src="https://user-images.githubusercontent.com/24547207/98938049-39be1e80-24df-11eb-9aa5-64d385e93d3e.png">

#### Phone
<img width="396" alt="Screenshot 2020-11-12 at 12 01 02" src="https://user-images.githubusercontent.com/24547207/98938062-3cb90f00-24df-11eb-899b-bdc2fcd65c86.png">
