### PR TITLE
Revert "Update element to list"

### DIFF
--- a/app/views/transition_landing_page/_buckets.html.erb
+++ b/app/views/transition_landing_page/_buckets.html.erb
@@ -1,4 +1,5 @@
 <% guidance_header = t("transition_landing_page.guidance_header") %>
+
 <div class="landing-page__section"
   data-analytics-ecommerce
   data-ecommerce-start-index="1"
@@ -14,30 +15,29 @@
       } %>
     </div>
   </div>
+
+  <% campaign_links = I18n.t("transition_landing_page.campaign_links") %>
+  <%
+    links = campaign_links[:links].map do |link|
+      link_to(link[:text], link[:path], class: "govuk-link", data: {
+        track_action: link[:path],
+        track_category: "transition-landing-page",
+        track_label: "What you can do now"
+      })
+    end
+  %>
   <div class="govuk-grid-row landing-page__section-list-wrapper">
     <div class="govuk-grid-column-two-thirds">
-      <% campaign_links = I18n.t("transition_landing_page.campaign_links") %>
       <p class='govuk-body'><%= campaign_links[:lead_in] %></p>
-      <%
-        links = campaign_links[:links].map do |link|
-          link_to(link[:text], link[:path], class: "govuk-link", data: {
-            track_action: link[:path],
-            track_category: "transition-landing-page",
-            track_label: "What you can do now"
-          })
-        end
-      %>
-      <%= tag.div data: { module: "track-click" } do %>
-        <%= render "govuk_publishing_components/components/list", {
-          visible_counters: true,
-          extra_spacing: true,
-          items: links.each do | link |
-            {
-              items: link,
-            }
-          end
-        } %>
+
+      <%= tag.ul class: %w[govuk-list govuk-list--bullet govuk-list--spaced], data: { module: "track-click" } do %>
+        <% links.each do |link| %>
+          <%= tag.li do %>
+            <%= link %>
+          <% end %>
+        <% end %>
       <% end %>
+
       <p class="govuk-body govuk-!-padding-top-2"><%= sanitize(campaign_links[:lead_out], attributes: %w(href class data-module data-track-action data-track-category data-track-label)) %></p>
     </div>
   </div>


### PR DESCRIPTION
This reverts commit b350f4d136a95f5dc1c90bc2bb6208a2e1691cad which accidentally broke tracking on the main list of actions on `/transition`. The [list component](https://components.publishing.service.gov.uk/component-guide/list) doesn't yet support data attributes, hence we roll-back to using a basic `<ul>` until that is resolved.

[Trello card](https://trello.com/c/aJj8mHl8)

Preview after revert:

<img width="1438" alt="Screenshot 2021-02-04 at 09 04 48" src="https://user-images.githubusercontent.com/788096/106870081-9b4ded80-66c8-11eb-9569-3567ed595773.png">
