### PR TITLE
Adds styling to the statistics blocks and creates new partial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "6.0.3.4"
 
 gem "dalli"
+gem "faraday"
 gem "gds-api-adapters"
 gem "govspeak"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ DEPENDENCIES
   climate_control
   cucumber-rails
   dalli
+  faraday
   gds-api-adapters
   govspeak
   govuk-content-schema-test-helpers

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -269,3 +269,12 @@ $c19-landing-page-header-background: #272828;
   width: 100%;
   margin-top: govuk-spacing(4);
 }
+
+.covid-statistics__statistic-wrapper {
+  margin-bottom: govuk-spacing(5);
+}
+
+.covid-statistics__statistic-value {
+  @include govuk-font(80, $weight: bold);
+  margin-bottom: 0;
+}

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,10 +1,9 @@
 require "active_model"
 
 class CoronavirusLandingPageController < ApplicationController
-  skip_before_action :set_expiry
-  before_action -> { set_expiry(5.minutes) }
-
   def show
+    set_expiry 5.minutes
+
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
     title = {
@@ -21,6 +20,8 @@ class CoronavirusLandingPageController < ApplicationController
   end
 
   def hub
+    set_expiry 5.minutes
+
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/" }]
     title = {

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -2,7 +2,8 @@ require "active_model"
 
 class CoronavirusLandingPageController < ApplicationController
   def show
-    set_expiry 5.minutes
+    @statistics = FetchCoronavirusStatisticsService.call
+    set_expiry(@statistics ? 5.minutes : 30.seconds)
 
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/", is_page_parent: true }]
@@ -20,7 +21,7 @@ class CoronavirusLandingPageController < ApplicationController
   end
 
   def hub
-    set_expiry 5.minutes
+    set_expiry(5.minutes)
 
     @content_item = content_item.to_hash
     breadcrumbs = [{ title: "Home", url: "/" }]

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -14,7 +14,7 @@ class FetchCoronavirusStatisticsService
   def call
     statistics = Rails.cache.fetch(
       "coronavirus_statistics",
-      expires_in: 30.minutes,
+      expires_in: 5.minutes,
       race_condition_ttl: 30.seconds,
     ) { request_statistics }
 

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -1,0 +1,74 @@
+class FetchCoronavirusStatisticsService
+  Statistics = Struct.new(:cumulative_vaccinations,
+                          :cumulative_vaccinations_date,
+                          :hospital_admissions,
+                          :hospital_admissions_date,
+                          :new_positive_tests,
+                          :new_positive_tests_date,
+                          keyword_init: true)
+
+  def self.call
+    new.call
+  end
+
+  def call
+    statistics = Rails.cache.fetch(
+      "coronavirus_statistics",
+      expires_in: 30.minutes,
+      race_condition_ttl: 30.seconds,
+    ) { request_statistics }
+
+    Statistics.new(statistics) unless statistics.empty?
+  rescue StandardError => e
+    Rails.logger.warn("Failed to load coronavirus statistics: #{e}")
+    GovukError.notify(e) unless e.is_a?(Faraday::TimeoutError)
+    nil
+  end
+
+  private_class_method :new
+
+private
+
+  def request_statistics
+    connection = Faraday.new("https://coronavirus.data.gov.uk") do |f|
+      f.response(:raise_error)
+      f.options.timeout = 1
+    end
+
+    response = connection.get do |request|
+      request.url("/api/v1/data", {
+        filters: "areaName=United Kingdom;areaType=overview",
+        structure: {
+          "date" => "date",
+          "cumulativeVaccinations" => "cumPeopleVaccinatedFirstDoseByPublishDate",
+          "hospitalAdmissions" => "newAdmissions",
+          "newPositiveTests" => "newCasesByPublishDate",
+        }.to_json,
+      })
+    end
+
+    parse_response(response)
+  end
+
+  def parse_response(response)
+    data = JSON.parse(response.body).fetch("data")
+    parsed = {}
+
+    if (latest_vaccinations = data.find { |d| d["cumulativeVaccinations"] })
+      parsed[:cumulative_vaccinations] = latest_vaccinations["cumulativeVaccinations"]
+      parsed[:cumulative_vaccinations_date] = Date.parse(latest_vaccinations["date"])
+    end
+
+    if (latest_admissions = data.find { |d| d["hospitalAdmissions"] })
+      parsed[:hospital_admissions] = latest_admissions["hospitalAdmissions"]
+      parsed[:hospital_admissions_date] = Date.parse(latest_admissions["date"])
+    end
+
+    if (latest_tests = data.find { |d| d["newPositiveTests"] })
+      parsed[:new_positive_tests] = latest_tests["newPositiveTests"]
+      parsed[:new_positive_tests_date] = Date.parse(latest_tests["date"])
+    end
+
+    parsed
+  end
+end

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
@@ -1,0 +1,27 @@
+<div class="covid-statistics__statistic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+      text: title,
+      heading_level: 3,
+      font_size: "s",
+      margin_bottom: 1
+    } %>
+
+  <p class="covid-statistics__statistic-value govuk-body">
+    <%= stat %>
+  </p>
+  <p class="govuk-body"><%= subtext %></p>
+
+  <p class="govuk-body-s">
+    Last updated <%= last_updated_date.strftime("%d %B %Y") %>
+  </p>
+
+  <p class="govuk-body">
+    <%= link_to guidance_link[:label], guidance_link[:href], class: "govuk-link", data: {
+      module: "gem-track-click",
+      track_category: "pageElementInteraction",
+      track_action: "Statistics",
+      track_label: guidance_link[:href],
+    }, %>
+  </p>
+  <hr>
+</div>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -7,58 +7,42 @@
   } %>
 
   <% if statistics && statistics.cumulative_vaccinations %>
-    <div>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Total vaccinations"
-      } %>
-
-      <span class="govuk-heading-xl">
-        <%= number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1) %>
-        million
-      </span>
-
-      <p class="govuk-body">people have received their first dose</p>
-
-      <p class="govuk-body">
-        Last updated <%= statistics.cumulative_vaccinations_date.strftime("%d %B %Y") %>
-      </p>
-    </div>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Total vaccinations",
+      stat: "#{number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1)} million",
+      subtext: "people have received their first dose",
+      last_updated_date: statistics.cumulative_vaccinations_date,
+      guidance_link: {
+        label: "Vaccination data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/vaccinations",
+      },
+    } %>
   <% end %>
 
   <% if statistics && statistics.hospital_admissions %>
-    <div>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Daily hospital admissions"
-      } %>
-
-      <span class="govuk-heading-xl">
-        <%= number_with_delimiter(statistics.hospital_admissions) %>
-      </span>
-
-      <p class="govuk-body">new patients have been admitted to hospital</p>
-
-      <p class="govuk-body">
-        Last updated <%= statistics.hospital_admissions_date.strftime("%d %B %Y") %>
-      </p>
-    </div>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Daily hospital admissions",
+      stat: number_with_delimiter(statistics.hospital_admissions),
+      subtext: "new patients have been admitted to hospital",
+      last_updated_date: statistics.hospital_admissions_date,
+      guidance_link: {
+        label: "Healthcare data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/healthcare",
+      },
+    } %>
   <% end %>
 
   <% if statistics && statistics.new_positive_tests %>
-    <div>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Daily new cases"
-      } %>
-
-      <span class="govuk-heading-xl">
-        <%= number_with_delimiter(statistics.new_positive_tests) %>
-      </span>
-
-      <p class="govuk-body">people tested positive with COVID-19</p>
-
-      <p class="govuk-body">
-        Last updated <%= statistics.new_positive_tests_date.strftime("%d %B %Y") %>
-      </p>
-    </div>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "Daily new cases",
+      stat: number_with_delimiter(statistics.new_positive_tests),
+      subtext: "people tested positive with COVID-19",
+      last_updated_date: statistics.new_positive_tests_date,
+      guidance_link: {
+        label: "Cases data from the coronavirus data dashboard",
+        href: "https://coronavirus.data.gov.uk/details/cases",
+      },
+    } %>
   <% end %>
 
   <ul class="govuk-list">

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -1,0 +1,81 @@
+<section class="covid__topic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: topic_section["header"],
+    padding: true,
+    border_top: 2,
+    margin_bottom: 6
+  } %>
+
+  <% if statistics && statistics.cumulative_vaccinations %>
+    <div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Total vaccinations"
+      } %>
+
+      <span class="govuk-heading-xl">
+        <%= number_with_precision(statistics.cumulative_vaccinations / 1_000_000.0, precision: 1) %>
+        million
+      </span>
+
+      <p class="govuk-body">people have received their first dose</p>
+
+      <p class="govuk-body">
+        Last updated <%= statistics.cumulative_vaccinations_date.strftime("%d %B %Y") %>
+      </p>
+    </div>
+  <% end %>
+
+  <% if statistics && statistics.hospital_admissions %>
+    <div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Daily hospital admissions"
+      } %>
+
+      <span class="govuk-heading-xl">
+        <%= number_with_delimiter(statistics.hospital_admissions) %>
+      </span>
+
+      <p class="govuk-body">new patients have been admitted to hospital</p>
+
+      <p class="govuk-body">
+        Last updated <%= statistics.hospital_admissions_date.strftime("%d %B %Y") %>
+      </p>
+    </div>
+  <% end %>
+
+  <% if statistics && statistics.new_positive_tests %>
+    <div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Daily new cases"
+      } %>
+
+      <span class="govuk-heading-xl">
+        <%= number_with_delimiter(statistics.new_positive_tests) %>
+      </span>
+
+      <p class="govuk-body">people tested positive with COVID-19</p>
+
+      <p class="govuk-body">
+        Last updated <%= statistics.new_positive_tests_date.strftime("%d %B %Y") %>
+      </p>
+    </div>
+  <% end %>
+
+  <ul class="govuk-list">
+    <% topic_section["links"].each do | link | %>
+      <li class="covid__topic-list-item">
+        <%= link_to(
+          link["label"].html_safe,
+          link["url"],
+          class: 'covid__topic-list-link govuk-link',
+          data: {
+            module: "gem-track-click",
+            track_category: "pageElementInteraction",
+            track_action: "Statistics",
+            track_label: link["url"],
+          },
+        ) %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -65,10 +65,9 @@
       <%#= render partial: 'coronavirus_landing_page/components/shared/video_player_section' %>
       <%= render partial: 'coronavirus_landing_page/components/shared/announcements_section', locals: { details: details } %>
       <%= render partial: 'coronavirus_landing_page/components/landing_page/live_stream_section', locals: { live_stream: details.live_stream } %>
-      <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
+      <%= render partial: 'coronavirus_landing_page/components/landing_page/statistics_section', locals: {
         topic_section: details.statistics_section,
-        tracking_category: "pageElementInteraction",
-        tracking_action: "Statistics",
+        statistics: @statistics,
       } %>
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: {
         topic_section: details.topic_section,


### PR DESCRIPTION
This commit moves the repeated code into a partial and adds styling.

This makes it aligned with the latest designs.

## Desktop

![Screenshot 2021-03-19 at 11 41 57](https://user-images.githubusercontent.com/4599889/111775095-35987800-88a8-11eb-92bb-7412c22f3554.png)

## Mobile

![Screenshot 2021-03-19 at 11 42 10](https://user-images.githubusercontent.com/4599889/111775109-3b8e5900-88a8-11eb-9042-101931d3da7e.png)


https://trello.com/c/WVZPCn3t/203-spike-explore-embedding-covid-statistics-into-coronavirus-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
