### PR TITLE
Switch to use "link" query param for email signups

### DIFF
--- a/app/views/components/docs/accordion.yml
+++ b/app/views/components/docs/accordion.yml
@@ -63,7 +63,7 @@ examples:
           title: 'Alternative provision censuses',
           panel: '<div class="govuk-govspeak">
             <div class="subscriptions">
-              <a href="/email-signup/?topic=/education/alternative-provision-censuses" class="email-alerts">
+              <a href="/email-signup/?link=/education/alternative-provision-censuses" class="email-alerts">
                 Get emails for this topic
                 <span class="visuallyhidden">Alternative provision censuses</span>
               </a>
@@ -84,7 +84,7 @@ examples:
           title: 'General hospital school censuses',
           panel: '<div class="govuk-govspeak">
             <div class="subscriptions">
-              <a href="/email-signup/?topic=/education/general-hospital-school-censuses" class="email-alerts">
+              <a href="/email-signup/?link=/education/general-hospital-school-censuses" class="email-alerts">
                 Get emails for this topic
                 <span class="visuallyhidden">General hospital school censuses</span>
               </a>

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -11,7 +11,7 @@
 
     <div class="govuk-grid-column-one-third add-title-margin govuk-!-margin-bottom-3">
       <%= render "govuk_publishing_components/components/subscription-links", {
-        email_signup_link: "/email-signup?topic=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
+        email_signup_link: "/email-signup?link=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
         email_signup_link_text: "Get emails for this topic",
       } %>
 

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -15,7 +15,7 @@
     <div class="full-page-width-wrapper">
       <%= render partial: "components/signup-link", locals: {
         link_text: "Sign up for updates to this topic page",
-        link_href: "/email-signup/?topic=#{presented_taxon.base_path}",
+        link_href: "/email-signup/?link=#{presented_taxon.base_path}",
         data: {
           "module": "track-click",
           "track-category": "emailAlertLinkClicked",

--- a/app/views/taxons/_email_alerts.html.erb
+++ b/app/views/taxons/_email_alerts.html.erb
@@ -1,6 +1,6 @@
 <% if taxon_is_live?(presented_taxon) %>
   <div class='subscriptions'>
-    <a href="/email-signup/?topic=<%= presented_taxon.base_path %>" class='email-alerts'>
+    <a href="/email-signup/?link=<%= presented_taxon.base_path %>" class='email-alerts'>
       Get emails for this topic
       <span class='visuallyhidden'><%= presented_taxon.title %></span>
     </a>

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -185,7 +185,7 @@ private
   def and_i_can_see_the_email_signup_link
     assert page.has_link?(
       "Sign up for updates to this topic page",
-      href: "/email-signup/?topic=#{current_path}",
+      href: "/email-signup/?link=#{current_path}",
     )
     assert page.has_css?("a[data-track-category='emailAlertLinkClicked']", text: "Sign up for updates to this topic page")
     assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: "Sign up for updates to this topic page")
@@ -195,7 +195,7 @@ private
   def and_i_cannot_see_an_email_signup_link
     assert_not page.has_link?(
       "Sign up for updates to this topic page",
-      href: "/email-signup/?topic=#{current_path}",
+      href: "/email-signup/?link=#{current_path}",
     )
   end
 


### PR DESCRIPTION
https://trello.com/c/oYRFCtBm/668-iterate-error-content-and-behaviour-for-new-signup-workflow

This is preferred for the signup API [1] [2].

[1]: https://github.com/alphagov/email-alert-frontend/pull/971
[2]: https://github.com/alphagov/email-alert-frontend/blob/5f132d43d0dfc378248b228525e1393a495931cb/app/controllers/content_item_signups_controller.rb#L43