### PR TITLE
Cache content store request

### DIFF
--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -23,7 +23,12 @@ class TransitionLandingPageController < ApplicationController
 private
 
   def taxon
-    Taxon.find(request.path)
+    base_path = request.path
+    @taxon ||= begin
+      Rails.cache.fetch("collections_content_items#{base_path}", expires_in: 10.minutes) do
+        Taxon.find(base_path)
+      end
+    end
   end
 
   def presented_taxon


### PR DESCRIPTION
We sometimes get spikes of requests hitting origin. The content item doesn't really change much, and is only used to find the translations, and also to generate links for search. 

Caching for 10 minutes is fine, and should protect content store from any surges.

http://govuk-collec-erk-ywottumtg2whd.herokuapp.com/transition
http://govuk-collec-erk-ywottumtg2whd.herokuapp.com/transition.cy