### PR TITLE
Adjust social links hidden text

### DIFF
--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -17,7 +17,7 @@ module Organisations
         links << {
           href: link["href"],
           text: link["title"],
-          hidden_text: "Follow on",
+          hidden_text: link["title"].include?('Sign up') ? "" : "Follow on",
           icon: link["service_type"],
         }
       end

--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -14,10 +14,11 @@ module Organisations
       links = []
 
       org.social_media_links.each do |link|
+        link_has_cta = ["Sign up", "Follow", "Watch", "Read"].any? { |cta| link["title"].include?(cta) }
         links << {
           href: link["href"],
           text: link["title"],
-          hidden_text: link["title"].include?('Sign up') ? "" : "Follow on",
+          hidden_text: link_has_cta ? "" : "Follow on",
           icon: link["service_type"],
         }
       end


### PR DESCRIPTION
## What
Amend the hidden text for organisation social media links. So that AT users can have a better experience.

## Why
There are instances where it does not make sense to have "Follow on" hidden text before the social media link text. Prime example here: https://www.gov.uk/government/organisations/land-registry

<img width="427" alt="Screenshot 2020-11-18 at 11 46 03" src="https://user-images.githubusercontent.com/7116819/99526779-a9c31d80-2993-11eb-9003-106314b88faf.png">


Screen reader software would read these social links as 
- Follow on Sign up for email alerts
- Follow on Read our blog posts
- Follow on Follow us on Twitter @HMLandRegistry

...etc etc


It makes sense to add "Follow on" for more context when the link text is just one word (for instance "Follow on Facebook" would make more sense to a screen reader user than just "Facebook"). 
It does not make sense to add hidden text when the social link text already contains a verb like "Watch our videos on YouTube".


https://trello.com/c/shAQ6AQu