### PR TITLE
Restore link style

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -142,18 +142,6 @@ $c19-landing-page-header-background: #272828;
   color: govuk-colour("white");
 }
 
-.covid__list--accordion {
-  margin-bottom: govuk-spacing(6);
-
-  .covid__list-item {
-    margin-bottom: govuk-spacing(4);
-
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(3);
-    }
-  }
-}
-
 .covid__list-item-description {
   @include govuk-font(19);
   padding-left: govuk-spacing(6);
@@ -214,18 +202,6 @@ $c19-landing-page-header-background: #272828;
 
 .covid__inverse {
   color: govuk-colour("white");
-}
-
-.covid__accordion-link {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-
-    &:focus {
-      text-decoration: none;
-    }
-  }
 }
 
 .covid__topic-wrapper {

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 4,
     } %>
   <% end %>
-  <ul class="covid__list covid__list--accordion">
+  <ul class="covid__list">
     <% sub_section["list"].each do | item | %>
       <li class="covid__list-item">
         <% if item["featured_link"] %>
@@ -32,7 +32,7 @@
           <%= link_to(
             item["label"],
             item["url"],
-            class: "govuk-link covid__accordion-link",
+            class: "govuk-link",
             data: {
               track_category: "pageElementInteraction",
               track_action: "AccordionClick",

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -181,17 +181,17 @@ module CoronavirusLandingPageSteps
 
   def then_i_can_see_the_accordions
     assert page.has_selector?("h2", text: "Guidance and support")
-    assert page.has_selector?(".gem-c-accordion__section-heading", text: "How to protect yourself and others")
+    assert page.has_selector?(".gem-c-accordion__section-header", text: "How to protect yourself and others")
   end
 
   def then_i_can_see_the_business_accordions
     assert page.has_selector?("h2", text: "Guidance and support")
-    assert page.has_selector?(".gem-c-accordion__section-heading", text: "Funding and support")
+    assert page.has_selector?(".gem-c-accordion__section-header", text: "Funding and support")
   end
 
   def then_i_can_see_the_education_accordions
     assert page.has_selector?("h2", text: "Guidance and support")
-    assert page.has_selector?(".gem-c-accordion__section-heading", text: "School curriculum and teaching")
+    assert page.has_selector?(".gem-c-accordion__section-header", text: "School curriculum and teaching")
   end
 
   def and_i_click_on_an_accordion


### PR DESCRIPTION
## What?

Restoring underline from gem to indicate to a user this is a link so it doesn't rely on colour alone.

## Why?

Divergence from [gem](https://components.publishing.service.gov.uk/component-guide) & [WCAG 1.4.1 issue](https://www.w3.org/TR/WCAG20-TECHS/F73.html)

## Visuals

Before (left) / After (right)

![Screenshot 2021-02-10 at 17 21 02](https://user-images.githubusercontent.com/71266765/107546663-868bc100-6bc4-11eb-9ce2-d3108468b7d7.png)

![Screenshot 2021-02-10 at 17 21 50](https://user-images.githubusercontent.com/71266765/107546675-8986b180-6bc4-11eb-9de7-d0c55e29e3f0.png)

## Anything else?

This PR is dependant on [Accordion Design updates PR](https://github.com/alphagov/govuk_publishing_components/pull/1884) being merged and released first.