### PR TITLE
Remove link style from locale file

### DIFF
--- a/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
+++ b/app/views/coronavirus_local_restrictions/_travel_guidance.html.erb
@@ -1,8 +1,11 @@
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_local_restrictions.results.travel_heading"),
+  text: t("coronavirus_local_restrictions.results.travel.heading"),
   font_size: "m",
   margin_bottom: 3
 } %>
-<p class="govuk-body">
-  <%= sanitize(t("coronavirus_local_restrictions.results.travel_text")) %>
-</p>
+
+<%= link_to(
+  t("coronavirus_local_restrictions.results.travel.label"),
+  t("coronavirus_local_restrictions.results.travel.link"),
+  class: "govuk-body govuk-link"
+) %>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -28,8 +28,10 @@ en:
       link_text: Find a postcode on Royal Mail’s postcode finder
       href: https://www.royalmail.com/find-a-postcode
     results:
-      travel_heading: Find information about somewhere else
-      travel_text: <a class="govuk-link" href="/find-coronavirus-local-restrictions">Enter another postcode.</a>
+      travel:
+        heading: Find information about somewhere else
+        label: Enter another postcode.
+        link: "/find-coronavirus-local-restrictions"
       changing_levels_title: The tier for this area is changing soon
       guidance_label: Find out what the Tier %{level} rules are
       match: "We've matched the postcode"


### PR DESCRIPTION
# What's changed and why?

We were in a hurry when we added the links to the travel guidance and
put all of the html and styling required to render the link in the locale file.
This puts the html and css where it should be: in the view.

The users won't see a difference:

![screenshot-collections dev gov uk-2020 12 02-09_00_12](https://user-images.githubusercontent.com/5793815/100851266-d8a1bf00-347c-11eb-8997-e9e835d74161.png)
