### PR TITLE
Replace section with div

### DIFF
--- a/app/views/people/_biography.html.erb
+++ b/app/views/people/_biography.html.erb
@@ -1,5 +1,5 @@
 <% if person.biography %>
-<section id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+<div id="biography" class="govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("people.biography"),
     margin_bottom: 2,
@@ -9,5 +9,5 @@
   } do %>
     <%= person.biography.html_safe %>
   <% end %>
-</section>
+</div>
 <% end %>

--- a/app/views/people/_current_roles.html.erb
+++ b/app/views/people/_current_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.currently_in_a_role? %>
-  <section id="current-roles" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %> <%= lang_attribute %>>
+  <div id="current-roles" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %> <%= lang_attribute %>>
     <% person.current_roles.each do |role| %>
       <div class="role_appointment role govuk-!-padding-bottom-8">
         <%= render "govuk_publishing_components/components/heading", {
@@ -28,5 +28,5 @@
         </p>
       </div>
     <% end %>
-  </section>
+  </div>
 <% end %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,5 +1,5 @@
 <% if person.has_previous_roles? %>
-  <section class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+  <div class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
       text: t("people.previous_roles_in_government"),
       lang: t_fallback("people.previous_roles_in_government"),
@@ -10,5 +10,5 @@
     <%= render "govuk_publishing_components/components/document_list", {
       items: person.previous_roles_items
     } %>
-  </section>
+  </div>
 <% end %>

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% if announcements.items.present? %>
-  <section id="announcements" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %>>
+  <div id="announcements" <%= direction_rtl_class(prefix: true) %> <%= dir_attribute %>>
     <%= render "govuk_publishing_components/components/heading", {
         text: t("organisations.content_item.schema_name.announcement.other"),
         lang: t_fallback("organisations.content_item.schema_name.announcement.other"),
@@ -19,5 +19,5 @@
     <div class="read-more">
       <%= link_to "View all announcements", announcements.links[:link_to_news_and_communications], class: "govuk-link", lang: "en" %>
     </div>
-  </section>
+  </div>
 <% end %>


### PR DESCRIPTION
This replaces a section tags with div tags. There is no visual impact from this but nested sections are controversial and after our accessibility audit we were advised to avoid them to promote a better assistive tech experience. 

Sample page: https://www.gov.uk/government/people/rishi-sunak

https://trello.com/c/03oBprsG/568-people-page-has-a-section-within-a-section

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
