### PR TITLE
Update welsh translations on Transition landing page

### DIFF
--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -58,6 +58,13 @@ cy:
     comms:
       links:
       - link:
+          text: "Government publishes updated GB-EU Border Operating Model"
+          path: "/government/news/government-publishes-updated-gb-eu-border-operating-model"
+          description: The government has published further detail on how the borders between Great Britain and the EU will work and the actions that traders, hauliers and passengers need to take.
+        metadata:
+          public_updated_at: 2020-10-08
+          document_type: "News Story"
+      - link:
           text: "£650 million investment for Northern Ireland"
           path: "/government/news/major-650-million-investment-for-northern-ireland"
           description: "The Chancellor of the Duchy of Lancaster and the Secretary of State for Northern Ireland have announced a £650m package of investment."
@@ -78,13 +85,6 @@ cy:
         metadata:
           public_updated_at: 2020-02-27
           document_type: "Policy Paper"
-      - link:
-          text: "Government speeds up border planning for the end of the transition period"
-          path: "/government/news/government-accelerates-border-planning-for-the-end-of-the-transition-period"
-          description: Border controls for EU goods imported into Great Britain will be introduced in stages from the end of the transition period.
-        metadata:
-          public_updated_at: 2020-06-12
-          document_type: "News Story"
     topic_section_header: Yr holl wybodaeth am y cyfnod pontio
     topic_section_subheading: Pori’r holl wybodaeth sy’n berthnasol i’r cyfnod pontio
     email_mailto_subject: "Dechrau%20newydd%20y%20DU:%20Ymlaen%20â%20ni-%20GOV.UK"
@@ -97,7 +97,7 @@ cy:
       research_and_statistics: Ymchwil ag ystadegau
       policy_and_engagement: Polisi ac ymgynghoriadau
       transparency: Tryloywder a datganiadau rhyddid gwybodaeth
-    ## Unused keys? 
+    ## Unused keys?
     guidance_subheader: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
     email_intro: "I gael y manylion diweddaraf"
     email: "Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio"

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -39,6 +39,21 @@ cy:
       to_watch_text: i wylio’r fideo
       or_text: neu
       watch_link_text: Gwylio ar YouTube
+    guidance_header: "Newidiadau i fusnesau a dinasyddion"
+    campaign_links:
+      lead_in: "Mae’n rhaid i chi gymryd camau nawr os ydych chi’n:"
+      links:
+        - text: mewnforio nwyddau i mewn i’r DU
+          path: /prepare-to-import-to-great-britain-from-january-2021
+        - text: allforio nwyddau allan o’r DU
+          path: /prepare-to-export-from-great-britain-from-january-2021
+        - text: teithio i’r UE
+          path: /visit-europe-1-january-2021
+        - text: byw a gweithio yn yr UE
+          path: /uk-nationals-living-eu
+        - text: aros yn y DU os ydych chi’n ddinesydd o’r UE
+          path: /staying-uk-eu-citizen
+      lead_out: <a href="/transition-check/questions" class="govuk-link">Cael y rhestr gyflawn</a> o'r hyn y mae angen i chi ei wneud ar eich cyfer chi, eich busnes a'ch teulu.
     comms_header: "Cyhoeddiadau"
     comms:
       links:
@@ -70,26 +85,8 @@ cy:
         metadata:
           public_updated_at: 2020-06-12
           document_type: "News Story"
-    guidance_header: "Newidiadau i fusnesau a dinasyddion"
-    guidance_subheader: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
-    campaign_links:
-      lead_in: "Mae’n rhaid i chi gymryd camau nawr os ydych chi’n:"
-      links:
-        - text: mewnforio nwyddau i mewn i’r DU
-          path: /prepare-to-import-to-great-britain-from-january-2021
-        - text: allforio nwyddau allan o’r DU
-          path: /prepare-to-export-from-great-britain-from-january-2021
-        - text: teithio i’r UE
-          path: /visit-europe-1-january-2021
-        - text: byw a gweithio yn yr UE
-          path: /uk-nationals-living-eu
-        - text: aros yn y DU os ydych chi’n ddinesydd o’r UE
-          path: /staying-uk-eu-citizen
-      lead_out: <a href="/transition-check/questions" class="govuk-link">Cael y rhestr gyflawn</a> o'r hyn y mae angen i chi ei wneud ar eich cyfer chi, eich busnes a'ch teulu.
     topic_section_header: Yr holl wybodaeth am y cyfnod pontio
     topic_section_subheading: Pori’r holl wybodaeth sy’n berthnasol i’r cyfnod pontio
-    email_intro: "I gael y manylion diweddaraf"
-    email: "Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio"
     email_mailto_subject: "Dechrau%20newydd%20y%20DU:%20Ymlaen%20â%20ni-%20GOV.UK"
     share_links: "Rhannu’r dudalen hon"
     sections:
@@ -100,3 +97,7 @@ cy:
       research_and_statistics: Ymchwil ag ystadegau
       policy_and_engagement: Polisi ac ymgynghoriadau
       transparency: Tryloywder a datganiadau rhyddid gwybodaeth
+    ## Unused keys? 
+    guidance_subheader: "Camau y gallwch eu cymryd nawr sydd ddim yn ddibynnol ar drafodaethau."
+    email_intro: "I gael y manylion diweddaraf"
+    email: "Cofrestrwch i gael hysbysiadau ebost am y cyfnod pontio"

--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -2,7 +2,7 @@ cy:
   transition_landing_page:
     meta_title: Pontio’r DU
     meta_description: "Mae’r DU wedi gadael yr UE. Ewch i weld beth mae’n ei olygu i chi."
-    page_header: "Pontio’r DU:<br/>mae amser yn rhedeg allan"
+    page_header: "Pontio Brexit:<br/>mae amser yn rhedeg allan"
     page_header_highlight: Bydd rheolau newydd
     page_header_explainer: i fusnesau a dinasyddion o 1 Ionawr 2021.
     countdown_days_to_go: diwrnod i fynd
@@ -18,7 +18,7 @@ cy:
       green: Ewch
     video_section_title: "Mae amser yn rhedeg allan"
     video_section_description: |
-      <p>Mae’r DU yn gadael marchnad sengl ac undeb tollau’r UE, a bydd diwedd y cyfnod pontio yn effeithio ar ddinasyddion, busnesau a theithio i’r UE ac oddi yno.</p>
+      <p>Mae’n rhaid i chi weithredu nawr. Mae’r rheolau newydd yn effeithio ar ddinasyddion, busnesau a theithio i’r UE. Gwnewch yn siŵr eich bod yn barod ar gyfer ddiwedd cyfnod pontio Brexit.</p>
       <p>Gwyliwch y fideo i wybod beth fydd 2021 yn ei olygu i chi.</p>
     video_section_link: https://www.youtube.com/watch?v=_Hyq5U4mLdQ
     video_section_transcription_summary: Gwelwch y trawsgrifiad fideo
@@ -43,10 +43,12 @@ cy:
     campaign_links:
       lead_in: "Mae’n rhaid i chi gymryd camau nawr os ydych chi’n:"
       links:
-        - text: mewnforio nwyddau i mewn i’r DU
+        - text: mewnforio nwyddau o’r UE
           path: /prepare-to-import-to-great-britain-from-january-2021
-        - text: allforio nwyddau allan o’r DU
+        - text: allforio nwyddau i’r UE
           path: /prepare-to-export-from-great-britain-from-january-2021
+        - text: symud nwyddau i mewn neu allan o Ogledd Iwerddon
+          path: /guidance/moving-goods-into-out-of-or-through-northern-ireland-from-1-january-2021
         - text: teithio i’r UE
           path: /visit-europe-1-january-2021
         - text: byw a gweithio yn yr UE


### PR DESCRIPTION
## What

- Reorder the content on the Welsh transition landing page yaml file so it matches the order of content on the English language version. 

- Amend the announcements section of the welsh version of the page so it matches those on the English language version. This had unintentionally become out of date.  

- Update the content of the welsh page to reflect the recent batch of changes https://github.com/alphagov/collections/pull/2065

Might be easier to review commit by commit.

[Trello](https://trello.com/c/CKDnHATh/593-welsh-translations-for-landing-page)
[Review app](https://govuk-collec-update-wel-rip1l2.herokuapp.com/transition.cy)
[Welsh translation file](https://drive.google.com/file/d/10bvSTeJ3Jb8PNBAbsQUAIxBSS03gKvOZ/view?usp=sharing)

