### PR TITLE
Add placeholder locale files for supported languages

### DIFF
--- a/config/locales/gu/people.yml
+++ b/config/locales/gu/people.yml
@@ -1,0 +1,9 @@
+gu:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/gu/roles.yml
+++ b/config/locales/gu/roles.yml
@@ -1,0 +1,13 @@
+gu:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/gu/shared.yml
+++ b/config/locales/gu/shared.yml
@@ -1,3 +1,3 @@
 gu:
   shared:
-    language_name:
+    language_name: ગુજરાતી

--- a/config/locales/gu/shared.yml
+++ b/config/locales/gu/shared.yml
@@ -1,0 +1,3 @@
+gu:
+  shared:
+    language_name:

--- a/config/locales/no/shared.yml
+++ b/config/locales/no/shared.yml
@@ -1,3 +1,3 @@
 "no":
   shared:
-    language_name:
+    language_name: Norsk

--- a/config/locales/no/shared.yml
+++ b/config/locales/no/shared.yml
@@ -1,0 +1,3 @@
+"no":
+  shared:
+    language_name:

--- a/config/locales/pa-pk/people.yml
+++ b/config/locales/pa-pk/people.yml
@@ -1,0 +1,9 @@
+pa-pk:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/pa-pk/roles.yml
+++ b/config/locales/pa-pk/roles.yml
@@ -1,0 +1,13 @@
+pa-pk:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/pa-pk/shared.yml
+++ b/config/locales/pa-pk/shared.yml
@@ -1,0 +1,3 @@
+pa-pk:
+  shared:
+    language_name:

--- a/config/locales/pa-pk/shared.yml
+++ b/config/locales/pa-pk/shared.yml
@@ -1,3 +1,4 @@
 pa-pk:
   shared:
-    language_name:
+    language_name: پن٘جابی
+    language_direction: rtl

--- a/config/locales/pa/people.yml
+++ b/config/locales/pa/people.yml
@@ -1,0 +1,9 @@
+pa:
+  people:
+    biography:
+    heading:
+      one:
+      other:
+    previous_roles:
+    previous_roles_in_government:
+    read_more:

--- a/config/locales/pa/roles.yml
+++ b/config/locales/pa/roles.yml
@@ -1,0 +1,13 @@
+pa:
+  roles:
+    heading:
+      one:
+      other:
+    headings:
+      current_holder:
+      previous_holders:
+      responsibilities:
+    ministerial:
+    policies_responsible_with_person:
+    previous_holders:
+    read_more:

--- a/config/locales/pa/shared.yml
+++ b/config/locales/pa/shared.yml
@@ -1,3 +1,4 @@
 pa:
   shared:
-    language_name:
+    language_name: ਪੰਜਾਬੀ
+    language_direction: rtl

--- a/config/locales/pa/shared.yml
+++ b/config/locales/pa/shared.yml
@@ -1,0 +1,3 @@
+pa:
+  shared:
+    language_name:


### PR DESCRIPTION
We support publishing in a total of 65 languages, but do not have translations available for all of them.

Adding placeholder locale files and required keys here so it is easier to identify which keys will need translating in later work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello card: https://trello.com/c/XbwUsOQr