### PR TITLE
Remove NHS Banner hardcoded copy

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_nhs_notice.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_nhs_notice.html.erb
@@ -1,18 +1,3 @@
-<%
-  # hardcoding data that is expected to be in the Content Item
-  nhs_banner = {
-    "sections" => [
-      {
-        "heading" => "If you have no symptoms:",
-        "markdown" => "Check if you should get [regular rapid lateral flow tests](/getting-tested-for-coronavirus).",
-      },
-      {
-        "heading" => "If you have coronavirus symptoms:",
-        "markdown" => "- [get a PCR test](/get-coronavirus-test)\n- stay at home",
-      }
-    ]
-  }
-%>
 <section class="covid__nhs-notice"
          aria-label="notice"
          role="region"


### PR DESCRIPTION
Trello: https://trello.com/c/NSprpQLr/295-update-nhs-box

Once this copy is within the Content Item this hardcoding is no longer
necessary. This must not be deployed until
https://github.com/alphagov/govuk-coronavirus-content/pull/587 has been
merged and published as part of the content item.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
