### PR TITLE
Add event tracking to covid

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,7 +20,7 @@
 //= require modules/coronavirus-landing-page
 //= require modules/coronavirus-track-local-restriction-results
 //= require modules/coronavirus-local-restrictions-postcode-form
-//= require modules/track-timeline-links
+//= require modules/track-links
 
 $(document).on('ready', function () {
   var toggleAttribute = new GOVUK.Modules.ToggleAttribute()

--- a/app/assets/javascripts/modules/track-links.js
+++ b/app/assets/javascripts/modules/track-links.js
@@ -4,9 +4,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  Modules.TrackTimelineLinks = function () {
+  Modules.TrackLinks = function () {
     this.start = function (element) {
+      var category = element[0].getAttribute('data-track-category')
+      var action = element[0].getAttribute('data-track-action')
       var links = element[0].getElementsByTagName('a')
+
+      if (!category) return
 
       for (var i = 0; i < links.length; i++) {
         var link = links[i]
@@ -16,7 +20,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             label: e.target.getAttribute('href')
           }
 
-          GOVUK.analytics.trackEvent('pageElementInteraction', 'Timeline', options)
+          if (!action) action = e.target.innerText
+
+          GOVUK.analytics.trackEvent(category, action, options)
         })
       }
     }

--- a/app/views/components/_header-notice.html.erb
+++ b/app/views/components/_header-notice.html.erb
@@ -43,7 +43,12 @@
 
     <% if call_to_action.present? %>
       <p class="app-c-header-notice__call-to-action">
-        <%= link_to(call_to_action[:title], call_to_action[:href], class: "app-c-header-notice__call-to-action-link govuk-link") %>
+        <%= link_to(
+          call_to_action[:title],
+          call_to_action[:href],
+          class: "app-c-header-notice__call-to-action-link govuk-link",
+          data: call_to_action[:link_data_attributes]
+        ) %>
         <%= call_to_action[:subtext] %>
       </p>
       <% if call_to_action[:description].present? %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_find_help.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_find_help.html.erb
@@ -24,7 +24,8 @@
       dark_icon: true,
       compact: true,
       href: call_to_action[:href],
-      text: call_to_action[:text]
+      text: call_to_action[:text],
+      data: call_to_action[:data_attributes],
     } %>
   <% end %>
 </section>

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -1,9 +1,14 @@
 <% guidance ||= nil %>
 
 <% if guidance.present? && guidance["intro"].present? %>
-  <p class="govuk-body">
+  <div 
+    class="govuk-body"
+    data-module="track-links"
+    data-track-category="pageElementInteraction"
+    data-track-action="AccordionClick"
+  >
     <%= render_govspeak(guidance["intro"]) %>
-  </p>
+  </div>
 <% end %>
 <% if guidance.present? && guidance["links"].present? %>
   <%

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -8,7 +8,14 @@
 <% if guidance.present? && guidance["links"].present? %>
   <%
     guidance_links = guidance["links"].map do | link |
-      link_to(link["label"],link["url"], class: "govuk-link")
+      link_to(
+        link["label"], link["url"], class: "govuk-link",
+        data: {
+          track_category: "pageElementInteraction",
+          track_action: "AccordionClick",
+          track_label: link["url"],
+        }
+      )
     end
   %>
   <p class="govuk-body">

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -15,7 +15,12 @@
             simple: true,
             href: item["url"],
             text: item["label"],
-            margin_bottom: 1
+            margin_bottom: 1,
+            data: {
+              track_category: "pageElementInteraction",
+              track_action: "AccordionFeatureClick",
+              track_label: item["url"],
+            }
           }%>
           <% item_description = item["description"] %>
           <% if item_description %>

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -27,7 +27,12 @@
           <%= link_to(
             item["label"],
             item["url"],
-            class: "govuk-link covid__accordion-link"
+            class: "govuk-link covid__accordion-link",
+            data: {
+              track_category: "pageElementInteraction",
+              track_action: "AccordionClick",
+              track_label: item["url"],
+            }
           ) %>
         <% end %>
       </li>

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -1,4 +1,4 @@
-<div class="covid-timeline" data-module="track-timeline-links">
+<div class="covid-timeline" data-module="track-links" data-track-category="pageElementInteraction" data-track-action="Timeline">
   <%= render "govuk_publishing_components/components/heading", {
     text: timeline["heading"],
     padding: true,

--- a/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
@@ -1,3 +1,9 @@
+<%
+  tracking_category ||= nil
+  tracking_action ||= nil
+  tracking = true if tracking_category.present? && tracking_action.present?
+%>
+
 <section class="covid__topic-wrapper">
   <%= render "govuk_publishing_components/components/heading", {
     text: topic_section["header"],
@@ -9,7 +15,23 @@
   <ul class="govuk-list">
     <% topic_section["links"].each do | link | %>
       <li class="covid__topic-list-item">
-        <%= link_to link["label"].html_safe, link["url"], class: 'covid__topic-list-link govuk-link' %>
+        <%
+          data = if tracking
+            {
+              module: "track-click",
+              track_category: tracking_category,
+              track_action: tracking_action,
+              track_label: link["url"],
+            }
+          end
+        %>
+
+        <%= link_to( 
+          link["label"].html_safe,
+          link["url"],
+          class: 'covid__topic-list-link govuk-link',
+          data: data,
+        ) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -25,8 +25,14 @@
         call_to_action: {
           href: details.nhs_banner["call_to_action"]["href"],
           title: details.nhs_banner["call_to_action"]["title"],
+          link_data_attributes: {
+            module: "track-click",
+            track_category: "pageElementInteraction",
+            track_action: "callOutBox",
+            track_label: details.nhs_banner["call_to_action"]["href"],
+          },
           subtext: details.nhs_banner["call_to_action"]["subtext"],
-          description: details.nhs_banner["call_to_action"]["description"]
+          description: details.nhs_banner["call_to_action"]["description"],
         }
       } %>
 

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -41,7 +41,13 @@
         copy: details.find_help["paragraph"],
         call_to_action: {
           href: details.find_help["link"]["href"],
-          text: details.find_help["link"]["text"]
+          text: details.find_help["link"]["text"],
+          data_attributes: {
+            module: "track-click",
+            track_category: "pageElementInteraction",
+            track_action: "callOutBox",
+            track_label: details.find_help["link"]["href"],
+          },
         }
       } %>
     </div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -53,7 +53,11 @@
       <%#= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { live_stream: details.live_stream } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.statistics_section } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
+        topic_section: details.statistics_section,
+        tracking_category: "pageElementInteraction",
+        tracking_action: "Statistics",
+      } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
       <%= content_tag :section, class: "covid__topic-wrapper" do
         render partial: 'components/signup-link', locals: {

--- a/spec/javascripts/modules/track-links_spec.js
+++ b/spec/javascripts/modules/track-links_spec.js
@@ -1,11 +1,11 @@
 GOVUK.analytics = GOVUK.analytics || {}
 GOVUK.analytics.trackEvent = function () {}
 
-describe('Track timeline links', function () {
+describe('Track links', function () {
   'use strict'
 
   var html =
-    '<div class="covid-timeline" data-module="track-timeline-links">' +
+    '<div class="covid-timeline" data-module="track-links" data-track-category="pageElementInteraction" data-track-action="Timeline">' +
       '<h2 class="gem-c-heading gem-c-heading--font-size-27 gem-c-heading--padding   govuk-!-margin-bottom-4">Recent and upcoming changes</h2>' +
       '<div class="covid-timeline__item">' +
         '<h3 class="covid-timeline__item-heading govuk-heading-s">24 September</h3>' +
@@ -34,7 +34,7 @@ describe('Track timeline links', function () {
     element.innerHTML = html
     element = element.firstElementChild
 
-    var tracker = new GOVUK.Modules.TrackTimelineLinks()
+    var tracker = new GOVUK.Modules.TrackLinks()
     tracker.start([element])
   })
 


### PR DESCRIPTION
## What

Add event tracking clicks so we know which content is clicked and where on the page. 

We need to add tracking to clicks on

- Accordion content
- Statistics and all guidance sections
- The call out boxes to the testing service and find coronavirus support

More detail here 
https://docs.google.com/document/d/1YvBU48g-tsY_HqaBE4z6BIP9c8W3W4MW5i0dhjAyZy8/edit?usp=sharing

## Why

We can sort of do it using page pathing information but it can get a little bit complicated when the link exists in more than one location on the page


https://trello.com/c/qUfhSJU9/1003-add-event-tracking-to-landing-page-content-clicks