### PR TITLE
Add helper for hiding global bar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,18 @@ module ApplicationHelper
       raw(Govspeak::Document.new(content, sanitize: false).to_html)
     end
   end
+
+  def hide_global_bar?
+    paths_to_hide_global_bar_on = [
+      "^/coronavirus$",
+      "^/coronavirus/.*$",
+      "^/transition(.cy)?$",
+      "^/transition-check/.*$",
+      "^/eubusiness(\\..*)?$"
+    ]
+
+    concatenated_regexes = Regexp.new(paths_to_hide_global_bar_on.join("|"))
+
+    return request.path.match(concatenated_regexes).present?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,10 @@
+<%
+  body_classes = %w[]
+  body_classes << content_for(:body_classes) if content_for(:body_classes)
+  body_classes << "full-width" if content_for(:is_full_width_header)
+  body_classes << "hide-global-bar" if hide_global_bar?
+%>
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -11,7 +18,7 @@
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>
 
-<body <% if content_for(:is_full_width_header) %>class="full-width"<% end %>>
+<%= content_tag(:body, class: body_classes) do %>
   <div class="wrapper" id="wrapper">
     <%= yield :back_link %>
     <% unless (content_for(:is_full_width_header) || content_for(:back_link)) %>
@@ -37,5 +44,5 @@
       <%= render 'govuk_publishing_components/components/feedback' %>
     <% end %>
   </div>
-</body>
+<% end %>
 </html>


### PR DESCRIPTION

## What

Adds a helper that checks whether a page should hide the global bar; the view can then add a class to the body element that will hide the global bar.

These changes won't have any effect until Static has been updated as Static needs to contain the CSS for this to have any impact. Static needs to be updated to flip the behaviour from hide by default to show by default.

## Why

Currently the global bar is initially hidden, then shown using JavaScript - this causes a shift in the layout of the page (aka jank aka Cumulative Layout Shift) and means that the global bar is not available for users without JavaScript. 

([More about Cumulative Layout Shift on web.dev](https://web.dev/cls/).)

### CLS

To avoid this, a change will need to be made in Static to the make the global bar be initially shown by default. The bar can then be hidden on pages that don't need it - and doing this using CSS will avoid jank.

The screenshot below shows the layout shift that occurs when the global bar appears:

![image](https://user-images.githubusercontent.com/1732331/115542310-0fe00380-a298-11eb-9f67-7c32b26e0d19.png)

As the search form is present, it's frustrating for users when they select a link only for the layout shift to move the page and a different link to be selected.

This is also present on larger screens, though the effect is dwarfed by the CLS caused by the appearance of the cookie banner:

![image](https://user-images.githubusercontent.com/1732331/115542903-ac0a0a80-a298-11eb-834d-f165e6e9b031.png)

Worth bearing in mind that for users that have made a cookie choice, the CLS will only be due to the global bar. 

### No JavaScript

And for users without JavaScript turned on, the global bar does not appear at all:

![image](https://user-images.githubusercontent.com/1732331/115543221-073bfd00-a299-11eb-9e0e-3a19daf7b89e.png)

### But why does this change involve collections?

The global bar should not appear on certain pages - such as the Brexit or Coronavirus landing pages. Previously there was some JavaScript to prevent the global bar from appearing. This has been changed to an helper in the application that can be used to add a class to the body if the global should not appear. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
