### PR TITLE
Redirect taxons to their override url if present

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -4,6 +4,8 @@ class TaxonsController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
+    redirect_to(url_override, status: :temporary_redirect) and return if url_override
+
     render locals: {
       presented_taxon: presented_taxon,
       presentable_section_items: presentable_section_items,
@@ -35,5 +37,9 @@ private
     end
 
     @presentable_section_items
+  end
+
+  def url_override
+    @content_item.dig("details", "url_override")
   end
 end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -4,7 +4,7 @@ class TaxonsController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(taxon)
 
-    redirect_to(url_override, status: :temporary_redirect) and return if url_override
+    redirect_to(url_override, status: :temporary_redirect) and return if url_override.present?
 
     render locals: {
       presented_taxon: presented_taxon,

--- a/spec/controllers/taxons_controller_spec.rb
+++ b/spec/controllers/taxons_controller_spec.rb
@@ -44,4 +44,18 @@ RSpec.describe TaxonsController do
       expect(response).to have_http_status(:not_found)
     end
   end
+
+  context "when the taxon has a url_override field" do
+    before do
+      stub_content_store_has_item(
+        taxon["base_path"],
+        taxon.merge("details" => { "url_override" => "/guidance/foo" }),
+      )
+    end
+
+    it "redirects to the url_override" do
+      get :show, params: { taxon_base_path: taxon["base_path"][1..-1] }
+      expect(response).to have_http_status(:temporary_redirect)
+    end
+  end
 end

--- a/spec/support/taxon_browsing_helper.rb
+++ b/spec/support/taxon_browsing_helper.rb
@@ -349,12 +349,6 @@ module TaxonBrowsingHelper
     generate_search_results(5)
   end
 
-  def taxon
-    GovukSchemas::Example.find("taxon", example_name: "taxon").tap do |content_item|
-      content_item["phase"] = "live"
-    end
-  end
-
   def tagged_organisations
     [
       tagged_organisation,

--- a/spec/support/taxon_browsing_helper.rb
+++ b/spec/support/taxon_browsing_helper.rb
@@ -341,6 +341,7 @@ module TaxonBrowsingHelper
         "title" => "Taxon title",
         "phase" => "live",
         "links" => {},
+        "details" => {},
       )
     end
   end


### PR DESCRIPTION
## What

We have added an optional field to the details hash of the taxon [content schema](https://github.com/alphagov/govuk-content-schemas/pull/1059). If that field has been populated (in [content tagger](https://github.com/alphagov/content-tagger/pull/1204)) , then Collections should redirect to it.


[trello](https://trello.com/c/V2nmHHA6/1516-make-it-possible-to-add-an-overrideurl-to-taxons-in-content-tagger) 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
