### PR TITLE
Redirect to postcode checker to full guidance page

### DIFF
--- a/app/lib/coronavirus_local_restrictions_constraint.rb
+++ b/app/lib/coronavirus_local_restrictions_constraint.rb
@@ -1,0 +1,5 @@
+class CoronavirusLocalRestrictionsConstraint
+  def matches?(*)
+    !Rails.env.production?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,12 @@ Rails.application.routes.draw do
   end
 
   # Route for local restrictions postcode lookup
-  get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
+  constraints CoronavirusLocalRestrictionsConstraint.new do
+    get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
+  end
+
+  # This redirects to the full guidance when the checker is offline
+  get "/find-coronavirus-local-restrictions", to: redirect("/guidance/national-lockdown-stay-at-home")
 
   # TODO: this redirect causes the request to be routed to Whitehall where
   # the country A-Z currently lives. This needs to be removed when the world index

--- a/test/lib/coronavirus_local_restrictions_constraint_test.rb
+++ b/test/lib/coronavirus_local_restrictions_constraint_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+require "mocha"
+
+class CoronavirusLocalRestrictionsConstraintTest < ActiveSupport::TestCase
+  describe "#matches?" do
+    it "returns false when the environment is production" do
+      Rails.stubs(:env).returns(ActiveSupport::StringInquirer.new("production"))
+      assert_equal described_class.new.matches?, false
+    end
+
+    it "returns true if the environment is not production" do
+      assert_equal described_class.new.matches?, true
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/cr8l3ddo

# What's changed and why?

We're expecting potential spike in traffic. This a standby change that's
only to be used if we need to take the postcode checker offline quickly,
to take pressure of the system whilst we increase capacity to respond to
the spike.