### PR TITLE
Remove unused pluralisation keys from locale files

### DIFF
--- a/config/locales/az/people.yml
+++ b/config/locales/az/people.yml
@@ -2,7 +2,6 @@ az:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/az/roles.yml
+++ b/config/locales/az/roles.yml
@@ -1,7 +1,6 @@
 az:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/fa/people.yml
+++ b/config/locales/fa/people.yml
@@ -2,7 +2,6 @@ fa:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/fa/roles.yml
+++ b/config/locales/fa/roles.yml
@@ -1,7 +1,6 @@
 fa:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/id/people.yml
+++ b/config/locales/id/people.yml
@@ -2,7 +2,6 @@ id:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/id/roles.yml
+++ b/config/locales/id/roles.yml
@@ -1,7 +1,6 @@
 id:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/ja/people.yml
+++ b/config/locales/ja/people.yml
@@ -2,7 +2,6 @@ ja:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/ja/roles.yml
+++ b/config/locales/ja/roles.yml
@@ -1,7 +1,6 @@
 ja:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/ka/people.yml
+++ b/config/locales/ka/people.yml
@@ -2,7 +2,6 @@ ka:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/ka/roles.yml
+++ b/config/locales/ka/roles.yml
@@ -1,7 +1,6 @@
 ka:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/ko/people.yml
+++ b/config/locales/ko/people.yml
@@ -2,7 +2,6 @@ ko:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/ko/roles.yml
+++ b/config/locales/ko/roles.yml
@@ -1,7 +1,6 @@
 ko:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/ms/people.yml
+++ b/config/locales/ms/people.yml
@@ -2,7 +2,6 @@ ms:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/ms/roles.yml
+++ b/config/locales/ms/roles.yml
@@ -1,7 +1,6 @@
 ms:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/th/people.yml
+++ b/config/locales/th/people.yml
@@ -2,7 +2,6 @@ th:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/th/roles.yml
+++ b/config/locales/th/roles.yml
@@ -1,7 +1,6 @@
 th:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/vi/people.yml
+++ b/config/locales/vi/people.yml
@@ -2,7 +2,6 @@ vi:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/vi/roles.yml
+++ b/config/locales/vi/roles.yml
@@ -1,7 +1,6 @@
 vi:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:

--- a/config/locales/zh/people.yml
+++ b/config/locales/zh/people.yml
@@ -2,7 +2,6 @@ zh:
   people:
     biography:
     heading:
-      one:
       other:
     previous_roles:
     previous_roles_in_government:

--- a/config/locales/zh/roles.yml
+++ b/config/locales/zh/roles.yml
@@ -1,7 +1,6 @@
 zh:
   roles:
     heading:
-      one:
       other:
     headings:
       current_holder:


### PR DESCRIPTION
In https://github.com/alphagov/collections/pull/2312, we updated the plural rules for each language that we support that is not included [in the ruby-i18n gem](https://github.com/ruby-i18n/i18n/blob/master/test/test_data/locales/plurals.rb).

This removes the keys that are no longer required in each language from their locale files.

Trello card: https://trello.com/c/lkVB57ri

I have not made any changes to `tr` as I believe the i18n rules for this could be wrong, so will write a card to look into this.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️