### PR TITLE
Change coronavirus header link variables back

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -72,8 +72,8 @@
             <%= render 'govuk_publishing_components/components/action_link', {
               light_text: true,
               transparent_icon: true,
-              href: header["link"]["url"],
-              text: header["link"]["text"],
+              href: header["link"]["href"],
+              text: header["link"]["link_text"],
               subtext: header["link"]["subtext"],
               mobile_subtext: true,
               nowrap_text: header["link"]["link_nowrap_text"],
@@ -81,7 +81,7 @@
                 module: "track-click",
                 track_category: "pageElementInteraction",
                 track_action: "Announcements",
-                track_label: header["link"]["url"]
+                track_label: header["link"]["href"]
               }
             } %>
           <% end %>


### PR DESCRIPTION
This restores the variables to their old names this seemed to get lost
in the transition from the changes in [1] and [2].

This depends on the data in
https://github.com/alphagov/govuk-coronavirus-content/pull/543 which has
been pushed live.

[1] https://github.com/alphagov/collections/pull/2206/files#diff-ce8ea314cd8b38b89a839207c9df92eeb91d154ac8fe60ea6436f9d0bc935287L88-L97
[2]: https://github.com/alphagov/collections/pull/2210/files#diff-ce8ea314cd8b38b89a839207c9df92eeb91d154ac8fe60ea6436f9d0bc935287L70-L79