### PR TITLE
Replace remaining references to "transition period" with Brexit on /transition

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -76,8 +76,8 @@ en:
         metadata:
           public_updated_at: 2020-07-13
           document_type: "Press Release"
-    topic_section_header: All transition period information
-    topic_section_subheading: Browse all information related to the transition period
+    topic_section_header: All Brexit information
+    topic_section_subheading: Browse all information related to Brexit
     email_mailto_subject: "UK's%20new%20start:%20let's%20get%20going-%20GOV.UK"
     share_links: "Share this page"
     sections:

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -81,7 +81,7 @@ en:
     email_mailto_subject: "UK's%20new%20start:%20let's%20get%20going-%20GOV.UK"
     share_links: "Share this page"
     sections:
-      aria_string_suffix: related to the transition period
+      aria_string_suffix: related to Brexit
       services: Services
       guidance_and_regulation: Guidance and regulation
       news_and_communications: News and communications

--- a/test/presenters/transition_landing_page_presenter_test.rb
+++ b/test/presenters/transition_landing_page_presenter_test.rb
@@ -25,7 +25,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "Services",
           path: "/search/services?parent=%2Fbase_path&topic=content_id",
-          aria_label: "Services related to the transition period",
+          aria_label: "Services related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",
@@ -36,7 +36,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "Guidance and regulation",
           path: "/search/guidance-and-regulation?parent=%2Fbase_path&topic=content_id",
-          aria_label: "Guidance and regulation related to the transition period",
+          aria_label: "Guidance and regulation related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",
@@ -47,7 +47,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "News and communications",
           path: "/search/news-and-communications?parent=%2Fbase_path&topic=content_id",
-          aria_label: "News and communications related to the transition period",
+          aria_label: "News and communications related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",
@@ -58,7 +58,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "Research and statistics",
           path: "/search/research-and-statistics?parent=%2Fbase_path&topic=content_id",
-          aria_label: "Research and statistics related to the transition period",
+          aria_label: "Research and statistics related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",
@@ -69,7 +69,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "Policy papers and consultations",
           path: "/search/policy-papers-and-consultations?parent=%2Fbase_path&topic=content_id",
-          aria_label: "Policy papers and consultations related to the transition period",
+          aria_label: "Policy papers and consultations related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",
@@ -80,7 +80,7 @@ describe TransitionLandingPagePresenter do
         {
           text: "Transparency and freedom of information releases",
           path: "/search/transparency-and-freedom-of-information-releases?parent=%2Fbase_path&topic=content_id",
-          aria_label: "Transparency and freedom of information releases related to the transition period",
+          aria_label: "Transparency and freedom of information releases related to Brexit",
           data_attributes: {
             track_category: "SeeAllLinkClicked",
             track_action: "/base_path",

--- a/test/support/transition_landing_page_steps.rb
+++ b/test/support/transition_landing_page_steps.rb
@@ -39,7 +39,7 @@ module TransitionLandingPageSteps
   end
 
   def and_i_can_see_the_explore_topics_section
-    assert page.has_selector?("h2.govuk-heading-m", text: "All transition period information")
+    assert page.has_selector?("h2.govuk-heading-m", text: "All Brexit information")
 
     supergroups = [
       "Services": "services",


### PR DESCRIPTION
## What

Remove references to the "transition period" from /transition.

## Changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img width="700" alt="Screenshot 2021-02-09 at 21 25 03" src="https://user-images.githubusercontent.com/17908089/107430613-4a515580-6b1d-11eb-9ef2-9450454d444d.png">
</td>
<td>
<img width="682" alt="Screenshot 2021-02-09 at 21 25 25" src="https://user-images.githubusercontent.com/17908089/107430643-576e4480-6b1d-11eb-8123-b12f99f9f9fe.png">
</td>
</tr>
<table>

---
[Trello card](https://trello.com/c/ZfMI7LNc)
[Review app](https://govuk-collec-minor-brex-ro4okn.herokuapp.com/transition)
