### PR TITLE
Delete current-location.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require support
 //= require browse-columns
 //= require organisation-list-filter
-//= require modules/current-location
 //= require modules/feeds.js
 //= require modules/toggle-attribute
 //= require components/accordion

--- a/app/assets/javascripts/modules/current-location.js
+++ b/app/assets/javascripts/modules/current-location.js
@@ -1,8 +1,0 @@
-(function (root) {
-  'use strict'
-  root.GOVUK = root.GOVUK || {}
-
-  root.GOVUK.getCurrentLocation = function () {
-    return root.location
-  }
-}(window))


### PR DESCRIPTION
## What
Delete current-location.js

## Why
Already [available via GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/lib/current-location.js)

## Visual Changes
n/a