### PR TITLE
Replace CTA links with buttons

### DIFF
--- a/app/views/coronavirus_local_restrictions/_national_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_national_restrictions.html.erb
@@ -1,7 +1,6 @@
-<%= render "govuk_publishing_components/components/action_link", {
-    text: t("coronavirus_local_restrictions.results.national_restrictions.action_label"),
-    href: t("coronavirus_local_restrictions.results.national_restrictions.action_link"),
-    simple: true,
+<%= render "govuk_publishing_components/components/button", {
+    text: t("coronavirus_local_restrictions.results.national_restrictions.button_label"),
+    href: t("coronavirus_local_restrictions.results.national_restrictions.button_link"),
     margin_bottom: 9
 } %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -32,10 +32,10 @@
     </p>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/action_link", {
+  <%= render "govuk_publishing_components/components/button", {
     text: t("coronavirus_local_restrictions.results.guidance_label", level: 1),
     href: t("coronavirus_local_restrictions.results.level_one.guidance_link"),
-    simple: true,
+    secondary: true,
     margin_bottom: 9
   } %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -32,10 +32,10 @@
     </p>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/action_link", {
+  <%= render "govuk_publishing_components/components/button", {
     text: t("coronavirus_local_restrictions.results.guidance_label", level: 3),
     href: t("coronavirus_local_restrictions.results.level_three.guidance_link"),
-    simple: true,
+    secondary: true,
     margin_bottom: 9
   } %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -32,10 +32,10 @@
     </p>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/action_link", {
+  <%= render "govuk_publishing_components/components/button", {
     text: t("coronavirus_local_restrictions.results.guidance_label", level: 2),
     href: t("coronavirus_local_restrictions.results.level_two.guidance_link"),
-    simple: true,
+    secondary: true,
     margin_bottom: 9
   } %>
 

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -35,8 +35,8 @@ en:
       guidance_label: Find out what the tier %{level} rules are
       national_restrictions:
         heading: From 2 December
-        action_label: Find out what the national rules are
-        action_link: /guidance/new-national-restrictions-from-5-november
+        button_label: Find out what the national rules are
+        button_link: /guidance/new-national-restrictions-from-5-november
       level_one:
         heading: "Tier 1"
         match: "We've matched the postcode"

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -284,7 +284,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_see_details_of_national_restrictions
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.national_restrictions.heading"))
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.national_restrictions.action_label"))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.national_restrictions.button_label"))
   end
 
   def then_i_see_the_results_for_wales


### PR DESCRIPTION
[Trello](https://trello.com/c/ueoaGIN5/950-update-cta-link-to-a-button-on-the-results-page-of-postcode-checker)

- Replace CTA link to national restriction guidance with a button.
- Replace CTA link to tier guidance with a secondary button.
- The aim of this is to improve click through rates and improve user experience.

- We will update the CTA links for devolved nations and 'No results' page in following PRs.

## Before

![cta-links-before](https://user-images.githubusercontent.com/5963488/100263019-df907500-2f44-11eb-90ad-6a2f1a76b798.png)

## After
![cta-links-as-buttons](https://user-images.githubusercontent.com/5963488/100262789-8cb6bd80-2f44-11eb-8567-c5d5f36f0aa0.png)

 Co-authored-by: Leena Gupte <leena.gupte@digital.cabinet-office.gov.uk>
 Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>