### PR TITLE
Error messages for postcode checker

### DIFF
--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -20,7 +20,7 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     @search = PostcodeLocalRestrictionSearch.new(params[:postcode])
 
-    if @search.invalid_postcode?
+    if @search.invalid_postcode? || @search.postcode_not_found?
       render
     elsif @search.no_restriction? || @search.no_information?
       render :no_information

--- a/app/controllers/coronavirus_local_restrictions_controller.rb
+++ b/app/controllers/coronavirus_local_restrictions_controller.rb
@@ -20,7 +20,7 @@ class CoronavirusLocalRestrictionsController < ApplicationController
 
     @search = PostcodeLocalRestrictionSearch.new(params[:postcode])
 
-    if @search.blank_postcode? || @search.invalid_postcode?
+    if @search.invalid_postcode?
       render
     elsif @search.no_restriction? || @search.no_information?
       render :no_information

--- a/app/models/postcode_local_restriction_search.rb
+++ b/app/models/postcode_local_restriction_search.rb
@@ -30,12 +30,13 @@ class PostcodeLocalRestrictionSearch
     return "fullPostcodeNoMapitValidation" if location_lookup.invalid_postcode?
   end
 
-  def blank_postcode?
-    %w[postcodeLeftBlank postcodeLeftBlankSanitized fullPostcodeNoMapitMatch].include?(error_code)
-  end
-
   def invalid_postcode?
-    %w[invalidPostcodeFormat fullPostcodeNoMapitValidation].include?(error_code)
+    %w[
+      postcodeLeftBlank
+      postcodeLeftBlankSanitized
+      invalidPostcodeFormat
+      fullPostcodeNoMapitValidation
+    ].include?(error_code)
   end
 
   def no_restriction?

--- a/app/models/postcode_local_restriction_search.rb
+++ b/app/models/postcode_local_restriction_search.rb
@@ -9,7 +9,7 @@ class PostcodeLocalRestrictionSearch
   }xi.freeze
 
   attr_reader :postcode
-  delegate :no_information?, to: :location_lookup
+  delegate :no_information?, :postcode_not_found?, to: :location_lookup
 
   def initialize(postcode)
     @postcode = postcode
@@ -26,7 +26,7 @@ class PostcodeLocalRestrictionSearch
     return "postcodeLeftBlank" if postcode.empty?
     return "postcodeLeftBlankSanitized" if sanitised_postcode.empty?
     return "invalidPostcodeFormat" unless sanitised_postcode.match?(UK_POSTCODE_PATTERN)
-    return "fullPostcodeNoMapitMatch" if location_lookup.postcode_not_found?
+    return "fullPostcodeNoMapitMatch" if postcode_not_found?
     return "fullPostcodeNoMapitValidation" if location_lookup.invalid_postcode?
   end
 

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -1,6 +1,8 @@
 <%
   error_key = if @search&.invalid_postcode?
                 "invalid_postcode"
+              elsif @search&.postcode_not_found?
+                "no_postcode"
               end
 
   title = t("coronavirus_local_restrictions.lookup.title")

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -2,7 +2,7 @@
   error_key = if @search&.invalid_postcode?
                 "invalid_postcode"
               elsif @search&.postcode_not_found?
-                "no_postcode"
+                "postcode_not_found"
               end
 
   title = t("coronavirus_local_restrictions.lookup.title")

--- a/app/views/coronavirus_local_restrictions/show.html.erb
+++ b/app/views/coronavirus_local_restrictions/show.html.erb
@@ -1,7 +1,5 @@
 <%
-  error_key = if @search&.blank_postcode?
-                "no_postcode"
-              elsif @search&.invalid_postcode?
+  error_key = if @search&.invalid_postcode?
                 "invalid_postcode"
               end
 

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -1,7 +1,7 @@
 en:
   coronavirus_local_restrictions:
     errors:
-      no_postcode:
+      postcode_not_found:
         error_message: There is a problem
         input_error: The postcode could not be found, enter a full postcode
         error_description: The postcode could not be found, enter a full postcode

--- a/config/locales/en/coronavirus_local_restrictions.yml
+++ b/config/locales/en/coronavirus_local_restrictions.yml
@@ -3,12 +3,12 @@ en:
     errors:
       no_postcode:
         error_message: There is a problem
-        input_error: Enter a postcode
-        error_description: Enter a postcode
+        input_error: The postcode could not be found, enter a full postcode
+        error_description: The postcode could not be found, enter a full postcode
       invalid_postcode:
         error_message: There is a problem
-        input_error: Enter a valid postcode
-        error_description: Enter a valid postcode
+        input_error: Enter a full postcode, like LS1 1UR
+        error_description: Enter a full postcode, like LS1 1UR
     out_of_date_warning: |
       This service is being updated, at the moment it might not show the latest information for your area
     lookup:

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -226,7 +226,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     stub_no_local_restriction(postcode: postcode, name: @area)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_an_unusually_formatted_postcode
@@ -234,7 +234,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     @area = "Hoth"
     stub_local_restriction(postcode: @postcode, name: @area, current_alert_level: 1)
 
-    fill_in "Enter a full postcode", with: "e18qs"
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: "e18qs"
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_level_two_restriction
@@ -245,7 +245,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
                            current_alert_level: 1,
                            future_alert_level: 2)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_level_three_restriction
@@ -256,7 +256,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
                            current_alert_level: 2,
                            future_alert_level: 3)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_a_future_level_four_restriction
@@ -267,14 +267,14 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
                            current_alert_level: 3,
                            future_alert_level: 4)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_with_an_extra_special_character
     @area = "Coruscant Planetary Council"
     stub_local_restriction(postcode: "E1 8QS", name: @area, current_alert_level: 2)
 
-    fill_in "Enter a full postcode", with: ".e18qs"
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: ".e18qs"
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_one
@@ -282,7 +282,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     stub_local_restriction(postcode: "E1 8QS", name: @area, current_alert_level: 1)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_two
@@ -290,7 +290,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     stub_local_restriction(postcode: postcode, name: @area, current_alert_level: 2)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_three
@@ -298,7 +298,7 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     stub_local_restriction(postcode: postcode, name: @area, current_alert_level: 3)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_english_postcode_in_tier_four
@@ -306,28 +306,28 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     postcode = "E1 8QS"
     stub_local_restriction(postcode: postcode, name: @area, current_alert_level: 4)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_welsh_postcode
     postcode = "LL11 0BY"
     stub_local_restriction(postcode: postcode, country_name: "Wales")
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_scottish_postcode
     postcode = "G20 9SH"
     stub_local_restriction(postcode: postcode, country_name: "Scotland")
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_enter_a_valid_northern_ireland_postcode
     postcode = "BT48 7PX"
     stub_local_restriction(postcode: postcode, country_name: "Northern Ireland")
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def when_i_enter_a_valid_postcode_that_returns_no_results
@@ -337,19 +337,19 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     stub_request(:get, "#{mapit_endpoint}/postcode/" + postcode.tr(" ", "+") + ".json")
         .to_return(body: { "postcode" => postcode.to_s, "areas" => {} }.to_json, status: 200)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def when_i_enter_an_invalid_postcode
     @postcode = "Hello"
-    fill_in "Enter a full postcode", with: @postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: @postcode
   end
 
   def when_i_enter_a_postcode_that_does_not_exist
     postcode = "XM4 5HQ"
     stub_mapit_does_not_have_a_postcode(postcode)
 
-    fill_in "Enter a full postcode", with: postcode
+    fill_in I18n.t("coronavirus_local_restrictions.lookup.input_label"), with: postcode
   end
 
   def then_i_click_on_find

--- a/test/integration/coronavirus_local_restrictions_test.rb
+++ b/test/integration/coronavirus_local_restrictions_test.rb
@@ -91,9 +91,10 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     it "errors gracefully if you don't enter a postcode" do
       given_i_am_on_the_local_restrictions_page
       then_i_can_see_the_postcode_lookup_form
+      when_i_enter_an_invalid_postcode
       then_i_click_on_find
       then_i_can_see_the_postcode_lookup_form
-      then_i_see_a_no_postcode_error_message
+      then_i_see_an_invalid_postcode_error_message
     end
 
     it "errors gracefully if the postcode is invalid" do
@@ -103,6 +104,15 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
       then_i_click_on_find
       then_i_can_see_the_invalid_postcode_in_the_form
       then_i_see_an_invalid_postcode_error_message
+    end
+
+    it "errors gracefully if the postcode doesn't exist" do
+      given_i_am_on_the_local_restrictions_page
+      then_i_can_see_the_postcode_lookup_form
+      when_i_enter_a_postcode_that_does_not_exist
+      then_i_click_on_find
+      then_i_can_see_the_postcode_lookup_form
+      then_i_see_a_postcode_not_found_error_message
     end
   end
 
@@ -335,6 +345,13 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     fill_in "Enter a full postcode", with: @postcode
   end
 
+  def when_i_enter_a_postcode_that_does_not_exist
+    postcode = "XM4 5HQ"
+    stub_mapit_does_not_have_a_postcode(postcode)
+
+    fill_in "Enter a full postcode", with: postcode
+  end
+
   def then_i_click_on_find
     click_on "Find"
   end
@@ -381,12 +398,12 @@ class CoronavirusLocalRestrictionsTest < ActionDispatch::IntegrationTest
     assert page.has_text?(I18n.t("coronavirus_local_restrictions.results.devolved_nations.northern_ireland.guidance.label"))
   end
 
-  def then_i_see_a_no_postcode_error_message
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.errors.no_postcode.error_message"))
+  def then_i_see_a_postcode_not_found_error_message
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.errors.postcode_not_found.input_error"))
   end
 
   def then_i_see_an_invalid_postcode_error_message
-    assert page.has_text?(I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.error_message"))
+    assert page.has_text?(I18n.t("coronavirus_local_restrictions.errors.invalid_postcode.input_error"))
   end
 
   def then_i_see_the_no_information_page

--- a/test/models/postcode_local_restriction_search_test.rb
+++ b/test/models/postcode_local_restriction_search_test.rb
@@ -84,16 +84,6 @@ describe PostcodeLocalRestrictionSearch do
     end
   end
 
-  describe "#blank_postcode?" do
-    it "returns true for missing postcode scenarios" do
-      assert described_class.new("").blank_postcode?
-    end
-
-    it "returns false when a postcode is input" do
-      assert_not described_class.new("E1 8QS").blank_postcode?
-    end
-  end
-
   describe "#invalid_postcode?" do
     it "returns true for an invalid postcode scenarios" do
       assert described_class.new("not-a-postcode").invalid_postcode?
@@ -101,6 +91,16 @@ describe PostcodeLocalRestrictionSearch do
 
     it "returns false when the input is a valid postcode" do
       assert_not described_class.new("E1 8QS").invalid_postcode?
+    end
+
+    it "returns false if mapit doesn't know about the postcode" do
+      stub_mapit_does_not_have_a_postcode("E1 8QS")
+
+      assert_not described_class.new("E1 8QS").invalid_postcode?
+    end
+
+    it "returns true for missing postcode scenarios" do
+      assert described_class.new("").invalid_postcode?
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/vFwLB8Dz

# What's changed and why?

We have stats on the types of postcode errors that users are putting in to the checker.  We can make specific error messages and summaries for these errors, so users know how to rectify their mistakes. 

Creates 2 new error messages and summaries to replace the ones that already exist. 

## 1. Postcode not found 
Error message and summary: 
The postcode could not be found, enter a full postcode

Show for types of error: 
 Postcode couldn’t be found in Mapit

## 2.  Invalid format and other errors
Error message and summary: 
Enter a full postcode, like LS1 1UR

Show for types of error:
- Postcode invalid format
- Postcode failed validation in Mapit
- Postcode left blank
- Other errors

# Expected changes
## 1. Postcode not found 
![screenshot-collections dev gov uk-2021 02 03-12_54_24](https://user-images.githubusercontent.com/5793815/106752728-afd7aa80-6622-11eb-93c9-bc9df6785ede.png)

## 2.  Invalid format and other errors
![screenshot-collections dev gov uk-2021 02 03-12_51_35](https://user-images.githubusercontent.com/5793815/106752731-b108d780-6622-11eb-8135-d40b2ccc94e4.png)
