### PR TITLE
DIT landing page controller refactor

### DIFF
--- a/app/controllers/dit_landing_page_controller.rb
+++ b/app/controllers/dit_landing_page_controller.rb
@@ -1,31 +1,17 @@
 class DitLandingPageController < ApplicationController
   around_action :switch_locale
 
-  def show; end
-
-  helper_method :translation_links
-
-  def translation_links
-    available_translations.map do |translation|
-      {
-        locale: translation,
-        base_path: path(translation),
-        text: language_name(translation),
-        active: locale == translation,
-      }
-    end
+  def show
+    @presenter = presenter
   end
 
-  def path(language)
-    raw_path = request.path.split(".")[0]
-    language == :en ? raw_path : "#{raw_path}.#{language}"
+private
+
+  def content_item
+    ContentItem.find!(request.path)
   end
 
-  def language_name(language)
-    I18n.t("shared.language_names.#{language}")
-  end
-
-  def available_translations
-    %i[en de es fr it nl pl]
+  def presenter
+    DitLandingPagePresenter.new(content_item)
   end
 end

--- a/app/presenters/dit_landing_page_presenter.rb
+++ b/app/presenters/dit_landing_page_presenter.rb
@@ -1,0 +1,29 @@
+class DitLandingPagePresenter
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def translation_links
+    translations = available_translations.map do |item|
+      {
+        locale: item.locale,
+        base_path: item.base_path,
+        text: I18n.t("shared.language_names.#{item.locale}"),
+        active: (item.base_path == content_item.base_path),
+      }
+    end
+    sort_by_default_locale(translations)
+  end
+
+private
+
+  attr_reader :content_item
+
+  def available_translations
+    content_item.linked_items("available_translations")
+  end
+
+  def sort_by_default_locale(translations)
+    translations.sort_by { |t| t[:locale] == I18n.default_locale.to_s ? "" : t[:locale] }
+  end
+end

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -19,7 +19,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds dit-landing-page_header-text-container">
           <%= render "govuk_publishing_components/components/translation-nav", {
-            translations: translation_links
+            translations: @presenter.translation_links
           } %>
 
           <h1 class="dit-landing-page__page_title">

--- a/test/controllers/dit_landing_page_controller_test.rb
+++ b/test/controllers/dit_landing_page_controller_test.rb
@@ -1,10 +1,15 @@
 require "test_helper"
 
 describe DitLandingPageController do
+  include DitLandingPageHelpers
+
+  before do
+    stub_all_eubusiness_pages
+  end
+
   describe "GET show" do
     expected_content = {
       de: "Handel mit dem Vereinigten Königreich ab 1. Januar 2021 als Unternehmen mit Sitz in der EU",
-      en: "Trade with the UK from 1 January 2021 as a business based in the EU",
       es: "Cómo hacer negocios con el Reino Unido a partir del 1 de enero de 2021 en caso de ser una empresa con sede en la UE",
       fr: "Travailler avec le Royaume-Uni à partir du 1er janvier 2021 en tant qu'entreprise basée dans l'UE",
       it: "Se la tua azienda ha sede nell’UE, scopri le nuove regole per continuare a fare affari con il Regno Unito dal 1° gennaio 2021",
@@ -13,12 +18,19 @@ describe DitLandingPageController do
     }
 
     expected_content.each_key do |locale|
-      it "renders the page for the #{locale} locale" do
-        get :show, params: { locale: locale.to_s }
+      it "renders translated page for the #{locale} locale" do
+        get :show, params: { locale: locale }
         assert_response :success
         assert_select "h1", expected_content[locale]
         assert_select "main[lang=#{locale}]"
       end
+    end
+
+    it "renders the English page" do
+      get :show
+      assert_response :success
+      assert_select "h1", "Trade with the UK from 1 January 2021 as a business based in the EU"
+      assert_select "main[lang=en]", false
     end
   end
 end

--- a/test/fixtures/content_store/dit_landing_page.json
+++ b/test/fixtures/content_store/dit_landing_page.json
@@ -1,0 +1,67 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/eubusiness",
+  "content_id": "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
+  "document_type": "answer",
+  "first_published_at": "2020-09-04T16:14:37.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2020-09-04T16:14:36.000+00:00",
+  "publishing_app": "collections-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "collections",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "special_route",
+  "title": "Trade with the UK from 1 January 2021 as a business based in the EU",
+  "updated_at": "2020-11-25T16:25:53.298Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "27623-1599236077.071-10.13.4.55-537",
+  "links": {
+    "available_translations": [
+      {
+        "title": "Trade with the UK from 1 January 2021 as a business based in the EU",
+        "public_updated_at": "2020-09-04T16:14:36Z",
+        "document_type": "answer",
+        "schema_name": "special_route",
+        "base_path": "/eubusiness",
+        "api_path": "/api/content/eubusiness",
+        "withdrawn": false,
+        "content_id": "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/eubusiness",
+        "web_url": "https://www.gov.uk/eubusiness",
+        "links": {}
+      },
+      {
+        "title": "Trade with the UK from 1 January 2021 as a business based in the EU",
+        "public_updated_at": "2020-09-04T16:14:36Z",
+        "document_type": "answer",
+        "schema_name": "special_route",
+        "base_path": "/eubusiness.fr",
+        "api_path": "/api/content/eubusiness.fr",
+        "withdrawn": false,
+        "content_id": "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
+        "locale": "fr",
+        "api_url": "https://www.gov.uk/api/content/eubusiness.fr",
+        "web_url": "https://www.gov.uk/eubusiness.fr",
+        "links": {}
+      },
+      {
+        "title": "Trade with the UK from 1 January 2021 as a business based in the EU",
+        "public_updated_at": "2020-09-04T16:14:36Z",
+        "document_type": "answer",
+        "schema_name": "special_route",
+        "base_path": "/eubusiness.de",
+        "api_path": "/api/content/eubusiness.de",
+        "withdrawn": false,
+        "content_id": "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
+        "locale": "de",
+        "api_url": "https://www.gov.uk/api/content/eubusiness.de",
+        "web_url": "https://www.gov.uk/eubusiness.de",
+        "links": {}
+      }
+    ]
+  },
+  "description": "The UK has left the EU. On 31 December 2020 the UK will leave the EU single market and customs union. From 1 January 2021 the rules for trading with the UK will change.",
+  "details": {}
+}

--- a/test/integration/dit_landing_page_test.rb
+++ b/test/integration/dit_landing_page_test.rb
@@ -1,17 +1,35 @@
 require "integration_test_helper"
 
 class DitLandingPageTest < ActionDispatch::IntegrationTest
-  DIT_LANDING_PAGE_PATH = "/eubusiness".freeze
+  include DitLandingPageHelpers
 
   describe "the DIT landing page" do
+    before do
+      stub_dit_landing_page
+    end
     it "renders" do
       when_i_visit_the_dit_landing_page
       then_i_can_see_the_header_section
       and_i_can_see_the_guidance_links
       then_i_can_see_the_training_section
     end
+
+    context "in a different locale" do
+      before do
+        stub_all_eubusiness_pages
+      end
+      it "displays the translated content" do
+        when_i_visit_the_dit_landing_page
+        then_i_can_see_the_translation_nav
+        and_i_click_on_deutsch
+        then_i_see_the_german_translation_of_the_page
+        and_i_click_on_english
+        then_i_can_see_the_english_translation_of_the_page
+      end
+    end
   end
 
+  # test 1
   def when_i_visit_the_dit_landing_page
     visit DIT_LANDING_PAGE_PATH
   end
@@ -26,5 +44,26 @@ class DitLandingPageTest < ActionDispatch::IntegrationTest
 
   def then_i_can_see_the_training_section
     assert page.has_selector?("h2", text: "Webinars for EU-based businesses trading with the UK")
+  end
+
+  # test 2
+  def then_i_can_see_the_translation_nav
+    assert page.has_selector?("nav", text: "Deutsch")
+  end
+
+  def and_i_click_on_deutsch
+    click_on("Deutsch")
+  end
+
+  def then_i_see_the_german_translation_of_the_page
+    assert page.has_title? "Handel mit dem Vereinigten Königreich ab 1. Januar 2021 als Unternehmen mit Sitz in der EU"
+  end
+
+  def and_i_click_on_english
+    click_on("English")
+  end
+
+  def then_i_can_see_the_english_translation_of_the_page
+    then_i_can_see_the_header_section
   end
 end

--- a/test/support/dit_landing_page_helpers.rb
+++ b/test/support/dit_landing_page_helpers.rb
@@ -1,0 +1,34 @@
+module DitLandingPageHelpers
+  DIT_LANDING_PAGE_PATH = "/eubusiness".freeze
+
+  def dit_landing_page_content_item(locale = nil)
+    content_item = load_content_item("dit_landing_page.json")
+    return content_item unless locale
+
+    content_item["base_path"] = "#{DIT_LANDING_PAGE_PATH}.#{locale}"
+    content_item["locale"] = locale
+    content_item
+  end
+
+  def stub_dit_landing_page
+    stub_content_store_has_item(DIT_LANDING_PAGE_PATH, dit_landing_page_content_item)
+  end
+
+  def stub_translated_dit_landing_pages
+    %i[de es fr it nl pl].each do |locale|
+      stub_content_store_has_item("#{DIT_LANDING_PAGE_PATH}.#{locale}", dit_landing_page_content_item(locale))
+    end
+  end
+
+  def stub_all_eubusiness_pages
+    stub_dit_landing_page
+    stub_translated_dit_landing_pages
+  end
+
+  def load_content_item(file_name)
+    json = File.read(
+      Rails.root.join("test/fixtures/content_store/", file_name),
+    )
+    JSON.parse(json)
+  end
+end


### PR DESCRIPTION
## What
On Friday we [shipped](https://github.com/alphagov/collections/pull/2134) a refreshed version of the [DIT landing page](https://www.gov.uk/eubusiness). This PR makes no changes to the visible page. It is a refactor of the way we implement the translation nav: 
- Previously we had the available locales hard coded in the controller. 
- Now that the routes have been published, we can read the available translations from [the content item](https://www.gov.uk/api/content/eubusiness) instead. 

---
[trello card](https://trello.com/c/bL1fDWQs/704-dit-landing-page-code-tidy-up)
