### PR TITLE
Update copy around Christmas for the postcode checker

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -45,6 +45,5 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -45,6 +45,5 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -45,6 +45,5 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-  <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -20,7 +20,7 @@ en:
       inset_text: |
         <p class="govuk-body">There are different restrictions in <a class="govuk-link" href="https://www.gov.scot/check-local-covid-level/">Scotland</a>, <a class="govuk-link" href="https://gov.wales/coronavirus-regulations-guidance">Wales</a> and <a class="govuk-link" href="https://www.nidirect.gov.uk/articles/coronavirus-covid-19-regulations-and-localised-restrictions">Northern Ireland</a>.</p>
       body_content: |
-        <p class="govuk-body">There are 3 tiers. There are different rules depending on what tier an area is in.</p>
+        <p class="govuk-body">There are 4 tiers. There are different rules depending on what tier an area is in.</p>
         <p class="govuk-body">Enter the postcode where you’re living or spend most of your time to find out what the rules are.</p>
       meta_title: Find out the coronavirus restrictions in your local area
       meta_description: Use the postcode checker to find out the tier that your local area is in.

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -13,7 +13,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier two restrictions" do
@@ -22,7 +21,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_two
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier three restrictions" do
@@ -31,7 +29,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_three
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
-      then_i_see_details_of_christmas_rules
     end
   end
 


### PR DESCRIPTION
This relays the fact that there are now 4 tiers. It also removes the section on christmas bubbles. This will be reinstated once full guidance is in.

## Before
<img width="662" alt="Screenshot 2020-12-19 at 17 31 17" src="https://user-images.githubusercontent.com/24547207/102695546-f82c3c00-421f-11eb-9cc4-2fc3ac6eacc8.png">

<img width="653" alt="Screenshot 2020-12-19 at 16 56 24" src="https://user-images.githubusercontent.com/24547207/102695479-8fdd5a80-421f-11eb-95f9-ae39d1c4e8de.png">

## After
<img width="635" alt="Screenshot 2020-12-19 at 17 30 25" src="https://user-images.githubusercontent.com/24547207/102695525-d6cb5000-421f-11eb-8fb4-03a3c58157cd.png">

<img width="659" alt="Screenshot 2020-12-19 at 16 58 14" src="https://user-images.githubusercontent.com/24547207/102695483-966bd200-421f-11eb-8a36-d0f1ab08f585.png">
