### PR TITLE
Rename Shepway district council for the postcode checker

### DIFF
--- a/lib/local_restrictions/local-restrictions.yaml
+++ b/lib/local_restrictions/local-restrictions.yaml
@@ -1416,7 +1416,7 @@ E07000111:
       start_date: 2020-12-02
       start_time: "00:01"
 E07000112:
-  name: Shepway District Council
+  name: Folkestone and Hythe
   restrictions:
     - alert_level: 3
       start_date: 2020-12-02


### PR DESCRIPTION
Due to a misalignment between GOV.UK's mapit and a council name change in 2018 we've been displaying this wrong.

Trello - https://trello.com/c/UfQZK9c3/970-change-yaml-file-update-folkestone-and-hythe

## Before
<img width="594" alt="Screenshot 2020-12-02 at 16 19 12" src="https://user-images.githubusercontent.com/24547207/100899971-48826a80-34ba-11eb-90fb-92869781963e.png">

## After
<img width="576" alt="Screenshot 2020-12-02 at 16 19 47" src="https://user-images.githubusercontent.com/24547207/100899991-4c15f180-34ba-11eb-89f7-9b5a8d0ff2cc.png">
