### PR TITLE
Show statistics on Coronavirus landing page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "6.1.3.1"
 
 gem "dalli"
+gem "faraday"
 gem "gds-api-adapters"
 gem "govspeak"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,6 +511,7 @@ DEPENDENCIES
   climate_control
   cucumber-rails
   dalli
+  faraday
   gds-api-adapters
   govspeak
   govuk-content-schema-test-helpers

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -295,3 +295,12 @@ $c19-landing-page-header-background: govuk-colour('blue');
     margin-top: govuk-spacing(4);
   }
 }
+
+.covid-statistics__statistic-wrapper {
+  margin-bottom: govuk-spacing(5);
+}
+
+.covid-statistics__statistic-value {
+  @include govuk-font(80, $weight: bold);
+  margin-bottom: 0;
+}

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,10 +1,9 @@
 require "active_model"
 
 class CoronavirusLandingPageController < ApplicationController
-  skip_before_action :set_expiry
-  before_action -> { set_expiry(5.minutes) }
-
   def show
+    set_expiry 5.minutes
+
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
     title = {
@@ -21,6 +20,8 @@ class CoronavirusLandingPageController < ApplicationController
   end
 
   def hub
+    set_expiry 5.minutes
+
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/" }]
     title = {

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -2,7 +2,13 @@ require "active_model"
 
 class CoronavirusLandingPageController < ApplicationController
   def show
-    set_expiry 5.minutes
+    @statistics = FetchCoronavirusStatisticsService.call
+    if @statistics
+      set_expiry 5.minutes
+    else
+      logger.warn "Serving /coronavirus without statistics"
+      set_expiry 30.seconds
+    end
 
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -1,0 +1,88 @@
+class FetchCoronavirusStatisticsService
+  CACHE_KEY = "coronavirus_statistics".freeze
+
+  Statistics = Struct.new(:cumulative_vaccinations,
+                          :cumulative_vaccinations_date,
+                          :hospital_admissions,
+                          :hospital_admissions_date,
+                          :new_positive_tests,
+                          :new_positive_tests_date,
+                          keyword_init: true)
+
+  def self.call
+    new.call
+  end
+
+  def call
+    # This API times out on occassion, so we'll keep a copy of our potentially
+    # stale data to use as a backup
+    backup_statistics = Rails.cache.fetch(CACHE_KEY)
+    statistics = fetch_current_statistics || backup_statistics
+
+    Statistics.new(statistics) if statistics && statistics.any?
+  end
+
+  private_class_method :new
+
+private
+
+  def fetch_current_statistics
+    Rails.cache.fetch(CACHE_KEY, expires_in: 30.minutes, race_condition_ttl: 5.minutes) do
+      request_statistics
+    end
+  rescue StandardError => e
+    Rails.logger.warn("Failed to load coronavirus statistics: #{e}")
+    intermittent_error = case e
+                         when Faraday::TimeoutError, Faraday::ConnectionFailed
+                           true
+                         when Faraday::ServerError
+                           [502, 504].include?(e.response_status)
+                         end
+
+    GovukError.notify(e) unless intermittent_error
+    nil
+  end
+
+  def request_statistics
+    connection = Faraday.new("https://coronavirus.data.gov.uk") do |f|
+      f.response(:raise_error)
+      f.options.timeout = 2
+    end
+
+    response = connection.get do |request|
+      request.url("/api/v1/data", {
+        filters: "areaName=United Kingdom;areaType=overview",
+        structure: {
+          "date" => "date",
+          "cumulativeVaccinations" => "cumPeopleVaccinatedFirstDoseByPublishDate",
+          "hospitalAdmissions" => "newAdmissions",
+          "newPositiveTests" => "newCasesByPublishDate",
+        }.to_json,
+      })
+    end
+
+    parse_response(response)
+  end
+
+  def parse_response(response)
+    data = JSON.parse(response.body).fetch("data")
+    parsed = {}
+
+    if (latest_vaccinations = data.find { |d| d["cumulativeVaccinations"] })
+      parsed[:cumulative_vaccinations] = latest_vaccinations["cumulativeVaccinations"]
+      parsed[:cumulative_vaccinations_date] = Date.parse(latest_vaccinations["date"])
+    end
+
+    if (latest_admissions = data.find { |d| d["hospitalAdmissions"] })
+      parsed[:hospital_admissions] = latest_admissions["hospitalAdmissions"]
+      parsed[:hospital_admissions_date] = Date.parse(latest_admissions["date"])
+    end
+
+    if (latest_tests = data.find { |d| d["newPositiveTests"] })
+      parsed[:new_positive_tests] = latest_tests["newPositiveTests"]
+      parsed[:new_positive_tests_date] = Date.parse(latest_tests["date"])
+    end
+
+    parsed
+  end
+end

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
@@ -1,0 +1,27 @@
+<div class="covid-statistics__statistic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: title,
+      heading_level: 3,
+      font_size: "s",
+      margin_bottom: 1
+    } %>
+
+  <p class="covid-statistics__statistic-value govuk-body">
+    <%= stat %>
+  </p>
+  <p class="govuk-body"><%= subtext %></p>
+
+  <p class="govuk-body-s">
+    Last updated <%= last_updated_date.strftime("%d %B %Y") %>
+  </p>
+
+  <p class="govuk-body">
+    <%= link_to guidance_link[:label], guidance_link[:href], class: "govuk-link", data: {
+      module: "gem-track-click",
+      track_category: "pageElementInteraction",
+      track_action: "Statistics",
+      track_label: guidance_link[:href],
+    } %>
+  </p>
+  <hr>
+</div>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
@@ -7,20 +7,20 @@
     } %>
 
   <p class="covid-statistics__statistic-value govuk-body">
-    <%= stat %>
+    <%= statistic %>
   </p>
-  <p class="govuk-body"><%= subtext %></p>
+  <p class="govuk-body"><%= statistic_meaning %></p>
 
   <p class="govuk-body-s">
     Last updated <%= last_updated_date.strftime("%d %B %Y") %>
   </p>
 
   <p class="govuk-body">
-    <%= link_to guidance_link[:label], guidance_link[:href], class: "govuk-link", data: {
+    <%= link_to guidance_link["label"], guidance_link["url"], class: "govuk-link", data: {
       module: "gem-track-click",
       track_category: "pageElementInteraction",
       track_action: "Statistics",
-      track_label: guidance_link[:href],
+      track_label: guidance_link["url"],
     } %>
   </p>
   <hr>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -1,0 +1,65 @@
+<section class="covid__topic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: topic_section["header"],
+    padding: true,
+    border_top: 2,
+    margin_bottom: 6
+  } %>
+
+  <% if statistics && statistics.cumulative_vaccinations %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Total vaccinations",
+      stat: "#{number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1)} million",
+      subtext: "people have received their first dose",
+      last_updated_date: statistics.cumulative_vaccinations_date,
+      guidance_link: {
+        label: "Vaccination data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/vaccinations",
+      },
+    } %>
+  <% end %>
+
+  <% if statistics && statistics.hospital_admissions %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Daily hospital admissions",
+      stat: number_with_delimiter(statistics.hospital_admissions),
+      subtext: "new patients have been admitted to hospital",
+      last_updated_date: statistics.hospital_admissions_date,
+      guidance_link: {
+        label: "Healthcare data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/healthcare",
+      },
+    } %>
+  <% end %>
+
+  <% if statistics && statistics.new_positive_tests %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Daily new cases",
+      stat: number_with_delimiter(statistics.new_positive_tests),
+      subtext: "people tested positive with COVID-19",
+      last_updated_date: statistics.new_positive_tests_date,
+      guidance_link: {
+        label: "Cases data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/cases",
+      },
+    } %>
+  <% end %>
+
+  <ul class="govuk-list">
+    <% topic_section["links"].each do | link | %>
+      <li class="covid__topic-list-item">
+        <%= link_to(
+          link["label"].html_safe,
+          link["url"],
+          class: 'covid__topic-list-link govuk-link',
+          data: {
+            module: "gem-track-click",
+            track_category: "pageElementInteraction",
+            track_action: "Statistics",
+            track_label: link["url"],
+          },
+        ) %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -8,40 +8,31 @@
 
   <% if statistics && statistics.cumulative_vaccinations %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
-      title: "Total vaccinations",
-      stat: "#{number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1)} million",
-      subtext: "people have received their first dose",
+      title: topic_section.dig("cumulative_vaccinations", "title"),
+      statistic: "#{number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1)} million",
+      statistic_meaning: topic_section.dig("cumulative_vaccinations", "statistic_meaning"),
       last_updated_date: statistics.cumulative_vaccinations_date,
-      guidance_link: {
-        label: "Vaccination data from the coronavirus data dashboard",
-        href: "https://coronavirus.data.gov.uk/details/vaccinations",
-      },
+      guidance_link: topic_section.dig("cumulative_vaccinations", "guidance_link"),
     } %>
   <% end %>
 
   <% if statistics && statistics.hospital_admissions %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
-      title: "Daily hospital admissions",
-      stat: number_with_delimiter(statistics.hospital_admissions),
-      subtext: "new patients have been admitted to hospital",
+      title: topic_section.dig("hospital_admissions", "title"),
+      statistic: number_with_delimiter(statistics.hospital_admissions),
+      statistic_meaning: topic_section.dig("hospital_admissions", "statistic_meaning"),
       last_updated_date: statistics.hospital_admissions_date,
-      guidance_link: {
-        label: "Healthcare data from the coronavirus data dashboard",
-        href: "https://coronavirus.data.gov.uk/details/healthcare",
-      },
+      guidance_link: topic_section.dig("hospital_admissions", "guidance_link"),
     } %>
   <% end %>
 
   <% if statistics && statistics.new_positive_tests %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
-      title: "Daily new cases",
-      stat: number_with_delimiter(statistics.new_positive_tests),
-      subtext: "people tested positive with COVID-19",
+      title: topic_section.dig("new_positive_tests", "title"),
+      statistic: number_with_delimiter(statistics.new_positive_tests),
+      statistic_meaning: topic_section.dig("new_positive_tests", "statistic_meaning"),
       last_updated_date: statistics.new_positive_tests_date,
-      guidance_link: {
-        label: "Cases data from the coronavirus data dashboard",
-        href: "https://coronavirus.data.gov.uk/details/cases",
-      },
+      guidance_link: topic_section.dig("new_positive_tests", "guidance_link"),
     } %>
   <% end %>
 

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -48,10 +48,9 @@
       <%#= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { live_stream: details.live_stream } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
+      <%= render partial: 'coronavirus_landing_page/components/landing_page/statistics_section', locals: {
         topic_section: details.statistics_section,
-        tracking_category: "pageElementInteraction",
-        tracking_action: "Statistics",
+        statistics: @statistics,
       } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
         topic_section: details.topic_section,

--- a/spec/controllers/coronavirus_landing_page_controller_spec.rb
+++ b/spec/controllers/coronavirus_landing_page_controller_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe CoronavirusLandingPageController do
+  include CoronavirusContentItemHelper
+
+  describe "GET show" do
+    before do
+      stub_content_store_has_item("/coronavirus", coronavirus_content_item)
+      stub_coronavirus_statistics
+    end
+
+    it "has a success response" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+
+    it "sets a 5 minute cache header" do
+      get :show
+      expect(response.headers["Cache-Control"]).to eq("max-age=#{5.minutes}, public")
+    end
+
+    context "when coronavirus statistics are not available" do
+      before { stub_request(:get, /coronavirus.data.gov.uk/).to_return(status: 500) }
+
+      it "reduces the cache time to 30 seconds" do
+        get :show
+        expect(response.headers["Cache-Control"]).to eq("max-age=#{30.seconds}, public")
+      end
+    end
+  end
+end

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature "Coronavirus Pages" do
   include CoronavirusContentItemHelper
 
   describe "the landing page" do
+    before { stub_coronavirus_statistics }
+
     scenario "renders" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page

--- a/spec/fixtures/content_store/coronavirus_landing_page.json
+++ b/spec/fixtures/content_store/coronavirus_landing_page.json
@@ -348,6 +348,30 @@
     },
     "statistics_section": {
       "header": "Statistics",
+      "cumulative_vaccinations": {
+        "title": "Total vaccinations",
+        "statistic_meaning": "people have received their first dose",
+        "guidance_link": {
+          "label": "Vaccination data from the coronavirus data dashboard",
+          "url": "https://coronavirus.data.gov.uk/details/vaccinations"
+        }
+      },
+      "hospital_admissions": {
+        "title": "Daily hospital admissions",
+        "statistic_meaning": "new patients have been admitted to hospital",
+        "guidance_link": {
+          "label": "Healthcare data from the coronavirus data dashboard",
+          "url": "https://coronavirus.data.gov.uk/details/healthcare"
+        }
+      },
+      "new_positive_tests": {
+        "title": "Daily new cases",
+        "statistic_meaning": "people tested positive with COVID-19",
+        "guidance_link": {
+          "label": "Cases data from the coronavirus data dashboard",
+          "url": "https://coronavirus.data.gov.uk/details/cases"
+        }
+      },
       "links": [
         {
           "label": "Track coronavirus cases in the UK",

--- a/spec/services/fetch_coronavirus_statistics_service_spec.rb
+++ b/spec/services/fetch_coronavirus_statistics_service_spec.rb
@@ -1,0 +1,122 @@
+RSpec.describe FetchCoronavirusStatisticsService do
+  describe ".call" do
+    it "returns a Statistics object" do
+      body = {
+        data: [
+          { "date" => "2021-03-18", "cumulativeVaccinations" => nil, "hospitalAdmissions" => nil, "newPositiveTests" => 6303 },
+          { "date" => "2021-03-17", "cumulativeVaccinations" => 25_735_472, "hospitalAdmissions" => nil, "newPositiveests" => 5758 },
+          { "date" => "2021-03-16", "cumulativeVaccinations" => 25_273_226, "hospitalAdmissions" => nil, "newPositiveests" => 5294 },
+          { "date" => "2021-03-15", "cumulativeVaccinations" => 24_839_906, "hospitalAdmissions" => nil, "newPositiveests" => 5089 },
+          { "date" => "2021-03-14", "cumulativeVaccinations" => 24_453_221, "hospitalAdmissions" => 426, "newPositiveests" => 4618 },
+          { "date" => "2021-03-13", "cumulativeVaccinations" => 24_196_211, "hospitalAdmissions" => 460, "newPositiveests" => 5534 },
+        ],
+      }
+
+      stub_request(:get, /coronavirus.data.gov.uk/)
+        .to_return(status: 200, body: body.to_json)
+
+      statistics = described_class.call
+      expect(statistics).to be_a(described_class::Statistics)
+      expect(statistics).to have_attributes(
+        cumulative_vaccinations: 25_735_472,
+        cumulative_vaccinations_date: Date.new(2021, 3, 17),
+        hospital_admissions: 426,
+        hospital_admissions_date: Date.new(2021, 3, 14),
+        new_positive_tests: 6303,
+        new_positive_tests_date: Date.new(2021, 3, 18),
+      )
+    end
+
+    context "when there is missing data" do
+      it "returns nil for no data" do
+        stub_request(:get, /coronavirus.data.gov.uk/)
+          .to_return(status: 200, body: { data: [] }.to_json)
+
+        expect(described_class.call).to be_nil
+      end
+
+      it "sets only the fields that have data" do
+        body = { data: [{ "date" => "2021-03-18",
+                          "cumulativeVaccinations" => nil,
+                          "hospitalAdmissions" => nil,
+                          "newPositiveTests" => 6303 }] }
+
+        stub_request(:get, /coronavirus.data.gov.uk/)
+          .to_return(status: 200, body: body.to_json)
+
+        expect(described_class.call).to have_attributes(
+          cumulative_vaccinations: nil,
+          cumulative_vaccinations_date: nil,
+          hospital_admissions: nil,
+          hospital_admissions_date: nil,
+          new_positive_tests: 6303,
+          new_positive_tests_date: Date.new(2021, 3, 18),
+        )
+      end
+    end
+
+    context "when the request to load data fails" do
+      it "notifies GovukError for a general error" do
+        stub_request(:get, /coronavirus.data.gov.uk/).to_return(status: 500)
+        expect(GovukError).to receive(:notify)
+
+        described_class.call
+      end
+
+      it "doesn't notify GovukError when a timeout occurs" do
+        stub_request(:get, /coronavirus.data.gov.uk/).to_timeout
+        expect(GovukError).not_to receive(:notify)
+
+        described_class.call
+      end
+
+      it "doesn't notify GovukError on 502 and 504 errors" do
+        stub_request(:get, /coronavirus.data.gov.uk/)
+          .to_return(status: 502)
+          .then
+          .to_return(status: 504)
+
+        expect(GovukError).not_to receive(:notify)
+
+        2.times { described_class.call }
+      end
+    end
+
+    context "when the cache has stale data and the request to load new data fails" do
+      it "returns Statistics with the stale data" do
+        stale_stats = {
+          cumulative_vaccinations: 25_735_472,
+          cumulative_vaccinations_date: Date.new(2021, 3, 17),
+          hospital_admissions: 426,
+          hospital_admissions_date: Date.new(2021, 3, 14),
+          new_positive_tests: 6303,
+          new_positive_tests_date: Date.new(2021, 3, 18),
+        }
+
+        fresh_attributes = { expires_in: 30.minutes, race_condition_ttl: 5.minutes }
+
+        allow(Rails.cache).to receive(:fetch)
+                          .with(described_class::CACHE_KEY)
+                          .and_return(stale_stats)
+
+        allow(Rails.cache).to receive(:fetch)
+                          .with(described_class::CACHE_KEY, fresh_attributes)
+                          .and_raise("Failed to load fresh data")
+
+        expect(described_class.call).to have_attributes(stale_stats)
+        expect(Rails.cache).to have_received(:fetch)
+                           .with(described_class::CACHE_KEY, fresh_attributes)
+      end
+    end
+
+    context "when the cache is empty and the request to load data fails" do
+      before do
+        stub_request(:get, /coronavirus.data.gov.uk/).to_return(status: 500)
+      end
+
+      it "returns nil" do
+        expect(described_class.call).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/coronavirus_content_item_helper.rb
+++ b/spec/support/coronavirus_content_item_helper.rb
@@ -20,6 +20,15 @@ module CoronavirusContentItemHelper
     load_content_item("coronavirus_education_page.json")
   end
 
+  def stub_coronavirus_statistics
+    body = { data: [{ "date" => "2021-03-18",
+                      "cumulativeVaccinations" => 25_000_000,
+                      "hospitalAdmissions" => 1000,
+                      "newPositiveTests" => 5000 }] }
+
+    stub_request(:get, /coronavirus.data.gov.uk/).to_return(status: 200, body: body.to_json)
+  end
+
   def random_landing_page
     GovukSchemas::RandomExample.for_schema(frontend_schema: "coronavirus_landing_page") do |item|
       yield(item)


### PR DESCRIPTION
Trello: https://trello.com/c/WVZPCn3t/203-spike-explore-embedding-covid-statistics-into-coronavirus-page

I've marked this PR as draft and do-not-merge as there are a number of steps that are needed before this can be merged:

- [x] Receive approval that statistics can be displayed in this form
- [x] Move the hardcoded copy into https://github.com/alphagov/govuk-coronavirus-content for consistency
- [x]  Publish the hardcoded copy in production

This adds a synchronous call when rendering /coronavirus to load statistic data from https://coronavirus.data.gov.uk. There are some concerns that this data could timeout, so there are a few safeguards. See commits for more details. 

The change looks like this:

![Screenshot 2021-03-23 at 17 25 39](https://user-images.githubusercontent.com/282717/112191454-f21e7080-8bfd-11eb-8b12-32de4d179c09.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️