### PR TITLE
Remove an announcement from transition landing page

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -35,15 +35,6 @@ en:
           public_updated_at: 2020-03-11
           document_type: Press release
       - link:
-          text: Agreements reached between the United Kingdom of Great Britain and
-            Northern Ireland and the European Union
-          path: "/government/publications/agreements-reached-between-the-united-kingdom-of-great-britain-and-northern-ireland-and-the-european-union"
-          description: This document summarises the Agreements between the United
-            Kingdom and the European Union.
-        metadata:
-          public_updated_at: 2020-12-24
-          document_type: International treaty
-      - link:
           text: Government publishes updated GB-EU Border Operating Model
           path: "/government/news/government-publishes-updated-gb-eu-border-operating-model"
           description: The government has published further detail on how the borders


### PR DESCRIPTION
## What

Remove an announcement from the Transition landing page.

[Trello](https://trello.com/c/XOLTuDxb/1502-remove-second-announcement-from-the-brexit-landing-page)

[Review app](https://govuk-collec-remove-ann-katcqt.herokuapp.com/transition)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
