### PR TITLE
Add tier 1 areas to local restrictions data

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -14,7 +14,7 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     if @search.blank_postcode? || @search.invalid_postcode?
       render
-    elsif @search.no_information?
+    elsif @search.no_restriction? || @search.no_information?
       render :no_information
     else
       expires_in(restriction_expiry(@search), public: true)

--- a/app/models/postcode_local_restriction_search.rb
+++ b/app/models/postcode_local_restriction_search.rb
@@ -42,6 +42,10 @@ class PostcodeLocalRestrictionSearch
     %w[invalidPostcodeFormat fullPostcodeNoMapitValidation].include?(error_code)
   end
 
+  def no_restriction?
+    location_lookup.data.first&.england? && local_restriction.nil?
+  end
+
   def location_lookup
     @location_lookup ||= LocationLookupService.new(sanitised_postcode)
   end

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -17,14 +17,14 @@
 
 <%= tag.div :data => {
   :module => "coronavirus-track-local-restriction-results",
-  "tracking-label" => "Tier one: #{location_lookup.lower_tier_area_name}"
+  "tracking-label" => "Tier one: #{restriction.area_name}"
 } do %>
   <%= render "govuk_publishing_components/components/title", {
     title: sanitize(title)
   } %>
 
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= location_lookup.lower_tier_area_name %></strong>.
+    <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= restriction.area_name %></strong>.
   </p>
 
   <% if restriction.present? && restriction.future.present? %>

--- a/app/views/coronavirus_local_restrictions/results.html.erb
+++ b/app/views/coronavirus_local_restrictions/results.html.erb
@@ -17,14 +17,14 @@
     %>
     <% if !@search.location_lookup.data.first.england? %>
       <%= render partial: "coronavirus_local_restrictions/devolved_nation", locals: locals %>
+    <% elsif @search.local_restriction&.tier_one? %>
+      <%= render partial: "coronavirus_local_restrictions/tier_one_restrictions", locals: locals %>
     <% elsif @search.local_restriction&.tier_two? %>
       <%= render partial: "coronavirus_local_restrictions/tier_two_restrictions", locals: locals %>
     <% elsif @search.local_restriction&.tier_three? %>
       <%= render partial: "coronavirus_local_restrictions/tier_three_restrictions", locals: locals %>
     <% elsif @search.local_restriction&.tier_four? %>
       <%= render partial: "coronavirus_local_restrictions/tier_four_restrictions", locals: locals %>
-    <% else %>
-      <%= render partial: "coronavirus_local_restrictions/tier_one_restrictions", locals: locals %>
     <% end %>
   </div>
 </div>

--- a/config/local_restrictions.yml
+++ b/config/local_restrictions.yml
@@ -2196,3 +2196,21 @@ E07000202:
     - alert_level: 2
       start_date: 2020-12-02
       start_time: "00:01"
+E06000052:
+  name: Cornwall Council
+  restrictions:
+    - alert_level: 1
+      start_date: 2020-12-02
+      start_time: "00:01"
+E06000046:
+  name: Isle of Wight Council
+  restrictions:
+    - alert_level: 1
+      start_date: 2020-12-02
+      start_time: "00:01"
+E06000053:
+  name: Council of the Isles of Scilly
+  restrictions:
+    - alert_level: 1
+      start_date: 2020-12-02
+      start_time: "00:01"

--- a/test/models/postcode_local_restriction_search_test.rb
+++ b/test/models/postcode_local_restriction_search_test.rb
@@ -84,6 +84,32 @@ describe PostcodeLocalRestrictionSearch do
     end
   end
 
+  describe "#no_restriction?" do
+    it "returns true when an english postcode has no restriction data" do
+      LocalRestriction.stubs(:find).with("E09000030").returns(nil)
+
+      assert described_class.new("E1 8QS").no_restriction?
+    end
+
+    it "returns false when an english postcode has a restriction" do
+      restriction = LocalRestriction.new("E09000030", { "name" => "London Borough of Tower Hamlets" })
+      LocalRestriction.stubs(:find).with("E09000030").returns(restriction)
+
+      assert_not described_class.new("E1 8QS").no_restriction?
+    end
+
+    it "returns false for a develolved nation postcode" do
+      stub_mapit_has_a_postcode_and_areas("EH7 4EW", [], [{
+        "gss" => "S12000036",
+        "name" => "Edinburgh",
+        "type" => "LBO",
+        "country_name" => "Scotland",
+      }])
+
+      assert_not described_class.new("EH7 4EW").no_restriction?
+    end
+  end
+
   describe "#local_restriction" do
     it "matches a postcode to its local restriction" do
       stub_mapit_has_a_postcode_and_areas("SW1A 2AA", [], [


### PR DESCRIPTION
[Trello](https://trello.com/c/K69U9Y1V/989-add-tier-1-places-to-the-yaml-file)

- Add tier 1 restriction data to local_restrictions.yml.
- Display 'No tier information' result page to user if a postcode is valid but the restriction is not defined within the YML data.


## Tier 1 result

![tier-1-results](https://user-images.githubusercontent.com/5963488/102387268-1435a080-3fc8-11eb-8c81-912a1628ce84.png)


## Tier 1 with future restrictions (please note... this is just test data)

![tier-1-with-future-restrictions](https://user-images.githubusercontent.com/5963488/102387673-932ad900-3fc8-11eb-972d-ff485f32773a.png)

## No tier information

![no-tier-information-results](https://user-images.githubusercontent.com/5963488/102387277-1566cd80-3fc8-11eb-9471-340ed49b499a.png)


