### PR TITLE
Update postcode error tracking on local restrictions

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-track-local-restrictions.js
+++ b/app/assets/javascripts/modules/coronavirus-track-local-restrictions.js
@@ -24,12 +24,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var errorMessage = element.querySelector('[data-tracking=local-restrictions-postcode-error]')
 
     if (errorMessage) {
+      var errorCode = errorMessage.getAttribute('data-error-code')
       var options = {
         transport: "beacon",
         label: errorMessage.textContent.trim()
       }
 
-      GOVUK.analytics.trackEvent("userAlerts:local_lockdown", "postcodeErrorShown: invalidPostcodeFormat", options)
+      GOVUK.analytics.trackEvent("userAlerts:local_lockdown", "postcodeErrorShown: " + errorCode, options)
     }
   }
 

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -16,15 +16,15 @@ class CoronavirusLocalRestrictionsController < ApplicationController
     @content_item = content_item.to_hash
 
     if params["postcode-lookup"].blank?
-      return render_no_postcode_error
+      return render_no_postcode_error("postcodeLeftBlank")
     end
 
     @postcode = PostcodeService.new(params["postcode-lookup"]).sanitize
 
     if @postcode.blank?
-      return render_no_postcode_error
+      return render_no_postcode_error("postcodeLeftBlankSanitized")
     elsif !PostcodeService.new(@postcode).valid?
-      return render_invalid_postcode_error
+      return render_invalid_postcode_error("invalidPostcodeFormat")
     end
 
     @location_lookup = LocationLookupService.new(@postcode)
@@ -32,9 +32,9 @@ class CoronavirusLocalRestrictionsController < ApplicationController
     if @location_lookup.no_information?
       return render :no_information
     elsif @location_lookup.invalid_postcode?
-      return render_invalid_postcode_error
+      return render_invalid_postcode_error("fullPostcodeNoMapitValidation")
     elsif @location_lookup.postcode_not_found?
-      return render_no_postcode_error
+      return render_no_postcode_error("fullPostcodeNoMapitMatch")
     end
 
     if @location_lookup.data.present?
@@ -51,21 +51,23 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
 private
 
-  def render_no_postcode_error
+  def render_no_postcode_error(error_code)
     render :show,
            locals: {
              error_message: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"),
              input_error: I18n.t("coronavirus_local_restrictions.errors.no_postcode.input_error"),
              error_description: I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_description"),
+             error_code: error_code,
            }
   end
 
-  def render_invalid_postcode_error
+  def render_invalid_postcode_error(error_code)
     render :show,
            locals: {
              error_message: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"),
              input_error: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"),
              error_description: I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_description"),
+             error_code: error_code,
            }
   end
 

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -28,7 +28,8 @@
             text: error_description,
             href: "#postcodeLookup",
             data_attributes: {
-              tracking: "local-restrictions-postcode-error"
+              tracking: "local-restrictions-postcode-error",
+              "error-code": error_code,
             }
           }
         ]

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -10,11 +10,11 @@ en:
         input_error: Enter a valid postcode
         error_description: Enter a valid postcode
     lookup:
-      input_label: Enter a full postcode 
+      input_label: Enter a full postcode
       hint_text: |
         For example, LS1 1UR
 
-        We use this to give you more accurate information about the area. 
+        We use this to give you more accurate information about the area.
       button_text: Find
       title: Find out the coronavirus restrictions in a local area
       inset_text: |

--- a/spec/javascripts/modules/coronavirus-track-local-restrictions_spec.js
+++ b/spec/javascripts/modules/coronavirus-track-local-restrictions_spec.js
@@ -45,7 +45,7 @@ describe('Coronavirus local restrictions landing page', function () {
         <h2 class="govuk-error-summary__title">There is a problem</h2> \
       <div class="govuk-error-summary__body"> \
           <ul class="govuk-list govuk-error-summary__list"> \
-              <li class="gem-c-error-summary__list-item" data-tracking="local-restrictions-postcode-error"><a href="#postcodeLookup">Enter a postcode</a></li> \
+              <li class="gem-c-error-summary__list-item" data-tracking="local-restrictions-postcode-error" data-error-code="invalidPostcodeFormat"><a href="#postcodeLookup">Enter a postcode</a></li> \
           </ul> \
       </div> \
       </div>\


### PR DESCRIPTION
## What and why
Update postcode error tracking on local restrictions to capture more system-level errors so we can get a better understanding of what's causing the failures.

[Trello card](https://trello.com/c/ie3LZgOW)

## Examples
`postcodeLeftBlank`

<img width="1438" alt="Screenshot 2020-11-19 at 16 15 41" src="https://user-images.githubusercontent.com/788096/99693123-ede11b80-2a82-11eb-86cf-52ea8ce57100.png">

`invalidPostcodeFormat`

<img width="1438" alt="Screenshot 2020-11-19 at 16 16 05" src="https://user-images.githubusercontent.com/788096/99693135-f174a280-2a82-11eb-9184-db79583883e8.png">
