### PR TITLE
Move translation navigation under the main h1 on the transition and EU business landing pages

### DIFF
--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -23,16 +23,18 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds dit-landing-page_header-text-container">
-          <%= render "govuk_publishing_components/components/translation_nav", {
-            translations: @presenter.translation_links
-          } %>
-
+          
           <div class="govuk-!-margin-top-8">
             <%= render "govuk_publishing_components/components/heading", {
               text: sanitize(t("dit_landing_page.page_header")),
               heading_level: 1,
               font_size: "xl",
               margin_bottom: 6,
+            } %>
+
+            <%= render "govuk_publishing_components/components/translation_nav", {
+              translations: @presenter.translation_links,
+              no_margin_top: true,
             } %>
           </div>
           <div class="dit-landing-page__intro">

--- a/app/views/transition_landing_page/_page_header.html.erb
+++ b/app/views/transition_landing_page/_page_header.html.erb
@@ -26,16 +26,17 @@
     <div class="govuk-width-container">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds landing-page_header-text-container">
-          <%= render "govuk_publishing_components/components/translation_nav", {
-            translations: presented_taxon.translation_links
-          } %>
-
           <div class="govuk-!-margin-top-7">
             <%= render "govuk_publishing_components/components/heading", {
               text: sanitize(t("transition_landing_page.page_header")),
               heading_level: 1,
               font_size: "xl",
               margin_bottom: 4,
+            } %>
+
+            <%= render "govuk_publishing_components/components/translation_nav", {
+              translations: presented_taxon.translation_links,
+              no_margin_top: true,
             } %>
           </div>
 


### PR DESCRIPTION
## What
Moves the translation navigation component below the H1 on the [transition landing page](https://www.gov.uk/transition) and the [EU business page](https://www.gov.uk/eubusiness).

## Why
This ensures that instances of our translation navigation across gov.uk are compliant with [WCAG 3.2.3](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html). Currently, the majority of translation nav components sit broadly below the H1 so this change ensures that gov.uk is consistent and therefore passes 3.2.3.

### Note
The brexit team still need to let No. 10 know this is changing to minimise any surprises causing problems so this is review only until they've given the goahead.

[Card](https://trello.com/c/Qa5BazvX/439-inconsistently-placed-translation-navigation)

## Visual changes

| Before | After |
| --- | --- |
| ![Screenshot 2021-04-13 at 15 46 55](https://user-images.githubusercontent.com/64783893/114575962-98e0b480-9c72-11eb-94cd-3cc2f1207616.png) | ![Screenshot 2021-04-13 at 15 48 01](https://user-images.githubusercontent.com/64783893/114575979-9e3dff00-9c72-11eb-8d62-c137e24e8ed4.png) |
| ![Screenshot 2021-04-13 at 17 34 20](https://user-images.githubusercontent.com/64783893/114588954-20342500-9c7f-11eb-9333-aaa6109f5449.png) | ![Screenshot 2021-04-13 at 17 34 34](https://user-images.githubusercontent.com/64783893/114588857-0b579180-9c7f-11eb-9b6d-d26fb7676870.png) |



