### PR TITLE
Change names of buckinghamshire councils

### DIFF
--- a/config/local_restrictions.yml
+++ b/config/local_restrictions.yml
@@ -837,25 +837,29 @@ E09000033:
       start_date: 2020-12-16
       start_time: "00:01"
 E07000004:
-  name: Aylesbury Vale District Council
+  name: Buckinghamshire Council
+  delete_later: true
   restrictions:
     - alert_level: 2
       start_date: 2020-12-02
       start_time: "00:01"
 E07000005:
-  name: Chiltern District Council
+  name: Buckinghamshire Council
+  delete_later: true
   restrictions:
     - alert_level: 2
       start_date: 2020-12-02
       start_time: "00:01"
 E07000006:
-  name: South Bucks District Council
+  name: Buckinghamshire Council
+  delete_later: true
   restrictions:
     - alert_level: 2
       start_date: 2020-12-02
       start_time: "00:01"
 E07000007:
-  name: Wycombe District Council
+  name: Buckinghamshire Council
+  delete_later: true
   restrictions:
     - alert_level: 2
       start_date: 2020-12-02


### PR DESCRIPTION
This changes the names of the old councils that have been absorbed into Buckinghamshire Council. This will stop the old names from being displayed until we can get the new Mapit data in. I've added an arbitrary `delete_later` tag under the old lower tier local authority codes so we know which ones we need to get rid of once the Mapit data goes live.

## Before
<img width="580" alt="Screenshot 2020-12-17 at 08 21 25" src="https://user-images.githubusercontent.com/24547207/102462586-dffec600-4041-11eb-91b1-c5520dff3ff0.png">

## After
<img width="603" alt="Screenshot 2020-12-17 at 08 27 52" src="https://user-images.githubusercontent.com/24547207/102462613-eb51f180-4041-11eb-934d-76cff6fe07e1.png">
