### PR TITLE
Add Christmas rules to postcode checker

### DIFF
--- a/app/views/coronavirus_local_restrictions/_christmas_rules.html.erb
+++ b/app/views/coronavirus_local_restrictions/_christmas_rules.html.erb
@@ -1,0 +1,17 @@
+<%= render "govuk_publishing_components/components/heading", {
+    text: t("coronavirus_local_restrictions.results.christmas_rules.heading"),
+    font_size: "m",
+    margin_bottom: 4,
+    mobile_top_margin: true,
+  } %>
+
+<p class="govuk-body">
+  <%= t("coronavirus_local_restrictions.results.christmas_rules.body") %>
+</p>
+
+<%= render "govuk_publishing_components/components/button", {
+    text: t("coronavirus_local_restrictions.results.christmas_rules.guidance.label"),
+    href: t("coronavirus_local_restrictions.results.christmas_rules.guidance.link"),
+    margin_bottom: true,
+    secondary_solid: true,
+  } %>

--- a/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
@@ -16,7 +16,7 @@
     <%= render "govuk_publishing_components/components/button", {
       text: t("coronavirus_local_restrictions.results.guidance_label", level: @restriction.future_alert_level),
       href: t("coronavirus_local_restrictions.results.level_one.guidance_link"),
-      secondary: true,
+      secondary_solid: true,
       margin_bottom: 9
     } %>
   <% elsif @restriction.future_alert_level == 2 %>
@@ -27,7 +27,7 @@
     <%= render "govuk_publishing_components/components/button", {
       text: t("coronavirus_local_restrictions.results.guidance_label", level: @restriction.future_alert_level),
       href: t("coronavirus_local_restrictions.results.level_two.guidance_link"),
-      secondary: true,
+      secondary_solid: true,
       margin_bottom: 9
     } %>
   <% elsif @restriction.future_alert_level == 3 %>
@@ -38,7 +38,7 @@
     <%= render "govuk_publishing_components/components/button", {
       text: t("coronavirus_local_restrictions.results.guidance_label", level: @restriction.future_alert_level),
       href: t("coronavirus_local_restrictions.results.level_three.guidance_link"),
-      secondary: true,
+      secondary_solid: true,
       margin_bottom: 9
     } %>
   <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -44,6 +44,7 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -44,6 +44,7 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -44,6 +44,7 @@
     margin_bottom: 9
   } %>
 
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/config/locales/en/lookup.yml
+++ b/config/locales/en/lookup.yml
@@ -77,3 +77,10 @@ en:
           alert_level: "%{area} will be in Tier 2: High alert."
         level_three:
           alert_level: "%{area} will be in Tier 3: Very High alert."
+      christmas_rules:
+        heading: From 23 to 27 December
+        body: |
+          There are different Christmas rules for meeting friends and family.
+        guidance:
+           label: Find out what the Christmas rules are
+           link: "/guidance/guidance-for-the-christmas-period"

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -17,6 +17,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier two restrictions" do
@@ -25,6 +26,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_two
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier three restrictions" do
@@ -33,6 +35,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_three
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
+      then_i_see_details_of_christmas_rules
     end
   end
 
@@ -319,6 +322,10 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
     assert page.has_text?(area)
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.changing_alert_level", area: area))
+  end
+
+  def then_i_see_details_of_christmas_rules
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
   end
 
   def level_two_area


### PR DESCRIPTION
## What

Add Christmas rules to postcode checker results.

## Why

So the checker shows the most up to date information on what rules to follow

## NOTE

Please note that the button component could not be used at this time as there is no support for the style of secondary button that we need. 

## Screenshot

<img width="778" alt="Screenshot 2020-12-08 at 22 57 32" src="https://user-images.githubusercontent.com/4599889/101551401-d2de3900-39a8-11eb-9ca5-49bb1926a8a4.png">

### With future restrictions

<img width="689" alt="Screenshot 2020-12-09 at 20 26 19" src="https://user-images.githubusercontent.com/4599889/101684222-fa430d80-3a5d-11eb-9a5d-083b40ec37cf.png">


https://trello.com/c/zjaqrsBT/971-add-christmas-rules-to-postcode-checker
