### PR TITLE
Add Buckinghamshire council

### DIFF
--- a/lib/local_restrictions/local-restrictions.yaml
+++ b/lib/local_restrictions/local-restrictions.yaml
@@ -755,6 +755,12 @@ E07000007:
     - alert_level: 2
       start_date: 2020-12-02
       start_time: "00:01"
+E06000060:
+  name: Buckinghamshire Council
+  restrictions:
+    - alert_level: 2
+      start_date: 2020-12-02
+      start_time: "00:01"
 E07000008:
   name: Cambridge City Council
   restrictions:


### PR DESCRIPTION
An update in Mapit, namely the replacement of 4 district councils with Buckinghamshire council (unitary authority) has caused some postcodes to incorrectly report that they're in tier 1. This is because the data for the district councils has been removed from Mapit and the tool defaults to tier 1 if it can't find a gss code for a postcode.

Once the new Mapit data has been released to prod we can remove the following lower tier authorities from the yaml
- E07000004	Aylesbury Vale
- E07000005	Chiltern
- E07000006	South Bucks
- E07000007	Wycombe
And there is a PR to do just that - https://github.com/alphagov/collections/pull/2130

Trello - https://trello.com/c/4RYRAlPM/978-update-buckinghamshire-data-before-mapit-data-goes-live

# South Bucks
## Current
<img width="626" alt="Screenshot 2020-12-07 at 15 50 42" src="https://user-images.githubusercontent.com/24547207/101372799-2fa3fb80-38a4-11eb-8428-17a1c82111a1.png">

## New Mapit data Current Yaml
<img width="640" alt="Screenshot 2020-12-07 at 15 42 03" src="https://user-images.githubusercontent.com/24547207/101372817-33378280-38a4-11eb-8080-48eac6a05117.png">

## New Mapit data New Yaml
<img width="622" alt="Screenshot 2020-12-07 at 15 20 05" src="https://user-images.githubusercontent.com/24547207/101372838-3763a000-38a4-11eb-966b-199746526d56.png">

# Wycombe
## Current
<img width="634" alt="Screenshot 2020-12-07 at 15 53 09" src="https://user-images.githubusercontent.com/24547207/101372955-57935f00-38a4-11eb-8112-aac938da566d.png">

## New Mapit data Current Yaml
<img width="650" alt="Screenshot 2020-12-07 at 15 50 08" src="https://user-images.githubusercontent.com/24547207/101372975-5bbf7c80-38a4-11eb-9bcc-49ad2955fd03.png">

## New Mapit data New Yaml
<img width="619" alt="Screenshot 2020-12-07 at 15 28 09" src="https://user-images.githubusercontent.com/24547207/101372989-5feb9a00-38a4-11eb-88c3-cd2f1a088162.png">

# Chiltern
## Current
<img width="593" alt="Screenshot 2020-12-07 at 15 55 10" src="https://user-images.githubusercontent.com/24547207/101373176-932e2900-38a4-11eb-9aeb-9b3b1d5703ed.png">

## New Mapit data Current Yaml
<img width="650" alt="Screenshot 2020-12-07 at 15 47 38" src="https://user-images.githubusercontent.com/24547207/101373321-b5c04200-38a4-11eb-8b37-9150efcebb48.png">

## New Mapit data New Yaml
<img width="609" alt="Screenshot 2020-12-07 at 15 20 38" src="https://user-images.githubusercontent.com/24547207/101373337-b9ec5f80-38a4-11eb-8ae2-11d21db2ca78.png">

# Aylesbury Vale
## Current
<img width="671" alt="Screenshot 2020-12-07 at 15 57 09" src="https://user-images.githubusercontent.com/24547207/101373439-d8eaf180-38a4-11eb-868b-0f12d203f0d7.png">

## New Mapit data Current Yaml
<img width="661" alt="Screenshot 2020-12-07 at 15 49 56" src="https://user-images.githubusercontent.com/24547207/101373453-dbe5e200-38a4-11eb-9dc5-1bd6c4cc0e7d.png">

## New Mapit data New Yaml
<img width="635" alt="Screenshot 2020-12-07 at 15 29 11" src="https://user-images.githubusercontent.com/24547207/101373463-df796900-38a4-11eb-8182-e07e6aa2385c.png">

