### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
         GovukHealthcheck::RailsCache,
       )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::RailsCache,
+  )
+
   ["/coronavirus-taxon", "/coronavirus-taxon/*slug"].each do |path|
     get path, to: "taxons_redirection#redirect"
   end


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)