### PR TITLE
Remove district councils from Buckinghamshire

### DIFF
--- a/config/local_restrictions.yml
+++ b/config/local_restrictions.yml
@@ -899,34 +899,6 @@ E09000033:
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
-E07000004:
-  name: Buckinghamshire Council
-  delete_later: true
-  restrictions:
-    - alert_level: 4
-      start_date: 2020-12-20
-      start_time: "00:01"
-E07000005:
-  name: Buckinghamshire Council
-  delete_later: true
-  restrictions:
-    - alert_level: 4
-      start_date: 2020-12-20
-      start_time: "00:01"
-E07000006:
-  name: Buckinghamshire Council
-  delete_later: true
-  restrictions:
-    - alert_level: 4
-      start_date: 2020-12-20
-      start_time: "00:01"
-E07000007:
-  name: Buckinghamshire Council
-  delete_later: true
-  restrictions:
-    - alert_level: 4
-      start_date: 2020-12-20
-      start_time: "00:01"
 E06000060:
   name: Buckinghamshire Council
   restrictions:


### PR DESCRIPTION
This removes four district councils that now fall under Buckinghamshire County Council. This is a follow up PR to https://github.com/alphagov/collections/pull/2129.

Trello - https://trello.com/c/4RYRAlPM/978-update-buckinghamshire-data-before-mapit-data-goes-live