### PR TITLE
Strip all postcode parameters from being sent to Analytics

### DIFF
--- a/app/views/coronavirus_local_restrictions/_meta_tags.html.erb
+++ b/app/views/coronavirus_local_restrictions/_meta_tags.html.erb
@@ -6,6 +6,6 @@
   <meta property="og:title" content="<%= t("coronavirus_local_restrictions.lookup.meta_title") %>">
   <meta property="og:description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
   <meta name="description" content="<%= t("coronavirus_local_restrictions.lookup.meta_description") %>">
-  <meta name="govuk:static-analytics:strip-postcodes" content="true">
+  <meta name="govuk:static-analytics:strip-query-string-parameters" content="postcode">
   <link rel="canonical" href="<%= page_url %>">
 <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/LiAOrW5F/1000-remove-or-redact-values-at-the-end-of-postcode-look-up-string-that-dont-match-postcode-format

This depends on https://github.com/alphagov/static/pull/2367 and can't be merged until that is released.

This changes our approach to stripping postcodes out of strings that are
sent to Google Analytics. Rather than matching a postcode pattern we
instead match any instances of a query string that has a postcode=
parameter and strip the value of that parameter.

This has been done as we've had occurrences of users entering PII that
is not a postcode and, as it doesn't match our postcode pattern, it is not
stripped. This instead strips any user input to the postcode field.

## Difference:

Given a URL of `https://www.integration.publishing.service.gov.uk/find-coronavirus-local-restrictions?postcode=52+made+up+address+London+E1+8QS`

Before this change this would be submitted to Analytics as: `https://www.integration.publishing.service.gov.uk/find-coronavirus-local-restrictions?postcode=52+made+up+address+London+[postcode]`
After this change this would be submitted to Analytics as: `https://www.integration.publishing.service.gov.uk/find-coronavirus-local-restrictions?postcode=[postcode]`