### PR TITLE
Fix whitespace problem for some searches on organisations page

### DIFF
--- a/app/assets/javascripts/organisation-list-filter.js
+++ b/app/assets/javascripts/organisation-list-filter.js
@@ -86,13 +86,14 @@
       var totalMatchingOrgs = 0
 
       listsToFilter.each(function () {
-        var matchingOrgCount = $(this).find('[data-filter="item"]:visible').length
         var departmentSection = $(this).closest('[data-filter="block"]')
-        var departmentCountWrapper = departmentSection.find('[data-filter="count"]')
+        departmentSection.removeClass('js-hidden')
+
+        var matchingOrgCount = $(this).find('[data-filter="item"]:visible').length
         var departmentCount = departmentSection.find('.js-department-count')
         var accessibleDepartmentCount = departmentSection.find('.js-accessible-department-count')
 
-        departmentCountWrapper.toggleClass('js-hidden', matchingOrgCount === 0)
+        departmentSection.toggleClass('js-hidden', matchingOrgCount === 0)
 
         if (matchingOrgCount > 0) {
           departmentCount.text(matchingOrgCount)

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -138,7 +138,7 @@ describe('organisation-list-filter.js', function () {
     $('[data-filter="form"] input').trigger('keyup')
 
     setTimeout(function () {
-      expect($('.count-for-logos')).toHaveClass('js-hidden')
+      expect($('.count-for-logos').parent()).toHaveClass('js-hidden')
       expect($('.js-search-results')).toHaveText('1 result found')
       done()
     }, timeout)


### PR DESCRIPTION
## What

Amend the JS for the organisations search so that if a department (i.e. a group of organisations, contained in a parent div) contains no matching results, we completely hide that wrapper, instead of just hiding the list items for each non-matching organisation and hiding the result count.

## Why

This change is because previously if you searched for something that occurred at the bottom of the list (e.g. 'the scottish government') we only hid the non-matching contents of the departments, not the element that contained them. This element has bottom margin, so the result was a load of effectively empty divs with bottom margin, creating a gap between the top of the page and the visible result.

Fixes #1905.

## Visual changes

Before | After
------ | ------
![Screenshot 2021-02-15 at 13 50 09](https://user-images.githubusercontent.com/861310/107955396-a3920c80-6f95-11eb-9846-d729aca1803c.png) | ![Screenshot 2021-02-15 at 13 50 15](https://user-images.githubusercontent.com/861310/107955411-a987ed80-6f95-11eb-9e05-64008b468674.png)
