### PR TITLE
Increase length of time content item is cached

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -74,7 +74,7 @@ private
   def content_item
     base_path = request.path
     @content_item ||= begin
-      Rails.cache.fetch("collections_content_items#{base_path}", expires_in: 1.minute) do
+      Rails.cache.fetch("collections_content_items#{base_path}", expires_in: 10.minutes) do
         ContentItem.find!(base_path)
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/QYrVBb9M

The content item for the local restrictions postcode checker changes very rarely, so it's ok to cache it for longer.