### PR TITLE
Add a 3 hour Rails cache to mapit postcode lookup

### DIFF
--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -49,7 +49,9 @@ private
 
   def response
     @response ||= begin
-                    JSON.parse(mapit.location_for_postcode(postcode).to_json)
+                    Rails.cache.fetch("mapit-location-#{postcode}", expires_in: 3.hours) do
+                      JSON.parse(mapit.location_for_postcode(postcode).to_json)
+                    end
                   rescue GdsApi::HTTPNotFound, GdsApi::HTTPClientError => e
                     {
                       error: {


### PR DESCRIPTION
This line returns the area a postcode is in. Area boundaries are
infrequently updated, (rarely more than twice a year).

Repeated queries for the same postcode will return the same area, making
this a good candidate for caching to boost performance.

We use a three hour expiry because long enough that it should help cover
spikes in traffic, but not require cache busting when there is a rare
area boundary update.