### PR TITLE
Update Brexit meta description

### DIFF
--- a/config/locales/en/transition_landing_page.yml
+++ b/config/locales/en/transition_landing_page.yml
@@ -54,7 +54,7 @@ en:
     data_list_title: 'Brexit landing page: %{header}'
     email_mailto_subject: UK's%20new%20start:%20let's%20get%20going-%20GOV.UK
     guidance_header: Changes for businesses and citizens
-    meta_description: The Brexit transition period has ended. Check how the new rules affect you.
+    meta_description: Find out how new Brexit rules apply to things like travel and doing business with Europe. Use the Brexit checker to get a personalised list of actions.
     meta_title: Brexit
     no_cookies:
       change_settings_text: Change your cookie settings


### PR DESCRIPTION
This is still configured by the translation files partly because there's no UI for updating the Welsh page in content tagger.

Matches: https://docs.google.com/document/d/1ZIVFiua6o7fbex80QHzGWtyCs3MKBm4LixVFKAAVRvk/edit

https://trello.com/c/EE9N3eYN/1545-improve-the-meta-descriptions-of-the-landing-page-and-hub-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
