### PR TITLE
Allow scroll tracking

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/analytics/explicit-cross-domain-links
+//= require govuk_publishing_components/analytics/scroll-tracker
 
 //= require support
 //= require browse-columns


### PR DESCRIPTION
Scroll tracking needs to be added here so that [the configuration](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/analytics/scroll-tracker.js) that has been set will work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
