### PR TITLE
Rewrite Technical Docs to explain alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ If you are using GOV.UK Docker, remember to combine it with the commands that fo
 
 ### Running the test suite
 
-Use `bundle exec rake` to run the test suite, excluding JavaScript.
+```
+bundle exec rake
+```
 
 To test a single file:
 
@@ -44,9 +46,11 @@ To test a single file:
 bundle exec rails test test/unit/application_helper_test.rb
 ```
 
-#### Javascript tests
+To run JavaScript tests (only):
 
-Use `bundle exec rake jasmine:ci` to run Jasmine tests
+```
+bundle exec rake jasmine:ci
+```
 
 ### Pact tests
 

--- a/README.md
+++ b/README.md
@@ -28,51 +28,21 @@ At time of writing, it also serves the priority campaign pages. See the [Campaig
 
 ## Technical documentation
 
-This is a public facing Ruby on Rails application that retrieves browse content from APIs and presents it.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-### Running the application
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) or the local `startup.sh` script to run the app. Read the [guidance on local frontend development](https://docs.publishing.service.gov.uk/manual/local-frontend-development.html) to find out more about each approach, before you get started.
 
-- #### With startup scripts
-
-```
-./startup.sh
-```
-
-The app should start on http://localhost:3070
-
-```
-./startup.sh --live
-```
-
-This will run the app and point it at the production GOV.UK `content-store` and `static` instances.
-
-```
-./startup.sh --dummy
-```
-
-This will run the app and point it at the [dummy content store](https://govuk-content-store-examples.herokuapp.com/), which serves the content schema examples and random content.
-
-- #### With govuk-docker
-
-Once you have installed [govuk-docker](https://github.com/alphagov/govuk-docker#installation), do the following
-```
-> cd govuk/govuk-docker
-> git pull origin master
-> make collections
-
-> cd govuk/collections
-> govuk-docker-up
-```
-
-Collections will be running locally at collections.dev.gov.uk.
+If you are using GOV.UK Docker, remember to combine it with the commands that follow. See the [GOV.UK Docker usage instructions](https://github.com/alphagov/govuk-docker#usage) for examples.
 
 ### Running the test suite
 
-Use `bundle exec rake` to run the test suite, excluding JavaScript. Or if you are running in docker, `govuk-docker-run bundle exec rake`
+Use `bundle exec rake` to run the test suite, excluding JavaScript.
 
 To test a single file:
 
-`govuk-docker-run bundle exec rails test test/unit/application_helper_test.rb`
+```
+bundle exec rails test test/unit/application_helper_test.rb
+```
 
 #### Javascript tests
 

--- a/startup.sh
+++ b/startup.sh
@@ -2,36 +2,16 @@
 
 bundle check || bundle install
 
-if [[ $1 == "--integration" ]] ; then
-  GOVUK_APP_DOMAIN=www.integration.publishing.service.gov.uk \
-  GOVUK_WEBSITE_ROOT=https://www.integration.publishing.service.gov.uk \
-  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.integration.publishing.service.gov.uk/api} \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.integration.publishing.service.gov.uk} \
-  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.integration.publishing.service.gov.uk/api} \
-  bundle exec rails s -p 3070
-
-elif [[ $1 == "--staging" ]] ; then
-  GOVUK_APP_DOMAIN=www.staging.publishing.service.gov.uk \
-  GOVUK_WEBSITE_ROOT=https://www.staging.publishing.service.gov.uk \
-  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.staging.publishing.service.gov.uk/api} \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.staging.publishing.service.gov.uk} \
-  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.staging.publishing.service.gov.uk/api} \
-  bundle exec rails s -p 3070
-
-elif [[ $1 == "--live" ]] ; then
+if [[ $1 == "--live" ]] ; then
   GOVUK_APP_DOMAIN=www.gov.uk \
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3070
-elif [[ $1 == "--dummy" ]] ; then
-  GOVUK_APP_DOMAIN=www.gov.uk \
-  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://govuk-content-store-examples.herokuapp.com/api} \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
-  bundle exec rails s -p 3070
 else
-  bundle exec rails s -p 3070
+  echo "ERROR: other startup modes are not supported"
+  echo ""
+  echo "https://docs.publishing.service.gov.uk/manual/local-frontend-development.html"
+  exit 1
 fi


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This continues the changes in https://github.com/alphagov/collections/pull/2362, but focuses on the technical 
documentation, which will specifically affect frontend devs. 

Please see the commit messages for more details.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
