### PR TITLE
Make Christmas partial changes

### DIFF
--- a/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_one_restrictions.html.erb
@@ -44,11 +44,10 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-
-  <% unless restriction.future_alert_level == 4 || after_christmas? %>
+  <% unless after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_three_restrictions.html.erb
@@ -44,11 +44,10 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-
-  <% unless restriction.future_alert_level == 4 || after_christmas? %>
+  <% unless after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
+++ b/app/views/coronavirus_local_restrictions/_tier_two_restrictions.html.erb
@@ -44,11 +44,10 @@
     margin_bottom: 9
   } %>
 
-  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
-
-  <% unless restriction.future_alert_level == 4 || after_christmas? %>
+  <% unless after_christmas? %>
     <%= render partial: "coronavirus_local_restrictions/christmas_rules" %>
   <% end %>
 
+  <%= render partial: "coronavirus_local_restrictions/future_restrictions", locals: { restriction: restriction } %>
   <%= render partial: "coronavirus_local_restrictions/travel_guidance" %>
 <% end %>

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -197,11 +197,11 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_see_details_of_christmas_rules
     end
 
-    it "does not display christmas rules for future tier four restrictions" do
+    it "displays christmas rules for future tier four restrictions" do
       given_i_am_on_the_local_restrictions_page
       then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
       then_i_click_on_find
-      then_i_do_not_see_details_of_christmas_rules
+      then_i_see_details_of_christmas_rules
     end
   end
 


### PR DESCRIPTION
Now that we can be confident that there are no changes before to tiers before Christmas we need to make some changes to how things are displayed. This flips the partials for Christmas rules and future restrictions to ensure that things are displayed in chronological order. It also changes the conditional showing of the Christmas rules because there will be no new areas in tier 4 before Christmas. There was a test associated with this that has also been changed to reflect the fact that Christmas rules should always display unless an area is currently in Tier 4 or it's after Christmas.

## Before (POSTCODE USED AS AN EXAMPLE, NOT REAL DATA)
<img width="608" alt="Screenshot 2020-12-23 at 08 51 54" src="https://user-images.githubusercontent.com/24547207/102978964-46ca2680-44fd-11eb-82c5-09332ad93ee9.png">

## After (POSTCODE USED AS AN EXAMPLE, NOT REAL DATA)
<img width="616" alt="Screenshot 2020-12-23 at 08 53 17" src="https://user-images.githubusercontent.com/24547207/102978957-4467cc80-44fd-11eb-82bb-c47fe531b11d.png">
