### PR TITLE
Fix past role holders header hierarchy

### DIFF
--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -13,11 +13,12 @@
       text: t("roles.previous_holders"),
     } %>
     <%= render "components/taxon-list", {
+      heading_level: 3,
       items: role.past_holders.map do |rh|
         {
           text: rh['title'],
           path: rh['base_path'],
-          description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}"
+          description: "#{rh['details']['start_year']} to #{rh['details']['end_year']}",
         }
       end
     } %>


### PR DESCRIPTION
## What

Changes the header level for the past role holders taxon list from `h2` to `h3`.

## Why

The past role holders use of the taxon list created a header hierarchy that didn't make sense - the h2 heading "Previous role holders" was followed by a list of h2s. Changing this to `h3` nests it underneath the h2 heading, which means that the page hierarchy makes more sense.

## Differences

No visual differences, as the styling is independent of the element used.

Before:

<img width="1775" alt="Screenshot 2021-06-07 at 13 19 33" src="https://user-images.githubusercontent.com/1732331/121015557-0ac90c00-c793-11eb-90d8-8d72426659b8.png">

After:

<img width="1782" alt="Screenshot 2021-06-07 at 13 18 24" src="https://user-images.githubusercontent.com/1732331/121015430-e705c600-c792-11eb-9714-bc3866b44d23.png">

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
