### PR TITLE
Remove POST route in postcode checker

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -1,6 +1,5 @@
 class CoronavirusLocalRestrictionsController < ApplicationController
   MAX_CACHE_TIME = 30.minutes
-  skip_before_action :verify_authenticity_token, only: [:legacy]
 
   def show
     expires_in(MAX_CACHE_TIME, public: true)
@@ -22,12 +21,6 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
       render :results
     end
-  end
-
-  # This action is temporary. It exists to prevent errors while the application
-  # transitions from a POST endpoint to a GET one.
-  def legacy
-    redirect_to find_coronavirus_local_restrictions_path(postcode: params["postcode-lookup"])
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,9 +27,8 @@ Rails.application.routes.draw do
     get ":subtopic_slug", on: :member, to: "subtopics#show"
   end
 
-  # Routes for local restrictions postcode lookup
+  # Route for local restrictions postcode lookup
   get "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#show"
-  post "/find-coronavirus-local-restrictions" => "coronavirus_local_restrictions#legacy"
 
   # TODO: this redirect causes the request to be routed to Whitehall where
   # the country A-Z currently lives. This needs to be removed when the world index

--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -87,12 +87,4 @@ describe CoronavirusLocalRestrictionsController do
       end
     end
   end
-
-  describe "POST legacy" do
-    it "redirects to the GET endpoint" do
-      post :legacy, params: { "postcode-lookup" => "E1 8QS" }
-
-      assert_redirected_to find_coronavirus_local_restrictions_path(postcode: "E1 8QS")
-    end
-  end
 end


### PR DESCRIPTION
# What's changed and why?

In https://github.com/alphagov/collections/pull/2136 the postcode
checker was changed to use GET requests rather than POST requests
to find and display the results.

To make sure that people who were half way through the journey weren't
affected by this change, we changed the POST route to redirect to the
GET. But this was only meant to be temporary. It should now be safe to
remove the POST route completely.