### PR TITLE
Add feature flag for new link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 $covid-grey: #272828;
 $covid-yellow: #fff500;
+$govuk-new-link-styles: true;
 
 // gem components
 @import 'govuk_publishing_components/govuk_frontend_support';

--- a/app/assets/stylesheets/components/_topic-list.scss
+++ b/app/assets/stylesheets/components/_topic-list.scss
@@ -4,18 +4,6 @@
   margin-bottom: govuk-spacing(2);
 }
 
-.app-c-topic-list__link--no-underline {
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:hover:focus {
-    text-decoration: none;
-  }
-}
-
 .app-c-topic-list--small {
   .app-c-topic-list__item {
     margin-bottom: govuk-spacing(1);

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -31,6 +31,20 @@
           width: 35%;
           margin-right: 40%;
         }
+
+        a {
+          text-decoration: none;
+
+          h3 {
+            @include govuk-link-decoration;
+          }
+
+          &:hover {
+            h3 {
+              @include govuk-link-hover-decoration;
+            }
+          }
+        }
       }
     }
 
@@ -116,18 +130,16 @@
       ul li {
         list-style: none;
         position: relative;
-        margin-top: 4px;
       }
 
       ul a {
         position: relative;
         display: block;
         @include govuk-font(19);
-        text-decoration: none;
-        padding: 12px 25px 8px 0;
+        padding: govuk-spacing(3) govuk-spacing(5) govuk-spacing(4) 0;
 
         @include govuk-media-query($from: tablet) {
-          padding: 12px govuk-spacing(6) 8px govuk-spacing(3);
+          padding: govuk-spacing(3) govuk-spacing(6) govuk-spacing(4) govuk-spacing(3);
           @include govuk-font(16);
         }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -234,15 +234,6 @@ $c19-landing-page-header-background: govuk-colour('blue');
 
 .covid__topic-list-link {
   @include govuk-font(19, $weight: bold);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-
-    &:focus {
-      text-decoration: none;
-    }
-  }
 }
 
 .covid__page-guidance {

--- a/app/views/components/_topic-list.html.erb
+++ b/app/views/components/_topic-list.html.erb
@@ -19,7 +19,7 @@
             item[:path],
             data: item[:data_attributes],
             "aria-label": item[:aria_label],
-            class: "govuk-link app-c-topic-list__link app-c-topic-list__link--no-underline #{brand_helper.color_class}"
+            class: "govuk-link govuk-link--no-underline app-c-topic-list__link #{brand_helper.color_class}"
           )
         %>
       </li>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -42,7 +42,7 @@
         <%= link_to(
           link["label"].html_safe,
           link["url"],
-          class: 'covid__topic-list-link govuk-link',
+          class: 'covid__topic-list-link govuk-link govuk-link--no-underline',
           data: {
             module: "gem-track-click",
             track_category: "pageElementInteraction",

--- a/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_announcements.html.erb
@@ -4,7 +4,7 @@
       <% if announcement["href"].present? %>
         <a
           href="<%= announcement["href"] %>"
-          class="govuk-link covid__topic-list-link"
+          class="govuk-link govuk-link--no-underline covid__topic-list-link"
           data-module="gem-track-click"
           data-track-category="pageElementInteraction"
           data-track-action="Announcements"

--- a/app/views/coronavirus_landing_page/components/shared/_related_topic_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_related_topic_section.html.erb
@@ -10,7 +10,7 @@
     <% related_topic_section["links"].each do | link | %>
       <li class="covid__topic-list-item">
         <%= link_to(
-          link["label"], link["url"], class: 'covid__topic-list-link govuk-link',
+          link["label"], link["url"], class: 'covid__topic-list-link govuk-link govuk-link--no-underline',
           data: {
             track_category: "pageElementInteraction",
             track_action: "RelatedTopics",

--- a/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_topic_section.html.erb
@@ -29,7 +29,7 @@
         <%= link_to( 
           link["label"].html_safe,
           link["url"],
-          class: 'covid__topic-list-link govuk-link',
+          class: 'covid__topic-list-link govuk-link govuk-link--no-underline',
           data: data,
         ) %>
       </li>


### PR DESCRIPTION
## What
Applies the feature flag for the new link styles from the latest release of GOV.UK Frontend and fixes a couple of links to ensure they are utilising these new link styles.

## Why
So that this feature can start adding value to users.

[Card](https://trello.com/c/4w8As94W/753-update-collections-app-to-use-new-link-styles)

## Visual changes
The following table additionally includes the pages that I tested against for review purposes.

| Page | Before | After |
| --- | --- | --- |
| https://www.gov.uk/coronavirus | ![Screenshot 2021-06-08 at 16 49 18](https://user-images.githubusercontent.com/64783893/121345190-77bbdd80-c91c-11eb-8f1c-ac7c2c1e70a1.png) ![Screenshot 2021-06-08 at 16 49 29](https://user-images.githubusercontent.com/64783893/121345227-80141880-c91c-11eb-923c-5a2859bdc66a.png) ![Screenshot 2021-06-08 at 16 49 37](https://user-images.githubusercontent.com/64783893/121345230-830f0900-c91c-11eb-977f-60367726bdc1.png) ![Screenshot 2021-06-08 at 16 49 51](https://user-images.githubusercontent.com/64783893/121345240-85716300-c91c-11eb-962e-32121c8d94c7.png) ![Screenshot 2021-06-08 at 16 49 59](https://user-images.githubusercontent.com/64783893/121345255-886c5380-c91c-11eb-8126-560e17414007.png) | ![Screenshot 2021-06-08 at 16 50 10](https://user-images.githubusercontent.com/64783893/121345437-c1a4c380-c91c-11eb-9cfe-a8b82c5934d7.png) ![Screenshot 2021-06-08 at 16 50 23](https://user-images.githubusercontent.com/64783893/121345444-c36e8700-c91c-11eb-84ca-abfe697cad94.png) ![Screenshot 2021-06-08 at 16 50 30](https://user-images.githubusercontent.com/64783893/121345448-c4071d80-c91c-11eb-86cf-cab5d355ffc8.png) ![Screenshot 2021-06-08 at 16 50 39](https://user-images.githubusercontent.com/64783893/121345449-c49fb400-c91c-11eb-9f82-2af696fc6f5c.png) ![Screenshot 2021-06-08 at 16 50 45](https://user-images.githubusercontent.com/64783893/121345452-c5384a80-c91c-11eb-8c40-59610fc96552.png) |
| https://www.gov.uk/eubusiness | ![Screenshot 2021-06-08 at 16 50 56](https://user-images.githubusercontent.com/64783893/121345592-f749ac80-c91c-11eb-9746-2cc53af2a3f8.png) ![Screenshot 2021-06-08 at 16 51 03](https://user-images.githubusercontent.com/64783893/121345596-f7e24300-c91c-11eb-8e49-6301897ab369.png) | ![Screenshot 2021-06-08 at 16 51 14](https://user-images.githubusercontent.com/64783893/121345674-0df00380-c91d-11eb-85aa-37ee05876fce.png) ![Screenshot 2021-06-08 at 16 51 25](https://user-images.githubusercontent.com/64783893/121345677-0e889a00-c91d-11eb-8f92-a386a414d8dc.png) |
| https://www.gov.uk/topic/business-tax/stamp-taxes/latest | ![Screenshot 2021-06-08 at 16 51 45](https://user-images.githubusercontent.com/64783893/121345830-3e37a200-c91d-11eb-999a-7bc19fb33ed4.png) | ![Screenshot 2021-06-08 at 16 51 54](https://user-images.githubusercontent.com/64783893/121345849-44c61980-c91d-11eb-87b8-f07d16701701.png) |
| https://www.gov.uk/government/organisations | ![Screenshot 2021-06-08 at 16 52 15](https://user-images.githubusercontent.com/64783893/121346211-bc944400-c91d-11eb-804d-165b75a0e4e0.png) | ![Screenshot 2021-06-08 at 16 52 41](https://user-images.githubusercontent.com/64783893/121346226-c322bb80-c91d-11eb-9f92-49d3e90289b9.png) |
| https://www.gov.uk/government/organisations/cabinet-office | ![Screenshot 2021-06-08 at 16 52 57](https://user-images.githubusercontent.com/64783893/121346300-dcc40300-c91d-11eb-9ca6-169b9527f148.png) ![Screenshot 2021-06-08 at 16 53 21](https://user-images.githubusercontent.com/64783893/121346308-de8dc680-c91d-11eb-9c6f-973b9141656f.png) ![Screenshot 2021-06-08 at 16 53 29](https://user-images.githubusercontent.com/64783893/121346312-dfbef380-c91d-11eb-9da9-fa1e6786f2e5.png) ![Screenshot 2021-06-08 at 16 53 39](https://user-images.githubusercontent.com/64783893/121346314-e0578a00-c91d-11eb-83dc-1618de230ba0.png) ![Screenshot 2021-06-08 at 16 53 46](https://user-images.githubusercontent.com/64783893/121346316-e0f02080-c91d-11eb-8458-a61d1ad07d09.png) ![Screenshot 2021-06-08 at 16 53 02](https://user-images.githubusercontent.com/64783893/121346302-dd5c9980-c91d-11eb-8c20-694b11b130de.png) ![Screenshot 2021-06-08 at 16 53 11](https://user-images.githubusercontent.com/64783893/121346305-ddf53000-c91d-11eb-9d42-222a62e76fb4.png) | ![Screenshot 2021-06-08 at 16 53 54](https://user-images.githubusercontent.com/64783893/121346657-4d6b1f80-c91e-11eb-91c3-8ca5f193921d.png) ![Screenshot 2021-06-08 at 16 54 19](https://user-images.githubusercontent.com/64783893/121346671-4fcd7980-c91e-11eb-867d-97f4d50ce4b3.png) ![Screenshot 2021-06-08 at 16 54 28](https://user-images.githubusercontent.com/64783893/121346679-50fea680-c91e-11eb-99dd-0979779ddcb7.png) ![Screenshot 2021-06-08 at 16 54 38](https://user-images.githubusercontent.com/64783893/121346683-51973d00-c91e-11eb-969b-f3cd8fe16bff.png) ![Screenshot 2021-06-08 at 16 54 47](https://user-images.githubusercontent.com/64783893/121346684-51973d00-c91e-11eb-9133-5e2f35f12d4c.png) ![Screenshot 2021-06-08 at 16 53 59](https://user-images.githubusercontent.com/64783893/121346663-4e03b600-c91e-11eb-8679-9b7a9c51db20.png) ![Screenshot 2021-06-08 at 16 54 10](https://user-images.githubusercontent.com/64783893/121346668-4e9c4c80-c91e-11eb-8a5c-25faad1cb35f.png) |
| https://www.gov.uk/government/people/eric-pickles | ![Screenshot 2021-06-08 at 16 55 03](https://user-images.githubusercontent.com/64783893/121346920-9327e800-c91e-11eb-81e5-eb18ee287d8b.png) | ![Screenshot 2021-06-08 at 16 55 16](https://user-images.githubusercontent.com/64783893/121346957-9ae78c80-c91e-11eb-8032-7d66237fc669.png) |
| https://www.gov.uk/government/ministers/minister-of-state | ![Screenshot 2021-06-08 at 16 55 31](https://user-images.githubusercontent.com/64783893/121347092-b3f03d80-c91e-11eb-8d25-a7079a7bb919.png) | ![Screenshot 2021-06-08 at 16 55 40](https://user-images.githubusercontent.com/64783893/121347125-b9e61e80-c91e-11eb-8dde-57866b7f1e3f.png) |
| https://www.gov.uk/browse/education/school-life | ![Screenshot 2021-06-08 at 16 55 56](https://user-images.githubusercontent.com/64783893/121347189-cec2b200-c91e-11eb-8c61-095c9290d130.png) | ![Screenshot 2021-06-08 at 16 56 04](https://user-images.githubusercontent.com/64783893/121347215-d5512980-c91e-11eb-999e-e64e4a28bb3f.png) |
| https://www.gov.uk/government/organisations/hm-revenue-customs/services-information | ![Screenshot 2021-06-08 at 16 56 15](https://user-images.githubusercontent.com/64783893/121347269-e6019f80-c91e-11eb-9b33-3cb3ba57c05c.png) | ![Screenshot 2021-06-08 at 16 56 22](https://user-images.githubusercontent.com/64783893/121347291-ec901700-c91e-11eb-83a9-6a5389895f83.png) |
| https://www.gov.uk/tell-dvla-changed-address | ![Screenshot 2021-06-08 at 16 56 36](https://user-images.githubusercontent.com/64783893/121347389-09c4e580-c91f-11eb-94cb-6079478e25e9.png) | ![Screenshot 2021-06-08 at 16 56 48](https://user-images.githubusercontent.com/64783893/121347405-10ebf380-c91f-11eb-9253-c1d797ec19c6.png) |
| https://www.gov.uk/topic/keeping-farmed-animals/bovine-tb | ![Screenshot 2021-06-08 at 16 57 03](https://user-images.githubusercontent.com/64783893/121347455-206b3c80-c91f-11eb-96ad-ae5ae2e66d8d.png) | ![Screenshot 2021-06-08 at 16 57 15](https://user-images.githubusercontent.com/64783893/121347547-3b3db100-c91f-11eb-89c0-17022a603c17.png) |
| https://www.gov.uk/government/emergency-preparation-reponse-and-recovery | ![Screenshot 2021-06-08 at 16 57 31](https://user-images.githubusercontent.com/64783893/121347599-498bcd00-c91f-11eb-9322-d2a340affdf9.png) ![Screenshot 2021-06-08 at 16 57 42](https://user-images.githubusercontent.com/64783893/121347777-7b049880-c91f-11eb-93ad-38c9eba0cc89.png) | [Screenshot 2021-06-08 at 16 57 59](https://user-images.githubusercontent.com/64783893/121347823-86f05a80-c91f-11eb-969b-f9fa2b268810.png) ![Screenshot 2021-06-08 at 16 58 10](https://user-images.githubusercontent.com/64783893/121347828-88218780-c91f-11eb-83a4-a9a4d6db62ca.png) |
| https://www.gov.uk/topic/environmental-management | ![Screenshot 2021-06-08 at 16 58 22](https://user-images.githubusercontent.com/64783893/121347895-9cfe1b00-c91f-11eb-9576-34829df2ae56.png) | ![Screenshot 2021-06-08 at 16 58 31](https://user-images.githubusercontent.com/64783893/121347902-9e2f4800-c91f-11eb-8973-d88b48538b54.png) |
| https://www.gov.uk/brexit | ![Screenshot 2021-06-08 at 16 59 02](https://user-images.githubusercontent.com/64783893/121347966-b1421800-c91f-11eb-946c-e9f4a311c25a.png) ![Screenshot 2021-06-08 at 16 59 13](https://user-images.githubusercontent.com/64783893/121347969-b2734500-c91f-11eb-9935-e6ef525b1c45.png) | ![Screenshot 2021-06-08 at 16 59 21](https://user-images.githubusercontent.com/64783893/121347971-b2734500-c91f-11eb-8302-0cab42a21967.png) ![Screenshot 2021-06-08 at 16 59 27](https://user-images.githubusercontent.com/64783893/121347972-b2734500-c91f-11eb-87b3-40c61c03f095.png) |
| https://www.gov.uk/world/brazil | ![Screenshot 2021-06-08 at 16 59 44](https://user-images.githubusercontent.com/64783893/121348059-c9b23280-c91f-11eb-82dc-e5e4295d79a6.png) | ![Screenshot 2021-06-08 at 16 59 58](https://user-images.githubusercontent.com/64783893/121348065-cb7bf600-c91f-11eb-80ee-8f81fed3632f.png) |