### PR TITLE
Hide the Brexit countdown component on the transition landing page after 23.30

### DIFF
--- a/app/lib/countdown_clock.rb
+++ b/app/lib/countdown_clock.rb
@@ -1,16 +1,16 @@
 class CountdownClock
-  END_OF_TRANSITION_PERIOD = Date.new(2021, 1, 1)
+  END_OF_TRANSITION_PERIOD = Time.zone.local(2020, 12, 31, 23, 59)
 
   def days_left
-    sprintf "%02d", days_left_integer
+    sprintf "%02d", days_left_until_deadline
   end
 
   def show?
-    days_left_integer.positive?
+    minutes_left_until_deadline >= 30
   end
 
   def days_text
-    if days_left_integer == 1
+    if days_left_until_deadline == 1
       I18n.t("transition_landing_page.countdown_day_to_go")
     else
       I18n.t("transition_landing_page.countdown_days_to_go")
@@ -19,11 +19,19 @@ class CountdownClock
 
 private
 
-  def days_left_integer
-    (END_OF_TRANSITION_PERIOD - today_in_london).to_i
+  def days_left_until_deadline
+    (minutes_left_until_deadline / 60 / 24).ceil
   end
 
-  def today_in_london
-    Time.zone.today
+  def minutes_left_until_deadline
+    (seconds_left_until_deadline / 60)
+  end
+
+  def seconds_left_until_deadline
+    END_OF_TRANSITION_PERIOD - now_in_london
+  end
+
+  def now_in_london
+    Time.zone.now
   end
 end

--- a/test/lib/countdown_clock_test.rb
+++ b/test/lib/countdown_clock_test.rb
@@ -7,33 +7,33 @@ class CountdownClockTest < ActiveSupport::TestCase
 
   describe "#days_left" do
     it "gives the days left until end of transition period" do
-      day_before_transition_period_ends = Date.new(2020, 12, 31)
-      travel_to day_before_transition_period_ends
+      nine_am_on_brexit_eve = Time.zone.local(2020, 12, 31, 9, 0)
+      travel_to nine_am_on_brexit_eve
       assert_equal("01", clock.days_left)
     end
   end
 
   describe "#show?" do
-    it "returns true until 23.59 on December 31st 2020" do
-      minute_to_midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 23, 59)
-      travel_to minute_to_midnight_on_brexit_eve
+    it "returns true until 23.29 on December 31st 2020" do
+      one_minute_before_component_shut_off_time = Time.zone.local(2020, 12, 31, 23, 29)
+      travel_to one_minute_before_component_shut_off_time
       assert_equal(true, clock.show?)
     end
 
-    it "returns false from midnight on the eve of January 1st 2021" do
-      midnight_on_brexit_eve = Time.zone.local(2020, 12, 31, 24, 0)
-      travel_to midnight_on_brexit_eve
+    it "returns false from 23.31 on December 31st 2020" do
+      one_minute_after_component_shut_off_time = Time.zone.local(2020, 12, 31, 23, 30)
+      travel_to one_minute_after_component_shut_off_time
       assert_equal(false, clock.show?)
     end
   end
 
-  describe "#days_left" do
+  describe "#days_text" do
     it "pluralizes day if necessary" do
-      one_day_left = Date.new(2020, 12, 31)
+      one_day_left = Time.zone.local(2020, 12, 31, 9, 0)
       travel_to one_day_left
       assert_equal("day to go", clock.days_text)
 
-      two_days_left = Date.new(2020, 12, 30)
+      two_days_left = Time.zone.local(2020, 12, 30, 9, 0)
       travel_to two_days_left
       assert_equal("days to go", clock.days_text)
     end


### PR DESCRIPTION
## What
We don't want to show "01 days to go" after midnight on Brexit eve. This could happen with the existing set up, because the landing page is cached. So we are turning off the component at 23.30 to be safe.

-- 
[trello](https://trello.com/c/NrxFXJ0e/726-update-logic-to-remove-countdown-visual-at-1130pm-vs-1159pm-on-31-december)