### PR TITLE
Switch section to div on people roles

### DIFF
--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,7 +1,7 @@
 <% if person.currently_in_a_role? %>
   <section id="current-roles" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %> <%= lang_attribute %>>
     <% person.current_roles.each do |role| %>
-      <section class="role_appointment role govuk-!-padding-bottom-8">
+      <div class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {
           text: role["title"],
           margin_bottom: 2,
@@ -26,7 +26,7 @@
             .to_sentence
             .html_safe %>
         </p>
-      </section>
+      </div>
     <% end %>
   </section>
 <% end %>


### PR DESCRIPTION
## What
This updates a section tag to be a div tag on pages such as https://www.gov.uk/government/people/rishi-sunak

## Why
Nesting section tags is generally controversial (although it doesn't seem to be invalid HTML). After the GOV.UK accessibility audit this was highlighted as potentially confusing to assistive tech. Switching out the inner tag makes no visual difference as styles are based on the classname which is preserved.

https://trello.com/c/03oBprsG/568-people-page-has-a-section-within-a-section


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
