### PR TITLE
Add new Brexit deal explainer to the Brexit landing page

### DIFF
--- a/config/locales/cy/transition_landing_page.yml
+++ b/config/locales/cy/transition_landing_page.yml
@@ -20,6 +20,13 @@ cy:
     comms:
       links:
       - link:
+          text: "Summary: The UK’s new relationship with the EU"
+          path: "/government/publications/summary-the-uks-new-relationship-with-the-eu"
+          description: This explainer gives an overview of what has changed, and what remains the same. For businesses and citizens across the UK, there are actions you may need to take.
+        metadata:
+          public_updated_at: 2021-06-08
+          document_type: Policy paper
+      - link:
           text: Agreements reached between the United Kingdom of Great Britain and Northern Ireland and the European Union
           path: "/government/publications/agreements-reached-between-the-united-kingdom-of-great-britain-and-northern-ireland-and-the-european-union"
           description: This document summarises the Agreements between the United Kingdom and the European Union.

--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -22,6 +22,13 @@ en:
     comms:
       links:
       - link:
+          text: "Summary: The UK’s new relationship with the EU"
+          path: "/government/publications/summary-the-uks-new-relationship-with-the-eu"
+          description: This explainer gives an overview of what has changed, and what remains the same. For businesses and citizens across the UK, there are actions you may need to take.
+        metadata:
+          public_updated_at: 2021-06-08
+          document_type: Policy paper
+      - link:
           text: Government focuses on recovery from COVID with new timeline for border control processes on import of goods
           path: "/government/news/government-focuses-on-recovery-from-covid-with-new-timeline-for-border-control-processes-on-import-of-goods"
           description: A new timetable for introducing import border control processes has been set out by the government to enable UK businesses to focus on their recovery.


### PR DESCRIPTION
## What

A new deal explainer has been published - adding it to the announcements section of the Brexit landing page.

<img width="1344" alt="Screenshot 2021-06-09 at 11 21 11" src="https://user-images.githubusercontent.com/17908089/121338168-2825e380-c915-11eb-9675-62bcaf3095a0.png">

- #### Trello
https://trello.com/c/GCuQkbXC/1573-add-link-to-new-deal-explainer-to-the-live-version-of-the-landing-page

- #### Review app
https://govuk-collec-update-ann-y0y6vp.herokuapp.com/brexit

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
