### PR TITLE
Fix filter whitespace bug; add filter by acronym

### DIFF
--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -1,3 +1,6 @@
+/* global $ GOVUK */
+/* eslint-disable no-var */
+
 (function () {
   'use strict'
   window.GOVUK = window.GOVUK || {}
@@ -44,18 +47,33 @@
     },
 
     matchSearchTerm: function (organisation, term) {
+      var normaliseWhitespace = function (string) {
+        return string
+          .trim() // Removes spaces at beginning and end of string.
+          .replace(/\r?\n|\r/g, ' ') // Replaces line breaks with one space.
+          .replace(/\s+/g, ' ') // Squashes multiple spaces to one space.
+      }
+
       var organisationText = ''
+      var organisationAcronym = organisation.attr('data-filter-acronym') || ''
 
       organisation.removeClass('js-hidden')
 
       if (organisation.find('.gem-c-organisation-logo__name').length > 0) {
-        organisationText = organisation.find('.gem-c-organisation-logo__name').text()
+        organisationText = normaliseWhitespace(
+          organisation.find('.gem-c-organisation-logo__name').text()
+        )
       } else {
-        organisationText = organisation.find('.organisation-list__item-title').text()
+        organisationText = normaliseWhitespace(
+          organisation.find('.organisation-list__item-title').text()
+        )
       }
 
-      var searchTermRegexp = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
-      if (searchTermRegexp.exec(organisationText) !== null) {
+      var searchTermRegexp = new RegExp(term.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
+      if (
+        searchTermRegexp.exec(organisationText) !== null ||
+        searchTermRegexp.exec(organisationAcronym) !== null
+      ) {
         return true
       }
     },

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -18,7 +18,14 @@
     <div class="govuk-grid-column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
       <ol data-filter="list">
         <% organisations.each do |organisation| %>
-          <li class="organisations-list__item" id="<%= organisation['slug'] %>" data-filter="item">
+          <%= content_tag :li, {
+            class: "organisations-list__item",
+            id: organisation['slug'],
+            data: {
+              filter: "item",
+              "filter-acronym": organisation["acronym"].presence,
+            },
+          } do %>
             <% if @presented_organisations.ministerial_organisation?(organisation_type) %>
               <%= render "govuk_publishing_components/components/organisation_logo", {
                 organisation: {
@@ -47,7 +54,7 @@
                   } %>
               </div>
             <% end %>
-          </li>
+          <% end # </li> %>
         <% end %>
       </ol>
     </div>

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -1,3 +1,7 @@
+/* global $ GOVUK */
+/* eslint-env jasmine */
+/* eslint-disable no-var */
+
 describe('organisation-list-filter.js', function () {
   'use strict'
 
@@ -28,8 +32,12 @@ describe('organisation-list-filter.js', function () {
           '<li data-filter="item" class="org-logo-1">' +
             '<div class="gem-c-organisation-logo__name">Cabinet Office</div>' +
           '</li>' +
-          '<li data-filter="item" class="org-logo-2">' +
+          '<li data-filter="item" class="org-logo-2" data-filter-acronym="CO">' +
             '<div class="gem-c-organisation-logo__name">Cabinet Office</div>' +
+          '</li>' +
+          '<li data-filter="item" class="org-logo-3" data-filter-acronym="MFW">' +
+            // Double space and line break added on purpose:
+            '<div class="gem-c-organisation-logo__name">Ministry of  Funny\nWalks</div>' +
           '</li>' +
         '</ol>' +
       '</div>' +
@@ -89,6 +97,42 @@ describe('organisation-list-filter.js', function () {
     }, timeout)
   })
 
+  it('show items that do have acronyms that match the search term', function (done) {
+    $('[data-filter="form"] input').val('mfw')
+    $('[data-filter="form"] input').trigger('keyup')
+
+    setTimeout(function () {
+      expect($('.org-logo-3')).not.toHaveClass('js-hidden')
+      expect($('.js-search-results')).toHaveText('1 result found')
+      done()
+    }, timeout)
+  })
+
+  it('show items that do have acronyms and/or name that match the search term', function (done) {
+    $('[data-filter="form"] input').val('co')
+    $('[data-filter="form"] input').trigger('keyup')
+
+    setTimeout(function () {
+      expect($('.org-logo-2')).not.toHaveClass('js-hidden')
+      expect($('.org-no-logo-1')).not.toHaveClass('js-hidden')
+      expect($('.org-no-logo-2')).not.toHaveClass('js-hidden')
+      expect($('.js-search-results')).toHaveText('3 results found')
+      done()
+    }, timeout)
+  })
+
+  it('hides items that do not have acronyms and/or name that match the search term', function (done) {
+    $('[data-filter="form"] input').val('co')
+    $('[data-filter="form"] input').trigger('keyup')
+
+    setTimeout(function () {
+      expect($('.org-logo-1')).toHaveClass('js-hidden')
+      expect($('.org-logo-3')).toHaveClass('js-hidden')
+      expect($('.js-search-results')).toHaveText('3 results found')
+      done()
+    }, timeout)
+  })
+
   it('hide department counts and names if they have no matching organisations', function (done) {
     $('[data-filter="form"] input').val('Advisory cou')
     $('[data-filter="form"] input').trigger('keyup')
@@ -119,6 +163,16 @@ describe('organisation-list-filter.js', function () {
 
     setTimeout(function () {
       expect($('.js-search-results')).toHaveText('0 results found')
+      done()
+    }, timeout)
+  })
+
+  it('copes when organisation name contains line breaks and multiple spaces', function (done) {
+    $('[data-filter="form"] input').val('ministry of funny walks')
+    $('[data-filter="form"] input').trigger('keyup')
+
+    setTimeout(function () {
+      expect($('.js-search-results')).toHaveText('1 result found')
       done()
     }, timeout)
   })


### PR DESCRIPTION
## What
This changes the filter to trim the whitespace in the string that's being searched for and normalises the strings being searched in. This means that `  department of  `, `department of` and `department\nof` are all  treated as equivalent.

An extra `data-filter-acronym` attribute has been added to allow the filter to filter by organisational acronym - so `MOD` will show `Ministry of Defence`.

Tests have been added and updated to cope with these scenarios.

👉 [Organisation search page on preview app](https://govuk-collec-update-org-sqfukm.herokuapp.com/government/organisations) 👈

## Why

The organisation filter - found only on www.gov.uk/government/organisations - was not showing the correct results when searching for certain organisations - for example searching for "ministry of defence" does not show the results for the Ministry of Defence:

<img width="653" alt="" src="https://user-images.githubusercontent.com/1732331/105501248-e117b880-5cbb-11eb-8562-f0c66c2183bf.png">

Searching for "department" shows 19 results:
<img width="653" alt="" src="https://user-images.githubusercontent.com/1732331/105501429-20460980-5cbc-11eb-81b3-a7bb116b0991.png">

And then adding a single space on the end changes the number of results to 13:
<img width="664" alt="" src="https://user-images.githubusercontent.com/1732331/105501533-44a1e600-5cbc-11eb-8200-5bd67f375837.png">

This is because some of the names in the organisation list have newlines instead of spaces, and some have double spaces instead of single spaces. Whilst this should also be fixed at a content level, it's also good for the filter to able to cope with this.

When an organisation name had a newline or multiple spaces in it the filter was unable to find it. This is because `Ministry ` (with a space at the end) is not equivalent to `Ministry`; and `Ministry ` (with a space) is not equivalent to `Ministry\n`.