### PR TITLE
Fix leaky locale assignment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,11 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def switch_locale(&action)
+    locale = params[:locale] || I18n.default_locale
+    I18n.with_locale(locale, &action)
+  end
+
   def restrict_request_formats
     unless can_handle_format?(request.format)
       render status: :not_acceptable, plain: "Request format #{request.format} not handled."

--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -1,14 +1,8 @@
 class MinistersController < ApplicationController
-  before_action :set_locale
+  around_action :switch_locale
 
   def index
     @ministers = MinistersIndex.find!(request.path)
     setup_content_item_and_navigation_helpers(@ministers)
-  end
-
-private
-
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,7 +1,7 @@
 class OrganisationsController < ApplicationController
   skip_before_action :set_expiry
   before_action -> { set_expiry(5.minutes) }
-  before_action :set_locale, only: %i[show court]
+  around_action :switch_locale, only: %i[show court]
 
   def index
     @organisations = ContentStoreOrganisations.find!("/government/organisations")
@@ -49,9 +49,5 @@ private
 
   def locale
     ".#{params[:locale]}" if params[:locale]
-  end
-
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,15 +1,9 @@
 class PeopleController < ApplicationController
-  before_action :set_locale
+  around_action :switch_locale
 
   def show
     @person = Person.find!(request.path)
     setup_content_item_and_navigation_helpers(@person)
     render :show, locals: { person: @person }
-  end
-
-private
-
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,15 +1,9 @@
 class RolesController < ApplicationController
-  before_action :set_locale
+  around_action :switch_locale
 
   def show
     @role = Role.find!(request.path)
     setup_content_item_and_navigation_helpers(@role)
     render :show, locals: { role: @role }
-  end
-
-private
-
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
   end
 end

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -43,11 +43,6 @@ private
     true
   end
 
-  def switch_locale(&action)
-    locale = params[:locale] || I18n.default_locale
-    I18n.with_locale(locale, &action)
-  end
-
   def set_account_variant
     return unless Rails.configuration.feature_flag_govuk_accounts
     return unless show_signed_in_header? || show_signed_out_header?


### PR DESCRIPTION
A number of controllers in this app were using a before_action to set
the value of `I18n.locale` based on the request locale. This changes the
locale for the entire application, including subsequent requests. [1]

We learnt of this becoming a problem when we heard reports that users of
"/find-coronavirus-local-restrictions" were occasionally seeing a
back button in Welsh (Yn ôl). Investigating further we learnt that this
problem could be replicated by visiting a page in Welsh in this app (such as
[2]) and then visiting the postcode checker. The reason it was only
the back button that exhibited this problem is because it's the only
content with an available Welsh translation on this page.

To resolve this we need to change the approach used to change locale to
be encapsulated to only the particular action that is running. The Rails
documentation explains how this is done [1].

I've taken this as an opportunity to DRY up the locale setting so we
have one action on the superclass that other controllers can use.

[1]: https://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests
[2]: https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales.cy

----

Before:
![welsh-leak](https://user-images.githubusercontent.com/282717/101481765-93ceca00-394d-11eb-8bd1-b95e9544c996.gif)


After:

![welsh-fixed-leak](https://user-images.githubusercontent.com/282717/101481750-8f0a1600-394d-11eb-9a69-d25cee298a69.gif)
