### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,7 @@ library("govuk")
 node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections")
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
     publishingE2ETests: true,
-    sassLint: false,
     brakeman: true,
   )
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82