### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,18 +7,16 @@
 # Ignore bundler config.
 /.bundle
 
-# Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
-
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp
 /coverage
-/public/collections
 
 # Yarn
 /node_modules
 /yarn-error.log
 
 /public/assets
+
+# pact reports
+/spec/reports


### PR DESCRIPTION
This adds in /spec/reports so pact tests runs aren't included in git. It
removes paths that hold relevance, the legacy assets path
(/public/collections) and the sqlite dbs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
