### PR TITLE
Add route for the Brexit taxon's new base path.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
   end
 
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
+  get "/brexit(.:locale)", to: "transition_landing_page#show"
   get "/transition(.:locale)", to: "transition_landing_page#show"
 
   # We get requests for URLs like

--- a/docs/campaign-pages.md
+++ b/docs/campaign-pages.md
@@ -2,7 +2,7 @@
 
 Collections currently renders the following campaign pages:
 
-## Transition landing page ([/transition](https://www.gov.uk/transition))
+## Brexit landing page ([/brexit](https://www.gov.uk/brexit))
 
 All content for the transition landing pages are currently read from yaml files. [Welsh](config/locales/cy/transition_landing_page.yml) and [English](config/locales/en/transition_landing_page.yml) translations are available.
 

--- a/spec/controllers/transition_landing_page_controller_spec.rb
+++ b/spec/controllers/transition_landing_page_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TransitionLandingPageController do
   describe "GET show" do
     before do
       brexit_taxon = taxon
-      brexit_taxon["base_path"] = "/transition"
+      brexit_taxon["base_path"] = "/brexit"
       stub_content_store_has_item(brexit_taxon["base_path"], brexit_taxon)
       stub_content_store_has_item(brexit_taxon["base_path"] + ".cy", brexit_taxon)
     end

--- a/spec/support/transition_landing_page_steps.rb
+++ b/spec/support/transition_landing_page_steps.rb
@@ -6,7 +6,7 @@ module TransitionLandingPageSteps
   include SearchApiHelpers
 
   TRANSITION_TAXON_CONTENT_ID = "d6c2de5d-ef90-45d1-82d4-5f2438369eea".freeze
-  TRANSITION_TAXON_PATH = "/transition".freeze
+  TRANSITION_TAXON_PATH = "/brexit".freeze
 
   def given_there_is_a_transition_taxon
     stub_content_store_has_item(TRANSITION_TAXON_PATH, content_item)
@@ -85,7 +85,7 @@ module TransitionLandingPageSteps
   def and_there_is_metadata
     expect(page).to have_selector("meta[property='og:title'][content='#{I18n.t('transition_landing_page.meta_title')}']", visible: false)
     expect(page).to have_selector("meta[name='description'][content='#{I18n.t('transition_landing_page.meta_description')}']", visible: false)
-    expect(page).to have_selector("link[rel='canonical'][href='http://www.example.com/transition']", visible: false)
+    expect(page).to have_selector("link[rel='canonical'][href='http://www.example.com/brexit']", visible: false)
   end
 
   def content_item


### PR DESCRIPTION
## What

We are planning to change the url of the transition landing page from `/transition` to `/brexit`. 

Once merged, a user visiting `/transition` will see a basic taxon page. 

The taxon can then be given a new base path of `/brexit` in content tagger. This will create a redirect from /transition to /brexit, so users visiting either path will see a correctly styled page. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
https://trello.com/c/wxR5o06H/1539-implement-brexit-landing-page-url-change