### PR TITLE
Update content on postcode checker results pages before it goes live again

### DIFF
--- a/app/views/coronavirus_local_restrictions/_national_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_national_restrictions.html.erb
@@ -1,12 +1,12 @@
-<%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_local_restrictions.results.national_restrictions.heading"),
-    font_size: "m",
-    margin_bottom: 4
-} %>
-
 <%= render "govuk_publishing_components/components/action_link", {
     text: t("coronavirus_local_restrictions.results.national_restrictions.action_label"),
     href: t("coronavirus_local_restrictions.results.national_restrictions.action_link"),
     simple: true,
     margin_bottom: 9
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+    text: t("coronavirus_local_restrictions.results.national_restrictions.heading"),
+    font_size: "m",
+    margin_bottom: 4
 } %>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/action_link", {
-    text: t("coronavirus_local_restrictions.results.guidance_label"),
+    text: t("coronavirus_local_restrictions.results.guidance_label", level: 1),
     href: t("coronavirus_local_restrictions.results.level_one.guidance_link"),
     simple: true,
     margin_bottom: 9

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -1,8 +1,8 @@
 <%
   title = if @restriction.present? && @restriction.future.present?
-    t("coronavirus_local_restrictions.results.changing_levels_title")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   else
-    t("coronavirus_local_restrictions.results.level_one.heading")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   end
 %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -20,20 +20,15 @@
     <%= t("coronavirus_local_restrictions.results.level_one.match") %> <strong><%= @postcode %></strong> to <strong><%= @location_lookup.lower_tier_area_name %></strong>.
   </p>
 
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_local_restrictions.results.current_level_heading"),
-    font_size: "m",
-    margin_bottom: 4
-  } %>
   <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_one.changing_alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_one.alert_level", area: @location_lookup.lower_tier_area_name) %>
     </p>
   <% else %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_one.alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_one.alert_level", area: @location_lookup.lower_tier_area_name) %>
     </p>
   <% end %>
 
@@ -43,8 +38,6 @@
     simple: true,
     margin_bottom: 9
   } %>
-
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -25,6 +25,7 @@
     font_size: "m",
     margin_bottom: 4
   } %>
+  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
@@ -44,8 +45,6 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -1,8 +1,8 @@
 <%
   title = if @restriction.present? && @restriction.future.present?
-    t("coronavirus_local_restrictions.results.changing_levels_title")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   else
-    t("coronavirus_local_restrictions.results.level_three.heading")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   end
 %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/action_link", {
-    text: t("coronavirus_local_restrictions.results.guidance_label"),
+    text: t("coronavirus_local_restrictions.results.guidance_label", level: 3),
     href: t("coronavirus_local_restrictions.results.level_three.guidance_link"),
     simple: true,
     margin_bottom: 9

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -20,20 +20,15 @@
     <%= t("coronavirus_local_restrictions.results.level_three.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
   </p>
 
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_local_restrictions.results.current_level_heading"),
-    font_size: "m",
-    margin_bottom: 4
-  } %>
   <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_three.changing_alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_three.alert_level", area: @restriction.area_name) %>
     </p>
   <% else %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_three.alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_three.alert_level", area: @restriction.area_name) %>
     </p>
   <% end %>
 
@@ -43,8 +38,6 @@
     simple: true,
     margin_bottom: 9
   } %>
-
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -25,6 +25,7 @@
     font_size: "m",
     margin_bottom: 4
   } %>
+  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
@@ -44,8 +45,6 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -1,8 +1,8 @@
 <%
   title = if @restriction.present? && @restriction.future.present?
-    t("coronavirus_local_restrictions.results.changing_levels_title")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   else
-    t("coronavirus_local_restrictions.results.level_two.heading")
+    t("coronavirus_local_restrictions.results.current_level_heading")
   end
 %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -38,7 +38,7 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/action_link", {
-    text: t("coronavirus_local_restrictions.results.guidance_label"),
+    text: t("coronavirus_local_restrictions.results.guidance_label", level: 2),
     href: t("coronavirus_local_restrictions.results.level_two.guidance_link"),
     simple: true,
     margin_bottom: 9

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -25,6 +25,7 @@
     font_size: "m",
     margin_bottom: 4
   } %>
+  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
@@ -44,8 +45,6 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
-
-  <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -20,20 +20,15 @@
     <%= t("coronavirus_local_restrictions.results.level_two.match") %> <strong><%= @postcode %></strong> to <strong><%= @restriction.area_name %></strong>.
   </p>
 
-  <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_local_restrictions.results.current_level_heading"),
-    font_size: "m",
-    margin_bottom: 4
-  } %>
   <%= render partial: "coronavirus_local_restrictions/national_restrictions" %>
 
   <% if @restriction.present? && @restriction.future.present? %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_two.changing_alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_two.alert_level", area: @restriction.area_name) %>
     </p>
   <% else %>
     <p class="govuk-body">
-      <%= t("coronavirus_local_restrictions.results.level_two.alert_level") %>
+      <%= t("coronavirus_local_restrictions.results.level_two.alert_level", area: @restriction.area_name) %>
     </p>
   <% end %>
 
@@ -43,8 +38,6 @@
     simple: true,
     margin_bottom: 9
   } %>
-
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
 
   <%= render partial: "coronavirus_local_restrictions/travel_guidance", locals: { travel_heading: t("coronavirus_local_restrictions.results.travel_heading") } %>
 <% end %>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -32,7 +32,7 @@ en:
     results:
       travel_heading: Find information about somewhere else
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>
-      current_level_heading: Current tier
+      current_level_heading: National restrictions are in place
       changing_levels_title: The tier is changing soon
       guidance_label: What you can and cannot do
       national_restrictions:

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -34,7 +34,7 @@ en:
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>
       current_level_heading: National restrictions are in place
       changing_levels_title: The tier is changing soon
-      guidance_label: What you can and cannot do
+      guidance_label: Find out what the tier %{level} rules are
       national_restrictions:
         heading: From 2 December
         action_label: Find out what the national rules are

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -36,8 +36,8 @@ en:
       changing_levels_title: The tier is changing soon
       guidance_label: What you can and cannot do
       national_restrictions:
-        heading: National restrictions begin in England from 5 November
-        action_label: Find out about new restrictions and what you can and cannot do
+        heading: From 2 December
+        action_label: Find out what the national rules are
         action_link: /guidance/new-national-restrictions-from-5-november
       level_one:
         heading: "Tier 1"

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -42,18 +42,18 @@ en:
       level_one:
         heading: "Tier 1"
         match: "We've matched the postcode"
-        alert_level: "This area is in tier 1."
+        alert_level: "%{area} will be in tier 1."
         changing_alert_level: "At the moment this area is in tier 1."
         guidance_link: "/guidance/local-covid-alert-level-medium"
       level_two:
         heading: "Tier 2"
-        alert_level: "This area is in tier 2."
+        alert_level: "%{area} will be in tier 2."
         changing_alert_level: "At the moment this area is in tier 2."
         guidance_link: "/guidance/local-covid-alert-level-high"
         match: "We've matched the postcode"
       level_three:
         heading: "Tier 3"
-        alert_level: "This area is in tier 3."
+        alert_level: "%{area} will be in tier 3."
         changing_alert_level: "At the moment this area is in tier 3."
         guidance_link: "/guidance/local-covid-alert-level-very-high"
         match: "We've matched the postcode"

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -32,29 +32,29 @@ en:
     results:
       travel_heading: Find information about somewhere else
       travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>
-      current_level_heading: Current Local COVID Alert Level
-      changing_levels_title: The Local COVID Alert Level is changing soon
+      current_level_heading: Current tier
+      changing_levels_title: The tier is changing soon
       guidance_label: What you can and cannot do
       national_restrictions:
         heading: National restrictions begin in England from 5 November
         action_label: Find out about new restrictions and what you can and cannot do
         action_link: /guidance/new-national-restrictions-from-5-november
       level_one:
-        heading: "Local COVID Alert Level: Medium"
+        heading: "Tier 1"
         match: "We've matched the postcode"
-        alert_level: "This area is in Local COVID Alert Level: Medium."
-        changing_alert_level: "At the moment this area is in Local COVID Alert Level: Medium."
+        alert_level: "This area is in tier 1."
+        changing_alert_level: "At the moment this area is in tier 1."
         guidance_link: "/guidance/local-covid-alert-level-medium"
       level_two:
-        heading: "Local COVID Alert Level: High"
-        alert_level: "This area is in Local COVID Alert Level: High."
-        changing_alert_level: "At the moment this area is in Local COVID Alert Level: High."
+        heading: "Tier 2"
+        alert_level: "This area is in tier 2."
+        changing_alert_level: "At the moment this area is in tier 2."
         guidance_link: "/guidance/local-covid-alert-level-high"
         match: "We've matched the postcode"
       level_three:
-        heading: "Local COVID Alert Level: Very High"
-        alert_level: "This area is in Local COVID Alert Level: Very High."
-        changing_alert_level: "At the moment this area is in Local COVID Alert Level: Very High."
+        heading: "Tier 3"
+        alert_level: "This area is in tier 3."
+        changing_alert_level: "At the moment this area is in tier 3."
         guidance_link: "/guidance/local-covid-alert-level-very-high"
         match: "We've matched the postcode"
       devolved_nations:
@@ -78,11 +78,11 @@ en:
           label: Full list of Local COVID Alert Levels by area
           link: "/guidance/full-list-of-local-covid-alert-levels-by-area"
       future:
-        heading: Future Local COVID Alert Level
+        heading: Future tier
         guidance_label: What you can and cannot do from %{date}
         level_one:
-          alert_level: "From %{date} this area will be in Local COVID Alert Level: Medium."
+          alert_level: "From %{date} this area will be in tier 1."
         level_two:
-          alert_level: "From %{date} this area will be Local COVID Alert Level: High."
+          alert_level: "From %{date} this area will be in tier 2."
         level_three:
-          alert_level: "From %{date} this area will be in Local COVID Alert Level: Very High."
+          alert_level: "From %{date} this area will be in tier 3."

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -265,21 +265,21 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_see_the_results_page_for_level_one
-    assert page.has_text?("Tatooine")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.heading"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.alert_level"))
+    area = "Tatooine"
+    assert page.has_text?(area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.alert_level", area: area))
   end
 
   def then_i_see_the_results_page_for_level_two
-    assert page.has_text?("Coruscant Planetary Council")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.heading"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level"))
+    area = "Coruscant Planetary Council"
+    assert page.has_text?(area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level", area: area))
   end
 
   def then_i_see_the_results_page_for_level_three
-    assert page.has_text?("Mandalore")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.heading"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.alert_level"))
+    area = "Mandalore"
+    assert page.has_text?(area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.alert_level", area: area))
   end
 
   def then_i_see_details_of_national_restrictions
@@ -312,19 +312,17 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   end
 
   def then_i_see_the_results_page_for_level_one_with_changing_restriction_levels
-    date = "2021-10-12".to_date.strftime("%-d %B")
+    area = "Naboo"
 
-    assert page.has_text?("Naboo")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.changing_alert_level"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.future.level_two.alert_level", date: date))
+    assert page.has_text?(area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.alert_level", area: area))
   end
 
   def then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
-    date = "2020-10-12".to_date.strftime("%-d %B")
+    area = "Alderaan"
 
-    assert page.has_text?("Alderaan")
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.changing_alert_level"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.future.level_three.alert_level", date: date))
+    assert page.has_text?(area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.alert_level", area: area))
   end
 
   def level_two_area


### PR DESCRIPTION
Trello: https://trello.com/c/xMzgVArN

# What's changed and why?

We need to iterate the content in the postcode checker before it goes live again, including:
- 'tiers' wording
- information about searching for where you live 
- information about following national restrictions until 2nd dec

# Expected changes
## Tier 1
### Before
<img width="1532" alt="Screenshot 2020-11-25 at 12 45 30" src="https://user-images.githubusercontent.com/5793815/100229435-21f18c00-2f1c-11eb-9333-d2d107860580.png">
### After
<img width="1532" alt="Screenshot 2020-11-25 at 12 28 49" src="https://user-images.githubusercontent.com/5793815/100228604-d25e9080-2f1a-11eb-82a4-37dc4b369c14.png">

## Tier 2
### Before
<img width="1532" alt="Screenshot 2020-11-25 at 12 45 03" src="https://user-images.githubusercontent.com/5793815/100229465-2ae25d80-2f1c-11eb-977d-9f39dbdfcc0c.png">
### After
<img width="1532" alt="Screenshot 2020-11-25 at 12 27 59" src="https://user-images.githubusercontent.com/5793815/100228605-d38fbd80-2f1a-11eb-9711-bd39dadc6f4f.png">

## Tier 3
### Before
<img width="1532" alt="Screenshot 2020-11-25 at 12 44 36" src="https://user-images.githubusercontent.com/5793815/100229472-2cac2100-2f1c-11eb-819f-6be09a8a4ace.png">
### After
<img width="1532" alt="Screenshot 2020-11-25 at 12 29 56" src="https://user-images.githubusercontent.com/5793815/100228594-cecb0980-2f1a-11eb-820e-4ac4d331134d.png">

# Note to reviewer
I haven't removed all of the labels (for example for future restrictions) from lookup.yml or the logic in the views as I'm conscious of the fact that a lot of this will have to be put back after 2nd December and I'm trying to make that as easy as possible.
