### PR TITLE
Remove FEATURE_FLAG_ACCOUNTS

### DIFF
--- a/app/controllers/concerns/account_concern.rb
+++ b/app/controllers/concerns/account_concern.rb
@@ -24,8 +24,6 @@ module AccountConcern
   end
 
   def set_account_variant
-    return unless Rails.configuration.feature_flag_govuk_accounts
-
     response.headers["Vary"] = [response.headers["Vary"], ACCOUNT_SESSION_RESPONSE_HEADER_NAME].compact.join(", ")
 
     set_slimmer_headers(

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,12 +45,5 @@ module Collections
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
-
-    # As part of the 2020 user discovery into GOV.UK accounts we want
-    # to deploy a live prototype allowing Brexit/Transition checker
-    # users to persisit their results page.  We'll display a different
-    # header on /transition prompting users to return to their
-    # account.
-    config.feature_flag_govuk_accounts = ENV["FEATURE_FLAG_ACCOUNTS"] == "enabled"
   end
 end

--- a/spec/controllers/transition_landing_page_controller_spec.rb
+++ b/spec/controllers/transition_landing_page_controller_spec.rb
@@ -18,32 +18,26 @@ RSpec.describe TransitionLandingPageController do
       end
     end
 
-    describe "accounts are enabled" do
-      before do
-        allow(Rails.configuration).to receive(:feature_flag_govuk_accounts).and_return(true)
-      end
+    it "disables the search field" do
+      get :show
+      expect(response.headers["X-Slimmer-Remove-Search"]).to eq("true")
+    end
 
-      it "disables the search field" do
+    it "sets the Vary: GOVUK-Account-Session response header" do
+      get :show
+      expect(response.headers["Vary"]).to include("GOVUK-Account-Session")
+    end
+
+    it "requests the signed-out header" do
+      get :show
+      expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-out")
+    end
+
+    context "the GOVUK-Account-Session header is set" do
+      it "requests the signed-in header" do
+        request.headers["GOVUK-Account-Session"] = "foo"
         get :show
-        expect(response.headers["X-Slimmer-Remove-Search"]).to eq("true")
-      end
-
-      it "sets the Vary: GOVUK-Account-Session response header" do
-        get :show
-        expect(response.headers["Vary"]).to include("GOVUK-Account-Session")
-      end
-
-      it "requests the signed-out header" do
-        get :show
-        expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-out")
-      end
-
-      context "the GOVUK-Account-Session header is set" do
-        it "requests the signed-in header" do
-          request.headers["GOVUK-Account-Session"] = "foo"
-          get :show
-          expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-in")
-        end
+        expect(response.headers["X-Slimmer-Show-Accounts"]).to eq("signed-in")
       end
     end
   end


### PR DESCRIPTION
We've removed this from finder-frontend, so we can remove it from
here.
