### PR TITLE
Implement cross-domain tracking on accounts redirects

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //= require support
 //= require browse-columns
 //= require organisation-list-filter
+//= require ga_cross_domain_accounts_tracking
 //= require modules/current-location
 //= require modules/feeds.js
 //= require modules/toggle-attribute

--- a/app/assets/javascripts/ga_cross_domain_accounts_tracking.js
+++ b/app/assets/javascripts/ga_cross_domain_accounts_tracking.js
@@ -1,0 +1,26 @@
+/* eslint-env jquery */
+/* global ga */
+
+function attachCrossDomainTrackerToLink (link, trackers) {
+  if (trackers.length) {
+    var existingHref = link.attr('href')
+    var linker = new window.gaplugins.Linker(trackers[0])
+    var trackedHref = linker.decorate(existingHref)
+    link.attr('href', trackedHref)
+  }
+}
+
+window.GOVUK = window.GOVUK || {}
+var GOVUK = window.GOVUK
+GOVUK.attachCrossDomainTrackerToLink = attachCrossDomainTrackerToLink
+
+$(window).on('load', function () {
+  if (window.ga !== undefined && typeof window.ga.getAll === 'function') {
+    var trackers = ga.getAll()
+
+    var links = $('href[data-account-cross-domain="yes"]')
+    links.each(function (link) {
+      window.GOVUK.attachCrossDomainTrackerToLink(link, trackers)
+    })
+  }
+})

--- a/spec/javascripts/ga_cross_domain_accounts_tracking_spec.js
+++ b/spec/javascripts/ga_cross_domain_accounts_tracking_spec.js
@@ -1,0 +1,50 @@
+/* eslint-env jasmine, jquery */
+
+describe('attachCrossDomainTrackerToLink', function () {
+  var link
+  var tracker
+  var linker
+  var GOVUK = window.GOVUK || {}
+
+  beforeEach(function () {
+    link = $('<a href="/somewhere" data-account-cross-domain="yes">')
+
+    window.ga = {
+      getAll: function () {}
+    }
+
+    window.gaplugins = {
+      Linker: function () {}
+    }
+
+    linker = {
+      decorate: function () {}
+    }
+
+    spyOn(window.ga, 'getAll').and.returnValue([])
+    spyOn(window.gaplugins, 'Linker').and.returnValue(linker)
+    spyOn(linker, 'decorate').and.returnValue('/somewhere?_ga=abc123')
+  })
+
+  afterEach(function () {
+    link.remove()
+  })
+
+  it('leaves the link href unchanged if ga is not present', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToLink(link, tracker)
+    expect(link.attr('href')).toEqual('/somewhere')
+  })
+
+  it('leaves the link href if unchanged there are no trackers in ga', function () {
+    tracker = []
+    GOVUK.attachCrossDomainTrackerToLink(link, tracker)
+    expect(link.attr('href')).toEqual('/somewhere')
+  })
+
+  it('modifies the link href to append ids from ga to the destination url', function () {
+    tracker = [{ ga_mock: 'foobar' }]
+    GOVUK.attachCrossDomainTrackerToLink(link, tracker)
+    expect(link.attr('href')).toEqual('/somewhere?_ga=abc123')
+  })
+})


### PR DESCRIPTION
There are some links to www.gov.uk which may redirect to the accounts
domain.  We want cross-domain tracking to work in the case where there
is a redirect, which means we need to pass along the cross-domain _ga
parameter.

Since these are links to www.gov.uk, they don't get decorated
automatically.  So instead, decorate links with a specific data
attribute.

See also github.com/alphagov/static/pull/2346

---

[Trello card](https://trello.com/c/ISYymNsg/426-fix-cross-domain-tracking-on-redirects)