### PR TITLE
Improve content for devolved nations

### DIFF
--- a/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
+++ b/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
@@ -22,7 +22,7 @@
   <% if location.scotland? %>
     <%= render "govuk_publishing_components/components/button", {
       text: t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance.label"),
-      href: t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance.link"),
+      href: t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance.link", postcode: postcode.gsub(/\s+/, '')),
       margin_bottom: 9
     } %>
   <% elsif location.northern_ireland? %>

--- a/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
+++ b/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
@@ -15,6 +15,10 @@
   <p class="govuk-body">
     <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= location_lookup.lower_tier_area_name %></strong>.
   </p>
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.devolved_nations.country_rules", country: location.country) %>
+  </p>
+
   <% if location.scotland? %>
     <%= render "govuk_publishing_components/components/button", {
       text: t("coronavirus_local_restrictions.results.devolved_nations.scotland.guidance.label"),

--- a/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
+++ b/app/views/coronavirus_local_restrictions/_devolved_nation.html.erb
@@ -13,7 +13,7 @@
     title: title
   } %>
   <p class="govuk-body">
-    <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= location.country %></strong>.
+    <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= location_lookup.lower_tier_area_name %></strong>.
   </p>
   <% if location.scotland? %>
     <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -52,6 +52,7 @@ en:
         guidance_link: "/guidance/tier-3-very-high-alert"
       devolved_nations:
         heading: There might be restrictions in this area
+        country_rules: The rules are different in %{country}.
         scotland:
           guidance:
            label: Find out what the rules are in Scotland

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -56,7 +56,7 @@ en:
         scotland:
           guidance:
            label: Find out what the rules are in Scotland
-           link: "https://www.gov.scot/check-local-covid-level/"
+           link: "https://www.gov.scot/check-local-covid-level/#!/%{postcode}"
         wales:
           guidance:
             label: Find out what the rules are in Wales


### PR DESCRIPTION
Trello: https://trello.com/c/Tz6It6TX

# What's changed and why?
Entering a postcode for one of the devolved nations will take you to the generic page for that nation. This means that users in nations other than England may have to enter their postcode twice and visit two different websites to get the information they need.

# Expected changes

- Display council name for postcode in devolved nation
- Add extra line of content to display the country
- Link directly to results page of Scottish postcode checker on results page for Scotland

| Before             |  After|
:-------------------------:|:-------------------------:
<img width="1532" alt="Screenshot 2020-12-17 at 14 20 28" src="https://user-images.githubusercontent.com/5793815/102499400-08eb7f00-4073-11eb-9a96-8c06d46a8e97.png">|<img width="1532" alt="Screenshot 2020-12-17 at 14 07 23" src="https://user-images.githubusercontent.com/5793815/102499166-c45fe380-4072-11eb-9d64-056c8260aff4.png">
<img width="1532" alt="Screenshot 2020-12-17 at 14 21 48" src="https://user-images.githubusercontent.com/5793815/102499539-389a8700-4073-11eb-93f0-48564e077c1c.png">|<img width="1532" alt="Screenshot 2020-12-17 at 13 53 25" src="https://user-images.githubusercontent.com/5793815/102499263-df325800-4072-11eb-8624-728bfc0d4b38.png">
<img width="1532" alt="Screenshot 2020-12-17 at 14 23 08" src="https://user-images.githubusercontent.com/5793815/102499709-68e22580-4073-11eb-82e5-7b47e0479f61.png">|<img width="1532" alt="Screenshot 2020-12-17 at 13 52 23" src="https://user-images.githubusercontent.com/5793815/102499292-e48fa280-4072-11eb-82f9-c7e442a017d3.png">


