### PR TITLE
Flip the partials for christmas rules and future restrictions

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -44,7 +44,7 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -44,7 +44,7 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -44,7 +44,7 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>


### PR DESCRIPTION
All restrictions are meant to be in date order. The new restrictions that come into being before the christmas rule changes are in the wrong place. This swaps the christmas rules and future restrictions so it displays properly. This will have to be reverted before any new restrictions that come in after christmas are made live.

## Before
### Desktop
<img width="681" alt="Screenshot 2020-12-14 at 16 06 08" src="https://user-images.githubusercontent.com/24547207/102104741-722a8280-3e26-11eb-95e3-f8139483c5b5.png">
### Mobile
<img width="408" alt="Screenshot 2020-12-14 at 16 07 10" src="https://user-images.githubusercontent.com/24547207/102104770-7b1b5400-3e26-11eb-8524-b05e3539b7c6.png">


## After
### Desktop
<img width="665" alt="Screenshot 2020-12-14 at 16 06 36" src="https://user-images.githubusercontent.com/24547207/102104805-840c2580-3e26-11eb-92ef-5a97bb7fed28.png">
### Mobile
<img width="409" alt="Screenshot 2020-12-14 at 16 06 56" src="https://user-images.githubusercontent.com/24547207/102104824-88d0d980-3e26-11eb-86b0-854cb201176d.png">

