### PR TITLE
Add "Brexit checker" reference to transition landing page

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -9,7 +9,7 @@ en:
     countdown_day_to_go: day to go
     take_action_title: Make sure you’re ready
     take_action_text: |
-      Your business, family, and personal circumstances will be affected. Answer a few questions to get a personalised list of actions. You can also sign up for emails to get updates for what you need to do.
+      Your business, family, and personal circumstances will be affected. Use the Brexit checker to get a personalised list of actions. You can also sign up for emails to get updates for what you need to do.
     take_action_start_now: Start now
     take_action_start_now_link: "/transition-check/questions"
     take_action_list:


### PR DESCRIPTION
## What
Add reference to the Brexit checker to the transition landing page. NB: English page only at this stage. Awaiting Welsh translation. 

## Before 

<img width="889" alt="Screenshot 2020-12-07 at 11 27 51" src="https://user-images.githubusercontent.com/17908089/101345643-44ba6380-387f-11eb-96c3-08b6a08dfe58.png">


## After

<img width="896" alt="Screenshot 2020-12-07 at 11 27 39" src="https://user-images.githubusercontent.com/17908089/101345660-497f1780-387f-11eb-901e-288c84e55081.png">

---
Trello: https://trello.com/c/xwJACueh/677-update-landing-page-body-text-to-include-phrase-brexit-checker
Review app: https://govuk-collec-brexit-che-gp9s2h.herokuapp.com/transition