### PR TITLE
Pact test refactors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,21 +6,6 @@ node {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections")
   govuk.buildProject(
     publishingE2ETests: true,
-    brakeman: true,
-    extraParameters: [
-      stringParam(
-        name: "GDS_API_ADAPTERS_PACT_BRANCH",
-        defaultValue: "master",
-        description: "The branch of gds-api-adapters pact tests to run against"
-      ),
-    ],
-    beforeTest: {
-      govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
-    },
-    afterTest: {
-      stage("Verify pact with gds-api-adapters") {
-        govuk.runRakeTask("pact:verify:branch[${env.GDS_API_ADAPTERS_PACT_BRANCH}]")
-      }
-    }
+    brakeman: true
   )
 }

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -34,7 +34,7 @@ Pact.service_provider "Collections Organisation API" do
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_part = "versions/#{url_encode(ENV.fetch('GDS_API_PACT_VERSION', 'master'))}"
+      version_part = "versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
 
       pact_uri "#{url}/#{version_part}"
     end


### PR DESCRIPTION
## What
1. Correct environment variable typo
`GDS_API_ADAPTERS_PACT_VERSION` is set in the pact verify branch rake [task](https://github.com/alphagov/collections/blob/80975aa6d0e4f94241a2fd1105ec63ce58d92d5e/lib/tasks/pact.rake#L12),
and used by the pact_helper to compose the [pact_uri](https://github.com/alphagov/collections/blob/b9aae620f3617c01194c72a357a62aba9ca68d3b/spec/service_consumers/pact_helper.rb#L37). There was a typo, and the pact_helper was trying to fetch `GDS_API_PACT_VERSION`. As a consequence, pact files for each [new build](https://github.com/alphagov/gds-api-adapters/blob/b5686a840fcc3cac4021b6210272daa89501f1d2/Jenkinsfile#L70) of gds-api-adaptors
have not been validated against the provider, instead the master version of the pactfile was used. This is of little consequence luckily, as none of the consumer pact tests have changed since this typo was deployed.

2. Remove `pact:verify:branch` from the jenkinsfile, as we are already running the pact tests as part of the default rake task defined in the [rakefile](https://github.com/alphagov/collections/blob/80975aa6d0e4f94241a2fd1105ec63ce58d92d5e/Rakefile#L8). See commit [message](https://github.com/alphagov/collections/pull/2297/commits/0307d69e23f7d7781e0160cc6dc6fad1fda13b50) for more information. 

### Before
In the output of the [first](https://ci.integration.publishing.service.gov.uk/job/collections/job/pact_test_variables/1/console) commit of this pr, you can see the tests are running twice.

### After
In the [second](https://ci.integration.publishing.service.gov.uk/job/collections/job/pact_test_variables/2/console) commit of this pr you can see the tests are running once.