### PR TITLE
Only show social media links with the same locale as the current page

### DIFF
--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -6,14 +6,18 @@ module Organisations
       @org = organisation
     end
 
-    def has_share_links?
-      org.social_media_links.present?
+    def has_share_links?(req)
+      return unless req && org.social_media_links.present?
+
+      request_locale = req.filtered_parameters["locale"] || "en"
+      org.social_media_links.select { |k, _| k["locale"] == request_locale }
     end
 
-    def share_links
+    def share_links(req)
+      social = has_share_links?(req)
       links = []
 
-      org.social_media_links.each do |link|
+      social.each do |link|
         link_has_cta = ["Sign up", "Follow", "Watch", "Read"].any? { |cta| link["title"].include?(cta) }
         links << {
           href: link["href"],

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -27,7 +27,7 @@
       <% end %>
     </div>
 
-    <% if @what_we_do.has_share_links? %>
+    <% if @what_we_do.has_share_links?(@_request).present? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {
           text: t('organisations.follow_us'),
@@ -36,9 +36,7 @@
           font_size: 19,
           lang: t_fallback('organisations.follow_us')
         } %>
-        <div lang="en">
-          <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
-        </div>
+        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links(@_request) %>
       </div>
     <% end %>
   </div>

--- a/test/integration/organisation_test.rb
+++ b/test/integration/organisation_test.rb
@@ -40,11 +40,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             service_type: "twitter",
             title: "Twitter - @10DowningStreet",
             href: "https://twitter.com/@10DowningStreet",
+            locale: "en",
           },
           {
             service_type: "facebook",
             title: "Facebook",
             href: "https://www.facebook.com/10downingstreet",
+            locale: "en",
           },
         ],
         ordered_promotional_features: [
@@ -171,6 +173,7 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             service_type: "twitter",
             title: "Twitter - @attorneygeneral",
             href: "https://twitter.com/@attorneygeneral",
+            locale: "en",
           },
         ],
         ordered_promotional_features: [
@@ -356,11 +359,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             service_type: "twitter",
             title: "Twitter",
             href: "https://twitter.com/chtycommission",
+            locale: "en",
           },
           {
             service_type: "youtube",
             title: "YouTube",
             href: "http://www.youtube.com/TheCharityCommission",
+            locale: "en",
           },
         ],
       },
@@ -424,11 +429,13 @@ class OrganisationTest < ActionDispatch::IntegrationTest
             service_type: "twitter",
             title: "Twitter",
             href: "https://twitter.com/UKGovWales",
+            locale: "en",
           },
           {
-            service_type: "twitter",
-            title: "Trydar",
-            href: "https://twitter.com/LlywDUCymru",
+            service_type: "facebook",
+            title: "Facebook",
+            href: "https://facebook.com/LlywDUCymru",
+            locale: "cy",
           },
         ],
       },
@@ -882,5 +889,19 @@ class OrganisationTest < ActionDispatch::IntegrationTest
 
     org_schema = schemas.detect { |schema| schema["@type"] == "GovernmentOrganization" }
     assert_equal org_schema["name"], "Student Loans Company"
+  end
+
+  it "only shows social media links that have English as locale on pages in English" do
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales"
+
+    assert page.has_css?("a[href='https://twitter.com/cabinetofficeuk']", text: "Twitter")
+    assert_not page.has_css?("a[href='https://facebook.com/LlywDUCymru']", text: "Facebook")
+  end
+
+  it "only shows social media links that do not have English as locale on pages not in English" do
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+
+    assert_not page.has_css?("a[href='https://twitter.com/cabinetofficeuk']", text: "Twitter")
+    assert page.has_css?("a[href='https://facebook.com/LlywDUCymru']", text: "Facebook")
   end
 end


### PR DESCRIPTION
Requires [this PR](https://github.com/alphagov/whitehall/pull/5981) to be merged first
[Trello](https://trello.com/c/RRvGDDmD/2243-5-make-whitehall-social-media-links-translatable)