### PR TITLE
Update sign up link for taxons

### DIFF
--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -18,7 +18,7 @@
   <div class="taxon-page__email-link-wrapper">
     <div class="full-page-width-wrapper">
       <%= render partial: "components/signup-link", locals: {
-        link_text: "Sign up for updates to this topic page",
+        link_text: "Get emails about this topic",
         link_href: "/email-signup/?link=#{presented_taxon.base_path}",
         data: {
           "module": "track-click",

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -183,18 +183,16 @@ private
   end
 
   def and_i_can_see_the_email_signup_link
-    assert page.has_link?(
-      "Sign up for updates to this topic page",
-      href: "/email-signup/?link=#{current_path}",
-    )
-    assert page.has_css?("a[data-track-category='emailAlertLinkClicked']", text: "Sign up for updates to this topic page")
-    assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: "Sign up for updates to this topic page")
-    assert page.has_css?("a[data-track-label=\"\"]", text: "Sign up for updates to this topic page")
+    link_text = "Get emails about this topic"
+    assert page.has_link?(link_text, href: "/email-signup/?link=#{current_path}")
+    assert page.has_css?("a[data-track-category='emailAlertLinkClicked']", text: link_text)
+    assert page.has_css?("a[data-track-action=\"#{current_path}\"]", text: link_text)
+    assert page.has_css?("a[data-track-label=\"\"]", text: link_text)
   end
 
   def and_i_cannot_see_an_email_signup_link
     assert_not page.has_link?(
-      "Sign up for updates to this topic page",
+      "Get emails about this topic",
       href: "/email-signup/?link=#{current_path}",
     )
   end


### PR DESCRIPTION
This got missed in [1]. Although the link did not contain the word
"alert", the intention was also to update other links to make them
consistent across the site.

[1]: https://github.com/alphagov/collections/pull/2143