### PR TITLE
Preserve original link styles when video partial is used with the `inverse` flag

### DIFF
--- a/app/assets/stylesheets/components/_youtube-player.scss
+++ b/app/assets/stylesheets/components/_youtube-player.scss
@@ -37,6 +37,10 @@
     color: govuk-colour("black");
   }
 
+  .govuk-link {
+    @include govuk-link-style-default;
+  }
+
   .govuk-details__summary {
     color: govuk-colour('white');
 


### PR DESCRIPTION
The youtube video player partial has an `--inverse` modifier meant to be used when the component is called within an element with a dark background, as it's the case with the transition page. However, in such scenario, we don't protect the links within the component from getting the 'white' rules on links – required for anchors used on a dark background – resulting in invisible links when cookies are not yet accepted or disabled. With this change, we make sure the default link styles are being used when the video player is called with the `--inverse` flag.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1437" alt="before" src="https://user-images.githubusercontent.com/788096/103551149-d7134e80-4ea1-11eb-9989-f1105ecb7f2e.png">


</td><td valign="top">

<img width="1437" alt="after" src="https://user-images.githubusercontent.com/788096/103551158-d8dd1200-4ea1-11eb-85d2-3b36cc4688db.png">


</td></tr>
</table>
