### PR TITLE
Show Christmas rules in tiers where they apply

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -45,5 +45,8 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <% unless restriction.future.present? && restriction.future["alert_level"] == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -45,5 +45,8 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <% unless restriction.future.present? && restriction.future["alert_level"] == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -45,5 +45,8 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+  <% unless restriction.future.present? && restriction.future["alert_level"] == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -86,7 +86,7 @@ en:
         level_four:
           alert_level: "%{area} will be in Tier 4: Stay at Home."
       christmas_rules:
-        heading: From 23 to 27 December
+        heading: On 25 December
         body: |
           There are different Christmas rules for meeting friends and family.
         guidance:

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -13,6 +13,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier two restrictions" do
@@ -21,6 +22,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_two
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier three restrictions" do
@@ -29,6 +31,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_three
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier four restrictions" do
@@ -37,6 +40,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_four
       then_i_click_on_find
       then_i_see_the_results_page_for_level_four
+      then_i_do_not_see_details_of_christmas_rules
     end
   end
 
@@ -120,6 +124,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one_with_changing_restriction_levels
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level two to level three" do
@@ -127,6 +132,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level three to level four" do
@@ -134,6 +140,23 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three_with_changing_restriction_levels
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "displays restrictions changing from level two to level four" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_changing_from_level_two_to_four
+      then_i_click_on_find
+      then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "displays restrictions changing from level one to level four" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_changing_from_level_one_to_four
+      then_i_click_on_find
+      then_i_see_the_results_page_for_level_one_with_changing_restriction_levels
+      then_i_do_not_see_details_of_christmas_rules
     end
   end
 
@@ -194,8 +217,30 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     @area = "Kashyyyk"
     postcode = "E1 8QS"
     stub_local_restriction(postcode: postcode,
+      name: @area,
+      current_alert_level: 3,
+      future_alert_level: 4)
+
+    fill_in "Enter a full postcode", with: postcode
+  end
+
+  def then_i_enter_a_valid_english_postcode_changing_from_level_one_to_four
+    @area = "Dagobah"
+    postcode = "E1 8QS"
+    stub_local_restriction(postcode: postcode,
+      name: @area,
+      current_alert_level: 1,
+      future_alert_level: 4)
+
+    fill_in "Enter a full postcode", with: postcode
+  end
+
+  def then_i_enter_a_valid_english_postcode_changing_from_level_two_to_four
+    @area = "Batuu"
+    postcode = "E1 8QS"
+    stub_local_restriction(postcode: postcode,
                            name: @area,
-                           current_alert_level: 3,
+                           current_alert_level: 2,
                            future_alert_level: 4)
 
     fill_in "Enter a full postcode", with: postcode
@@ -343,6 +388,10 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_see_details_of_christmas_rules
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
+  end
+
+  def then_i_do_not_see_details_of_christmas_rules
+    refute page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
   end
 
   def and_there_is_metadata


### PR DESCRIPTION
This is dependent on the guidance at
https://www.gov.uk/guidance/guidance-for-the-christmas-period being
updated to reflect the new Christmas guidance.

The behaviour I think we want is:

* If your postcode is in tier 1 and isn't moving to tier 4, the
  Christmas guidance should appear for you
* If your postcode is in tier 2 and isn't moving to tier 4, the
  Christmas guidance should appear for you
* If your postcode is in tier 3 and isn't moving to tier 4, the
  Christmas guidance should appear for you
* If your postcode is in tier 4, the Christmas guidance should NOT
  appear for you
* If your postcode is moving to tier 4, the Christmas guidance should
  NOT appear for you

I haven't tried to be any more clever than that (e.g. handling areas
which are moving to tier 4 _after_ Christmas), because I think it's
unlikely these situations will arise in the next 6 days.