### PR TITLE
Set extremely long expiry for Mapit cache

### DIFF
--- a/app/services/location_lookup_service.rb
+++ b/app/services/location_lookup_service.rb
@@ -49,7 +49,7 @@ private
 
   def response
     @response ||= begin
-                    Rails.cache.fetch("mapit-location-#{postcode}", expires_in: 3.hours) do
+                    Rails.cache.fetch("mapit-location-#{postcode}", expires_in: 30.days) do
                       JSON.parse(mapit.location_for_postcode(postcode).to_json)
                     end
                   rescue GdsApi::HTTPNotFound, GdsApi::HTTPClientError => e


### PR DESCRIPTION
This sets the mapit cache to the hugely long value of 30 days - which
effectively may as well be considered permanent. This has been done to
effectively cut the dependency on Mapit out of processing once the cache
for postcodes is warm - which reduces response time by approximately
50%.

Whenever the postcodes in Mapit change we will need to manually run
`Rails.cache.clear` in a Rails console - running the rake task
"tmp:clear" isn't enough (that clears tmp files whereas this data is
stored in memcache).

This change is going through with a switch to a shared memcache instance
so cache is shared across all the frontend machines (see:
https://github.com/alphagov/govuk-aws/pull/1394 for more information)
which will improve cache hits.