### PR TITLE
Add back content for Christmas rules

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -45,5 +45,10 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+
+  <% unless restriction.future_alert_level == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
+
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -45,5 +45,10 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+
+  <% unless restriction.future_alert_level == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
+
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -45,5 +45,10 @@
   } %>
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
+
+  <% unless restriction.future_alert_level == 4 %>
+    <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
+  <% end %>
+
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -86,9 +86,9 @@ en:
         level_four:
           alert_level: "%{area} will be in Tier 4: Stay at Home."
       christmas_rules:
-        heading: From 23 to 27 December
+        heading: On 25 December
         body: |
           There are different Christmas rules for meeting friends and family.
         guidance:
            label: Find out what the Christmas rules are
-           link: "/guidance/guidance-for-the-christmas-period"
+           link: "/government/publications/making-a-christmas-bubble-with-friends-and-family/making-a-christmas-bubble-with-friends-and-family"

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -13,6 +13,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier two restrictions" do
@@ -21,6 +22,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_two
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier three restrictions" do
@@ -29,6 +31,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_three
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier four restrictions" do
@@ -37,6 +40,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_four
       then_i_click_on_find
       then_i_see_the_results_page_for_level_four
+      then_i_do_not_see_details_of_christmas_rules
     end
   end
 
@@ -120,6 +124,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one_with_changing_restriction_levels
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level two to level three" do
@@ -127,6 +132,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
+      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level three to level four" do
@@ -134,6 +140,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three_with_changing_restriction_levels
+      then_i_do_not_see_details_of_christmas_rules
     end
   end
 
@@ -343,6 +350,10 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_see_details_of_christmas_rules
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
+  end
+
+  def then_i_do_not_see_details_of_christmas_rules
+    assert_not page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
   end
 
   def and_there_is_metadata


### PR DESCRIPTION
# What's changed and why?

The Christmas rules were removed from the postcode checker whilst the guidance is being updated as we didn't want to be unintentionally giving people the wrong information.

The Christmas rules only apply to tiers 1 - 3, they do not apply to tier 4, nor do they apply to the places about to go into tier 4.

# Expected changes
<img width="1532" alt="Screenshot 2020-12-19 at 18 52 23" src="https://user-images.githubusercontent.com/5793815/102697164-a5f11800-422b-11eb-867f-bbd8948e30e5.png">

<img width="1532" alt="Screenshot 2020-12-19 at 18 53 17" src="https://user-images.githubusercontent.com/5793815/102697166-a7224500-422b-11eb-91a8-bfc31ab86e5c.png">

# No change
<img width="1532" alt="Screenshot 2020-12-19 at 18 54 29" src="https://user-images.githubusercontent.com/5793815/102697165-a689ae80-422b-11eb-80f3-998219cd323c.png">
