### PR TITLE
Remove account A/B test

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -3,28 +3,12 @@
 module AccountConcern
   extend ActiveSupport::Concern
 
-  ACCOUNT_AB_CUSTOM_DIMENSION = 42
-  ACCOUNT_AB_TEST_NAME = "AccountExperiment"
-
   ACCOUNT_SESSION_REQUEST_HEADER_NAME = "HTTP_GOVUK_ACCOUNT_SESSION"
   ACCOUNT_SESSION_RESPONSE_HEADER_NAME = "GOVUK-Account-Session"
   ACCOUNT_SESSION_DEV_COOKIE_NAME = "govuk_account_session"
 
   included do
-    helper_method :account_variant
     before_action :set_account_variant
-  end
-
-  def account_variant
-    @account_variant ||= begin
-      ab_test = GovukAbTesting::AbTest.new(
-        ACCOUNT_AB_TEST_NAME,
-        dimension: ACCOUNT_AB_CUSTOM_DIMENSION,
-        allowed_variants: %w[LoggedIn LoggedOut],
-        control_variant: "LoggedOut",
-      )
-      ab_test.requested_variant(request.headers)
-    end
   end
 
   def account_session_header
@@ -36,13 +20,12 @@ module AccountConcern
   end
 
   def show_signed_in_header?
-    account_session_header.present? || account_variant.variant?("LoggedIn")
+    account_session_header.present?
   end
 
   def set_account_variant
     return unless Rails.configuration.feature_flag_govuk_accounts
 
-    account_variant.configure_response(response)
     response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_RESPONSE_HEADER_NAME].compact.join(", ")
 
     set_slimmer_headers(

--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AccountAbTestable
+module AccountConcern
   extend ActiveSupport::Concern
 
   ACCOUNT_AB_CUSTOM_DIMENSION = 42

--- a/app/controllers/transition_landing_page_controller.rb
+++ b/app/controllers/transition_landing_page_controller.rb
@@ -1,5 +1,5 @@
 class TransitionLandingPageController < ApplicationController
-  include AccountAbTestable
+  include AccountConcern
   include Slimmer::Headers
 
   skip_before_action :set_expiry

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -19,7 +19,6 @@
   } %>
   
   <link rel="canonical" href="<%= page_url %>">
-  <%= account_variant.analytics_meta_tag.html_safe %>
 <% end %>
 
 <header class="landing-page__header--with-bg-image">

--- a/test/controllers/transition_landing_page_controller_test.rb
+++ b/test/controllers/transition_landing_page_controller_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 describe TransitionLandingPageController do
   include TaxonHelpers
-  include GovukAbTesting::MinitestHelpers
 
   describe "GET show" do
     before do
@@ -46,34 +45,6 @@ describe TransitionLandingPageController do
           request.headers["GOVUK-Account-Session"] = "foo"
           get :show
           assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-        end
-      end
-
-      context "with the LoggedIn A/B variant" do
-        it "requests the signed-in header" do
-          with_variant AccountExperiment: "LoggedIn" do
-            get :show
-            assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-          end
-        end
-      end
-
-      context "with the LoggedOut A/B variant" do
-        it "requests the signed-out header" do
-          with_variant AccountExperiment: "LoggedOut" do
-            get :show
-            assert_equal "signed-out", response.headers["X-Slimmer-Show-Accounts"]
-          end
-        end
-
-        context "the GOVUK-Account-Session header is set" do
-          it "requests the signed-in header" do
-            with_variant AccountExperiment: "LoggedOut" do
-              request.headers["GOVUK-Account-Session"] = "foo"
-              get :show
-              assert_equal "signed-in", response.headers["X-Slimmer-Show-Accounts"]
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
We've now fully switched over to the custom header approach.

---

[Trello card](https://trello.com/c/uHdKokkS/643-switch-from-the-old-cookie-to-the-new-cookie)