### PR TITLE
Replace govuk prefix meta tags with the govuk meta tag component

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,7 +1,11 @@
 <% content_for :title, "All categories" %>
 <% content_for :page_class, "browse" %>
 <% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='Browse Index'>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Browse Index",
+    }
+  } %>
 <% end %>
 
 <h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,7 +1,11 @@
 <% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='First Level Browse'>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "First Level Browse",
+    }
+  } %>
 <% end %>
 <% content_for :page_class, "browse" %>
 

--- a/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
@@ -12,7 +12,12 @@
   <meta property="og:title" content="<%= @content_item["title"] %>">
   <meta property="og:description" content="<%= @content_item["description"] %>">
   <meta name="description" content="<%= @content_item["description"] %>">
-  <meta name="govuk:navigation-page-type" content="Taxon Page" />
+
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Taxon Page",
+    }
+  } %>
 
   <% if corona_opengraph_images %>
     <meta property="og:image" content="<%= image_url("stay-at-home-social-share.png") %>" />

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -10,7 +10,12 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="<%= image_url("KBM_twitter.png") %>">
   <meta name="description" content="<%= t("dit_landing_page.meta_description") %>">
-  <meta name="govuk:navigation-page-type" content="Taxon Page" />
+  
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Taxon Page",
+    }
+  } %>
 <% end %>
 
 <header class="dit-landing-page__header--with-bg-image">

--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -7,7 +7,11 @@
 <% end %>
 
 <% content_for :meta_tags do %>
-  <meta name="govuk:section" content="<%= meta_section %>">
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      section: meta_section,
+    }
+  } %>
   <meta name="robots" content="noindex">
 <% end %>
 

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -2,8 +2,12 @@
 <% top_level_title = "#{t("shared.browse.prefix")} #{page.active_top_level_browse_page.title}" %>
 <%= render 'shared/tag_meta', tag: page %>
 <% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='Second Level Browse'>
-  <meta name="govuk:section" content="<%= meta_section %>">
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Second Level Browse",
+      section: meta_section,
+    }
+  } %>
 <% end %>
 <% content_for :page_class, "browse" %>
 

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,8 +1,12 @@
 <% content_for :title, subtopic.combined_title %>
 <%= render 'shared/tag_meta', tag: subtopic %>
 <% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='Second Level Topic'>
-  <meta name="govuk:section" content="<%= meta_section %>">
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Second Level Topic",
+      section: meta_section,
+    }
+  } %>
 <% end %>
 <% content_for :page_title do %>
   <%

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -5,7 +5,11 @@
     <meta name="robots" content="noindex">
   <% end %>
   <meta name="description" content="<%= presented_taxon.description %>">
-  <meta name="govuk:navigation-page-type" content="Taxon Page" />
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Taxon Page",
+    }
+  } %>
 <% end %>
 
 <%= render partial: 'page_header', locals: { presented_taxon: presented_taxon } %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -2,7 +2,11 @@
 <% content_for :title, title_with_suffix %>
 <%= render 'shared/tag_meta', tag: topic %>
 <% content_for :meta_tags do %>
-  <meta name='govuk:navigation-page-type' content='<%= navigation_page_type %>'>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: navigation_page_type,
+    }
+  } %>
 <% end %>
 <% content_for :page_class, "topics-page" %>
 

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -11,7 +11,13 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:image" content="<%= image_url("transition-period.png") %>">
   <meta name="description" content="<%= t("transition_landing_page.meta_description") %>">
-  <meta name="govuk:navigation-page-type" content="Taxon Page" />
+  
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Taxon Page",
+    }
+  } %>
+  
   <link rel="canonical" href="<%= page_url %>">
   <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>

--- a/app/views/world_wide_taxons/_common.html.erb
+++ b/app/views/world_wide_taxons/_common.html.erb
@@ -5,7 +5,11 @@
     <meta name="robots" content="noindex, nofollow">
   <% end %>
   <meta name="description" content="<%= presented_taxon.description %>">
-  <meta name="govuk:navigation-page-type" content="<%= presented_taxon.rendering_type %>" />
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: presented_taxon.rendering_type,
+    }
+  } %>
 <% end %>
 
 <%= render partial: 'page_header', locals: { presented_taxon: presented_taxon } %>


### PR DESCRIPTION
## What
Replace instances of meta tags prefixed with `govuk` in their name eg: `govuk:section` with the [govuk meta tags component](https://components.publishing.service.gov.uk/component-guide/meta_tags).

## Why
This is part of ongoing work to ensure our frontend apps are using components from our components gem as often as possible. Whilst this change makes the code more verbose, it allows us to easily extend our custom metadata ecosystem which is currently used for things like analytics and the govuk browser extension. This change hasn't included meta tags without the `govuk` prefix like opengraph tags because we currently don't cover these in the component.

No visual changes

[Card](https://trello.com/c/AomyVLLP/551-investigate-and-update-collections-to-use-meta-tag-component)