### PR TITLE
Ensure what_we_do translation is always grammatically correct

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -315,4 +315,4 @@ en:
       tribunal: Tribunal
     view_all: view all
     view_less: view less
-    what_we_do: What %{title} does
+    what_we_do: What we do


### PR DESCRIPTION
The Organisation page heading for what_we_do can be grammatically incorrect if the organisation is already pluralised e.g
`What The Business and Property Courts does`

This changes makes the heading more generic to ensure it is always correct.

# before
![Screenshot 2021-05-11 at 13 31 38](https://user-images.githubusercontent.com/13475227/117815354-48eb1280-b25d-11eb-9d9c-19f5bdfbd80d.png)

# after
![Screenshot 2021-05-11 at 13 31 31](https://user-images.githubusercontent.com/13475227/117815394-56080180-b25d-11eb-9f6a-1648c424f2b4.png)

[trello](https://trello.com/c/oivPgdFr/2499-2-no-deadline-amend-what-xxxx-does-heading-on-organisation-page-template)