### PR TITLE
Stop showing Christmas rules after 25th December

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -43,4 +43,12 @@ private
 
     [time_until_restriction, MAX_CACHE_TIME].min
   end
+
+  def after_christmas?
+    christmas = Time.zone.parse("2020-12-25")
+
+    Time.zone.today.after?(christmas)
+  end
+
+  helper_method :after_christmas?
 end

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.present? && restriction.future_alert_level == 4 %>
+  <% unless restriction.future_alert_level == 4 || after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.present? && restriction.future_alert_level == 4 %>
+  <% unless restriction.future_alert_level == 4 || after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -46,7 +46,7 @@
 
   <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
 
-  <% unless restriction.present? && restriction.future_alert_level == 4 %>
+  <% unless restriction.future_alert_level == 4 || after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -4,6 +4,7 @@ require "gds_api/test_helpers/mapit"
 class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
   include GdsApi::TestHelpers::Mapit
   include GdsApi::TestHelpers::ContentStore
+  include ActiveSupport::Testing::TimeHelpers
 
   describe "current restrictions" do
     it "displays the tier one restrictions" do
@@ -13,7 +14,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_one
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier two restrictions" do
@@ -22,7 +22,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_two
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier three restrictions" do
@@ -31,7 +30,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_three
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays the tier four restrictions" do
@@ -40,7 +38,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_in_tier_four
       then_i_click_on_find
       then_i_see_the_results_page_for_level_four
-      then_i_do_not_see_details_of_christmas_rules
     end
 
     it "displays no tier information" do
@@ -132,7 +129,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_one_with_changing_restriction_levels
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level two to level three" do
@@ -140,7 +136,6 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_two_with_changing_restriction_levels
-      then_i_see_details_of_christmas_rules
     end
 
     it "displays restrictions changing from level three to level four" do
@@ -148,6 +143,116 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
       then_i_click_on_find
       then_i_see_the_results_page_for_level_three_with_changing_restriction_levels
+    end
+  end
+
+  describe "on or before christmas" do
+    before do
+      travel_to Time.zone.parse("2020-12-25")
+    end
+
+    after do
+      travel_back
+    end
+
+    it "displays christmas rules for current tier one restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_one
+      then_i_click_on_find
+      then_i_see_details_of_christmas_rules
+    end
+
+    it "displays christmas rules for current tier two restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_two
+      then_i_click_on_find
+      then_i_see_details_of_christmas_rules
+    end
+
+    it "displays christmas rules for current tier three restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_three
+      then_i_click_on_find
+      then_i_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for current tier four restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_four
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "displays christmas rules for future tier two restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
+      then_i_click_on_find
+      then_i_see_details_of_christmas_rules
+    end
+
+    it "displays christmas rules for future tier three restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
+      then_i_click_on_find
+      then_i_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for future tier four restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+  end
+
+  describe "after christmas" do
+    before do
+      travel_to Time.zone.parse("2020-12-26")
+    end
+
+    after do
+      travel_back
+    end
+
+    it "does not display christmas rules for current tier one restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_one
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for current tier two restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_two
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for current tier three restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_three
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for future tier two restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for future tier three restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
+      then_i_click_on_find
+      then_i_do_not_see_details_of_christmas_rules
+    end
+
+    it "does not display christmas rules for future tier four restrictions" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
+      then_i_click_on_find
       then_i_do_not_see_details_of_christmas_rules
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/cZ7cBdfi

# What's changed and why?

At the moment the Christmas rules only apply to 25 December, so we
should stop showing the rules after that date. However the 25th is a
Friday, and the next working day is the 29th December. That means we
would be showing out of date Christmas rules on the checker for 4 days.

This change uses the date to hide the Christmas rules after 25 December.

The built-in `after?` method is used because that returns true for the
26th December onwards, whereas the `before?` method only returns true
for everything on 24 December and before, not 25 December.

The integration tests that look for Christmas content have also been
consolidated to make them easier to find and remove later on.

# Expected changes

## On and before Christmas Day 🎄 
<img width="1532" alt="Screenshot 2020-12-22 at 15 39 07" src="https://user-images.githubusercontent.com/5793815/102906288-52214180-446c-11eb-84f2-5279a3e127a5.png">

## After Christmas
<img width="1532" alt="Screenshot 2020-12-22 at 15 40 02" src="https://user-images.githubusercontent.com/5793815/102906297-58172280-446c-11eb-9f9f-459621872667.png">
