### PR TITLE
Adjust the cache time while the service is being updated

### DIFF
--- a/test/controllers/coronavirus_local_restrictions_controller_test.rb
+++ b/test/controllers/coronavirus_local_restrictions_controller_test.rb
@@ -23,6 +23,14 @@ describe CoronavirusLocalRestrictionsController do
       assert_equal "max-age=#{30.minutes}, public", response.headers["Cache-Control"]
     end
 
+    it "caches responses for for 5 minutes when the data is being updated" do
+      CoronavirusLocalRestrictionsController.any_instance.stubs(:out_of_date?).returns(true)
+
+      get :show
+
+      assert_equal "max-age=#{5.minutes}, public", response.headers["Cache-Control"]
+    end
+
     it "renders the show template when given an invalid postcode" do
       get :show, params: { postcode: "not-a-postcode" }
 


### PR DESCRIPTION
Trello: https://trello.com/c/NYHZel2U/1017-callout-box-for-when-service-is-being-updated-quick-version

When we're updating the service we shouldn't be returning a 30 minute
cache time otherwise users will have a rather odd staggered experience
where the /find-coronavirus-local-restrictions start page shows a
warning long after most of the results are showing updated data.

Setting this to 5 minutes should offer a reasonable balance of not
having our servers hit too frequently during the change, with only a
modest delay to wait for the change to take effect.