### PR TITLE
Require associated styling for contextual-sidebar component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/contents-list';
+@import 'govuk_publishing_components/components/contextual-sidebar';
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/document-list';
 @import 'govuk_publishing_components/components/error-message';


### PR DESCRIPTION
- Adds styling to the Brexit transition links in the sidebar

## Before

![brexit-transition-links-before-styling](https://user-images.githubusercontent.com/5963488/100226114-2ebfb100-2f17-11eb-8254-8b039672c48b.png)



## After

![brexit-transition-links-after-styling](https://user-images.githubusercontent.com/5963488/100226038-0932a780-2f17-11eb-98ae-29bb941d9dff.png)
