### PR TITLE
Add related links section to Coronavirus hub pages

### DIFF
--- a/app/presenters/coronavirus_hub_presenter.rb
+++ b/app/presenters/coronavirus_hub_presenter.rb
@@ -1,5 +1,5 @@
 class CoronavirusHubPresenter
-  COMPONENTS = %w[header_section guidance announcements_label announcements other_announcements guidance_section sections_heading sections topic_section notifications].freeze
+  COMPONENTS = %w[header_section guidance announcements_label announcements other_announcements guidance_section sections_heading sections related_topic_section topic_section notifications].freeze
 
   def initialize(content_item)
     COMPONENTS.each do |component|

--- a/app/views/coronavirus_landing_page/components/shared/_related_topic_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_related_topic_section.html.erb
@@ -1,0 +1,23 @@
+<section class="covid__topic-wrapper">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: related_topic_section["header"],
+    padding: true,
+    border_top: 2,
+    margin_bottom: 6
+  } %>
+
+  <ul class="govuk-list">
+    <% related_topic_section["links"].each do | link | %>
+      <li class="covid__topic-list-item">
+        <%= link_to(
+          link["label"], link["url"], class: 'covid__topic-list-link govuk-link',
+          data: {
+            track_category: "pageElementInteraction",
+            track_action: "RelatedTopics",
+            track_label: link["url"],
+          }
+        ) %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/coronavirus_landing_page/hub.html.erb
+++ b/app/views/coronavirus_landing_page/hub.html.erb
@@ -12,6 +12,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: 'coronavirus_landing_page/components/shared/accordion_sections', locals: { accordions: details.sections, heading: details.sections_heading } %>
+
+      <%= render partial: 'coronavirus_landing_page/components/shared/related_topic_section', locals: { related_topic_section: details.related_topic_section } %>
+
       <%= render partial: 'coronavirus_landing_page/components/shared/topic_section', locals: { topic_section: details.topic_section } %>
 
       <%# Have removed email section here until we work out how to line up the notifications %>

--- a/spec/fixtures/content_store/business_support_page.json
+++ b/spec/fixtures/content_store/business_support_page.json
@@ -51,10 +51,12 @@
       },
       {
         "text": "COVID-19: Call for rapid sanitising technology for ambulances",
-        "href": "/government/news/covid-19-call-for-rapid-sanitising-technology-for-ambulances"},
+        "href": "/government/news/covid-19-call-for-rapid-sanitising-technology-for-ambulances"
+      },
       {
         "text": "Coronavirus support for employees, benefit claimants and businesses",
-        "href": "/government/news/coronavirus-support-for-employees-benefit-claimants-and-businesses"},
+        "href": "/government/news/coronavirus-support-for-employees-benefit-claimants-and-businesses"
+      },
       {
         "text": "If you're self employed, you'll get up to £2,500 a month in grants, for up to 3 months",
         "href": "/government/news/chancellor-gives-support-to-millions-of-self-employed-individuals"
@@ -364,6 +366,19 @@
         {
           "label": "Northern Ireland",
           "url": "https://www.nidirect.gov.uk/campaigns/coronavirus-covid-19"
+        }
+      ]
+    },
+    "related_topic_section": {
+      "header": "Related coronavirus topics",
+      "links": [
+        {
+          "label": "Work and financial support",
+          "url": "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        },
+        {
+          "label": "Education, universities and childcare",
+          "url": "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
         }
       ]
     },

--- a/spec/fixtures/content_store/coronavirus_education_page.json
+++ b/spec/fixtures/content_store/coronavirus_education_page.json
@@ -128,6 +128,19 @@
       "intro": "Stay up to date with GOV.UK",
       "email_link": "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
     },
+    "related_topic_section": {
+      "header": "Related coronavirus topics",
+      "links": [
+        {
+          "label": "Business support during coronavirus",
+          "url": "/search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest"
+        },
+        {
+          "label": "Work and financial support",
+          "url": "/search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response"
+        }
+      ]
+    },
     "topic_section": {
       "text": "Browse information related to coronavirus",
       "links": [


### PR DESCRIPTION
In order to help users navigate between Coronavirus hub pages, we want to add links to all other Coronavirus hub pages on each Coronavirus hub page within a new UI component.

For example: on the `business` hub page we'd add links to the `education` and `worker` hub pages, and on the `education` hub page we'd add links to the `business` and `worker` hub pages.

This change adds a partial to render these links on the hub pages and adds this partial to the hub page view.

[Trello](https://trello.com/c/m5y819Z0/337-build-the-related-links-element-for-hub-pages)


## Before

![screencapture-gov-uk-coronavirus-business-support-2021-04-21-15_30_48](https://user-images.githubusercontent.com/44037625/115571491-f4382580-a2b6-11eb-9ebb-5ada41f9a9b4.png)

## After

![screencapture-collections-dev-gov-uk-coronavirus-business-support-2021-04-21-15_31_28](https://user-images.githubusercontent.com/44037625/115571534-ff8b5100-a2b6-11eb-96e8-3b241705951d.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
