### PR TITLE
Fix bug for tier 1 postcodes

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.future_alert_level == 4 %>
+  <% unless restriction.present? && restriction.future_alert_level == 4 %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.future_alert_level == 4 %>
+  <% unless restriction.present? && restriction.future_alert_level == 4 %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.future_alert_level == 4 %>
+  <% unless restriction.present? && restriction.future_alert_level == 4 %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 


### PR DESCRIPTION
Over the weekend we introduced some code to conditionally display christmas rules. Whilst this worked for the overwhelming majority of places, those areas in tier 1 don't technically have a restriction according to the code. This means that for those users things won't have displayed. This adds an extra check for the presence of a restriction before checking the future level of it which fixes the issue.