### PR TITLE
Update heading structure

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -42,6 +42,7 @@
 <div data-module="track-click">
   <div data-module="toggle-attribute">
     <%= render 'govuk_publishing_components/components/accordion', {
+      heading_level: 3,
       data_attributes: {
         module: "govuk-accordion"
       },

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -1,6 +1,6 @@
 <% section["sub_sections"].each do |sub_section| %>
   <% if sub_section["title"] %>
-    <h3 class="govuk-heading-s covid__accordion-heading"><%= sub_section["title"] %></h3>
+    <h4 class="govuk-heading-s covid__accordion-heading"><%= sub_section["title"] %></h4>
   <% end %>
   <ul class="covid__list covid__list--accordion">
     <% sub_section["list"].each do | item | %>

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -12,9 +12,9 @@ describe('Coronavirus landing page', function () {
       </div>\
       <div class="govuk-accordion__section">\
         <div class="govuk-accordion__section-header">\
-          <h2 class="govuk-accordion__section-heading">\
+          <h3 class="govuk-accordion__section-heading">\
             <button type="button">How to protect yourself and others</button><span class="govuk-accordion__icon" aria-hidden="true"></span>\
-          </h2>\
+          </h3>\
         </div>\
         <div class="govuk-accordion__section-content">\
           accordion content\


### PR DESCRIPTION
## What?

Fix to update headings within the accordion to be a sub-level to that of the parent.

## Why?
Related to WCAG 1.3.1
[Screen reader and user style users might get confused about the structure of the content and the relationship between different sections.](https://trello.com/c/zerL3LWn) 

## Anything else?

No visual change

![Screenshot 2020-11-13 at 10 23 25](https://user-images.githubusercontent.com/71266765/99062444-ead5bf00-259a-11eb-8366-43bb0887ec40.png)

![image](https://user-images.githubusercontent.com/71266765/99097319-605b8280-25cf-11eb-88c6-e5e0b8d4f009.png)
