### PR TITLE
Remove "Error: " from page heading

### DIFF
--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -38,7 +38,7 @@
       } %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/title", title: title %>
+    <%= render "govuk_publishing_components/components/title", title: t("coronavirus_local_restrictions.lookup.title") %>
 
     <%= render "govuk_publishing_components/components/inset_text", text: sanitize(t('coronavirus_local_restrictions.lookup.inset_text')) %>
 


### PR DESCRIPTION
Trello: https://trello.com/c/kjAcGOGg

# What's changed and why?

Removes "Error: " from page heading. "Error: " should only be prepended to the page title, not the H1 heading.

# Expected changes
## Before
<img width="1551" alt="Screenshot 2020-11-11 at 14 41 26" src="https://user-images.githubusercontent.com/5793815/98827932-5569ec00-242f-11eb-88ae-0e912007b951.png">

## After
<img width="1551" alt="Screenshot 2020-11-11 at 15 02 36" src="https://user-images.githubusercontent.com/5793815/98827947-5ac73680-242f-11eb-8f35-be09d9a4e44f.png">


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/collections), after merging.
