### PR TITLE
Change no results link to button

### DIFF
--- a/app/views/coronavirus_local_restrictions/no_information.html.erb
+++ b/app/views/coronavirus_local_restrictions/no_information.html.erb
@@ -14,10 +14,9 @@
     title: t("coronavirus_local_restrictions.results.no_information.heading")
   } %>
 
-  <%= render "govuk_publishing_components/components/action_link", {
+  <%= render "govuk_publishing_components/components/button", {
     text: t("coronavirus_local_restrictions.results.no_information.guidance.label"),
     href: t("coronavirus_local_restrictions.results.no_information.guidance.link"),
-    simple: true,
     margin_bottom: 9
   } %>
 

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -73,7 +73,7 @@ en:
       no_information:
         heading: There is no information about the restrictions in this area
         guidance:
-          label: Full list of tiers by area
+          label: Full list of areas and tiers
           link: "/guidance/full-list-of-local-restriction-tiers-by-area"
       future:
         heading: Future tier


### PR DESCRIPTION
Updates the styling of the no results link to be a button. Also changes the copy for the button.

## Before
### PC
<img width="969" alt="Screenshot 2020-11-30 at 11 00 38" src="https://user-images.githubusercontent.com/24547207/100603484-15df4300-32fd-11eb-87dc-e8446ec0dbc6.png">

### Phone
<img width="400" alt="Screenshot 2020-11-30 at 11 00 54" src="https://user-images.githubusercontent.com/24547207/100603503-1972ca00-32fd-11eb-9311-4a262d41d184.png">

## After
## PC
<img width="967" alt="Screenshot 2020-11-30 at 11 00 18" src="https://user-images.githubusercontent.com/24547207/100603515-1e377e00-32fd-11eb-9888-b4929683a5cd.png">

### Phone
<img width="395" alt="Screenshot 2020-11-30 at 11 00 31" src="https://user-images.githubusercontent.com/24547207/100603521-21cb0500-32fd-11eb-9984-f5207c0d6236.png">


Trello - https://trello.com/c/lDFTUR7D/956-add-button-and-change-content-on-no-results-page