### PR TITLE
Add support for the new session header & dev cookie

### DIFF
--- a/app/controllers/concerns/account_ab_testable.rb
+++ b/app/controllers/concerns/account_ab_testable.rb
@@ -1,6 +1,13 @@
 module AccountAbTestable
+  extend ActiveSupport::Concern
+
   ACCOUNT_AB_CUSTOM_DIMENSION = 42
   ACCOUNT_AB_TEST_NAME = "AccountExperiment".freeze
+
+  included do
+    helper_method :account_variant
+    before_action :set_account_variant
+  end
 
   def account_variant
     @account_variant ||= begin
@@ -20,5 +27,17 @@ module AccountAbTestable
 
   def show_signed_out_header?
     account_variant.variant?("LoggedOut")
+  end
+
+  def set_account_variant
+    return unless Rails.configuration.feature_flag_govuk_accounts
+    return unless show_signed_in_header? || show_signed_out_header?
+
+    account_variant.configure_response(response)
+
+    set_slimmer_headers(
+      remove_search: true,
+      show_accounts: show_signed_in_header? ? "signed-in" : "signed-out",
+    )
   end
 end

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -4,12 +4,8 @@ class TransitionLandingPageController < ApplicationController
 
   skip_before_action :set_expiry
   before_action -> { set_expiry(1.minute) }
-  before_action :set_account_variant
 
   around_action :switch_locale
-
-  helper_method :account_variant
-
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
@@ -46,17 +42,5 @@ private
 
   def show_comms?
     true
-  end
-
-  def set_account_variant
-    return unless Rails.configuration.feature_flag_govuk_accounts
-    return unless show_signed_in_header? || show_signed_out_header?
-
-    account_variant.configure_response(response)
-
-    set_slimmer_headers(
-      remove_search: true,
-      show_accounts: show_signed_in_header? ? "signed-in" : "signed-out",
-    )
   end
 end


### PR DESCRIPTION
The user is treated as logged in if:

- The `GOVUK-Account-Session` request header is set
- The `govuk_account_session` cookie is present and `Rails.env.development?`
- The user is in the `LoggedIn` A/B bucket

The A/B approach will be removed when we fully transition to the new
cookie.

We don't validate that the header or cookie actually contains correct
session data.  This is fine because if an attacker supplies a fake
value, all they'll do is change the "sign in" link in the header to a
"sign out" link.

---

[Trello card](https://trello.com/c/ZhjlysBW/642-preferentially-use-the-new-cookie-on-the-transition-landing-page)