### PR TITLE
Update email link text

### DIFF
--- a/app/views/components/docs/accordion.yml
+++ b/app/views/components/docs/accordion.yml
@@ -64,7 +64,7 @@ examples:
           panel: '<div class="govuk-govspeak">
             <div class="subscriptions">
               <a href="/email-signup/?topic=/education/alternative-provision-censuses" class="email-alerts">
-                Get email alerts for this topic
+                Get emails for this topic
                 <span class="visuallyhidden">Alternative provision censuses</span>
               </a>
             </div>
@@ -85,7 +85,7 @@ examples:
           panel: '<div class="govuk-govspeak">
             <div class="subscriptions">
               <a href="/email-signup/?topic=/education/general-hospital-school-censuses" class="email-alerts">
-                Get email alerts for this topic
+                Get emails for this topic
                 <span class="visuallyhidden">General hospital school censuses</span>
               </a>
             </div>

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -12,7 +12,7 @@
     <div class="govuk-grid-column-one-third add-title-margin govuk-!-margin-bottom-3">
       <%= render "govuk_publishing_components/components/subscription-links", {
         email_signup_link: "/email-signup?topic=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
-        email_signup_link_text: "Subscribe to email alerts",
+        email_signup_link_text: "Get emails for this topic",
       } %>
 
       <% if local_assigns[:link_to_latest_feed] %>

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,7 +1,7 @@
 <% if taxon_is_live?(presented_taxon) %>
   <div class='subscriptions'>
     <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
-      Get email alerts for this topic
+      Get emails for this topic
       <span class='visuallyhidden'><%= presented_taxon.title %></span>
     </a>
   </div>

--- a/app/views/transition_landing_page/_email_alerts.html.erb
+++ b/app/views/transition_landing_page/_email_alerts.html.erb
@@ -1,6 +1,0 @@
-<div class='subscriptions'>
-  <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
-    Get email alerts for this topic
-    <span class='visuallyhidden'><%= presented_taxon.title %></span>
-  </a>
-</div>

--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -2,14 +2,14 @@
   <% if presented_taxon.renders_as_accordion? %>
     <%= render "govuk_publishing_components/components/subscription-links", {
       email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "Get email alerts for this topic <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
+      email_signup_link_text: "Get emails for this topic <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
       feed_link: whitehall_atom_url,
       feed_link_box_value: whitehall_atom_url
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/subscription-links", {
       email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "Get email alerts for this topic <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
+      email_signup_link_text: "Get emails for this topic <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
     } %>
   <% end %>
 <% end %>

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -291,7 +291,7 @@ en:
     part_of: "Part of"
     separate_website: "separate website"
     subscription:
-      email: "Get email alerts"
+      email: "Get emails"
       feed: "Subscribe to feed"
     people:
       board_members: "Our management"

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -689,7 +689,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
   it "shows subscription links" do
     visit "/government/organisations/attorney-generals-office"
-    assert page.has_css?("a[href='/email-signup?link=/government/organisations/attorney-generals-office']", text: "Get email alerts")
+    assert page.has_css?("a[href='/email-signup?link=/government/organisations/attorney-generals-office']", text: "Get emails")
     assert page.has_css?("button", text: "Subscribe to feed")
   end
 

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -27,7 +27,7 @@ class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
     email_url = Plek.new.website_root + "/email-signup?link=#{@base_path}"
     feed_url = Plek.new.website_root + "/world/usa.atom"
 
-    assert page.has_selector?("a[href='#{email_url}']", text: "Get email alerts")
+    assert page.has_selector?("a[href='#{email_url}']", text: "Get emails for this topic")
     assert page.has_selector?("button", text: "Subscribe to feed")
     assert page.has_selector?(".gem-c-subscription-links input[value='#{feed_url}']")
   end

--- a/test/integration/world_wide_taxon_browsing_test.rb
+++ b/test/integration/world_wide_taxon_browsing_test.rb
@@ -75,7 +75,7 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
   end
 
   def and_i_can_see_the_email_signup_link
-    assert page.has_link?("Get email alerts for this topic")
+    assert page.has_link?("Get emails for this topic")
   end
 
   def and_i_can_see_links_to_the_child_taxons_in_an_accordion


### PR DESCRIPTION
We're removing the 'alert' terminology from our email links. This text
has been content reviewed.

Example pages:

* https://www.gov.uk/government/organisations/attorney-generals-office
* https://www.gov.uk/world/usa

Trello:
https://trello.com/c/ssSnzp2L/640-remove-alert-from-all-the-sign-up-links