### PR TITLE
Include layout header component styles for /transition

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $covid-yellow: #fff500;
 @import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/inverse-header';
 @import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/layout-header';
 @import 'govuk_publishing_components/components/lead-paragraph';
 @import 'govuk_publishing_components/components/metadata';
 @import 'govuk_publishing_components/components/notice';


### PR DESCRIPTION
We have made some adjustments to use the layout header component in `static` where the account navigation should be present. This would be on the `transition` page as well as Brexit checker pages.
For more context: [PR to replace hard coded account nav with layout header](https://github.com/alphagov/static/pull/2408)


This is fine, however some of the layout styles are overriding the layout header component styles in static, resulting in extra left/right padding around the layout header content like so: 

<img width="1047" alt="Screenshot 2021-02-08 at 15 17 34" src="https://user-images.githubusercontent.com/7116819/107239874-345e6a80-6a21-11eb-872c-4ffe81c78ee2.png">



Importing the `layout_header` styles into `collections` seems to fix the issue:

<img width="1062" alt="Screenshot 2021-02-08 at 15 17 09" src="https://user-images.githubusercontent.com/7116819/107239859-30cae380-6a21-11eb-8b22-4d08ecc3359b.png">




https://trello.com/c/9Kjy1hjb/575-use-header-component-in-static