### PR TITLE
Replace references to Rummager with SearchAPI

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -17,12 +17,12 @@ module Services
   def self.cached_search(params, metric_key: "search.request_time")
     Rails.cache.fetch(params, expires_in: 5.minutes) do
       GovukStatsd.time(metric_key) do
-        rummager.search(params).to_h
+        search_api.search(params).to_h
       end
     end
   end
 
-  def self.rummager
-    @rummager ||= GdsApi::Search.new(Plek.new.find("search"))
+  def self.search_api
+    @search_api ||= GdsApi::Search.new(Plek.new.find("search"))
   end
 end

--- a/app/lib/services_and_information_links_grouper.rb
+++ b/app/lib/services_and_information_links_grouper.rb
@@ -4,15 +4,15 @@ class ServicesAndInformationLinksGrouper
   end
 
   def parsed_grouped_links
-    grouped_links_from_rummager.map do |group|
+    grouped_links_from_search_api.map do |group|
       ServicesAndInformationGroup.new(group)
     end
   end
 
 private
 
-  def grouped_links_from_rummager
-    @grouped_links_from_rummager ||= begin
+  def grouped_links_from_search_api
+    @grouped_links_from_search_api ||= begin
       params = {
         count: "0",
         filter_organisations: @organisation_id,

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -59,9 +59,9 @@ private
   end
 
   def content_tagged_to_tag
-    @content_tagged_to_tag ||= RummagerSearch.new(
+    @content_tagged_to_tag ||= SearchApiSearch.new(
       :start => 0,
-      :count => RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      :count => SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       filter_name => [@tag_content_id],
       :fields => %w[title link format],
     )

--- a/app/models/search_api_organisation.rb
+++ b/app/models/search_api_organisation.rb
@@ -1,6 +1,6 @@
 require "active_model"
 
-class RummagerOrganisation
+class SearchApiOrganisation
   include ActiveModel::Model
 
   attr_accessor(

--- a/app/models/search_api_search.rb
+++ b/app/models/search_api_search.rb
@@ -1,4 +1,4 @@
-class RummagerSearch
+class SearchApiSearch
   PAGE_SIZE_TO_GET_EVERYTHING = 1000
 
   include Enumerable

--- a/app/models/search_api_search.rb
+++ b/app/models/search_api_search.rb
@@ -49,7 +49,7 @@ class SearchApiSearch
   def organisations
     @organisations ||= search_result.dig("aggregates", "organisations", "options").map do |option|
       organisation = option["value"]
-      RummagerOrganisation.new(
+      SearchApiOrganisation.new(
         title: organisation["title"],
         content_id: organisation["content_id"],
         link: organisation["link"],

--- a/app/models/topic/changed_documents.rb
+++ b/app/models/topic/changed_documents.rb
@@ -1,7 +1,7 @@
 class Topic::ChangedDocuments
   include Enumerable
 
-  delegate :documents, :total, :start, to: :rummager_search
+  delegate :documents, :total, :start, to: :search_api_search
   delegate :each, to: :documents
 
   DEFAULT_PAGE_SIZE = 50
@@ -26,8 +26,8 @@ private
     start >= 0 ? start : 0
   end
 
-  def rummager_search
-    @rummager_search ||= SearchApiSearch.new(
+  def search_api_search
+    @search_api_search ||= SearchApiSearch.new(
       start: start_param,
       count: page_size,
       order: "-public_timestamp",

--- a/app/models/topic/changed_documents.rb
+++ b/app/models/topic/changed_documents.rb
@@ -27,7 +27,7 @@ private
   end
 
   def rummager_search
-    @rummager_search ||= RummagerSearch.new(
+    @rummager_search ||= SearchApiSearch.new(
       start: start_param,
       count: page_size,
       order: "-public_timestamp",

--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -1,5 +1,5 @@
 module Organisations
-  # DocumentPresenter transforms a raw rummager result into a format
+  # DocumentPresenter transforms a raw search_api result into a format
   # required by the govuk_publishing_components document_list component.
   #
   # See https://govuk-publishing-components.herokuapp.com/component-guide/document_list
@@ -7,8 +7,8 @@ module Organisations
     include ApplicationHelper
     attr_accessor :include_metadata
 
-    def initialize(rummager_result, include_metadata: true)
-      @raw_document = rummager_result
+    def initialize(search_api_result, include_metadata: true)
+      @raw_document = search_api_result
       @include_metadata = include_metadata
     end
 

--- a/app/services/feed_content.rb
+++ b/app/services/feed_content.rb
@@ -15,7 +15,7 @@ private
     params = search_query.merge(
       start: 0,
       count: 20,
-      fields: RummagerFields::FEED_SEARCH_FIELDS,
+      fields: SearchApiFields::FEED_SEARCH_FIELDS,
       reject_content_purpose_supergroup: "other",
       order: "-public_timestamp",
     )

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -1,5 +1,5 @@
 class MostPopularContent
-  include RummagerFields
+  include SearchApiFields
 
   attr_reader :content_id, :filter_content_store_document_type, :number_of_links
 
@@ -24,7 +24,7 @@ private
     params = {
       start: 0,
       count: number_of_links,
-      fields: RummagerFields::TAXON_SEARCH_FIELDS,
+      fields: SearchApiFields::TAXON_SEARCH_FIELDS,
       filter_part_of_taxonomy_tree: Array(content_id),
       order: "-popularity",
       filter_content_store_document_type: filter_content_store_document_type,

--- a/app/services/most_popular_content.rb
+++ b/app/services/most_popular_content.rb
@@ -30,6 +30,6 @@ private
       filter_content_store_document_type: filter_content_store_document_type,
     }
 
-    RummagerSearch.new(params)
+    SearchApiSearch.new(params)
   end
 end

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -1,5 +1,5 @@
 class MostRecentContent
-  include RummagerFields
+  include SearchApiFields
 
   attr_reader :content_id, :filter_content_store_document_type, :number_of_links
 
@@ -23,7 +23,7 @@ private
     params = {
       start: 0,
       count: number_of_links,
-      fields: RummagerFields::TAXON_SEARCH_FIELDS,
+      fields: SearchApiFields::TAXON_SEARCH_FIELDS,
       filter_part_of_taxonomy_tree: [content_id],
       order: "-public_timestamp",
       filter_content_store_document_type: filter_content_store_document_type,

--- a/app/services/most_recent_content.rb
+++ b/app/services/most_recent_content.rb
@@ -29,6 +29,6 @@ private
       filter_content_store_document_type: filter_content_store_document_type,
     }
 
-    RummagerSearch.new(params)
+    SearchApiSearch.new(params)
   end
 end

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -30,7 +30,7 @@ module Search
     def search_rummager(additional_params)
       params = default_rummager_params.merge(additional_params).compact
 
-      Services.rummager.search(params)["results"]
+      Services.search_api.search(params)["results"]
     end
 
     def default_rummager_params

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -15,7 +15,7 @@ module Search
     end
 
     def documents
-      @documents ||= search_rummager(documents_query)
+      @documents ||= search_search_api(documents_query)
     end
 
     def documents_query
@@ -27,13 +27,13 @@ module Search
 
   private
 
-    def search_rummager(additional_params)
-      params = default_rummager_params.merge(additional_params).compact
+    def search_search_api(additional_params)
+      params = default_search_api_params.merge(additional_params).compact
 
       Services.search_api.search(params)["results"]
     end
 
-    def default_rummager_params
+    def default_search_api_params
       {
         count: 2,
         order: DEFAULT_SORT_ORDER,

--- a/app/services/search_api_fields.rb
+++ b/app/services/search_api_fields.rb
@@ -1,4 +1,4 @@
-module RummagerFields
+module SearchApiFields
   TAXON_SEARCH_FIELDS = %w[title
                            link
                            description

--- a/app/services/tagged_content.rb
+++ b/app/services/tagged_content.rb
@@ -18,12 +18,12 @@ private
   def search_response
     params = {
       start: 0,
-      count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      count: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w[title description link content_store_document_type],
       filter_taxons: content_ids,
       order: "title",
     }
 
-    RummagerSearch.new(params)
+    SearchApiSearch.new(params)
   end
 end

--- a/app/services/tagged_organisations.rb
+++ b/app/services/tagged_organisations.rb
@@ -19,10 +19,10 @@ private
   def search_response
     params = {
       count: 0,
-      aggregate_organisations: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      aggregate_organisations: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       filter_part_of_taxonomy_tree: content_ids,
     }
 
-    RummagerSearch.new(params)
+    SearchApiSearch.new(params)
   end
 end

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -20,7 +20,7 @@ Given(/^there is latest content for a subtopic$/) do
       "document_type" => "edition",
     }
   end
-  Services.rummager.stubs(:search).with(
+  Services.search_api.stubs(:search).with(
     has_entries(
       start: 0,
       count: 50,

--- a/features/step_definitions/latest_changes_steps.rb
+++ b/features/step_definitions/latest_changes_steps.rb
@@ -1,7 +1,7 @@
 Given(/^there is latest content for a subtopic$/) do
   stub_topic_lookups
 
-  @stubbed_rummager_documents = %w[
+  @stubbed_search_api_documents = %w[
     what-is-oil
     apply-for-an-oil-licence
     environmental-policy
@@ -27,9 +27,9 @@ Given(/^there is latest content for a subtopic$/) do
       filter_topic_content_ids: %w[content-id-for-fields-and-wells],
       order: "-public_timestamp",
     ),
-  ).returns("results" => @stubbed_rummager_documents,
+  ).returns("results" => @stubbed_search_api_documents,
             "start" => 0,
-            "total" => @stubbed_rummager_documents.size)
+            "total" => @stubbed_search_api_documents.size)
 end
 
 When(/^I view the latest changes page for that subtopic$/) do
@@ -37,7 +37,7 @@ When(/^I view the latest changes page for that subtopic$/) do
 end
 
 Then(/^I see a date\-ordered list of content with change notes$/) do
-  @stubbed_rummager_documents.each_with_index do |document, index|
+  @stubbed_search_api_documents.each_with_index do |document, index|
     within(".gem-c-document-list__item:nth-of-type(#{index + 1})") do
       assert page.has_selector?("a[href='#{document['link']}']", text: document["title"])
       assert page.has_content?(document["latest_change_note"]) if document["latest_change_note"]

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -17,7 +17,7 @@ Given(/^there is an alphabetical browse page set up with links$/) do
     %w[
       judge-dredd
     ],
-    page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+    page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
   )
 end
 

--- a/features/step_definitions/viewing_browse_steps.rb
+++ b/features/step_definitions/viewing_browse_steps.rb
@@ -12,7 +12,7 @@ Given(/^there is an alphabetical browse page set up with links$/) do
   )
   add_second_level_browse_pages(second_level_browse_pages)
 
-  rummager_has_documents_for_browse_page(
+  search_api_has_documents_for_browse_page(
     "judges-content-id",
     %w[
       judge-dredd

--- a/features/support/services_and_information_helper.rb
+++ b/features/support/services_and_information_helper.rb
@@ -1,10 +1,10 @@
 require "gds_api/test_helpers/search"
 
-require_relative "../../test/support/rummager_helpers"
+require_relative "../../test/support/search_api_helpers"
 
 module ServicesAndInformationHelpers
   include GdsApi::TestHelpers::Search
-  include RummagerHelpers
+  include SearchApiHelpers
 
   def stub_services_and_information_lookups
     @services_and_information = %w[

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -6,7 +6,7 @@ module TopicHelper
   include SearchApiHelpers
 
   def stub_topic_lookups
-    rummager_has_documents_for_subtopic(
+    search_api_has_documents_for_subtopic(
       "content-id-for-fields-and-wells",
       %w[
         what-is-oil

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -1,9 +1,9 @@
 require "gds_api/test_helpers/search"
-require_relative "../../test/support/rummager_helpers"
+require_relative "../../test/support/search_api_helpers"
 
 module TopicHelper
   include GdsApi::TestHelpers::Search
-  include RummagerHelpers
+  include SearchApiHelpers
 
   def stub_topic_lookups
     rummager_has_documents_for_subtopic(

--- a/features/support/topic_helper.rb
+++ b/features/support/topic_helper.rb
@@ -17,7 +17,7 @@ module TopicHelper
         well-report-2014
         oil-extraction-count-2013
       ],
-      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
     )
 
     stub_content_store_has_item(

--- a/test/controllers/organisations_api_controller_test.rb
+++ b/test/controllers/organisations_api_controller_test.rb
@@ -8,14 +8,14 @@ describe OrganisationsApiController do
         order: "title",
         count: 20,
         start: 0,
-      ).returns(rummager_organisations_results)
+      ).returns(search_api_organisations_results)
 
       Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         order: "title",
         count: 20,
         start: 20,
-      ).returns(rummager_organisations_many_results)
+      ).returns(search_api_organisations_many_results)
     end
 
     it "renders JSON" do
@@ -49,14 +49,14 @@ describe OrganisationsApiController do
         filter_slug: "hm-revenue-customs",
         count: 1,
         start: 0,
-      ).returns(rummager_organisation_results)
+      ).returns(search_api_organisation_results)
 
       Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         filter_slug: "something-else",
         count: 1,
         start: 0,
-      ).returns(rummager_organisation_no_results)
+      ).returns(search_api_organisation_no_results)
     end
 
     it "renders JSON" do
@@ -93,7 +93,7 @@ describe OrganisationsApiController do
     end
   end
 
-  def rummager_organisations_results
+  def search_api_organisations_results
     {
       results: [
         {
@@ -166,7 +166,7 @@ describe OrganisationsApiController do
     }.deep_stringify_keys
   end
 
-  def rummager_organisations_many_results
+  def search_api_organisations_many_results
     {
       results: [],
       total: 1000,
@@ -174,7 +174,7 @@ describe OrganisationsApiController do
     }.deep_stringify_keys
   end
 
-  def rummager_organisation_results
+  def search_api_organisation_results
     {
       results: [
         {
@@ -219,7 +219,7 @@ describe OrganisationsApiController do
     }.deep_stringify_keys
   end
 
-  def rummager_organisation_no_results
+  def search_api_organisation_no_results
     {
       results: [],
       total: 0,

--- a/test/controllers/organisations_api_controller_test.rb
+++ b/test/controllers/organisations_api_controller_test.rb
@@ -3,14 +3,14 @@ require "test_helper"
 describe OrganisationsApiController do
   describe "GET index" do
     setup do
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         order: "title",
         count: 20,
         start: 0,
       ).returns(rummager_organisations_results)
 
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         order: "title",
         count: 20,
@@ -44,14 +44,14 @@ describe OrganisationsApiController do
 
   describe "GET show" do
     setup do
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         filter_slug: "hm-revenue-customs",
         count: 1,
         start: 0,
       ).returns(rummager_organisation_results)
 
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         filter_format: "organisation",
         filter_slug: "something-else",
         count: 1,

--- a/test/controllers/organisations_controller_test.rb
+++ b/test/controllers/organisations_controller_test.rb
@@ -19,7 +19,7 @@ describe OrganisationsController do
         },
       )
 
-      Services.rummager.stubs(:search)
+      Services.search_api.stubs(:search)
         .returns(
           "results" => [],
           "start" => 0,

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe SecondLevelBrowsePageController do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   describe "GET second_level_browse_page" do
     describe "for a valid browse page" do

--- a/test/controllers/second_level_browse_page_controller_test.rb
+++ b/test/controllers/second_level_browse_page_controller_test.rb
@@ -23,7 +23,7 @@ describe SecondLevelBrowsePageController do
           },
         )
 
-        rummager_has_documents_for_browse_page(
+        search_api_has_documents_for_browse_page(
           "entitlement-content-id",
           %w[entitlement],
           page_size: 1000,

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe ServicesAndInformationController do
-  include RummagerHelpers
+  include SearchApiHelpers
   include ServicesAndInformationHelpers
 
   describe "with a valid organisation slug" do

--- a/test/controllers/services_and_information_controller_test.rb
+++ b/test/controllers/services_and_information_controller_test.rb
@@ -24,7 +24,7 @@ describe ServicesAndInformationController do
       assert_equal 404, response.status
     end
 
-    it "renders the page correctly when there are unexpanded links in the rummager results" do
+    it "renders the page correctly when there are unexpanded links in the search_api results" do
       stub_services_and_information_content_item
       stub_services_and_information_links_with_missing_keys("hm-revenue-customs")
 

--- a/test/controllers/subtopics_controller_test.rb
+++ b/test/controllers/subtopics_controller_test.rb
@@ -41,7 +41,7 @@ describe SubtopicsController do
       [ListSet::List.new("test", [])],
     )
 
-    Services.rummager.stubs(:search).with(
+    Services.search_api.stubs(:search).with(
       count: "0",
       filter_topic_content_ids: [content_id],
       facet_organisations: "1000",

--- a/test/controllers/taxons_controller_test.rb
+++ b/test/controllers/taxons_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require_relative "../../test/support/coronavirus_helper"
 
 describe TaxonsController do
-  include RummagerHelpers
+  include SearchApiHelpers
   include GovukAbTesting::MinitestHelpers
   include TaxonHelpers
 

--- a/test/controllers/topics_controller_test.rb
+++ b/test/controllers/topics_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe TopicsController do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   describe "GET topic" do
     describe "with a valid topic slug" do

--- a/test/integration/atom_feeds_test.rb
+++ b/test/integration/atom_feeds_test.rb
@@ -39,7 +39,7 @@ class AtomFeedsTest < ActionDispatch::IntegrationTest
   def given_there_is_a_government_feed
     @updated_at = "2018-12-25T00:00:00Z"
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
       .with(
         start: 0,
         count: 20,

--- a/test/integration/atom_feeds_test.rb
+++ b/test/integration/atom_feeds_test.rb
@@ -48,16 +48,16 @@ class AtomFeedsTest < ActionDispatch::IntegrationTest
         order: "-public_timestamp",
       )
       .returns(
-        "results" => results_from_rummager,
+        "results" => results_from_search_api,
         "start" => 0,
-        "total" => results_from_rummager.size,
+        "total" => results_from_search_api.size,
       )
 
     @base_path = "/government/feed"
   end
 
   def and_content_for_that_organisation
-    stub_content_for_organisation_feed(@organisation_slug, results_from_rummager)
+    stub_content_for_organisation_feed(@organisation_slug, results_from_search_api)
   end
 
   def but_no_content_for_that_organisation
@@ -135,7 +135,7 @@ class AtomFeedsTest < ActionDispatch::IntegrationTest
     document
   end
 
-  def results_from_rummager
+  def results_from_search_api
     [
       {
         "content_store_document_type" => "document_collection",

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -1,7 +1,7 @@
 require "integration_test_helper"
 
 class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
-  include RummagerHelpers
+  include SearchApiHelpers
 
   test "that we can handle all examples" do
     # Shuffle the examples to ensure tests don't become order dependent

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -12,7 +12,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     schemas.each do |content_item|
       stub_content_store_has_item(content_item["base_path"], content_item)
 
-      rummager_has_documents_for_browse_page(
+      search_api_has_documents_for_browse_page(
         content_item["content_id"],
         %w[
           employee-tax-codes

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -7,7 +7,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
     # Shuffle the examples to ensure tests don't become order dependent
     schemas = GovukSchemas::Example.find_all("mainstream_browse_page").shuffle
 
-    # Add all examples to the content store and rummager to allow pages to
+    # Add all examples to the content store and search_api to allow pages to
     # request their parents and links.
     schemas.each do |content_item|
       stub_content_store_has_item(content_item["base_path"], content_item)

--- a/test/integration/mainstream_browsing_test.rb
+++ b/test/integration/mainstream_browsing_test.rb
@@ -22,7 +22,7 @@ class MainstreamBrowsingTest < ActionDispatch::IntegrationTest
           pay-psa
           payroll-annual-reporting
         ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
     end
 

--- a/test/integration/organisation_status_test.rb
+++ b/test/integration/organisation_status_test.rb
@@ -220,17 +220,17 @@ class OrganisationStatusTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item("/government/organisations/replaced", @content_item_replaced)
     stub_content_store_has_item("/government/organisations/fire-service-college", @content_item_documents)
 
-    stub_rummager_latest_content_requests("changed_name")
-    stub_rummager_latest_content_requests("devolved")
-    stub_rummager_latest_content_requests("exempt")
-    stub_rummager_latest_content_requests("exempt-no-url")
-    stub_rummager_latest_content_requests("joining")
-    stub_rummager_latest_content_requests("left_gov")
-    stub_rummager_latest_content_requests("merged")
-    stub_rummager_latest_content_requests("split")
-    stub_rummager_latest_content_requests("no_longer_exists")
-    stub_rummager_latest_content_requests("replaced")
-    stub_rummager_latest_content_requests("fire-service-college")
+    stub_search_api_latest_content_requests("changed_name")
+    stub_search_api_latest_content_requests("devolved")
+    stub_search_api_latest_content_requests("exempt")
+    stub_search_api_latest_content_requests("exempt-no-url")
+    stub_search_api_latest_content_requests("joining")
+    stub_search_api_latest_content_requests("left_gov")
+    stub_search_api_latest_content_requests("merged")
+    stub_search_api_latest_content_requests("split")
+    stub_search_api_latest_content_requests("no_longer_exists")
+    stub_search_api_latest_content_requests("replaced")
+    stub_search_api_latest_content_requests("fire-service-college")
   end
 
   it "displays a changed_name organisation page correctly" do

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -564,12 +564,12 @@ class OrganisationTest < ActionDispatch::IntegrationTest
     stub_content_store_has_item("/government/organisations/civil-service-resourcing", @content_item_blank)
     stub_content_store_has_item("/government/organisations/student-loans-company", @content_item_separate_student_loans)
 
-    stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
-    stub_rummager_latest_content_requests("attorney-generals-office")
-    stub_rummager_latest_content_requests("charity-commission")
-    stub_rummager_latest_content_requests("office-of-the-secretary-of-state-for-wales")
-    stub_rummager_latest_content_requests("civil-service-resourcing")
-    stub_rummager_latest_content_requests("student-loans-company")
+    stub_search_api_latest_content_requests("prime-ministers-office-10-downing-street")
+    stub_search_api_latest_content_requests("attorney-generals-office")
+    stub_search_api_latest_content_requests("charity-commission")
+    stub_search_api_latest_content_requests("office-of-the-secretary-of-state-for-wales")
+    stub_search_api_latest_content_requests("civil-service-resourcing")
+    stub_search_api_latest_content_requests("student-loans-company")
   end
 
   it "doesn't fail if the content item is missing any data" do
@@ -715,7 +715,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
   end
 
   it "does not show the latest documents by type section if there are none" do
-    stub_empty_rummager_requests("attorney-generals-office")
+    stub_empty_search_api_requests("attorney-generals-office")
     visit "/government/organisations/attorney-generals-office"
     assert_not page.has_css?(".gem-c-heading", text: "Documents")
   end

--- a/test/integration/services_and_information_browsing_test.rb
+++ b/test/integration/services_and_information_browsing_test.rb
@@ -1,7 +1,7 @@
 require "integration_test_helper"
 
 class ServicesAndInformationBrowsingTest < ActionDispatch::IntegrationTest
-  include RummagerHelpers
+  include SearchApiHelpers
   include ServicesAndInformationHelpers
 
   before do

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -34,7 +34,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         north-sea-shipping-lanes
         undersea-piping-restrictions
       ],
-      page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
     )
   end
 

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -26,7 +26,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
   end
 
   before do
-    rummager_has_documents_for_subtopic(
+    search_api_has_documents_for_subtopic(
       "content-id-for-offshore",
       %w[
         oil-rig-safety-requirements
@@ -137,7 +137,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
     it "displays the latest page" do
       # Given there is latest content for a subtopic
-      rummager_has_latest_documents_for_subtopic(
+      search_api_has_latest_documents_for_subtopic(
         "content-id-for-offshore",
         %w[
           oil-and-gas-uk-field-data
@@ -178,7 +178,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
 
     it "paginates the results" do
       # Given there is latest content for a subtopic
-      rummager_has_latest_documents_for_subtopic(
+      search_api_has_latest_documents_for_subtopic(
         "content-id-for-offshore",
         (1..55).map { |n| "document-#{n}" },
       )

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -1,7 +1,7 @@
 require "integration_test_helper"
 
 class SubtopicPageTest < ActionDispatch::IntegrationTest
-  include RummagerHelpers
+  include SearchApiHelpers
 
   def oil_and_gas_subtopic_item(subtopic_slug, params = {})
     base = {

--- a/test/integration/subtopic_page_test.rb
+++ b/test/integration/subtopic_page_test.rb
@@ -80,7 +80,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
       end
 
       within ".gem-c-metadata" do
-        # The orgs are fixed in the rummager test helpers
+        # The orgs are fixed in the search_api test helpers
         assert page.has_text?("Department of Energy & Climate Change")
         assert page.has_text?("Foreign & Commonwealth Office")
       end
@@ -159,7 +159,7 @@ class SubtopicPageTest < ActionDispatch::IntegrationTest
         end
 
         within ".gem-c-metadata" do
-          # The orgs are fixed in the rummager test helpers
+          # The orgs are fixed in the search_api test helpers
           assert page.has_text?("Department of Energy & Climate Change")
           assert page.has_text?("Foreign & Commonwealth Office")
         end

--- a/test/integration/taxon_browsing_test.rb
+++ b/test/integration/taxon_browsing_test.rb
@@ -2,7 +2,7 @@ require "integration_test_helper"
 require_relative "../support/taxon_helpers"
 
 class TaxonBrowsingTest < ActionDispatch::IntegrationTest
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
   include GovukAbTesting::MinitestHelpers
 

--- a/test/integration/world_location_taxon_test.rb
+++ b/test/integration/world_location_taxon_test.rb
@@ -1,7 +1,7 @@
 require "integration_test_helper"
 
 class WorldLocationTaxonTest < ActionDispatch::IntegrationTest
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   it "contains both the atom and email signup url if we are browsing a world location" do

--- a/test/integration/world_wide_taxon_browsing_test.rb
+++ b/test/integration/world_wide_taxon_browsing_test.rb
@@ -23,7 +23,7 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
     content_item = content_item_without_children(base_path, content_id)
 
     stub_content_store_has_item(base_path, content_item)
-    stub_rummager_tagged_content_request(content_id, tagged_content)
+    stub_search_api_tagged_content_request(content_id, tagged_content)
   end
 
   def given_there_is_a_world_wide_country_taxon_with_children
@@ -55,9 +55,9 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
 
     stub_content_store_has_item(base_path, @content_item)
 
-    stub_rummager_tagged_content_request(content_id)
-    stub_rummager_tagged_content_request(child_one_content_id)
-    stub_rummager_tagged_content_request(child_two_content_id)
+    stub_search_api_tagged_content_request(content_id)
+    stub_search_api_tagged_content_request(child_one_content_id)
+    stub_search_api_tagged_content_request(child_two_content_id)
   end
 
   def when_i_visit_that_taxon
@@ -99,7 +99,7 @@ class WorldWideTaxonBrowsingTest < ActionDispatch::IntegrationTest
 
 private
 
-  def stub_rummager_tagged_content_request(content_id, search_result = [])
+  def stub_search_api_tagged_content_request(content_id, search_result = [])
     stub_request(:get, Plek.new.find("search") + "/search.json?count=1000&fields%5B%5D=content_store_document_type&fields%5B%5D=description&fields%5B%5D=link&fields%5B%5D=title&filter_taxons%5B%5D=#{content_id}&order=title&start=0")
       .to_return(body: { results: search_result }.to_json)
   end

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -34,7 +34,7 @@ describe ListSet do
           pay-psa
           payroll-annual-reporting
         ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
 
       @list_set = ListSet.new("specialist_sector", "paye-content-id", @group_data)
@@ -90,7 +90,7 @@ describe ListSet do
           employee-tax-codes
           payroll-annual-reporting
         ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
       @list_set = ListSet.new("specialist_sector", "paye-content-id", [])
     end
@@ -135,7 +135,7 @@ describe ListSet do
           employee-tax-codes
           payroll-annual-reporting
         ],
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
     end
 
@@ -188,7 +188,7 @@ describe ListSet do
         "content-id-for-living-abroad",
         %w[baz],
         ListSet::BROWSE_FORMATS_TO_EXCLUDE.to_a.last,
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
 
       assert_equal 0, @list_set.first.contents.length
@@ -199,7 +199,7 @@ describe ListSet do
         "content-id-for-living-abroad",
         %w[baz],
         "some-format-not-excluded",
-        page_size: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       )
 
       results = @list_set.first.contents

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -24,7 +24,7 @@ describe ListSet do
         },
       ]
 
-      rummager_has_documents_for_subtopic(
+      search_api_has_documents_for_subtopic(
         "paye-content-id",
         %w[
           employee-tax-codes
@@ -80,7 +80,7 @@ describe ListSet do
 
   describe "for a non-curated topic" do
     setup do
-      rummager_has_documents_for_subtopic(
+      search_api_has_documents_for_subtopic(
         "paye-content-id",
         %w[
           get-paye-forms-p45-p60
@@ -126,7 +126,7 @@ describe ListSet do
   describe "fetching content tagged to this tag" do
     setup do
       @subtopic_content_id = "paye-content-id"
-      rummager_has_documents_for_subtopic(
+      search_api_has_documents_for_subtopic(
         @subtopic_content_id,
         %w[
           pay-paye-penalty
@@ -161,7 +161,7 @@ describe ListSet do
 
   describe "handling missing fields in the search results" do
     it "handles documents that don't contain the public_timestamp field" do
-      result = rummager_document_for_slug("pay-psa")
+      result = search_api_document_for_slug("pay-psa")
       result.delete("public_timestamp")
 
       Services.search_api.stubs(:search).with(
@@ -184,7 +184,7 @@ describe ListSet do
     end
 
     it "shouldn't display a document if its format is excluded" do
-      rummager_has_documents_for_browse_page(
+      search_api_has_documents_for_browse_page(
         "content-id-for-living-abroad",
         %w[baz],
         ListSet::BROWSE_FORMATS_TO_EXCLUDE.to_a.last,
@@ -195,7 +195,7 @@ describe ListSet do
     end
 
     it "should display a document if its format isn't excluded" do
-      rummager_has_documents_for_browse_page(
+      search_api_has_documents_for_browse_page(
         "content-id-for-living-abroad",
         %w[baz],
         "some-format-not-excluded",

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -164,7 +164,7 @@ describe ListSet do
       result = rummager_document_for_slug("pay-psa")
       result.delete("public_timestamp")
 
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         has_entries(filter_topic_content_ids: %w[paye-content-id]),
       ).returns("results" => [result],
                 "start" => 0,

--- a/test/models/list_set_test.rb
+++ b/test/models/list_set_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe ListSet do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   describe "for a curated subtopic" do
     setup do

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -92,7 +92,7 @@ describe Person do
           "document_type" => "edition" },
       ]
 
-      Services.rummager.stubs(:search).returns(
+      Services.search_api.stubs(:search).returns(
         "results" => @results,
         "start" => 0,
         "total" => 1,

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -119,7 +119,7 @@ describe Role do
           "document_type" => "edition" },
       ]
 
-      Services.rummager.stubs(:search).returns(
+      Services.search_api.stubs(:search).returns(
         "results" => @results,
         "start" => 0,
         "total" => 1,

--- a/test/models/rummager_organisation_test.rb
+++ b/test/models/rummager_organisation_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 
-describe RummagerOrganisation do
+describe SearchApiOrganisation do
   it "returns the state of an organisation" do
-    organisation = RummagerOrganisation.new(
+    organisation = SearchApiOrganisation.new(
       organisation_state: "live",
     )
     assert(organisation.live?)
   end
 
   it "returns false if the state of an organisation is not live" do
-    organisation = RummagerOrganisation.new(
+    organisation = SearchApiOrganisation.new(
       organisation_state: "closed",
     )
     assert_not(organisation.live?)
@@ -17,7 +17,7 @@ describe RummagerOrganisation do
 
   describe "#has_logo?" do
     it "returns true if logo attributes are present" do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         logo_formatted_title: "some\ntitle",
         brand: "ministry-of-blah",
         crest: "single-identity",
@@ -26,7 +26,7 @@ describe RummagerOrganisation do
     end
 
     it "returns false if the crest is missing" do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         logo_formatted_title: "some\ntitle",
         brand: "ministry-of-blah",
         crest: "",
@@ -35,7 +35,7 @@ describe RummagerOrganisation do
     end
 
     it "returns false if the it is a custom logo" do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         crest: "custom",
         logo_url: "/logo.png",
       )
@@ -45,7 +45,7 @@ describe RummagerOrganisation do
 
   describe "#custom_logo?" do
     it 'returns true if the crest is "custom"' do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         crest: "custom",
         logo_url: "/logo.png",
       )
@@ -53,7 +53,7 @@ describe RummagerOrganisation do
     end
 
     it 'returns false if the crest is not "custom"' do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         crest: "somethingelse",
         logo_url: "/logo.png",
       )
@@ -61,7 +61,7 @@ describe RummagerOrganisation do
     end
 
     it "returns false if the logo url is missing" do
-      organisation = RummagerOrganisation.new(
+      organisation = SearchApiOrganisation.new(
         crest: "somethingelse",
       )
       assert_not(organisation.custom_logo?)

--- a/test/models/topic/changed_documents_test.rb
+++ b/test/models/topic/changed_documents_test.rb
@@ -6,7 +6,7 @@ describe Topic::ChangedDocuments do
   describe "with a single page of results available" do
     setup do
       @subtopic_content_id = "paye-content-id"
-      rummager_has_latest_documents_for_subtopic(
+      search_api_has_latest_documents_for_subtopic(
         @subtopic_content_id,
         %w[
           pay-paye-penalty
@@ -52,7 +52,7 @@ describe Topic::ChangedDocuments do
   describe "with multiple pages of results available" do
     setup do
       @subtopic_content_id = "paye-content-id"
-      rummager_has_latest_documents_for_subtopic(
+      search_api_has_latest_documents_for_subtopic(
         @subtopic_content_id,
         %w[
           pay-paye-penalty
@@ -88,7 +88,7 @@ describe Topic::ChangedDocuments do
 
   describe "handling missing fields in the search results" do
     it "handles documents that don't contain the public_timestamp field" do
-      result = rummager_document_for_slug("pay-psa")
+      result = search_api_document_for_slug("pay-psa")
       result.delete("public_timestamp")
 
       Services.search_api.stubs(:search).with(

--- a/test/models/topic/changed_documents_test.rb
+++ b/test/models/topic/changed_documents_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Topic::ChangedDocuments do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   describe "with a single page of results available" do
     setup do

--- a/test/models/topic/changed_documents_test.rb
+++ b/test/models/topic/changed_documents_test.rb
@@ -33,7 +33,7 @@ describe Topic::ChangedDocuments do
     it "provides the title, base_path and change_note for each document" do
       documents = Topic::ChangedDocuments.new(@subtopic_content_id).to_a
 
-      # Actual values come from rummager helpers.
+      # Actual values come from search_api helpers.
       assert_equal "/pay-psa", documents[2].base_path
       assert_equal "Employee tax codes", documents[3].title
       assert_equal "This has changed", documents[4].change_note
@@ -44,7 +44,7 @@ describe Topic::ChangedDocuments do
 
       assert documents[0].public_updated_at.is_a?(Time)
 
-      # Document timestamp value set in rummager helpers
+      # Document timestamp value set in search_api helpers
       assert_in_epsilon 1.hour.ago.to_i, documents[0].public_updated_at.to_i, 5
     end
   end

--- a/test/models/topic/changed_documents_test.rb
+++ b/test/models/topic/changed_documents_test.rb
@@ -91,7 +91,7 @@ describe Topic::ChangedDocuments do
       result = rummager_document_for_slug("pay-psa")
       result.delete("public_timestamp")
 
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         has_entries(filter_topic_content_ids: %w[paye-content-id]),
       ).returns("results" => [result],
                 "start" => 0,

--- a/test/presenters/organisations/contacts_presenter_test.rb
+++ b/test/presenters/organisations/contacts_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::ContactsPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationHelpers
 
   describe "FOI" do

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -15,8 +15,8 @@ describe Organisations::DocumentsPresenter do
       organisation = Organisation.new(content_item)
       @no_documents_presenter = Organisations::DocumentsPresenter.new(organisation)
 
-      stub_empty_rummager_requests("org-with-no-docs")
-      stub_rummager_latest_content_requests("attorney-generals-office")
+      stub_empty_search_api_requests("org-with-no-docs")
+      stub_search_api_latest_content_requests("attorney-generals-office")
     end
 
     it "formats the main large news story correctly" do
@@ -106,7 +106,7 @@ describe Organisations::DocumentsPresenter do
     organisation = Organisation.new(content_item)
     @documents_presenter = Organisations::DocumentsPresenter.new(organisation)
 
-    stub_rummager_latest_content_requests("prime-ministers-office-10-downing-street")
+    stub_search_api_latest_content_requests("prime-ministers-office-10-downing-street")
 
     expected = [
       {

--- a/test/presenters/organisations/documents_presenter_test.rb
+++ b/test/presenters/organisations/documents_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::DocumentsPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationHelpers
 
   describe "documents" do

--- a/test/presenters/organisations/people_presenter_test.rb
+++ b/test/presenters/organisations/people_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::PeoplePresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationHelpers
 
   describe "ministers" do

--- a/test/presenters/organisations/show_presenter_test.rb
+++ b/test/presenters/organisations/show_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::ShowPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationHelpers
 
   it "adds a prefix to a title when it should" do

--- a/test/presenters/organisations/supergroups_presenter_test.rb
+++ b/test/presenters/organisations/supergroups_presenter_test.rb
@@ -13,8 +13,8 @@ describe Organisations::SupergroupsPresenter do
     organisation = Organisation.new(content_item)
     @empty_supergroups_presenter = described_class.new(organisation)
 
-    stub_empty_rummager_requests("org-with-no-docs")
-    stub_rummager_latest_content_requests("attorney-generals-office")
+    stub_empty_search_api_requests("org-with-no-docs")
+    stub_search_api_latest_content_requests("attorney-generals-office")
   end
 
   def find_supergroup_by_name(name)

--- a/test/presenters/organisations/supergroups_presenter_test.rb
+++ b/test/presenters/organisations/supergroups_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::SupergroupsPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationHelpers
 
   before :each do

--- a/test/presenters/organisations_presenter_test.rb
+++ b/test/presenters/organisations_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Organisations::IndexPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include OrganisationsHelpers
 
   describe "ministerial departments" do

--- a/test/presenters/supergroups/guidance_and_regulation_test.rb
+++ b/test/presenters/supergroups/guidance_and_regulation_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::GuidanceAndRegulation do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   let(:taxon_id) { "12345" }
   let(:guidance_and_regulation_supergroup) { Supergroups::GuidanceAndRegulation.new }

--- a/test/presenters/supergroups/news_and_communications_test.rb
+++ b/test/presenters/supergroups/news_and_communications_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::NewsAndCommunications do
-  include RummagerHelpers
+  include SearchApiHelpers
   include SupergroupHelpers
 
   DEFAULT_IMAGE_URL = "https://assets.publishing.service.gov.uk/media/5e59279b86650c53b2cefbfe/placeholder.jpg".freeze

--- a/test/presenters/supergroups/policy_and_engagement_test.rb
+++ b/test/presenters/supergroups/policy_and_engagement_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::PolicyAndEngagement do
-  include RummagerHelpers
+  include SearchApiHelpers
   include SupergroupHelpers
 
   let(:taxon_id) { "12345" }

--- a/test/presenters/supergroups/research_and_statistics_test.rb
+++ b/test/presenters/supergroups/research_and_statistics_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::ResearchAndStatistics do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   let(:taxon_id) { "12345" }
   let(:research_and_statistics_supergroup) { Supergroups::ResearchAndStatistics.new }

--- a/test/presenters/supergroups/services_test.rb
+++ b/test/presenters/supergroups/services_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::Services do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   let(:taxon_id) { "12345" }
   let(:service_supergroup) { Supergroups::Services.new }

--- a/test/presenters/supergroups/supergroup_test.rb
+++ b/test/presenters/supergroups/supergroup_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::Supergroup do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   let(:taxon_id) { "12345" }
   let(:supergroup_name) { "news_and_communications" }

--- a/test/presenters/supergroups/transparency_test.rb
+++ b/test/presenters/supergroups/transparency_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Supergroups::Transparency do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   let(:taxon_id) { "12345" }
   let(:transparency_supergroup) { Supergroups::Transparency.new }

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -302,7 +302,7 @@ private
 
   def tagged_organisation
     [
-      RummagerOrganisation.new(
+      SearchApiOrganisation.new(
         title: "Department for Education",
         content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
         link: "/government/organisations/department-for-education",
@@ -319,7 +319,7 @@ private
 
   def tagged_organisation_with_logo
     [
-      RummagerOrganisation.new(
+      SearchApiOrganisation.new(
         title: "Department for Education",
         content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
         link: "/government/organisations/department-for-education",
@@ -336,7 +336,7 @@ private
 
   def tagged_custom_organisation
     [
-      RummagerOrganisation.new(
+      SearchApiOrganisation.new(
         title: "Department for Education",
         content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
         link: "/government/organisations/department-for-education",
@@ -356,7 +356,7 @@ private
 
     number_of_organisations.times do
       organisations.push(
-        RummagerOrganisation.new(
+        SearchApiOrganisation.new(
           title: "Department for Education",
           content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           link: "/government/organisations/department-for-education",

--- a/test/presenters/taxon_organisations_presenter_test.rb
+++ b/test/presenters/taxon_organisations_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe TaxonOrganisationsPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   let(:content_hash) { funding_and_finance_for_students_taxon }

--- a/test/presenters/taxon_presenter_test.rb
+++ b/test/presenters/taxon_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe TaxonPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   describe "options" do

--- a/test/presenters/world_wide_taxon_presenter_test.rb
+++ b/test/presenters/world_wide_taxon_presenter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe WorldWideTaxonPresenter do
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   describe "#rendering_type" do

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "./test/support/custom_assertions.rb"
 
 describe MostPopularContent do
-  include RummagerFields
+  include SearchApiFields
 
   def most_popular_content
     @most_popular_content ||= MostPopularContent.new(
@@ -43,7 +43,7 @@ describe MostPopularContent do
     end
 
     it "requests a limited number of fields" do
-      fields = RummagerFields::TAXON_SEARCH_FIELDS
+      fields = SearchApiFields::TAXON_SEARCH_FIELDS
 
       assert_includes_params(fields: fields) do
         most_popular_content.fetch

--- a/test/services/most_popular_content_test.rb
+++ b/test/services/most_popular_content_test.rb
@@ -24,7 +24,7 @@ describe MostPopularContent do
         ],
       }
 
-      Services.rummager.stubs(:search).returns(search_results)
+      Services.search_api.stubs(:search).returns(search_results)
 
       results = most_popular_content.fetch
       assert_equal(results.count, 2)

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -26,7 +26,7 @@ describe MostRecentContent do
         ],
       }
 
-      Services.rummager.stubs(:search).returns(search_results)
+      Services.search_api.stubs(:search).returns(search_results)
 
       results = most_recent_content.fetch
       assert_equal(results.count, 5)

--- a/test/services/most_recent_content_test.rb
+++ b/test/services/most_recent_content_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe MostRecentContent do
-  include RummagerFields
+  include SearchApiFields
 
   def most_recent_content
     @most_recent_content ||= MostRecentContent.new(
@@ -46,7 +46,7 @@ describe MostRecentContent do
   end
 
   it "requests a limited number of fields" do
-    fields = RummagerFields::TAXON_SEARCH_FIELDS
+    fields = SearchApiFields::TAXON_SEARCH_FIELDS
 
     assert_includes_params(fields: fields) do
       most_recent_content.fetch

--- a/test/services/search/supergroup_test.rb
+++ b/test/services/search/supergroup_test.rb
@@ -22,11 +22,11 @@ describe Search::Supergroup do
   end
 
   describe "#documents" do
-    it "provides a set of raw rummager search results" do
-      assert_equal @supergroup.documents, [raw_rummager_result]
+    it "provides a set of raw search_api search results" do
+      assert_equal @supergroup.documents, [raw_search_api_result]
     end
 
-    it "provides a set of raw rummager search results even if the set is empty" do
+    it "provides a set of raw search_api search results even if the set is empty" do
       assert_equal @no_docs_supergroup.documents, []
     end
   end
@@ -41,7 +41,7 @@ describe Search::Supergroup do
     )
   end
 
-  def raw_rummager_result
+  def raw_search_api_result
     {
       "title" => "Quiddich World Cup 2022 begins",
       "link" => "/government/news/its-coming-home",
@@ -52,7 +52,7 @@ describe Search::Supergroup do
 
   def stub_news_and_comms_supergroup_request
     stub_supergroup_request(
-      results: [raw_rummager_result],
+      results: [raw_search_api_result],
       additional_params: {
         filter_content_purpose_supergroup: "news_and_communications",
         filter_organisations: "attorney-generals-office",

--- a/test/services/search/supergroup_test.rb
+++ b/test/services/search/supergroup_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Search::Supergroup do
-  include RummagerHelpers
+  include SearchApiHelpers
 
   before :each do
     @supergroup = described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "news_and_communications")

--- a/test/services/search/supergroups_test.rb
+++ b/test/services/search/supergroups_test.rb
@@ -14,8 +14,8 @@ describe Search::Supergroups do
     @no_docs_supergroups = described_class.new(organisation: empty_organisation)
 
     Search::Supergroups::SUPERGROUP_TYPES.each do |supergroup|
-      stub_rummager_supergroup_request(supergroup, organisation, [raw_rummager_result])
-      stub_rummager_supergroup_request(supergroup, empty_organisation, [])
+      stub_search_api_supergroup_request(supergroup, organisation, [raw_search_api_result])
+      stub_search_api_supergroup_request(supergroup, empty_organisation, [])
     end
   end
 
@@ -50,7 +50,7 @@ describe Search::Supergroups do
     end
   end
 
-  def raw_rummager_result
+  def raw_search_api_result
     {
       "title" => "Quiddich World Cup 2022 begins",
       "link" => "/government/news/its-coming-home",
@@ -59,7 +59,7 @@ describe Search::Supergroups do
     }
   end
 
-  def stub_rummager_supergroup_request(group, organisation, results)
+  def stub_search_api_supergroup_request(group, organisation, results)
     stub_supergroup_request(
       results: results,
       additional_params: {

--- a/test/services/supergroup_sections/brexit_sections_test.rb
+++ b/test/services/supergroup_sections/brexit_sections_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe SupergroupSections::BrexitSections do
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   let(:taxon_id) { "12345" }

--- a/test/services/supergroup_sections_test.rb
+++ b/test/services/supergroup_sections_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe SupergroupSections::Sections do
-  include RummagerHelpers
+  include SearchApiHelpers
   include TaxonHelpers
 
   let(:taxon_id) { "12345" }

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -10,7 +10,7 @@ describe TaggedContent do
         }],
       }
 
-      Services.rummager.stubs(:search).returns(search_results)
+      Services.search_api.stubs(:search).returns(search_results)
 
       results = tagged_content.fetch
       assert_equal(results.count, 1)

--- a/test/services/tagged_content_test.rb
+++ b/test/services/tagged_content_test.rb
@@ -24,7 +24,7 @@ describe TaggedContent do
     end
 
     it "requests all results" do
-      assert_includes_params(count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING) do
+      assert_includes_params(count: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING) do
         tagged_content.fetch
       end
     end

--- a/test/services/tagged_organisations_test.rb
+++ b/test/services/tagged_organisations_test.rb
@@ -26,7 +26,7 @@ describe TaggedOrganisations do
         },
       }
 
-      Services.rummager.stubs(:search).returns(search_results)
+      Services.search_api.stubs(:search).returns(search_results)
 
       organisations = tagged_organisations.fetch
       assert_equal(1, organisations.count)
@@ -54,7 +54,7 @@ describe TaggedOrganisations do
         },
       }
 
-      Services.rummager.stubs(:search).returns(search_results)
+      Services.search_api.stubs(:search).returns(search_results)
 
       organisations = tagged_organisations.fetch
       assert_equal(1, organisations.count)
@@ -102,6 +102,6 @@ private
       },
     }
 
-    Services.rummager.stubs(:search).returns(search_results)
+    Services.search_api.stubs(:search).returns(search_results)
   end
 end

--- a/test/support/coronavirus_landing_page_steps.rb
+++ b/test/support/coronavirus_landing_page_steps.rb
@@ -1,10 +1,10 @@
 require "gds_api/test_helpers/content_item_helpers"
 require "gds_api/test_helpers/search"
-require_relative "../../test/support/rummager_helpers"
+require_relative "../../test/support/search_api_helpers"
 require_relative "../../test/support/coronavirus_helper"
 module CoronavirusLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
-  include RummagerHelpers
+  include SearchApiHelpers
 
   CORONAVIRUS_PATH = "/coronavirus".freeze
   BUSINESS_PATH = "/coronavirus/business-support".freeze

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -23,7 +23,7 @@ class ActiveSupport::TestCase
     }
 
     Services
-      .rummager
+      .search_api
       .stubs(:search)
       .with { |params| _(params).including?(expected_params) }
       .returns(search_results)

--- a/test/support/organisation_feed_helpers.rb
+++ b/test/support/organisation_feed_helpers.rb
@@ -9,7 +9,7 @@ module OrganisationFeedHelpers
       order: "-public_timestamp",
     }
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
       .with(params)
       .returns(
         "results" => results,
@@ -19,7 +19,7 @@ module OrganisationFeedHelpers
   end
 
   def stub_empty_results
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
       .returns(
         "results" => [],
         "start" => 0,

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -3,14 +3,14 @@ require_relative "../../test/support/search_api_helpers"
 module OrganisationHelpers
   include ::SearchApiHelpers
 
-  def stub_rummager_latest_content_requests(organisation_slug)
+  def stub_search_api_latest_content_requests(organisation_slug)
     stub_latest_content_from_supergroups_request(organisation_slug)
     stub_search_api_latest_documents_request(organisation_slug)
   end
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty = false)
     Search::Supergroups::SUPERGROUP_TYPES.each do |group|
-      url = build_rummager_query_url(
+      url = build_search_api_query_url(
         {
           filter_organisations: organisation_slug,
           filter_content_purpose_supergroup: group,
@@ -43,15 +43,15 @@ module OrganisationHelpers
     }
   end
 
-  def build_rummager_query_url(params = {})
+  def build_search_api_query_url(params = {})
     query = Rack::Utils.build_nested_query default_params.merge(params)
     "#{Plek.new.find('search')}/search.json?#{query}"
   end
 
-  def stub_empty_rummager_requests(organisation_slug)
+  def stub_empty_search_api_requests(organisation_slug)
     stub_latest_content_from_supergroups_request(organisation_slug, true)
 
-    url = build_rummager_query_url(
+    url = build_search_api_query_url(
       filter_organisations: organisation_slug,
       reject_content_purpose_supergroup: "other",
       count: 3,

--- a/test/support/organisation_helper.rb
+++ b/test/support/organisation_helper.rb
@@ -1,7 +1,7 @@
-require_relative "../../test/support/rummager_helpers"
+require_relative "../../test/support/search_api_helpers"
 
 module OrganisationHelpers
-  include ::RummagerHelpers
+  include ::SearchApiHelpers
 
   def stub_rummager_latest_content_requests(organisation_slug)
     stub_latest_content_from_supergroups_request(organisation_slug)

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -1,5 +1,5 @@
 module RummagerHelpers
-  include RummagerFields
+  include SearchApiFields
 
   def stub_content_for_taxon(content_ids, results)
     params = {
@@ -27,7 +27,7 @@ module RummagerHelpers
 
   def stub_most_popular_content_for_taxon(content_id, results,
                                           filter_content_store_document_type: %w[detailed_guide manual])
-    fields = RummagerFields::TAXON_SEARCH_FIELDS
+    fields = SearchApiFields::TAXON_SEARCH_FIELDS
 
     params = {
       start: 0,
@@ -49,7 +49,7 @@ module RummagerHelpers
 
   def stub_most_recent_content_for_taxon(content_id, results,
                                          filter_content_store_document_type: %w[detailed_guide guidance])
-    fields = RummagerFields::TAXON_SEARCH_FIELDS
+    fields = SearchApiFields::TAXON_SEARCH_FIELDS
 
     params = {
       start: 0,

--- a/test/support/rummager_helpers.rb
+++ b/test/support/rummager_helpers.rb
@@ -10,7 +10,7 @@ module RummagerHelpers
       order: "title",
     }
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
       .with(params)
       .returns(
         "results" => results,
@@ -38,7 +38,7 @@ module RummagerHelpers
       filter_content_store_document_type: filter_content_store_document_type,
     }
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
     .with(params)
     .returns(
       "results" => results,
@@ -60,7 +60,7 @@ module RummagerHelpers
       filter_content_store_document_type: filter_content_store_document_type,
     }
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
     .with(params)
     .returns(
       "results" => results,
@@ -76,7 +76,7 @@ module RummagerHelpers
       filter_part_of_taxonomy_tree: [content_id],
     }
 
-    Services.rummager
+    Services.search_api
     .stubs(:search)
     .with(params)
     .returns(
@@ -115,7 +115,7 @@ module RummagerHelpers
   end
 
   def stub_topic_organisations(slug, content_id)
-    Services.rummager.stubs(:search).with(
+    Services.search_api.stubs(:search).with(
       count: "0",
       filter_topic_content_ids: [content_id],
       facet_organisations: "1000",
@@ -125,7 +125,7 @@ module RummagerHelpers
   end
 
   def stub_services_and_information_links(organisation_id)
-    Services.rummager.stubs(:search).with(
+    Services.search_api.stubs(:search).with(
       count: "0",
       filter_organisations: organisation_id,
       facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
@@ -135,7 +135,7 @@ module RummagerHelpers
   end
 
   def stub_services_and_information_links_with_missing_keys(organisation_id)
-    Services.rummager.stubs(:search).with(
+    Services.search_api.stubs(:search).with(
       count: "0",
       filter_organisations: organisation_id,
       facet_specialist_sectors: "1000,examples:4,example_scope:query,order:value.title",
@@ -177,7 +177,7 @@ module RummagerHelpers
 
     results.each_slice(page_size).with_index do |results_page, page|
       start = page * page_size
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         has_entries(
           start: start,
           count: page_size,
@@ -197,7 +197,7 @@ module RummagerHelpers
 
     results.each_slice(page_size).with_index do |results_page, page|
       start = page * page_size
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         has_entries(
           start: start,
           count: page_size,
@@ -216,7 +216,7 @@ module RummagerHelpers
 
     results.each_slice(page_size).with_index do |results_page, page|
       start = page * page_size
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         has_entries(
           start: start,
           count: page_size,
@@ -235,7 +235,7 @@ module RummagerHelpers
 
     results.each_slice(page_size).with_index do |results_page, page|
       start = page * page_size
-      Services.rummager.stubs(:search).with(
+      Services.search_api.stubs(:search).with(
         start: start,
         count: page_size,
         filter_mainstream_browse_page_content_ids: [browse_page_content_id],
@@ -247,7 +247,7 @@ module RummagerHelpers
   end
 
   def expect_search_params(params)
-    GdsApi::Rummager.any_instance.expects(:search)
+    GdsApi::Search.any_instance.expects(:search)
       .with(has_entries(params))
       .returns(:some_results)
   end
@@ -285,7 +285,7 @@ module RummagerHelpers
       order: "-public_timestamp",
     }.merge(additional_params)
 
-    Services.rummager.stubs(:search)
+    Services.search_api.stubs(:search)
       .with(params)
       .returns(
         "results" => results,

--- a/test/support/search_api_helpers.rb
+++ b/test/support/search_api_helpers.rb
@@ -4,7 +4,7 @@ module SearchApiHelpers
   def stub_content_for_taxon(content_ids, results)
     params = {
       start: 0,
-      count: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      count: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       fields: %w[title description link content_store_document_type],
       filter_taxons: Array(content_ids),
       order: "title",
@@ -72,7 +72,7 @@ module SearchApiHelpers
   def stub_organisations_for_taxon(content_id, organisations)
     params = {
       count: 0,
-      aggregate_organisations: RummagerSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      aggregate_organisations: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       filter_part_of_taxonomy_tree: [content_id],
     }
 

--- a/test/support/search_api_helpers.rb
+++ b/test/support/search_api_helpers.rb
@@ -1,4 +1,4 @@
-module RummagerHelpers
+module SearchApiHelpers
   include SearchApiFields
 
   def stub_content_for_taxon(content_ids, results)

--- a/test/support/search_api_helpers.rb
+++ b/test/support/search_api_helpers.rb
@@ -93,23 +93,23 @@ module SearchApiHelpers
     (1..count).map do |number|
       case supergroup
       when "services"
-        rummager_document_for_supergroup_section("content-item-#{number}", "local_transaction")
+        search_api_document_for_supergroup_section("content-item-#{number}", "local_transaction")
       when "guidance_and_regulation"
         if number <= 2
-          rummager_document_for_supergroup_section("content-item-#{number}", "guide")
+          search_api_document_for_supergroup_section("content-item-#{number}", "guide")
         else
-          rummager_document_for_supergroup_section("content-item-#{number}", "guidance")
+          search_api_document_for_supergroup_section("content-item-#{number}", "guidance")
         end
       when "news_and_communications"
-        rummager_document_for_supergroup_section("content-item-#{number}", "news_story")
+        search_api_document_for_supergroup_section("content-item-#{number}", "news_story")
       when "policy_and_engagement"
-        rummager_document_for_supergroup_section("content-item-#{number}", "policy_paper")
+        search_api_document_for_supergroup_section("content-item-#{number}", "policy_paper")
       when "transparency"
-        rummager_document_for_supergroup_section("content-item-#{number}", "transparency")
+        search_api_document_for_supergroup_section("content-item-#{number}", "transparency")
       when "research_and_statistics"
-        rummager_document_for_supergroup_section("content-item-#{number}", "research")
+        search_api_document_for_supergroup_section("content-item-#{number}", "research")
       else
-        rummager_document_for_slug("content-item-#{number}")
+        search_api_document_for_slug("content-item-#{number}")
       end
     end
   end
@@ -144,7 +144,7 @@ module SearchApiHelpers
     )
   end
 
-  def rummager_document_for_slug(slug, updated_at = 1.hour.ago, format = "guide")
+  def search_api_document_for_slug(slug, updated_at = 1.hour.ago, format = "guide")
     {
       "format" => format.to_s,
       "latest_change_note" => "This has changed",
@@ -159,7 +159,7 @@ module SearchApiHelpers
     }
   end
 
-  def rummager_document_for_supergroup_section(slug, content_store_document_type)
+  def search_api_document_for_supergroup_section(slug, content_store_document_type)
     {
       "title" => slug.titleize.humanize.to_s,
       "link" => "/#{slug}",
@@ -170,9 +170,9 @@ module SearchApiHelpers
     }
   end
 
-  def rummager_has_latest_documents_for_subtopic(subtopic_content_id, document_slugs, page_size: 50)
+  def search_api_has_latest_documents_for_subtopic(subtopic_content_id, document_slugs, page_size: 50)
     results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago)
+      search_api_document_for_slug(slug, (i + 1).hours.ago)
     end
 
     results.each_slice(page_size).with_index do |results_page, page|
@@ -190,9 +190,9 @@ module SearchApiHelpers
     end
   end
 
-  def rummager_has_documents_for_subtopic(subtopic_content_id, document_slugs, format = "guide", page_size: 50)
+  def search_api_has_documents_for_subtopic(subtopic_content_id, document_slugs, format = "guide", page_size: 50)
     results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+      search_api_document_for_slug(slug, (i + 1).hours.ago, format)
     end
 
     results.each_slice(page_size).with_index do |results_page, page|
@@ -209,9 +209,9 @@ module SearchApiHelpers
     end
   end
 
-  def rummager_has_documents_for_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 50)
+  def search_api_has_documents_for_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 50)
     results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+      search_api_document_for_slug(slug, (i + 1).hours.ago, format)
     end
 
     results.each_slice(page_size).with_index do |results_page, page|
@@ -228,9 +228,9 @@ module SearchApiHelpers
     end
   end
 
-  def rummager_has_documents_for_second_level_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 1000)
+  def search_api_has_documents_for_second_level_browse_page(browse_page_content_id, document_slugs, format = "guide", page_size: 1000)
     results = document_slugs.map.with_index do |slug, i|
-      rummager_document_for_slug(slug, (i + 1).hours.ago, format)
+      search_api_document_for_slug(slug, (i + 1).hours.ago, format)
     end
 
     results.each_slice(page_size).with_index do |results_page, page|

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -1,10 +1,10 @@
 require "gds_api/test_helpers/content_item_helpers"
 require "gds_api/test_helpers/search"
-require_relative "../../test/support/rummager_helpers"
+require_relative "../../test/support/search_api_helpers"
 
 module TransitionLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
-  include RummagerHelpers
+  include SearchApiHelpers
 
   TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
   TRANSITION_TAXON_PATH = "/transition".freeze

--- a/test/unit/organisation_helper_test.rb
+++ b/test/unit/organisation_helper_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 describe OrganisationHelper do
   include OrganisationHelpers
-  include RummagerHelpers
+  include SearchApiHelpers
   describe "#organisation_type_name" do
     it "returns a human-readable name given an organisation_type" do
       assert_equal "Executive non-departmental public body", organisation_type_name("executive_ndpb")


### PR DESCRIPTION
## What

Update collections to refer to SearchApi by its true name, rather than by its legacy name.

## Why

It is time! 
