### PR TITLE
Prepare C19 page for an update

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -1,4 +1,4 @@
-$c19-landing-page-header-background: #0843a1;
+$c19-landing-page-header-background: #272828;
 
 .covid__page {
   .govuk-grid-column-one-third,
@@ -22,7 +22,7 @@ $c19-landing-page-header-background: #0843a1;
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
   border-top: solid govuk-spacing(2) $covid-yellow;
-  background-color: $c19-landing-page-header-background;
+  background-color: govuk-colour("black");
   color: govuk-colour("white");
 
   .covid__page-header-link {
@@ -132,8 +132,6 @@ $c19-landing-page-header-background: #0843a1;
 }
 
 .covid__page-header-title-wrapper {
-  border-bottom: 1px solid $covid-yellow;
-
   @include govuk-media-query($from: tablet) {
     position: relative;
   }

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -66,6 +66,10 @@ $c19-landing-page-header-background: #0843a1;
   @include govuk-media-query($from: tablet) {
     padding: 45px 0 40px;
   }
+
+  .gem-c-govspeak {
+    color: govuk-colour("white");
+  }
 }
 
 .covid__instruction-list {

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -23,41 +23,13 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: sanitize(header["title"]),
+            text: t("coronavirus_landing_page.header_title"),
             font_size: 24,
             margin_bottom: 6,
             inverse: true
           } %>
 
-          <% if header["description"] %>
-            <%= render "govuk_publishing_components/components/govspeak", {
-            } do %>
-              <%= sanitize(header["description"]) %>
-            <% end %>
-          <% end %>
-
-          <% if header["list"] %>
-            <ul class="covid__instruction-list">
-              <% icons = [
-                "icon-hand-wash",
-                "icon-face-cover",
-                "icon-make-space"
-              ] %>
-              <% header["list"].each_with_index do | item, index | %>
-                <li class="covid__instruction-list-item">
-                  <% if item.is_a?(Hash) %>
-                    <%= render "coronavirus_landing_page/components/landing_page/#{icons[index]}.svg" if icons[index] %>
-                    <span class="covid__instruction-text">
-                      <strong class="covid__instruction"><%= item["instruction"].capitalize %></strong>
-                      <%= item["detail"] %>
-                    </span>
-                  <% else %>
-                    <%= item %>
-                  <% end %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
+          <%= render_govspeak(t("coronavirus_landing_page.header_intro")) %>
         </div>
       </div>
 
@@ -95,8 +67,8 @@
             <%= render 'govuk_publishing_components/components/action_link', {
               light_text: true,
               transparent_icon: true,
-              href: header["link"]["href"],
-              text: header["link"]["link_text"],
+              href: t("coronavirus_landing_page.action_link_url"),
+              text: t("coronavirus_landing_page.action_link_text"),
               subtext: header["link"]["subtext"],
               mobile_subtext: true,
               nowrap_text: header["link"]["link_nowrap_text"],
@@ -104,7 +76,7 @@
                 module: "track-click",
                 track_category: "pageElementInteraction",
                 track_action: "Announcements",
-                track_label: header["link"]["href"]
+                track_label: t("coronavirus_landing_page.action_link_url")
               }
             } %>
           <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -24,7 +24,7 @@
         <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
             text: sanitize(header["title"]),
-            font_size: 19,
+            font_size: 24,
             margin_bottom: 6,
             inverse: true
           } %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -28,26 +28,29 @@
             margin_bottom: 6,
             inverse: true
           } %>
-          <ul class="covid__instruction-list">
-            <% icons = [
-              "icon-hand-wash",
-              "icon-face-cover",
-              "icon-make-space"
-            ] %>
-            <% header["list"].each_with_index do | item, index | %>
-              <li class="covid__instruction-list-item">
-                <% if item.is_a?(Hash) %>
-                  <%= render "coronavirus_landing_page/components/landing_page/#{icons[index]}.svg" if icons[index] %>
-                  <span class="covid__instruction-text">
-                    <strong class="covid__instruction"><%= item["instruction"].capitalize %></strong>
-                    <%= item["detail"] %>
-                  </span>
-                <% else %>
-                  <%= item %>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
+
+          <% if header["list"] %>
+            <ul class="covid__instruction-list">
+              <% icons = [
+                "icon-hand-wash",
+                "icon-face-cover",
+                "icon-make-space"
+              ] %>
+              <% header["list"].each_with_index do | item, index | %>
+                <li class="covid__instruction-list-item">
+                  <% if item.is_a?(Hash) %>
+                    <%= render "coronavirus_landing_page/components/landing_page/#{icons[index]}.svg" if icons[index] %>
+                    <span class="covid__instruction-text">
+                      <strong class="covid__instruction"><%= item["instruction"].capitalize %></strong>
+                      <%= item["detail"] %>
+                    </span>
+                  <% else %>
+                    <%= item %>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -29,6 +29,13 @@
             inverse: true
           } %>
 
+          <% if header["description"] %>
+            <%= render "govuk_publishing_components/components/govspeak", {
+            } do %>
+              <%= sanitize(header["description"]) %>
+            <% end %>
+          <% end %>
+
           <% if header["list"] %>
             <ul class="covid__instruction-list">
               <% icons = [

--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -1,5 +1,14 @@
 en:
   coronavirus_landing_page:
+    header_title: "National lockdown: stay at home"
+    header_intro: |
+      You must stay at home. This is the single most important action we can all take to protect the NHS and save lives.
+
+      You must not leave your home unless necessary.
+
+      Stay 2 metres apart from anyone not in your household.
+    action_link_url: /guidance/national-lockdown-stay-at-home
+    action_link_text: Find out what you can and cannot do
     video_section_heading: "Wash your hands, cover your face, make space"
     video_section_link: "https://www.youtube.com/watch?v=1CUrxdTd1bc&rel=0"
     video_section_transcription_summary: View the video transcript


### PR DESCRIPTION
This makes the frontend code for the `/coronavirus` lading page a bit more resilient to content change – that comes from https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml – as follows:

 - Hide the bespoke instruction list when no content is presented (we expect [a few content lines](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml#L7-L13) to be removed and we're updating the frontend code to cope with this)
 - Allow a custom description under the level 2 heading (we expect some description in form of paragraphs or list items to be added)
 - Increase size for level 2 heading (as requested by design, this is the only change that will be visible before any updates will be made via the [govuk-coronavirus-content](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml#L7-L13)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![localhost_3070_coronavirus (1)](https://user-images.githubusercontent.com/788096/103577279-67668900-4ecc-11eb-8df3-cb56cafb88a4.png)


</td><td valign="top">

![localhost_3070_coronavirus](https://user-images.githubusercontent.com/788096/103577285-69c8e300-4ecc-11eb-8058-aa9e7ea688bb.png)


</td></tr>
</table>
