### PR TITLE
Remove /transition routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
 
   get "/coronavirus", to: "coronavirus_landing_page#show", as: :coronavirus_landing_page
   get "/coronavirus/:hub_slug", to: "coronavirus_landing_page#hub"
+
+  # Brexit
+  get "/brexit(.:locale)", to: "transition_landing_page#show"
   get "/eubusiness(.:locale)", to: "dit_landing_page#show"
+
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: %i[index show], param: :top_level_slug do
@@ -79,8 +83,6 @@ Rails.application.routes.draw do
   end
 
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
-  get "/brexit(.:locale)", to: "transition_landing_page#show"
-  get "/transition(.:locale)", to: "transition_landing_page#show"
 
   # We get requests for URLs like
   # https://www.gov.uk/topic%2Flegal-aid-for-providers%2Fmake-application%2Flatest


### PR DESCRIPTION
The taxon was renamed last week, so we no longer need this.

I've also moved the routes up, as this takes them above the call to DocumentTypeRoutingConstraint in step by step routes. That constraint makes a content store request to work out whether the route refers to a step by step page or not. It's best to leave this out of the equation as much as possible.

https://trello.com/c/i4bVIMS0/1515-analytics-considerations-for-new-landing-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
