### PR TITLE
Add partial that displays "an out of date warning"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/translation-nav';
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/back-link";
+@import "govuk_publishing_components/components/warning-text";
 
 @import "helpers/layouts";
 @import "helpers/margins";

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -51,4 +51,10 @@ private
   end
 
   helper_method :after_christmas?
+
+  def out_of_date?
+    false
+  end
+
+  helper_method :out_of_date?
 end

--- a/app/views/coronavirus_local_restrictions/_out_of_date_warning.html.erb
+++ b/app/views/coronavirus_local_restrictions/_out_of_date_warning.html.erb
@@ -1,0 +1,5 @@
+<% if out_of_date? %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: t("coronavirus_local_restrictions.out_of_date_warning")
+  } %>
+<% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_four_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_four_restrictions.html.erb
@@ -19,6 +19,9 @@
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier four: #{restriction.area_name}"
 } do %>
+
+  <%= render partial: "coronavirus_local_restrictions/out_of_date_warning" %>
+
   <%= render "govuk_publishing_components/components/title", {
     title: sanitize(title)
   } %>

--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -19,6 +19,9 @@
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier one: #{restriction.area_name}"
 } do %>
+
+  <%= render partial: "coronavirus_local_restrictions/out_of_date_warning" %>
+
   <%= render "govuk_publishing_components/components/title", {
     title: sanitize(title)
   } %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -19,6 +19,9 @@
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier three: #{restriction.area_name}"
 } do %>
+
+  <%= render partial: "coronavirus_local_restrictions/out_of_date_warning" %>
+
   <%= render "govuk_publishing_components/components/title", {
     title: sanitize(title)
   } %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -19,6 +19,9 @@
   :module => "coronavirus-track-local-restriction-results",
   "tracking-label" => "Tier two: #{restriction.area_name}"
 } do %>
+
+  <%= render partial: "coronavirus_local_restrictions/out_of_date_warning" %>
+
   <%= render "govuk_publishing_components/components/title", {
     title: sanitize(title)
   } %>

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -36,6 +36,8 @@
 
     <%= sanitize(t("coronavirus_local_restrictions.lookup.body_content")) %>
 
+    <%= render partial: "coronavirus_local_restrictions/out_of_date_warning" %>
+
     <%= form_tag find_coronavirus_local_restrictions_path,
       method: :get,
       class: "coronavirus-local-restrictions__postcode-form",

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -9,6 +9,8 @@ en:
         error_message: There is a problem
         input_error: Enter a valid postcode
         error_description: Enter a valid postcode
+    out_of_date_warning: |
+      This service is being updated, at the moment it might not show the latest information for your area
     lookup:
       input_label: Enter a full postcode
       hint_text: |

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -257,6 +257,56 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  describe "when the restrictions are out of date" do
+    before do
+      CoronavirusLocalRestrictionsController.any_instance.stubs(:out_of_date?).returns(true)
+    end
+
+    it "displays an out of date warning on the lookup page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_see_an_out_of_date_warning
+    end
+
+    it "displays an out of date warning on the tier one page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_one
+      then_i_click_on_find
+      then_i_see_an_out_of_date_warning
+    end
+
+    it "displays an out of date warning on the tier two page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_two
+      then_i_click_on_find
+      then_i_see_an_out_of_date_warning
+    end
+
+    it "displays an out of date warning on the tier three page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_three
+      then_i_click_on_find
+      then_i_see_an_out_of_date_warning
+    end
+
+    it "displays an out of date warning on the tier four page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_enter_a_valid_english_postcode_in_tier_four
+      then_i_click_on_find
+      then_i_see_an_out_of_date_warning
+    end
+  end
+
+  describe "when the restrictions are up to date" do
+    before do
+      CoronavirusLocalRestrictionsController.any_instance.stubs(:out_of_date?).returns(false)
+    end
+
+    it "does not display an out of date warning on the lookup page" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_do_not_see_an_out_of_date_warning
+    end
+  end
+
   def given_i_am_on_the_local_restrictions_page
     stub_content_store_has_item("/find-coronavirus-local-restrictions", {})
 
@@ -476,6 +526,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
 
   def then_i_do_not_see_details_of_christmas_rules
     assert_not page.has_text?(I18n.t("coronavirus_local_restrictions.results.christmas_rules.heading"))
+  end
+
+  def then_i_see_an_out_of_date_warning
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.out_of_date_warning"))
+  end
+
+  def then_i_do_not_see_an_out_of_date_warning
+    assert_not page.has_text?(I18n.t("coronavirus_local_restrictions.out_of_date_warning"))
   end
 
   def and_there_is_metadata


### PR DESCRIPTION
Trello: https://trello.com/c/NYHZel2U

# What's changed and why?
Sometimes restrictions are announced before we have had a chance to
update the postcode checker. It can be hours before the checker is
updated with the latest restriction data.

Users coming to the checker will expect to see up to date information.
We need a way to let them know that their restriction may be changing
and that they should come back later.

A flag on the LocalRestriction model is being used to set whether or not
the data is up to date. This flag is stopgap measure so that the warning
can be displayed in time for the latest set of updates. The upside to
this approach is that it is fast to implement. The downside is that the
application needs to be deployed every time the flag changes.

The long term plan is to use a rake task to set a value in Redis that
determines when the warning should be shown in a similar manner to the
emergency banner.

# Expected changes
# Restrictions are out of date
<img width="1532" alt="Screenshot 2020-12-22 at 17 36 29" src="https://user-images.githubusercontent.com/5793815/102917054-6f5e0c00-447c-11eb-8b58-cd48ac6fd11a.png">
<img width="1532" alt="Screenshot 2020-12-22 at 17 36 44" src="https://user-images.githubusercontent.com/5793815/102917075-76851a00-447c-11eb-8600-f5067932a27d.png">

# Restrictions are up to date
<img width="1532" alt="Screenshot 2020-12-22 at 17 37 21" src="https://user-images.githubusercontent.com/5793815/102917099-813faf00-447c-11eb-8629-20c82596d690.png">
<img width="1532" alt="Screenshot 2020-12-22 at 17 37 38" src="https://user-images.githubusercontent.com/5793815/102917115-8866bd00-447c-11eb-977f-94b675735c9a.png">

