### PR TITLE
Fix, test and simplify the postcode pattern

### DIFF
--- a/app/models/postcode_local_restriction_search.rb
+++ b/app/models/postcode_local_restriction_search.rb
@@ -1,16 +1,12 @@
 class PostcodeLocalRestrictionSearch
   UK_POSTCODE_PATTERN = %r{
     \A
-    ([Gg][Ii][Rr] 0[Aa]{2}) # Unusual postcodes
-    |
-    (
-      # Outward code, for example SW1A
-      (([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))
-      \s?
-      [0-9][A-Za-z]{2} # Inward code, for example 2AA
-    )
+    # Outward code, for example SW1A
+    (([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9][A-Z]?))))
+    \s?
+    [0-9][A-Z]{2} # Inward code, for example 2AA
     \Z
-  }x.freeze
+  }xi.freeze
 
   attr_reader :postcode
   delegate :no_information?, to: :location_lookup

--- a/test/models/postcode_local_restriction_search_test.rb
+++ b/test/models/postcode_local_restriction_search_test.rb
@@ -13,6 +13,26 @@ describe PostcodeLocalRestrictionSearch do
     }])
   end
 
+  describe "UK_POSTCODE_PATTERN" do
+    let(:pattern) { described_class::UK_POSTCODE_PATTERN }
+
+    it "matches valid postcodes" do
+      assert_match pattern, "sw1a 2aa"
+      assert_match pattern, "LS11UR"
+      assert_match pattern, "BT15 3JX"
+    end
+
+    it "doesn't match invalid postcodes" do
+      assert_no_match pattern, "sw1a"
+      assert_no_match pattern, "LS 11UR"
+      assert_no_match pattern, " BT15 3JX "
+    end
+
+    it "doesn't match quirky non-geographical postcodes" do
+      assert_no_match pattern, "GIR 0AA"
+    end
+  end
+
   describe "#sanitised_postcode" do
     it "returns the postcode as a formatted UK postcode" do
       instance = described_class.new("e18qs")


### PR DESCRIPTION
It turned out that this pattern wasn't matching the infamously weird GIR
0AA postcode because of the unescaped white space. Whilst fixing this I
thought it would be good if this had some tests, and then I saw the
opportunity to make it case insensitive to cut out a lot of the
matching.