### PR TITLE
Add Tier 4

### DIFF
--- a/app/models/local_restriction.rb
+++ b/app/models/local_restriction.rb
@@ -44,6 +44,10 @@ class LocalRestriction
     future_restrictions.min_by { |rest| rest["start_date"] }
   end
 
+  def tier_four?
+    current.present? && current_alert_level == 4
+  end
+
   def tier_three?
     current.present? && current_alert_level == 3
   end

--- a/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_future_restrictions.html.erb
@@ -41,5 +41,16 @@
       secondary_solid: true,
       margin_bottom: 9
     } %>
+  <% elsif restriction.future_alert_level == 4 %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.future.level_four.alert_level", area: restriction.area_name) %>
+    </p>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("coronavirus_local_restrictions.results.guidance_label", level: restriction.future_alert_level),
+      href: t("coronavirus_local_restrictions.results.level_four.guidance_link"),
+      secondary_solid: true,
+      margin_bottom: 9
+    } %>
   <% end %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_four_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_four_restrictions.html.erb
@@ -1,0 +1,49 @@
+<% tier_heading = capture do %>
+  <%= t("coronavirus_local_restrictions.results.level_four.heading_pretext") %>
+  <span class="coronavirus-local-restriction__heading-tier-label">
+    <%= t("coronavirus_local_restrictions.results.level_four.heading_tier_label") %>
+  </span>
+<% end %>
+
+<%
+  title = if restriction.present? && restriction.future.present?
+    t("coronavirus_local_restrictions.results.changing_levels_title")
+  else
+    tier_heading
+  end
+%>
+
+<% content_for :title, strip_tags(title) %>
+
+<%= tag.div :data => {
+  :module => "coronavirus-track-local-restriction-results",
+  "tracking-label" => "Tier four: #{restriction.area_name}"
+} do %>
+  <%= render "govuk_publishing_components/components/title", {
+    title: sanitize(title)
+  } %>
+
+  <p class="govuk-body">
+    <%= t("coronavirus_local_restrictions.results.match") %> <strong><%= postcode %></strong> to <strong><%= restriction.area_name %></strong>.
+  </p>
+
+  <% if restriction.present? && restriction.future.present? %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: sanitize(tier_heading),
+      font_size: "m",
+      margin_bottom: 4
+    } %>
+    <p class="govuk-body">
+      <%= t("coronavirus_local_restrictions.results.level_four.changing_alert_level", area: restriction.area_name) %>
+    </p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("coronavirus_local_restrictions.results.guidance_label", level: 4),
+    href: t("coronavirus_local_restrictions.results.level_four.guidance_link"),
+    margin_bottom: 9
+  } %>
+
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
+<% end %>

--- a/app/views/coronavirus_local_restrictions/results.html.erb
+++ b/app/views/coronavirus_local_restrictions/results.html.erb
@@ -21,6 +21,8 @@
       <%= render partial: "coronavirus_local_restrictions/tier_two_restrictions", locals: locals %>
     <% elsif @search.local_restriction&.tier_three? %>
       <%= render partial: "coronavirus_local_restrictions/tier_three_restrictions", locals: locals %>
+    <% elsif @search.local_restriction&.tier_four? %>
+      <%= render partial: "coronavirus_local_restrictions/tier_four_restrictions", locals: locals %>
     <% else %>
       <%= render partial: "coronavirus_local_restrictions/tier_one_restrictions", locals: locals %>
     <% end %>

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -50,6 +50,11 @@ en:
         heading_tier_label: "Tier 3: Very High alert"
         changing_alert_level: "At the moment %{area} is in Tier 3."
         guidance_link: "/guidance/tier-3-very-high-alert"
+      level_four:
+        heading_pretext: This area is in
+        heading_tier_label: "Tier 4: Stay at Home"
+        changing_alert_level: "At the moment %{area} is in Tier 4."
+        guidance_link: "/guidance/tier-4-stay-at-home"
       devolved_nations:
         heading: There might be restrictions in this area
         country_rules: The rules are different in %{country}.
@@ -78,6 +83,8 @@ en:
           alert_level: "%{area} will be in Tier 2: High alert."
         level_three:
           alert_level: "%{area} will be in Tier 3: Very High alert."
+        level_four:
+          alert_level: "%{area} will be in Tier 4: Stay at Home."
       christmas_rules:
         heading: From 23 to 27 December
         body: |

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -30,6 +30,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
     end
+
+    it "displays the tier four restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_can_see_the_postcode_lookup_form
+      then_i_enter_a_valid_english_postcode_in_tier_four
+      then_i_click_on_find
+      then_i_see_the_results_page_for_level_four
+    end
   end
 
   describe "devolved_nations" do
@@ -120,6 +128,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
     end
+
+    it "displays restrictions changing from level three to level four" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
+      then_i_click_on_find
+      then_i_see_the_results_page_for_level_three_with_changing_restriction_levels
+    end
   end
 
   def given_i_am_on_the_local_restrictions_page
@@ -175,6 +190,17 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     fill_in "Enter a full postcode", with: postcode
   end
 
+  def then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
+    @area = "Kashyyyk"
+    postcode = "E1 8QS"
+    stub_local_restriction(postcode: postcode,
+                           name: @area,
+                           current_alert_level: 3,
+                           future_alert_level: 4)
+
+    fill_in "Enter a full postcode", with: postcode
+  end
+
   def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
     @area = "Coruscant Planetary Council"
     stub_local_restriction(postcode: "E1 8QS", name: @area, current_alert_level: 2)
@@ -194,6 +220,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     @area = "Mandalore"
     postcode = "E1 8QS"
     stub_local_restriction(postcode: postcode, name: @area, current_alert_level: 3)
+
+    fill_in "Enter a full postcode", with: postcode
+  end
+
+  def then_i_enter_a_valid_english_postcode_in_tier_four
+    @area = "Anoat"
+    postcode = "E1 8QS"
+    stub_local_restriction(postcode: postcode, name: @area, current_alert_level: 4)
 
     fill_in "Enter a full postcode", with: postcode
   end
@@ -262,6 +296,12 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     assert page.has_text?(heading)
   end
 
+  def then_i_see_the_results_page_for_level_four
+    heading = "#{I18n.t('coronavirus_local_restrictions.results.level_four.heading_pretext')} #{I18n.t('coronavirus_local_restrictions.results.level_four.heading_tier_label')}"
+    assert page.has_text?(@area)
+    assert page.has_text?(heading)
+  end
+
   def then_i_see_the_results_for_wales
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.devolved_nations.wales.guidance.label"))
   end
@@ -294,6 +334,11 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   def then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
     assert page.has_text?(@area)
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_two.changing_alert_level", area: @area))
+  end
+
+  def then_i_see_the_results_page_for_level_three_with_changing_restriction_levels
+    assert page.has_text?(@area)
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.level_three.changing_alert_level", area: @area))
   end
 
   def then_i_see_details_of_christmas_rules


### PR DESCRIPTION
This adds tier 4 into the postcode checker. As of yet this is just the logic to enable it. Full list of areas to follow. 

## Before
<img width="687" alt="Screenshot 2020-12-19 at 18 17 01" src="https://user-images.githubusercontent.com/24547207/102696469-7c81bd80-4226-11eb-9d71-7a3271def68f.png">

## After (AREA USED AS AN EXAMPLE)
<img width="700" alt="Screenshot 2020-12-19 at 18 20 31" src="https://user-images.githubusercontent.com/24547207/102696510-df735480-4226-11eb-9aa6-ebe2a64ae489.png">

