### PR TITLE
Comment video player section out of Coronavirus landing page

### DIFF
--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -49,7 +49,8 @@
         border_top: 2,
       } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/country_section', locals: { guidance: details.additional_country_guidance } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
+      <%# Video player no longer represents current guidance %>
+      <%#= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { live_stream: details.live_stream } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.statistics_section } %>


### PR DESCRIPTION
This video no longer provides the correct guidance so it has been hidden
on this page. I expect we may want to want to bring this back soon so I
felt commenting was better than removing.


After this change:

![Screenshot 2021-01-04 at 20 19 23](https://user-images.githubusercontent.com/282717/103576035-74827880-4eca-11eb-97ba-f5e480cdf9dd.png)
