### PR TITLE
Revert #2088

### DIFF
--- a/app/assets/stylesheets/views/_dit-landing-page.scss
+++ b/app/assets/stylesheets/views/_dit-landing-page.scss
@@ -119,12 +119,6 @@ $dark-grey: #282828;
   max-width: 100%;
 }
 
-.dit-landing-page__guidance-heading {
-  @extend %govuk-heading-s;
-
-  margin-bottom: govuk-spacing(2);
-}
-
 .govuk-table__header {
   color: govuk-colour("white");
 }

--- a/app/assets/stylesheets/views/_dit-landing-page.scss
+++ b/app/assets/stylesheets/views/_dit-landing-page.scss
@@ -16,12 +16,12 @@ $dark-grey: #282828;
   padding-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(3);
   margin-bottom: govuk-spacing(6);
-  background-color: govuk-colour("white");
-  color: govuk-colour("black");
+  background-color: $dark-red;
+  color: govuk-colour("white");
 }
 
 .dit-landing-page__header--with-bg-image  {
-  background-color: govuk-colour("white");
+  background-color: $dark-red;
   border-top: govuk-spacing(2) solid $red;
 
   @include govuk-media-query($from: $header-breakpoint) {
@@ -44,8 +44,8 @@ $dark-grey: #282828;
 }
 
 .dit-landing-page_header-text-container {
-  background-color: govuk-colour("white");
-  box-shadow: 15px 0 0 0 govuk-colour("white"), 4px 0 0 0 govuk-colour("white"), 3px 0 0 0 govuk-colour("white"), 1px 0 0 0 govuk-colour("white");
+  background-color: $dark-red;
+  box-shadow: 15px 0 0 0 $dark-red, 4px 0 0 0 $dark-red, 3px 0 0 0 $dark-red, 1px 0 0 0 $dark-red;
   padding-bottom: govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
@@ -61,16 +61,16 @@ $dark-grey: #282828;
 
 .dit-landing-page__header-text-block {
   @include govuk-media-query($from: $header-breakpoint) {
-    background: govuk-colour("white");
-    background: -webkit-linear-gradient(90deg, govuk-colour("white") 50%, $transparent 50%);
-    background: linear-gradient(90deg, govuk-colour("white") 50%, $transparent 50%);
+    background: $dark-red;
+    background: -webkit-linear-gradient(90deg, $dark-red 50%, $transparent 50%);
+    background: linear-gradient(90deg, $dark-red 50%, $transparent 50%);
   }
 }
 
 .dit-landing-page__intro {
   p {
     @include govuk-font($size: 24);
-    color: govuk-colour("black");
+    color: govuk-colour("white");
   }
 
   a:link,
@@ -86,7 +86,7 @@ $dark-grey: #282828;
 
 .dit-landing-page__page_title {
   @include govuk-font($size: 48, $weight: bold);
-  color: govuk-colour("black");
+  color: govuk-colour("white");
   margin-top: govuk-spacing(7);
   margin-bottom: govuk-spacing(4);
 }
@@ -113,14 +113,6 @@ $dark-grey: #282828;
       color: $govuk-focus-text-colour;
     }
   }
-}
-
-.dit-landing-page__section--border-top {
-  @include govuk-responsive-padding(8, "top");
-  @include govuk-responsive-padding(8, "bottom");
-
-  border-top: 2px solid govuk-colour("black");
-  margin-top: 0;
 }
 
 .dit-landing-page__training-image {

--- a/app/assets/stylesheets/views/_dit-landing-page.scss
+++ b/app/assets/stylesheets/views/_dit-landing-page.scss
@@ -3,13 +3,7 @@ $red: #FF003B;
 $dark-grey: #282828;
 
 .dit-landing-page__kbm-logo {
-  max-height: 70px;
-  margin-top: govuk-spacing(3);
-
-  @include govuk-media-query($from: desktop) {
-    max-height: 100px;
-    margin-top: 0;
-  }
+  max-height: 100px;
 }
 
 .dit-landing-page__header {
@@ -20,14 +14,20 @@ $dark-grey: #282828;
   color: govuk-colour("white");
 }
 
-.dit-landing-page__header--with-bg-image  {
+.dit-landing-page__header--with-bg-image {
+  padding-bottom: govuk-spacing(4);
+  padding-top: govuk-spacing(3);
   background-color: $dark-red;
   border-top: govuk-spacing(2) solid $red;
+  border-bottom: govuk-spacing(2) solid $red;
 
   @include govuk-media-query($from: $header-breakpoint) {
+    padding-bottom: govuk-spacing(4);
+    padding-top: govuk-spacing(8);
     background-image: image-url('DIT-banner@2x.jpg');
     background-size: cover;
-    background-position: right;
+    background-position: top;
+    min-height: 500px;
   }
 
   // HIDE BACKGROUND IMAGE ON IE
@@ -43,27 +43,13 @@ $dark-grey: #282828;
   }
 }
 
-.dit-landing-page_header-text-container {
-  background-color: $dark-red;
-  box-shadow: 15px 0 0 0 $dark-red, 4px 0 0 0 $dark-red, 3px 0 0 0 $dark-red, 1px 0 0 0 $dark-red;
-  padding-bottom: govuk-spacing(4);
-
-  @include govuk-media-query($from: tablet) {
-    padding-bottom: govuk-spacing(9);
-  }
-
-}
-
-.dit-landing-page_header-text-container--no-translation-nav {
-  padding-top: govuk-spacing(9);
-  padding-bottom: govuk-spacing(9);
-}
-
 .dit-landing-page__header-text-block {
   @include govuk-media-query($from: $header-breakpoint) {
-    background: $dark-red;
-    background: -webkit-linear-gradient(90deg, $dark-red 50%, $transparent 50%);
-    background: linear-gradient(90deg, $dark-red 50%, $transparent 50%);
+    padding-bottom: 80px;
+    padding-top: govuk-spacing(5);
+    background: $red;
+    background: -webkit-linear-gradient(90deg, $dark-red 66.66%, $transparent 66.66%);
+    background: linear-gradient(90deg, $dark-red 66.66%, $transparent 66.66%);
   }
 }
 
@@ -100,18 +86,6 @@ $dark-grey: #282828;
   h2,
   p {
     color: govuk-colour("white");
-  }
-
-  .govuk-link {
-    color: govuk-colour("white");
-
-    &:hover {
-      color: $gem-hover-dark-background;
-    }
-
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
   }
 }
 

--- a/app/views/dit_landing_page/_guidance.html.erb
+++ b/app/views/dit_landing_page/_guidance.html.erb
@@ -9,12 +9,18 @@
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-          <%= tag.p sanitize(t("dit_landing_page.guidance_text")), class: "govuk-body" %>
-
-          <% t("dit_landing_page.guidance_links").each do |guidance| %>
-            <%= tag.h3 link_to(guidance[:label], guidance[:url], class: "govuk-link"), class: "dit-landing-page__guidance-heading" %>
-            <%= tag.p sanitize(guidance[:text]), class: "govuk-body" %>
-          <% end %>
+        <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <h3 class="govuk-heading-m">
+            <%= t("dit_landing_page.guidance_subheader") %>
+          </h3>
+          <%= t("dit_landing_page.guidance_text").html_safe %>
+          <ul class="govuk-list govuk-list">
+            <% t("dit_landing_page.guidance_links").each do |guidance| %>
+              <li><%= link_to guidance[:label], guidance[:url]  %></li>
+            <% end %>
+          </ul>
+        <% end %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= image_tag 'KBM-logo.svg', class: "dit-landing-page__kbm-logo", alt: t("dit_landing_page.kbm-logo-alt-text")%>

--- a/app/views/dit_landing_page/_guidance.html.erb
+++ b/app/views/dit_landing_page/_guidance.html.erb
@@ -16,11 +16,13 @@
           </h3>
           <%= t("dit_landing_page.guidance_text").html_safe %>
           <ul class="govuk-list govuk-list">
-            <% t("dit_landing_page.guidance_links").each do |guidance| %>
-              <li><%= link_to guidance[:label], guidance[:url]  %></li>
+            <% t("dit_landing_page.countries").each do |country| %>
+              <li lang='<%= country[:lang] %>'><%= link_to country[:label], country[:url]  %></li>
             <% end %>
           </ul>
         <% end %>
+
+        <%= render_govspeak t("dit_landing_page.body_markdown") %>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= image_tag 'KBM-logo.svg', class: "dit-landing-page__kbm-logo", alt: t("dit_landing_page.kbm-logo-alt-text")%>

--- a/app/views/dit_landing_page/_guidance.html.erb
+++ b/app/views/dit_landing_page/_guidance.html.erb
@@ -1,4 +1,4 @@
-<div class="landing-page__section dit-landing-page__section--border-top">
+<div class="landing-page__section landing-page__section--light-grey">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -15,26 +15,19 @@
 
 <header class="dit-landing-page__header--with-bg-image">
   <div class="dit-landing-page__header-text-block">
-    <div class="govuk-width-container">
+    <div class="govuk-width-container landing-page_header-text-container">
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds dit-landing-page_header-text-container <%= 'dit-landing-page_header-text-container--no-translation-nav' unless defined?(presented_taxon) %>">
-          <% if defined?(presented_taxon) %>
-            <%= render "govuk_publishing_components/components/translation-nav", {
-              translations: presented_taxon.translation_links,
-              inverse: true,
-            } %>
-          <% end %>
-
+        <div class="govuk-grid-column-two-thirds">
           <h1 class="dit-landing-page__page_title">
-            <%= sanitize(t("dit_landing_page.page_header")) %>
+            <%= t("dit_landing_page.page_header") %>
           </h1>
-          <div class="dit-landing-page__intro">
-            <%= render "govuk_publishing_components/components/govspeak", {
-            } do %>
-              <%= t("dit_landing_page.page_header_explainer").html_safe %>
-            <% end %>
-          </div>
         </div>
+        <div class="govuk-grid-column-two-thirds dit-landing-page__intro">
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+            <%= t("dit_landing_page.page_header_explainer").html_safe %>
+          <% end %>
+          </div>
       </div>
     </div>
   </div>

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -21,6 +21,7 @@
           <% if defined?(presented_taxon) %>
             <%= render "govuk_publishing_components/components/translation-nav", {
               translations: presented_taxon.translation_links,
+              inverse: true,
             } %>
           <% end %>
 

--- a/app/views/dit_landing_page/_training.html.erb
+++ b/app/views/dit_landing_page/_training.html.erb
@@ -5,7 +5,7 @@
         <h2 class="govuk-heading-l">
           <%= t("dit_landing_page.training_section_title") %>
         </h2>
-        <p class="govuk-body"><%= sanitize(t("dit_landing_page.training_section_description", url: t("dit_landing_page.training_section_url"))) %></p>
+        <p class="govuk-body"><%= t("dit_landing_page.training_section_description") %></p>
       </div>
       <div class="govuk-grid-column-one-third">
         <%= image_tag 'DIT-small-image.jpg', class: "dit-landing-page__training-image", alt: "", loading: "lazy" %>

--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -3,7 +3,7 @@ en:
     kbm-logo-alt-text: Keep Business Moving
     meta_title: Trade with the UK from 1 January 2021 as a business based in the EU
     meta_description: The UK has left the EU. On 31 December 2020 the UK will leave the EU single market and customs union. From 1 January 2021 the rules for trading with the UK will change.
-    page_header: Trade with the UK from 1&nbsp;January 2021 as a business based in the EU
+    page_header: Trade with the UK from 1 January 2021 as a business based in the EU
     page_header_explainer: |
       <p>The UK has left the EU. On 31 December 2020 the UK will leave the EU single market and customs union.</p>
       <p>From 1 January 2021 the rules for trading with the UK will change.</p>
@@ -11,23 +11,183 @@ en:
     guidance_subheader: What your business needs to know
     guidance_text: |
       <p>If you run an EU-based business, you need to check the new rules and prepare for the changes so that you can continue trading with the UK from January 2021.</p>
-    guidance_links:
-      - label: Importing from the UK
-        url: "/guidance/eu-business-importing-from-the-uk"
-      - label: Exporting to the UK
-        url: "/guidance/eu-business-exporting-to-the-uk"
-      - label: Taxes and tariffs
-        url: "/guidance/eu-business-taxes-and-tariffs"
-      - label: Goods and services
-        url: "/guidance/eu-business-goods-and-services"
-      - label: Working in the UK
-        url: "/guidance/eu-business-working-in-the-uk"
-      - label: Data protection and copyright
-        url: "/guidance/eu-business-data-protection-and-copyright"
-    training_section_title: Webinars for EU-based businesses trading with the UK
+      <p>This information is also available in the following languages:</p>
+    countries:
+      - label: Deutsch
+        lang: de
+        url: government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/handel-mit-dem-vereinigten-konigreich-ab-1-januar-2021-fur-unternehmen-mit-sitz-in-der-eu
+      - label: Español
+        lang: es
+        url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/como-hacer-negocios-con-el-reino-unido-a-partir-del-1-de-enero-de-2021-en-caso-de-ser-una-empresa-con-sede-en-la-ue
+      - label: Français
+        lang: fr
+        url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/travailler-avec-le-royaume-uni-a-partir-du-1er-janvier-2021-en-tant-quentreprise-basee-dans-lue
+      - label: Italiano
+        lang: it
+        url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/come-le-aziende-presenti-nellunione-europea-potranno-effettuare-scambi-commerciali-con-il-regno-unito-a-partire-dal-01012021
+      - label: Nederlands
+        lang: nl
+        url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/bereid-uw-bedrijf-voor-op-januari-2021-als-u-in-de-eu-bent-gevestigd
+      - label: Polski
+        lang: pl
+        url: /government/publications/trade-with-the-uk-from-january-2021-prepare-your-eu-business/handel-z-wielka-brytania-od-1-stycznia-2021-roku-informacje-dla-firm-z-unii-europejskiej
+    body_markdown: |
+      ### Buying or selling goods
+
+      Rules are changing and there will be border requirements placed on the movement of goods between the EU and UK. [Find out more about how the border with the UK will work](/government/publications/the-border-operating-model).
+
+      Make sure you talk to your trading partners in the UK to agree responsibilities and have the correct paperwork for the type of goods you are trading with counterparts in the UK. Ensure you have completed the necessary border requirements.
+
+      There will be no substantive change for the movement of goods between [Northern Ireland](/government/publications/moving-goods-under-the-northern-ireland-protocol/moving-goods-under-the-northern-ireland-protocol-section-three-moving-goods-from-northern-ireland-to-the-european-union) and member states of the EU, including Ireland.
+
+      ### Check import procedures with your country’s customs authority
+
+      From 1 January 2021 businesses in Europe will need to make customs declarations when moving goods between the UK and the EU. If European businesses have not completed the right customs processes their goods will not be able to cross the EU border.
+
+      You must check with your country’s customs authority what customs procedures will need to be applied for bringing goods from the UK to the EU, including whether any import duties will be due.
+
+      If you sell agri-food products to the UK, your business may need to:
+
+      - check the requirements for exporting food, drink or agricultural products to the UK from the EU
+      - check what documents, licences and certificates are required for the goods you are exporting from the EU into the UK and how to apply for them
+      - pre-notify the UK authorities about the goods you are exporting from the EU into the UK
+
+      ### Exporting animals and animal products
+
+      If you export animals and animal products to Great Britain, you must comply with new Sanitary and Phytosanitary requirements from 1 January 2021. This may include the need for new export health certificates. These processes will be introduced in stages during 2021.
+
+      [Find out more about exporting animals and animal products to Great Britain](/guidance/importing-animals-animal-products-and-high-risk-food-and-feed-not-of-animal-origin-from-1-january-2021)
+
+      ### Importing animals and animal products
+
+      From 1 January 2021, imports of animal and animal products from Great Britain to the EU must comply with new Sanitary and Phytosanitary requirements. This includes being checked at an EU Border Control Post on entry.
+
+      The EU importer must notify the Border Control Post that the consignment is arriving.
+
+      [Find out more about importing animal products from Great Britain to the EU.](/guidance/exporting-animals-and-animal-products-to-the-eu-from-1-january-2021)
+
+      ### Exporting plants and plant products
+
+      From 1 January 2021, EU exports of plants, fruit and vegetables to Great Britain must comply with new Phytosanitary requirements, including phytosanitary certificates. If you export plants, fruit and vegetables to Great Britain, you should:
+
+      - check whether a phytosanitary certificate (PC) is required by contacting the plant health authority in your country or your local plant health inspector
+      - check if your plants require laboratory testing of samples to ensure they are free from pests and diseases or inspections during the growing season
+      - apply for a PC from the relevant National Plant Protection Organisation before export
+
+      [Find out more about exporting plants and plant products.](/guidance/importing-and-exporting-plants-and-plant-products-from-1-january-2021)
+
+      ### Importing plants and plant products
+
+      From 1 January 2021, imports of plants, fruit and vegetables from Great Britain to the EU must comply with new Phytosanitary requirements. Regulated plant and plant products imports may be subject to checks at the EU border. If you import plants, fruit and vegetables from Great Britain, you should:
+
+      - check whether a phytosanitary certificate (PC) is required by contacting the plant health authority in Great Britain or a plant health inspector in your country
+      - apply for a PC via your exporter from the relevant plant health authority in Great Britain before export
+      - check if your plants require laboratory testing of samples (to ensure they are free from pests and diseases) or inspections during the growing season and allow for sufficient time for this to occur
+
+      [Find out more about importing plants and plant products.](/guidance/importing-and-exporting-plants-and-plant-products-from-1-january-2021)
+
+      ### Manufactured goods
+
+      If you are placing manufactured goods on the market in Great Britain from 1 January 2021, there may be a number of changes that apply to you. You may need to:
+
+      - review your product marking, labelling, and packaging
+      - get additional approvals, certifications, or registrations
+      - appoint a legal representative based in the UK
+      - check whether your (or your distributors) legal responsibilities are changing
+
+      [Find out more about placing manufactured goods on the market in Great Britain.](/guidance/placing-manufactured-goods-on-the-market-in-great-britain-from-1-january-2021)
+
+      If you are placing manufactured goods on the market in Northern Ireland, the relevant EU rules relating to manufactured goods will apply. Where a business already holds the relevant approvals that goods meet EU rules, this will continue to provide the basis for placing those goods on the market in Northern Ireland. Further guidance will be published soon.
+
+      ### Energy-related products
+
+      From 1 January 2021, energy-related products placed on the market in Great Britain must comply with relevant UK legislation.
+
+      Compliant products placed on the market before 1 January 2021, with EU flags on their energy labels, may continue to remain in circulation following the end of the transition period.
+
+      Products placed on the Northern Ireland market must comply with relevant EU legislation. This includes using the EU flag and QR codes that link to the required product information on the European product database for energy labelling (EPREL).
+
+      [Check climate change requirements.](/government/publications/meeting-climate-change-requirements-if-theres-no-brexit-deal/meeting-climate-change-requirements-if-theres-no-brexit-deal)
+
+      ### Importing controlled goods
+
+      EU businesses importing controlled goods into the UK will need a licence from the relevant licencing authority from 1 January 2021.
+
+      [Check the guidance and take action to have the right licences.](/government/publications/the-border-operating-model)
+
+      ### Trading timber
+      From 1 January 2021, you need to [carry out due diligence when importing and exporting timber](/guidance/trading-timber-imports-and-exports-if-theres-no-brexit-deal).
+
+      ### Paying VAT or claiming VAT refunds
+
+      Make sure you understand the [new rules for paying import VAT on parcels](/government/publications/changes-to-vat-treatment-of-overseas-goods-sold-to-customers-from-1-january-2021) you send to UK buyers.
+
+      You must pay import VAT on parcels you sell to UK buyers if you:
+
+      - are based outside the UK
+      - sell goods sent in parcels worth £135 or less to UK buyers
+
+      If you sell goods sent in parcels worth over £135, the import VAT, Customs Duty (and Excise Duty where applicable) should be paid by the UK buyer and collected by the parcel operator.
+
+      Check how to [claim VAT refunds on goods and services](/guidance/claim-refunds-of-uk-vat-from-1-january-2021-if-youre-an-eu-business) you buy from the UK from 1 January 2021.
+
+      ### Transferring personal data to the UK
+
+      Your business may need to make some changes to allow you to continue to share personal data with businesses or other organisations in the UK.
+
+      Talk to your local data protection regulator to ensure you are prepared on data protection and data transfers.
+
+      ### Providing services in the UK
+
+      Your business might be affected by the changes from 1 January 2021. There may be new rules if:
+
+      - you have branches or subsidiaries in the UK
+      - your business is part of a service sector within the UK
+      - you are planning a merger with a UK company
+      - you or your employees travel to the UK for business
+      - you or your employees provide services in a UK regulated profession
+
+      Check the regulations for the UK, including visa requirements, and understand how changes could affect your business.
+
+      ### Legal professionals
+
+      UK legal professionals practising in the EU, either on a permanent basis or offering fly in or fly out services, could face restrictions to their practice rights.
+
+      UK legal professionals should contact their local regulators to understand the rules on third country lawyers in each member state of the EU. [Find out more about UK lawyers practising in the EU from 1 January 2021.](/government/publications/uk-lawyers-practising-in-the-eu-norway-iceland-or-liechtenstein-from-1-january-2021/uk-lawyers-practising-in-the-eu-norway-iceland-or-liechtenstein-after-1-january-2021)
+
+      ### Business activity in the UK
+
+      From 1 January 2021, freedom of movement between the EU and UK will end.
+
+      EU, EEA and Swiss citizens entering the UK for work purposes may need to apply for a visa through the UK’s points-based immigration system. This depends on the nature of their visit.
+
+      For visits under 6 months, EU, EEA and Swiss citizens will be able to enter the UK without applying for a visa. They may participate in business-related activities, such as meetings, events and conferences.
+
+      [Find out more about permitted business-related activity for visits to the UK under 6 months.](/guidance/immigration-rules/immigration-rules-appendix-v-visitor-rules)
+
+      If you require EU, EEA or Swiss citizens to go to the UK to work for longer than 6 months, you’ll need to check the UK’s immigration laws.
+
+      [Find out more about the UK’s immigration laws.](/guidance/new-immigration-system-what-you-need-to-know)
+
+      If you employ or intend to employ an EU, EEA or Swiss citizen to commute into the UK, you’ll need to consult guidance for frontier workers.
+
+      [Find out more about frontier working into the UK.](/guidance/frontier-workers-in-the-uk-rights-and-status)
+
+      The new rules do not apply to Irish citizens because of the Common Travel Area arrangement.
+
+      ### Copyright and unregistered designs
+
+      Changes to EU cross-border copyright mechanisms may impact your business. Make sure you have the right permissions from 1 January 2021.
+
+      [Check changes to copyright law from 1 January 2021.](/guidance/changes-to-copyright-law-after-the-transition-period)
+
+      You may not have protection for unregistered designs if you do not disclose your designs correctly.
+
+      [Check the new rules for unregistered design protection in the UK and EU from 1 January 2021.](/guidance/changes-to-unregistered-designs-after-the-transition-period)
+
+    training_section_title: Additional help and support
     training_section_description: |
-      Learn more about UK border requirements from 1 January 2021 by <a href="%{url}" class="govuk-link">registering for an upcoming webinar or industry day</a>.
-    training_section_url: "/guidance/webinars-for-eu-based-organisations-that-trade-with-the-uk"
+      Online events will help you understand the UK border requirements if you’re a trader in the EU, and what you need to do to prepare for the end of the transition period. Dates for these events are currently being scheduled and will be published on this page once they’re available.
     training_section_table:
       headings:
         - "Date"

--- a/config/locales/en/dit_landing_page.yml
+++ b/config/locales/en/dit_landing_page.yml
@@ -7,28 +7,23 @@ en:
     page_header_explainer: |
       <p>The UK has left the EU. On 31 December 2020 the UK will leave the EU single market and customs union.</p>
       <p>From 1 January 2021 the rules for trading with the UK will change.</p>
-    guidance_title: What your business needs to know
+    guidance_title: Prepare your business for January 2021 if you are based in the EU
+    guidance_subheader: What your business needs to know
     guidance_text: |
-      If you run an EU-based business, you need to check the new rules and prepare for the changes so that you can continue trading with the UK from January 2021.
+      <p>If you run an EU-based business, you need to check the new rules and prepare for the changes so that you can continue trading with the UK from January 2021.</p>
     guidance_links:
       - label: Importing from the UK
         url: "/guidance/eu-business-importing-from-the-uk"
-        text: Find out what you need to do to import from the UK, including customs procedures and importing goods such as food, drink, animal, and plant products.
       - label: Exporting to the UK
         url: "/guidance/eu-business-exporting-to-the-uk"
-        text: Find out what you need to do to export to the UK, including new rules for hauliers, checks, moving goods across borders and exporting goods such as food, drink, animal, plant, and energy-related products.
       - label: Taxes and tariffs
         url: "/guidance/eu-business-taxes-and-tariffs"
-        text: Learn more about paying or reclaiming VAT.
-      - label: Providing services to the UK
-        url: "/guidance/eu-business-services"
-        text: Find out how the way you provide services in the UK may change.
+      - label: Goods and services
+        url: "/guidance/eu-business-goods-and-services"
       - label: Working in the UK
         url: "/guidance/eu-business-working-in-the-uk"
-        text: Find out what EU workers in the UK need to do from 1 January 2021, including rules on driving, visas, and recognising professional qualifications.
       - label: Data protection and copyright
         url: "/guidance/eu-business-data-protection-and-copyright"
-        text: Learn more about changes to rules including intellectual property, copyright, and sharing personal data.
     training_section_title: Webinars for EU-based businesses trading with the UK
     training_section_description: |
       Learn more about UK border requirements from 1 January 2021 by <a href="%{url}" class="govuk-link">registering for an upcoming webinar or industry day</a>.

--- a/test/controllers/dit_landing_page_controller_test.rb
+++ b/test/controllers/dit_landing_page_controller_test.rb
@@ -5,7 +5,7 @@ describe DitLandingPageController do
     it "renders the page for the en locale" do
       get :show
       assert_response :success
-      assert_select "h1", "Trade with the UK from 1 January 2021 as a business based in the EU"
+      assert_select "h1", "Trade with the UK from 1 January 2021 as a business based in the EU"
     end
   end
 end

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -21,7 +21,7 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
   end
 
   def and_i_can_see_the_guidance_links
-    assert page.has_selector?("h3", text: "Importing from the UK")
+    assert page.has_selector?("li:first-child", text: "Importing from the UK")
   end
 
   def then_i_can_see_the_training_section

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -7,7 +7,7 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
     it "renders" do
       when_i_visit_the_dit_landing_page
       then_i_can_see_the_header_section
-      and_i_can_see_the_guidance_links
+      and_i_can_see_the_translation_links
       then_i_can_see_the_training_section
     end
   end
@@ -20,11 +20,11 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
     assert page.has_title? "Trade with the UK from 1 January 2021 as a business based in the EU"
   end
 
-  def and_i_can_see_the_guidance_links
-    assert page.has_selector?("li:first-child", text: "Importing from the UK")
+  def and_i_can_see_the_translation_links
+    assert page.has_selector?("li[lang='de']", text: "Deutsch")
   end
 
   def then_i_can_see_the_training_section
-    assert page.has_selector?("h2", text: "Webinars for EU-based businesses trading with the UK")
+    assert page.has_selector?("h2", text: "Additional help and support")
   end
 end


### PR DESCRIPTION
A revert of #2088 was requested 🙃

As the commits in #2088 ended up quite scattered in the git history, GitHub was unable to do a UI-based revert, so I did it using `git revert`.

To double-check the revert I compared [the version we had before #2088](https://web.archive.org/web/20201201234049/https://www.gov.uk/eubusiness) with [the result of this PR](https://govuk-collec-revert-pr--wsutvu.herokuapp.com/eubusiness).

Before merging this we'll need to re-publish the old translation pages and remove the redirects.

[Trello card](https://trello.com/c/u7gFwzY3)