### PR TITLE
Audit headings throughout collections

### DIFF
--- a/app/views/browse/_top_level_browse_pages.erb
+++ b/app/views/browse/_top_level_browse_pages.erb
@@ -1,5 +1,5 @@
 <div id="root" class="pane root-pane">
-  <h2 class="visuallyhidden" tabindex="-1">All categories</h2>
+  <h2 class="govuk-visually-hidden" tabindex="-1">All categories</h2>
   <ul>
     <% top_level_browse_pages.each_with_index do |page, index| %>
       <li class="<%= browsing_in_top_level_page?(page) ? 'active' : '' %>">

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -4,7 +4,7 @@
   <meta name='govuk:navigation-page-type' content='Browse Index'>
 <% end %>
 
-<h1 class="visuallyhidden"><%= t("shared.browse.title") %></h1>
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
 <div class="browse-panes root" data-module="track-click">
   <%= render 'top_level_browse_pages',

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <% content_for :page_class, "browse" %>
 
-<h1 class="visuallyhidden"><%= t("shared.browse.title") %></h1>
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
 <div class="browse-panes section" data-state="section" data-module="track-click">
   <div id="section" class="section-pane pane with-sort">

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -20,7 +20,12 @@
 
   <div class="app-c-header-notice__content">
     <% if heading.present? %>
-      <h2 class="app-c-header-notice__heading govuk-heading-m"><%= heading %></h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: heading,
+        heading_level: 2,
+        font_size: "m",
+        margin_bottom: 4,
+      } %>
     <% end %>
     <% if list.any? %>
       <ul class="app-c-header-notice__list govuk-list govuk-list--bullet">

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -3,7 +3,7 @@
 <% if guidance.present? && guidance["intro"].present? %>
   <p class="govuk-body">
     <%= render_govspeak(guidance["intro"]) %>
-  <p>
+  </p>
 <% end %>
 <% if guidance.present? && guidance["links"].present? %>
   <%

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -1,6 +1,11 @@
 <% section["sub_sections"].each do |sub_section| %>
   <% if sub_section["title"] %>
-    <h4 class="govuk-heading-s covid__accordion-heading"><%= sub_section["title"] %></h4>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: sub_section["title"],
+      heading_level: 4,
+      font_size: "s",
+      margin_bottom: 4,
+    } %>
   <% end %>
   <ul class="covid__list covid__list--accordion">
     <% sub_section["list"].each do | item | %>

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -7,7 +7,12 @@
 
   <% timeline["list"].each do | item | %>
     <div class="covid-timeline__item">
-      <h3 class="covid-timeline__item-heading govuk-heading-s"><%= item["heading"] %></h3>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: item["heading"],
+        heading_level: 3,
+        font_size: "s",
+        margin_bottom: 1,
+      } %>
       <%= render_govspeak(item["paragraph"]) %>
     </div>
   <% end %>

--- a/app/views/dit_landing_page/_guidance.html.erb
+++ b/app/views/dit_landing_page/_guidance.html.erb
@@ -2,7 +2,12 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= tag.h2 sanitize(t("dit_landing_page.ribbon_title")), class: "govuk-heading-l" %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: sanitize(t("dit_landing_page.ribbon_title")),
+          font_size: "l",
+          heading_level: 2,
+          margin_bottom: 6,
+        } %>
       </div>
     </div>
     <div class="govuk-grid-row">

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -22,9 +22,14 @@
             translations: @presenter.translation_links
           } %>
 
-          <h1 class="dit-landing-page__page_title">
-            <%= sanitize(t("dit_landing_page.page_header")) %>
-          </h1>
+          <div class="govuk-!-margin-top-8">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: sanitize(t("dit_landing_page.page_header")),
+              heading_level: 1,
+              font_size: "xl",
+              margin_bottom: 6,
+            } %>
+          </div>
           <div class="dit-landing-page__intro">
             <%= render "govuk_publishing_components/components/govspeak", {
             } do %>

--- a/app/views/dit_landing_page/_training.html.erb
+++ b/app/views/dit_landing_page/_training.html.erb
@@ -2,9 +2,12 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-l">
-          <%= t("dit_landing_page.training_section_title") %>
-        </h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("dit_landing_page.training_section_title"),
+          font_size: "l",
+          heading_level: 2,
+          margin_bottom: 6,
+        } %>
         <p class="govuk-body"><%= sanitize(t("dit_landing_page.training_section_description")) %></p>
       </div>
       <div class="govuk-grid-column-one-third">

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -28,7 +28,7 @@
   <ul class="changed-documents">
     <% subtopic.changed_documents.each do |document| -%>
       <li>
-        <h3><a href="<%= document.base_path %>"><%= document.title %></a></h3>
+        <a href="<%= document.base_path %>"><%= document.title %></a>
 
         <% if document.public_updated_at %>
           <time class="updated-at" datetime="<%= document.public_updated_at.iso8601 %>">

--- a/app/views/organisations/_expanded_works_with_organisations.html.erb
+++ b/app/views/organisations/_expanded_works_with_organisations.html.erb
@@ -4,7 +4,11 @@
 
 <div class="organisation-list__works-with js-hidden" id="toggle_<%= current_organisation.parameterize %>">
   <% works_with_organisations.each do |type, work_with_organisations| %>
-    <h4 class="organisation-list__works-with-title"><%=  t('organisations.type.' + type) %></h4>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t('organisations.type.' + type),
+      heading_level: 4,
+      font_size: "s",
+    } %>
     <ul class="organisation-list__works-with-list">
       <% work_with_organisations.each do |work_with_organisation| %>
         <li class="organisation-list__works-with-list-item">

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -1,7 +1,7 @@
 <% if @organisation.is_no_10? %>
   <h1 class="organisation__no10-banner organisation__margin-bottom"><%= @header.org.title %></h1>
 <% else %>
-  <h1 class="visually-hidden"><%= @header.org.title %></h1>
+  <h1 class="govuk-visually-hidden"><%= @header.org.title %></h1>
 
   <div class="govuk-grid-row">
     <div class="<%= @header.logo_wrapper_class %> organisation__margin-bottom">

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -32,7 +32,10 @@
 
   <% if page.related_topics.any? %>
     <div class="detailed-guidance">
-      <h2>Detailed guidance</h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Detailed guidance",
+        heading_level: 2,
+      } %>
       <ul>
         <% page.related_topics.each_with_index do |related_topic, index| %>
           <li>

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 <% content_for :page_class, "browse" %>
 
-<h1 class="visuallyhidden"><%= t("shared.browse.title") %></h1>
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
 <div class="browse-panes subsection" data-state="subsection" data-module="track-click">
   <div id="subsection" class="subsection-pane pane with-sort">

--- a/app/views/transition_landing_page/_brexit_finders.html.erb
+++ b/app/views/transition_landing_page/_brexit_finders.html.erb
@@ -1,8 +1,11 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-one-third">
-    <h2 class="govuk-heading-m">
-      <%= t("transition_landing_page.topic_section_header") %>
-    </h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("transition_landing_page.topic_section_header"),
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
   </div>
   <div class="govuk-body govuk-grid-column-two-thirds landing-page__finders">
     <p class="govuk-body"><%= t("transition_landing_page.topic_section_subheading") %></p>

--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -7,9 +7,12 @@
   data-search-query>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-l">
-        <%= guidance_header %>
-      </h2>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: guidance_header,
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 6,
+      } %>
     </div>
   </div>
 

--- a/app/views/transition_landing_page/_comms.html.erb
+++ b/app/views/transition_landing_page/_comms.html.erb
@@ -8,7 +8,12 @@
 %>
 
 <div class="landing-page__section landing-page__section--border-top">
-  <h2 class="govuk-heading-l"><%= I18n.t('transition_landing_page.comms_header') %></h2>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t('transition_landing_page.comms_header'),
+    heading_level: 2,
+    font_size: "l",
+    margin_bottom: 6,
+  } %>
   <div class="<%= grid_class %>" lang="en">
 
     <% if comms_links %>

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -25,9 +25,15 @@
             translations: presented_taxon.translation_links
           } %>
 
-          <h1 class="landing-page__page_title">
-            <%= sanitize(t("transition_landing_page.page_header")) %>
-          </h1>
+          <div class="govuk-!-margin-top-7">
+            <%= render "govuk_publishing_components/components/heading", {
+              text: sanitize(t("transition_landing_page.page_header")),
+              heading_level: 1,
+              font_size: "xl",
+              margin_bottom: 4,
+            } %>
+          </div>
+          
           <div class="landing-page__intro">
             <%= render "govuk_publishing_components/components/govspeak", {
             } do %>

--- a/app/views/transition_landing_page/_video_section.html.erb
+++ b/app/views/transition_landing_page/_video_section.html.erb
@@ -2,9 +2,12 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-l">
-          <%= t("transition_landing_page.video_section_title") %>
-        </h2>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: t("transition_landing_page.video_section_title"),
+          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 6,
+        } %>
         <%= render "govuk_publishing_components/components/govspeak", {
         } do %>
           <%= t("transition_landing_page.video_section_description").html_safe() %>

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -39,7 +39,7 @@ end
 Then(/^I see a date\-ordered list of content with change notes$/) do
   @stubbed_rummager_documents.each_with_index do |document, index|
     within(".browse-container li:nth-of-type(#{index + 1})") do
-      assert page.has_selector?("h3 a[href='#{document['link']}']", text: document["title"])
+      assert page.has_selector?("a[href='#{document['link']}']", text: document["title"])
       assert page.has_content?(document["latest_change_note"]) if document["latest_change_note"]
       assert page.has_selector?("time") if document["public_updated_at"]
     end

--- a/test/components/header_notice_test.rb
+++ b/test/components/header_notice_test.rb
@@ -78,12 +78,12 @@ class HeaderNoticeTest < ComponentTestCase
 
   test "does not renders a heading if no heading is passed in" do
     render_component(branded_notice.without(:heading))
-    assert_select ".app-c-header-notice__heading", count: 0
+    assert_select ".gem-c-heading", count: 0
   end
 
   test "renders a heading if heading is passed in" do
     render_component(branded_notice)
-    assert_select ".app-c-header-notice__heading", text: branded_notice[:heading]
+    assert_select ".gem-c-heading", text: branded_notice[:heading]
   end
 
   test "does not renders a list if no list is passed in" do

--- a/test/integration/content_store_organisations_test.rb
+++ b/test/integration/content_store_organisations_test.rb
@@ -64,8 +64,8 @@ class ContentStoreOrganisationsTest < ActionDispatch::IntegrationTest
 
   it "renders a list of organisations that an organisation works with" do
     assert page.has_css?(".organisation-list__works-with#toggle_attorney-general-s-office")
-    assert page.has_css?("#toggle_attorney-general-s-office .organisation-list__works-with-title", text: "Non-ministerial department")
-    assert page.has_css?("#toggle_attorney-general-s-office .organisation-list__works-with-title", text: "Other")
+    assert page.has_css?("#toggle_attorney-general-s-office h4", text: "Non-ministerial department")
+    assert page.has_css?("#toggle_attorney-general-s-office h4", text: "Other")
 
     assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/crown-prosecution-service']", text: "Crown Prosecution Service")
     assert page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/government-legal-department']", text: "Government Legal Department")

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -166,7 +166,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       end
 
       # And I should see the latest documents for the subtopic in date order
-      titles = page.all(".changed-documents li h3").map(&:text)
+      titles = page.all(".changed-documents li a").map(&:text)
       expected_titles = [
         "Oil and gas uk field data",
         "Oil and gas wells",

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -166,16 +166,16 @@ module CoronavirusLandingPageSteps
   def then_i_can_see_the_timeline
     assert page.has_selector?("h2", text: "Recent and upcoming changes")
 
-    assert page.has_selector?(".covid-timeline__item-heading", text: "18 September")
+    assert page.has_selector?(".covid-timeline .gem-c-heading", text: "18 September")
     assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "If you live, work or travel in the North East, you need to follow different covid rules")
 
-    assert page.has_selector?(".covid-timeline__item-heading", text: "15 September")
+    assert page.has_selector?(".covid-timeline .gem-c-heading", text: "15 September")
     assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "If you live, work or visit Bolton, you need to follow different covid rules")
 
-    assert page.has_selector?(".covid-timeline__item-heading", text: "14 September")
+    assert page.has_selector?(".covid-timeline .gem-c-heading", text: "14 September")
     assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "People must not meet in groups larger than 6 in England. There are exceptions to this ‘rule of 6’")
 
-    assert page.has_selector?(".covid-timeline__item-heading", text: "24 July")
+    assert page.has_selector?(".covid-timeline .gem-c-heading", text: "24 July")
     assert page.has_selector?(".covid-timeline__item .gem-c-govspeak", text: "Face coverings are mandatory in shops")
   end
 


### PR DESCRIPTION
## What
This PR:

- Replaces instances (where possible) of raw html h tags with the [govuk publishing components heading component](https://components.publishing.service.gov.uk/component-guide/heading)
- Replaces instances of visually hidden headings using the `visuallyhidden` or `visually-hidden` classes with the most up to date `govuk-visually-hidden` class
- Removes `h3` tags from the list items in the latest changes view
- Fixes a stray broken `p` tag on the covid landing page

## Why
As part of the work by the govuk accessibility team, we are ensuring that where possible, the govuk publishing components are being used. This ensures that any bug fixes or changes to our markup can be rolled out quickly and with greater confidence that a given problem has been fixed everywhere within our apps.

The latter 3 changes are just some little fixes whilst I'm in the code. The change to latest changes in particular is because the `h3` is overly verbose, especially because the view is styling the heading to not look like a heading. Screen reader users can navigate this page via tabbing or links and this change makes no difference to sighted users.

I've omitted a couple of instances of raw headings (such as visually hidden headings) that have some styling specific to their view, where headings aren't being used the way that the heading component should be used, making said component a poor use case. Probably these pages need a design review but that's not within the scope of this work.

## Pages tested against

- https://www.gov.uk/eubusiness
- https://www.gov.uk/transition
- https://www.gov.uk/browse/benefits/universal-credit
- https://www.gov.uk/coronavirus
- https://www.gov.uk/government/organisations
- https://www.gov.uk/topic/business-tax/alcohol-duties/latest

No visual changes.

[Card](https://trello.com/c/dxbqoY7q/545-use-heading-component-in-collections-app)