### PR TITLE
Add tracking to All covid information section

### DIFF
--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -70,7 +70,11 @@
         tracking_category: "pageElementInteraction",
         tracking_action: "Statistics",
       } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
+      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
+        topic_section: details.topic_section,
+        tracking_category: "pageElementInteraction",
+        tracking_action: "CoronavirusInformation",
+      } %>
       <%= content_tag :section, class: "covid__topic-wrapper" do
         render partial: 'components/signup-link', locals: {
           link_text: details.notifications["email_link"],


### PR DESCRIPTION
## What

Add event tracking clicks so we know which content is clicked and where on the page.

We need to add tracking to clicks on all guidance sections

More detail here
https://docs.google.com/document/d/1YvBU48g-tsY_HqaBE4z6BIP9c8W3W4MW5i0dhjAyZy8/edit?usp=sharing

## Why

We can sort of do it using page pathing information but it can get a little bit complicated when the link exists in more than one location on the page

https://trello.com/c/qUfhSJU9/1003-add-event-tracking-to-landing-page-content-clicks