### PR TITLE
Add AB test for alternate Brexit start button text

### DIFF
--- a/app/controllers/concerns/brexit_button_ab_testable.rb
+++ b/app/controllers/concerns/brexit_button_ab_testable.rb
@@ -1,0 +1,28 @@
+module BrexitButtonAbTestable
+  CUSTOM_DIMENSION = 44
+  TEST_NAME = "BrexitChecker".freeze
+
+  def brexit_button_variant
+    @brexit_button_variant ||= begin
+      ab_test = GovukAbTesting::AbTest.new(
+        TEST_NAME,
+        dimension: CUSTOM_DIMENSION,
+        allowed_variants: %w[A B Z],
+        control_variant: "Z",
+      )
+      ab_test.requested_variant(request.headers)
+    end
+  end
+
+  def show_brexit_button_variant?
+    is_english_transition_page? && brexit_button_variant.variant?("B")
+  end
+
+  def is_english_transition_page?
+    request.path == "/transition"
+  end
+
+  def set_brexit_button_variant
+    brexit_button_variant.configure_response(response) if is_english_transition_page?
+  end
+end

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -1,14 +1,17 @@
 class TransitionLandingPageController < ApplicationController
   include AccountAbTestable
+  include BrexitButtonAbTestable
   include Slimmer::Headers
 
   skip_before_action :set_expiry
   before_action -> { set_expiry(1.minute) }
   before_action :set_account_variant
+  before_action :set_brexit_button_variant
 
   around_action :switch_locale
 
-  helper_method :account_variant
+  helper_method :account_variant,
+                :brexit_button_variant, :is_english_transition_page?, :show_brexit_button_variant?
 
   def show
     setup_content_item_and_navigation_helpers(taxon)

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -14,6 +14,8 @@
   <meta name="govuk:navigation-page-type" content="Taxon Page" />
   <link rel="canonical" href="<%= page_url %>">
   <%= account_variant.analytics_meta_tag.html_safe %>
+  <%= brexit_button_variant.analytics_meta_tag.html_safe if is_english_transition_page? %>
+
 <% end %>
 
 <header class="landing-page__header--with-bg-image">

--- a/app/views/transition_landing_page/_take_action.html.erb
+++ b/app/views/transition_landing_page/_take_action.html.erb
@@ -12,15 +12,16 @@
                 text: t("transition_landing_page.take_action_text")
               } %>
             <% end %>
+            <% button_text = show_brexit_button_variant? ? "Brexit checker: start now" : t("transition_landing_page.take_action_start_now") %>
             <%= render "govuk_publishing_components/components/button", {
-              text: t("transition_landing_page.take_action_start_now"),
+              text: button_text,
               href: t("transition_landing_page.take_action_start_now_link"),
               start: true,
               data_attributes: {
                 "module": "track-click",
                 "track-action": t("transition_landing_page.take_action_start_now_link"),
                 "track-category": "transition-landing-page",
-                "track-label": t("transition_landing_page.take_action_start_now")
+                "track-label": button_text
               }
             } %>
           </div>

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -49,5 +49,38 @@ describe TransitionLandingPageController do
         end
       end
     end
+
+    describe "BrexitChecker AB test" do
+      context "In the en locale" do
+        %w[A Z].each do |variant|
+          it "Variant #{variant} shows the default button text" do
+            with_variant BrexitChecker: variant do
+              get :show
+              assert_select ".govuk-button", text: "Start now"
+            end
+          end
+        end
+
+        it "Variant B shows the alternate button text" do
+          with_variant BrexitChecker: "B" do
+            get :show
+            assert_select ".govuk-button", text: "Brexit checker: start now"
+          end
+        end
+      end
+
+      context "In the cy locale" do
+        %w[A B Z].each do |variant|
+          it "All variants shows the default button text" do
+            setup_ab_variant("BrexitChecker", variant)
+            get :show, params: { locale: "cy" }
+            assert_select ".govuk-button", text: "Dechrau nawr"
+
+            # we don't want to set Vary headers for pages that are not modified
+            assert_response_not_modified_for_ab_test("BrexitChecker")
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This tests whether aligning with the text used by the campaign advertising increases CTR for the Brexit checker.

It is only active on the English transition page.

## Variant A

<img width="883" alt="Screenshot 2020-12-17 at 16 46 34" src="https://user-images.githubusercontent.com/17908089/102517048-773a3c80-4087-11eb-9f10-81a45aae6f07.png">

## Variant B
<img width="884" alt="Screenshot 2020-12-17 at 16 46 13" src="https://user-images.githubusercontent.com/17908089/102517049-77d2d300-4087-11eb-89d6-834e617271d0.png">

---
[Trello](https://trello.com/c/LmSZNlem/719-a-b-test-brexit-checker-on-the-landing-page-green-button)
[Review app](https://govuk-collec-ab-brexit--s5yjxm.herokuapp.com/transition)