### PR TITLE
Make the postcode checker heading line break in the right place

### DIFF
--- a/app/assets/stylesheets/views/_coronavirus-local-restriction.scss
+++ b/app/assets/stylesheets/views/_coronavirus-local-restriction.scss
@@ -1,3 +1,7 @@
 .coronavirus-local-restriction__related-navigation {
   margin-top: govuk-spacing(8);
 }
+
+.coronavirus-local-restriction__heading-tier-label {
+  white-space: nowrap;
+}

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -1,19 +1,26 @@
+<% tier_heading = capture do %>
+  <%= t("coronavirus_local_restrictions.results.level_one.heading_pretext") %>
+  <span class="coronavirus-local-restriction__heading-tier-label">
+    <%= t("coronavirus_local_restrictions.results.level_one.heading_tier_label") %>
+  </span>
+<% end %>
+
 <%
   title = if @restriction.present? && @restriction.future.present?
     t("coronavirus_local_restrictions.results.changing_levels_title")
   else
-    t("coronavirus_local_restrictions.results.level_one.heading")
+    tier_heading
   end
 %>
 
-<% content_for :title, title %>
+<% content_for :title, strip_tags(title) %>
 
 <%= tag.div :data => {
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier one: #{@location_lookup.lower_tier_area_name}"
 } do %>
   <%= render "govuk_publishing_components/components/title", {
-    title: title
+    title: sanitize(title)
   } %>
 
   <p class="govuk-body">
@@ -22,7 +29,7 @@
 
   <% if @restriction.present? && @restriction.future.present? %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("coronavirus_local_restrictions.results.level_one.heading"),
+      text: sanitize(tier_heading),
       font_size: "m",
       margin_bottom: 4
     } %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -1,19 +1,26 @@
+<% tier_heading = capture do %>
+  <%= t("coronavirus_local_restrictions.results.level_three.heading_pretext") %>
+  <span class="coronavirus-local-restriction__heading-tier-label">
+    <%= t("coronavirus_local_restrictions.results.level_three.heading_tier_label") %>
+  </span>
+<% end %>
+
 <%
   title = if @restriction.present? && @restriction.future.present?
     t("coronavirus_local_restrictions.results.changing_levels_title")
   else
-    t("coronavirus_local_restrictions.results.level_three.heading")
+    tier_heading
   end
 %>
 
-<% content_for :title, title %>
+<% content_for :title, strip_tags(title) %>
 
 <%= tag.div :data => {
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier three: #{@restriction.area_name}"
 } do %>
   <%= render "govuk_publishing_components/components/title", {
-    title: title
+    title: sanitize(title)
   } %>
 
   <p class="govuk-body">
@@ -22,7 +29,7 @@
 
   <% if @restriction.present? && @restriction.future.present? %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("coronavirus_local_restrictions.results.level_three.heading"),
+      text: sanitize(tier_heading),
       font_size: "m",
       margin_bottom: 4
     } %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -1,19 +1,26 @@
+<% tier_heading = capture do %>
+  <%= t("coronavirus_local_restrictions.results.level_two.heading_pretext") %>
+  <span class="coronavirus-local-restriction__heading-tier-label">
+    <%= t("coronavirus_local_restrictions.results.level_two.heading_tier_label") %>
+  </span>
+<% end %>
+
 <%
   title = if @restriction.present? && @restriction.future.present?
     t("coronavirus_local_restrictions.results.changing_levels_title")
   else
-    t("coronavirus_local_restrictions.results.level_two.heading")
+    tier_heading
   end
 %>
 
-<% content_for :title, title %>
+<% content_for :title, strip_tags(title) %>
 
 <%= tag.div :data => {
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier two: #{@restriction.area_name}"
 } do %>
   <%= render "govuk_publishing_components/components/title", {
-    title: title
+    title: sanitize(title)
   } %>
 
   <p class="govuk-body">
@@ -22,7 +29,7 @@
 
   <% if @restriction.present? && @restriction.future.present? %>
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("coronavirus_local_restrictions.results.level_two.heading"),
+      text: sanitize(tier_heading),
       font_size: "m",
       margin_bottom: 4
     } %>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -36,15 +36,18 @@ en:
       guidance_label: Find out what the Tier %{level} rules are
       match: "We've matched the postcode"
       level_one:
-        heading: "This area is in Tier 1: Medium alert"
+        heading_pretext: This area is in
+        heading_tier_label: "Tier 1: Medium alert"
         changing_alert_level: "At the moment %{area} is in Tier 1."
         guidance_link: "/guidance/tier-1-medium-alert"
       level_two:
-        heading: "This area is in Tier 2: High alert"
+        heading_pretext: This area is in
+        heading_tier_label: "Tier 2: High alert"
         changing_alert_level: "At the moment %{area} is in Tier 2."
         guidance_link: "/guidance/tier-2-high-alert"
       level_three:
-        heading: "This area is in Tier 3: Very High alert"
+        heading_pretext: This area is in
+        heading_tier_label: "Tier 3: Very High alert"
         changing_alert_level: "At the moment %{area} is in Tier 3."
         guidance_link: "/guidance/tier-3-very-high-alert"
       devolved_nations:

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -264,20 +264,23 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_see_the_results_page_for_level_one
     area = "Tatooine"
+    heading = "#{I18n.t('coronavirus_local_restrictions.results.level_one.heading_pretext')} #{I18n.t('coronavirus_local_restrictions.results.level_one.heading_tier_label')}"
     assert page.has_text?(area)
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_one.heading"))
+    assert page.has_text?(heading)
   end
 
   def then_i_see_the_results_page_for_level_two
     area = "Coruscant Planetary Council"
+    heading = "#{I18n.t('coronavirus_local_restrictions.results.level_two.heading_pretext')} #{I18n.t('coronavirus_local_restrictions.results.level_two.heading_tier_label')}"
     assert page.has_text?(area)
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.heading"))
+    assert page.has_text?(heading)
   end
 
   def then_i_see_the_results_page_for_level_three
     area = "Mandalore"
+    heading = "#{I18n.t('coronavirus_local_restrictions.results.level_three.heading_pretext')} #{I18n.t('coronavirus_local_restrictions.results.level_three.heading_tier_label')}"
     assert page.has_text?(area)
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.heading"))
+    assert page.has_text?(heading)
   end
 
   def then_i_see_the_results_for_wales


### PR DESCRIPTION
## What
The results of the postcode checker have the heading 'This area is in [full tier name]'.

We want to make a line break so the full tier name is always on one line so people can easily understand it. So the options will display as:

This area is in
Tier 1: Medium alert

This area is in
Tier 2: High alert

This area is in
Tier 3: Very High alert

## Why
So people can easily identify their tier

## Before

<img width="927" alt="Screenshot 2020-12-08 at 10 36 14" src="https://user-images.githubusercontent.com/4599889/101473061-477d8d00-3941-11eb-898e-6cb6f2b4c134.png">

## After

<img width="856" alt="Screenshot 2020-12-08 at 10 36 27" src="https://user-images.githubusercontent.com/4599889/101473078-4c424100-3941-11eb-8993-5a09a49a8522.png">

https://trello.com/c/LCDIMFk5/967-make-the-postcode-checker-heading-line-break-in-the-right-place