### PR TITLE
Add an optional summary field to Coronavirus timeline

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -5,6 +5,10 @@
     margin_bottom: 4
   } %>
 
+  <% if timeline["summary"] %>
+    <%= render_govspeak(timeline["summary"]) %>
+  <% end %>
+
   <% timeline["list"].each do | item | %>
     <div class="covid-timeline__item">
       <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
This field has been added to meet an immediate need for contextual text
immediately below the timeline heading and before the timeline entries.

This is being added in a hurry as copy had been signed off that didn't
fully match what was available for editing. We plan to review this once
things are a little quieter.

With a summary the page looks like this:

![Screenshot 2021-02-22 at 16 10 51](https://user-images.githubusercontent.com/282717/108735536-98f0ed80-7528-11eb-91c8-09c238e79a10.png)

This doesn't seem quite ideal margin wise, but it is sufficient for launching this.