### PR TITLE
Add canonical url metadata

### DIFF
--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -10,12 +10,14 @@
 <% content_for :title, title %>
 
 <% content_for :meta_tags do %>
+  <% page_url = File.join(request.base_url, request.path) %>
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="GOV.UK">
-  <meta property="og:url" content="<%= request.base_url + request.path %>">
+  <meta property="og:url" content="<%= page_url %>">
   <meta property="og:title" content="<%= t("coronavirus_local_restrictions.lookup.meta_title") %>">
   <meta property="og:description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
   <meta name="description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
+  <link rel="canonical" href="<%= page_url %>">
 <% end %>
 
 <div class="govuk-grid-row" data-module="coronavirus-track-local-restrictions">

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -1,9 +1,10 @@
 <% content_for :is_full_width_header, true %>
 <% content_for :title, t("transition_landing_page.meta_title") %>
 <% content_for :meta_tags do %>
+  <% page_url = File.join(request.base_url, request.path) %>
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="GOV.UK">
-  <meta property="og:url" content="<%= request.base_url + request.path %>">
+  <meta property="og:url" content="<%= page_url %>">
   <meta property="og:title" content="<%= t("transition_landing_page.meta_title") %>">
   <meta property="og:description" content="<%= t("transition_landing_page.meta_description") %>">
   <meta property="og:image" content="<%= image_url("transition-time-is-running-out.jpg") %>" />
@@ -11,6 +12,7 @@
   <meta name="twitter:image" content="<%= image_url("transition-time-is-running-out.jpg") %>">
   <meta name="description" content="<%= t("transition_landing_page.meta_description") %>">
   <meta name="govuk:navigation-page-type" content="Taxon Page" />
+  <link rel="canonical" href="<%= page_url %>">
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -13,6 +13,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     it "displays the tier one restrictions" do
       given_i_am_on_the_local_restrictions_page
       then_i_can_see_the_postcode_lookup_form
+      and_there_is_metadata
       then_i_enter_a_valid_english_postcode
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
@@ -332,5 +333,11 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       "type" => "LBO",
       "country_name" => "England",
     }
+  end
+
+  def and_there_is_metadata
+    assert page.has_css?("meta[property='og:title'][content='#{I18n.t('coronavirus_local_restrictions.lookup.meta_title')}']", visible: false)
+    assert page.has_css?("meta[name='description'][content='#{I18n.t('coronavirus_local_restrictions.lookup.meta_description')}']", visible: false)
+    assert page.has_css?("link[rel='canonical'][href='http://www.example.com/find-coronavirus-local-restrictions']", visible: false)
   end
 end

--- a/test/integration/transition_landing_page_test.rb
+++ b/test/integration/transition_landing_page_test.rb
@@ -14,6 +14,7 @@ class TransitionLandingPageTest < ActionDispatch::IntegrationTest
       then_i_can_see_the_buckets_section
       then_i_can_see_the_share_links_section
       and_i_can_see_the_explore_topics_section
+      and_there_is_metadata
     end
 
     it "has tracking on all links" do

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -86,6 +86,12 @@ module TransitionLandingPageSteps
     page.assert_no_selector('meta[name="robots"]', visible: false)
   end
 
+  def and_there_is_metadata
+    assert page.has_css?("meta[property='og:title'][content='#{I18n.t('transition_landing_page.meta_title')}']", visible: false)
+    assert page.has_css?("meta[name='description'][content='#{I18n.t('transition_landing_page.meta_description')}']", visible: false)
+    assert page.has_css?("link[rel='canonical'][href='http://www.example.com/transition']", visible: false)
+  end
+
   def content_item
     GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |item|
       item.merge(


### PR DESCRIPTION
This helps machines understand where the canonical source for a page should be. We've discovered some duplicates in Google because of social tracking strings. This should help to dedupe them.

https://govuk-collec-canonical--273yzd.herokuapp.com/transition
https://govuk-collec-canonical--273yzd.herokuapp.com/find-coronavirus-local-restrictions


https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls?hl=en&visit_id=637420804074265432-3406485423&rd=1