### PR TITLE
set explicit height and width on SVG

### DIFF
--- a/app/assets/images/nhs-logo.svg
+++ b/app/assets/images/nhs-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 69.2 28">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 69.2 28" width="60" height="33">
   <desc>NHS</desc>
   <defs/>
   <path fill="#005eb8" d="M0 0h69.2v28H0z"/>


### PR DESCRIPTION
This is needed as IE does not scale SVGs properly. More information can be found here: https://stackoverflow.com/questions/27970520/svg-with-width-height-doesnt-scale-on-ie9-10-11#:~:text=The%20issue%20can%20be%20resolved,manipulate%20them%20via%20CSS%20only.&text=Note%3A%20If%20you%20are%20placing,so%20that%20it%20scales%20correctly.

## Before

<img width="335" alt="Screenshot 2021-03-29 at 17 18 20" src="https://user-images.githubusercontent.com/4599889/112867377-c34b4300-90b2-11eb-9e05-0b4aecbb2f90.png">


## After

<img width="382" alt="Screenshot 2021-03-29 at 17 17 09" src="https://user-images.githubusercontent.com/4599889/112867398-ca725100-90b2-11eb-8100-ec0d50939baa.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
