### PR TITLE
Make header["pretext"] display conditional

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_page_header.html.erb
@@ -33,12 +33,14 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds covid__page-header-list">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: header["pretext"],
-            font_size: 19,
-            margin_bottom: 3,
-            inverse: true
-          } %>
+          <% if header["pretext"].present? %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: header["pretext"],
+              font_size: 19,
+              margin_bottom: 3,
+              inverse: true
+            } %>
+          <% end %>
           <% if header["list_heading"].present? %>
             <p class="govuk-body covid__inverse">
               <%= header["list_heading"] %>


### PR DESCRIPTION
This is to allow a hub page to temporarily have no headers in the box
without leaving empty HTML elements.

Looks like this, with the various fields set to blank

![Screenshot 2021-01-04 at 21 28 16](https://user-images.githubusercontent.com/282717/103581630-4ace4f00-4ed4-11eb-9085-27dcbfab4d5f.png)
