### PR TITLE
Run pact tests with gds-api-adapters as part of deployment pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ end
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "climate_control"
   gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (0.2.0)
     coderay (1.1.3)
     concord (0.1.6)
       adamantium (~> 0.2.0)
@@ -506,6 +507,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  climate_control
   cucumber-rails
   dalli
   gds-api-adapters

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ node {
     brakeman: true,
     extraParameters: [
       stringParam(
-        name: "GDS_API_PACT_BRANCH",
+        name: "GDS_API_ADAPTERS_PACT_BRANCH",
         defaultValue: "master",
         description: "The branch of gds-api-adapters pact tests to run against"
       ),
@@ -17,9 +17,9 @@ node {
     beforeTest: {
       govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
     },
-    afterTest : {
+    afterTest: {
       stage("Verify pact with gds-api-adapters") {
-        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_PACT_BRANCH}]")
+        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_ADAPTERS_PACT_BRANCH}]")
       }
     }
   )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,20 @@ node {
   govuk.buildProject(
     publishingE2ETests: true,
     brakeman: true,
+    extraParameters: [
+      stringParam(
+        name: "GDS_API_PACT_BRANCH",
+        defaultValue: "master",
+        description: "The branch of gds-api-adapters pact tests to run against"
+      ),
+    ],
+    beforeTest: {
+      govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+    },
+    afterTest : {
+      stage("Verify pact with gds-api-adapters") {
+        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_PACT_BRANCH}]")
+      }
+    }
   )
 }

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint cucumber test spec jasmine:ci]
+task default: %i[lint cucumber test spec jasmine:ci pact:verify]

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,5 +1,17 @@
 return if Rails.env.production?
 
 require "pact/tasks"
-require "pact_broker/client/tasks"
 require "pact/tasks/task_helper"
+
+desc "Verify that Collections honours all contracts in the pactfile created by a given branch of gds-api-adapters"
+task "pact:verify:branch", [:branch_name] => :environment do |t, args|
+  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+
+  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
+
+  ClimateControl.modify GDS_API_PACT_VERSION: pact_version do
+    Pact::TaskHelper.handle_verification_failure do
+      Pact::TaskHelper.execute_pact_verify
+    end
+  end
+end

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -9,7 +9,7 @@ task "pact:verify:branch", [:branch_name] => :environment do |t, args|
 
   pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
 
-  ClimateControl.modify GDS_API_PACT_VERSION: pact_version do
+  ClimateControl.modify GDS_API_ADAPTERS_PACT_VERSION: pact_version do
     Pact::TaskHelper.handle_verification_failure do
       Pact::TaskHelper.execute_pact_verify
     end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -22,7 +22,7 @@ class ProxyApp
   end
 end
 
-Pact.service_provider "Organisations API" do
+Pact.service_provider "Collections Organisation API" do
   app { ProxyApp.new(Rails.application) }
   honours_pact_with "GDS API Adapters" do
     pact_uri "../gds-api-adapters/spec/pacts/gds_api_adapters-collections_organisation_api.json"

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -30,6 +30,15 @@ Pact.service_provider "Collections Organisation API" do
 end
 
 Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    WebMock.enable!
+    WebMock.reset!
+  end
+
+  tear_down do
+    WebMock.disable!
+  end
+
   provider_state "there is a list of organisations" do
     set_up do
       Services

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -22,10 +22,22 @@ class ProxyApp
   end
 end
 
+def url_encode(str)
+  ERB::Util.url_encode(str)
+end
+
 Pact.service_provider "Collections Organisation API" do
   app { ProxyApp.new(Rails.application) }
   honours_pact_with "GDS API Adapters" do
-    pact_uri "../gds-api-adapters/spec/pacts/gds_api_adapters-collections_organisation_api.json"
+    if ENV["USE_LOCAL_PACT"]
+      pact_uri ENV.fetch("GDS_API_PACT_PATH", "../gds-api-adapters/spec/pacts/gds_api_adapters-collections_organisation_api.json")
+    else
+      base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+      url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
+      version_part = "versions/#{url_encode(ENV.fetch('GDS_API_PACT_VERSION', 'master'))}"
+
+      pact_uri "#{url}/#{version_part}"
+    end
   end
 end
 


### PR DESCRIPTION
## What

Follow up PR to https://github.com/alphagov/collections/pull/2230

Verify via the deployment pipeline that each new build of collections honours its contracts with gds-api-adaptors.

See commit messages for further details. 

- GDS API Adaptors already has a [rake](https://github.com/alphagov/gds-api-adapters/blob/f838456c65c6ef40b6e85692145351405790c8ec/Rakefile#L26) task to publish its pactfiles to the broker as part of its deployment pipeline by [jenkins](https://github.com/alphagov/gds-api-adapters/blob/f838456c65c6ef40b6e85692145351405790c8ec/Jenkinsfile#L29).
- So the pactfile defining contracts between collections and gds-api-adapters is already [on the broker.](https://pact-broker.cloudapps.digital/pacts/provider/Collections%20Organisation%20API/consumer/GDS%20API%20Adapters/versions/master).
- This means that this PR is safe to be merged. 

- [trello](https://trello.com/c/Qpd7jgOq/628-add-contract-testing-to-the-collections-app)