### PR TITLE
Update port on pact_helper

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -16,7 +16,7 @@ class ProxyApp
   end
 
   def call(env)
-    env["HTTP_HOST"] = "localhost:4000"
+    env["HTTP_HOST"] = "localhost:3002"
     response = @real_provider_app.call(env)
     response
   end


### PR DESCRIPTION
- Following review of https://github.com/alphagov/gds-api-adapters/pull/1024
  the port number on which the stubbed organisation api is running is now 3001.