### PR TITLE
Remove past restrictions

### DIFF
--- a/config/local_restrictions.yml
+++ b/config/local_restrictions.yml
@@ -38,9 +38,6 @@ E06000006:
 E06000007:
   name: Warrington Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
@@ -114,12 +111,6 @@ E06000019:
   name: Herefordshire Council
   restrictions:
     - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
-    - alert_level: 1
-      start_date: 2020-12-19
-      start_time: "00:01"
-    - alert_level: 2
       start_date: 2020-12-26
       start_time: "00:01"
 E06000020:
@@ -144,23 +135,11 @@ E06000023:
   name: Bristol City Council
   restrictions:
     - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
-    - alert_level: 2
-      start_date: 2020-12-19
-      start_time: "00:01"
-    - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E06000024:
   name: North Somerset Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
-    - alert_level: 2
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
@@ -185,144 +164,96 @@ E06000027:
 E06000030:
   name: Swindon Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E06000031:
   name: Peterborough City Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000032:
   name: Luton Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000033:
   name: Southend-on-Sea Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000034:
   name: Thurrock Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000035:
   name: Medway Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000036:
   name: Bracknell Forest Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000037:
   name: West Berkshire Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000038:
   name: Reading Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000039:
   name: Slough Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000040:
   name: Royal Borough of Windsor and Maidenhead
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000041:
   name: Wokingham Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000042:
   name: Milton Keynes Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000043:
   name: Brighton and Hove City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E06000044:
   name: Portsmouth City Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000045:
   name: Southampton City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
@@ -335,18 +266,12 @@ E06000047:
 E06000049:
   name: Cheshire East Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E06000050:
   name: Cheshire West and Chester Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
@@ -365,18 +290,12 @@ E06000054:
 E06000055:
   name: Bedford Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000056:
   name: Central Bedfordshire Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -461,9 +380,6 @@ E08000010:
 E09000023:
   name: London Borough of Lewisham
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -626,288 +542,192 @@ E08000037:
 E09000001:
   name: City of London Corporation
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000002:
   name: London Borough of Barking and Dagenham
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000003:
   name: London Borough of Barnet
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000004:
   name: London Borough of Bexley
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000005:
   name: London Borough of Brent
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000006:
   name: London Borough of Bromley
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000007:
   name: London Borough of Camden
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000008:
   name: London Borough of Croydon
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000009:
   name: London Borough of Ealing
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000010:
   name: London Borough of Enfield
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000011:
   name: Royal Borough of Greenwich
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000012:
   name: London Borough of Hackney
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000013:
   name: London Borough of Hammersmith & Fulham
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000014:
   name: London Borough of Haringey
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000015:
   name: London Borough of Harrow
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000016:
   name: London Borough of Havering
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000017:
   name: London Borough of Hillingdon
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000018:
   name: London Borough of Hounslow
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000019:
   name: London Borough of Islington
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000020:
   name: Royal Borough of Kensington and Chelsea
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000021:
   name: Royal Borough of Kingston upon Thames
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000022:
   name: London Borough of Lambeth
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000024:
   name: London Borough of Merton
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000025:
   name: London Borough of Newham
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000026:
   name: London Borough of Redbridge
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000027:
   name: London Borough of Richmond upon Thames
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000028:
   name: London Borough of Southwark
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000029:
   name: London Borough of Sutton
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000030:
   name: London Borough of Tower Hamlets
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000031:
   name: London Borough of Waltham Forest
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000032:
   name: London Borough of Wandsworth
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E09000033:
   name: City of Westminster
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -915,9 +735,6 @@ E07000004:
   name: Buckinghamshire Council
   delete_later: true
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -925,9 +742,6 @@ E07000005:
   name: Buckinghamshire Council
   delete_later: true
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -935,9 +749,6 @@ E07000006:
   name: Buckinghamshire Council
   delete_later: true
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -945,63 +756,42 @@ E07000007:
   name: Buckinghamshire Council
   delete_later: true
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E06000060:
   name: Buckinghamshire Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000008:
   name: Cambridge City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000009:
   name: East Cambridgeshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000010:
   name: Fenland District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000011:
   name: Huntingdonshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000012:
   name: South Cambridgeshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
@@ -1140,261 +930,174 @@ E07000047:
 E07000061:
   name: Eastbourne Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000062:
   name: Hastings Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000063:
   name: Lewes District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000064:
   name: Rother District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000065:
   name: Wealden District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000066:
   name: Basildon Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000067:
   name: Braintree District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000068:
   name: Brentwood Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000069:
   name: Castle Point Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000070:
   name: Chelmsford City Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000071:
   name: Colchester Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000072:
   name: Epping Forest District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000073:
   name: Harlow Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000074:
   name: Maldon District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000075:
   name: Rochford District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000203:
   name: Mid Suffolk District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000244:
   name: East Suffolk District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000245:
   name: West Suffolk District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000207:
   name: Elmbridge Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000208:
   name: Epsom and Ewell Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000209:
   name: Guildford Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000210:
   name: Mole Valley District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000211:
   name: Reigate and Banstead Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000212:
   name: Runnymede Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000213:
   name: Spelthorne Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000214:
   name: Surrey Heath Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000215:
   name: Tandridge District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000216:
   name: Waverley Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000217:
   name: Woking Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -1431,63 +1134,42 @@ E07000222:
 E07000223:
   name: Adur District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000224:
   name: Arun District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000225:
   name: Chichester District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000226:
   name: Crawley Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000227:
   name: Horsham District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000228:
   name: Mid Sussex District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000229:
   name: Worthing Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
@@ -1530,369 +1212,246 @@ E07000239:
 E07000076:
   name: Tendring District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000077:
   name: Uttlesford District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000078:
   name: Cheltenham Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000079:
   name: Cotswold District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000080:
   name: Forest of Dean District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000081:
   name: Gloucester City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000082:
   name: Stroud District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000083:
   name: Tewkesbury Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000084:
   name: Basingstoke and Deane Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000085:
   name: East Hampshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000086:
   name: Eastleigh Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000087:
   name: Fareham Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000088:
   name: Gosport Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000089:
   name: Hart District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000090:
   name: Havant Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000091:
   name: New Forest District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000092:
   name: Rushmoor Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000093:
   name: Test Valley Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000094:
   name: Winchester City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000095:
   name: Borough of Broxbourne
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000096:
   name: Dacorum Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000098:
   name: Hertsmere Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000099:
   name: North Hertfordshire District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000102:
   name: Three Rivers District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000103:
   name: Watford Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-16
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000240:
   name: St Albans City and District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000241:
   name: Welwyn Hatfield Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000242:
   name: East Hertfordshire District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000243:
   name: Stevenage Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-19
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000105:
   name: Ashford Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000106:
   name: Canterbury City Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000107:
   name: Dartford Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000108:
   name: Dover District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000109:
   name: Gravesham Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000110:
   name: Maidstone Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000111:
   name: Sevenoaks District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000112:
   name: Folkestone and Hythe
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000113:
   name: Swale Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000114:
   name: Thanet District Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000115:
   name: Tonbridge and Malling Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
 E07000116:
   name: Tunbridge Wells Borough Council
   restrictions:
-    - alert_level: 3
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-20
       start_time: "00:01"
@@ -2055,126 +1614,84 @@ E07000142:
 E07000143:
   name: Breckland Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000144:
   name: Broadland District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000145:
   name: Great Yarmouth Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000146:
   name: Borough Council of Kings Lynn and West Norfolk
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000147:
   name: North Norfolk District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000148:
   name: Norwich City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000149:
   name: South Norfolk District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000150:
   name: Corby Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000151:
   name: Daventry District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000152:
   name: East Northamptonshire Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000153:
   name: Kettering Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000154:
   name: Northampton Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000155:
   name: South Northamptonshire Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000156:
   name: Wellingborough Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
@@ -2265,81 +1782,54 @@ E07000176:
 E07000177:
   name: Cherwell District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000178:
   name: Oxford City Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000179:
   name: South Oxfordshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000180:
   name: Vale of White Horse District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000181:
   name: West Oxfordshire District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000187:
   name: Mendip District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000188:
   name: Sedgemoor District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000189:
   name: South Somerset District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
 E07000246:
   name: Somerset West and Taunton District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"
@@ -2394,36 +1884,24 @@ E07000199:
 E07000200:
   name: Babergh District Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E07000202:
   name: Ipswich Borough Council
   restrictions:
-    - alert_level: 2
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 4
       start_date: 2020-12-26
       start_time: "00:01"
 E06000052:
   name: Cornwall Council
   restrictions:
-    - alert_level: 1
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 2
       start_date: 2020-12-26
       start_time: "00:01"
 E06000046:
   name: Isle of Wight Council
   restrictions:
-    - alert_level: 1
-      start_date: 2020-12-02
-      start_time: "00:01"
     - alert_level: 3
       start_date: 2020-12-26
       start_time: "00:01"


### PR DESCRIPTION
These are restrictions that have been superseded by current
restrictions. These are being removed to make it easier to determine the
changes if/when new restrictions are added.