### PR TITLE
Revert "Ensure what_we_do translation is always grammatically correct"

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -321,4 +321,4 @@ en:
       tribunal: Tribunal
     view_all: view all
     view_less: view less
-    what_we_do: What we do
+    what_we_do: What %{title} does


### PR DESCRIPTION
Reverts alphagov/collections#2385

Content would like to consider this change further

