### PR TITLE
Add margin top for mobile to headers

### DIFF
--- a/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
@@ -4,7 +4,8 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: t("coronavirus_local_restrictions.results.future.heading", date: date),
     font_size: "m",
-    margin_bottom: 4
+    margin_bottom: 4,
+    mobile_top_margin: true,
   } %>
 
   <% if @restriction.future_alert_level == 1 %>

--- a/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
@@ -1,7 +1,8 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: t("coronavirus_local_restrictions.results.travel_heading"),
   font_size: "m",
-  margin_bottom: 3
+  margin_bottom: 3,
+  mobile_top_margin: true,
 } %>
 <p class="govuk-body">
   <%= sanitize(t("coronavirus_local_restrictions.results.travel_text")) %>


### PR DESCRIPTION
## Before

<img width="385" alt="Screenshot 2020-12-02 at 14 57 21" src="https://user-images.githubusercontent.com/4599889/100889166-bfb20180-34ae-11eb-8e73-8219433c1f14.png">

## After

<img width="391" alt="Screenshot 2020-12-02 at 14 56 07" src="https://user-images.githubusercontent.com/4599889/100889189-c476b580-34ae-11eb-844f-62975b89ba3f.png">


https://trello.com/c/D3z94l8W/964-update-spacing-on-postcode-checker-results-page