### PR TITLE
Fix underline issue for 1st level links on 2nd liven browse pages

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -82,6 +82,20 @@
           margin-left: -13%;
           width: 25%;
         }
+
+        a {
+          text-decoration: none;
+
+          h3 {
+            @include govuk-link-decoration;
+          }
+
+          &:hover {
+            h3 {
+              @include govuk-link-hover-decoration;
+            }
+          }
+        }
       }
 
       .subsection-pane {
@@ -308,7 +322,7 @@
       }
 
       ul li a {
-        @include govuk-font(19, $weight: bold);
+        @include govuk-font(16, $weight: bold);
         display: block;
         padding: govuk-spacing(2) govuk-spacing(6) govuk-spacing(2) 0;
       }


### PR DESCRIPTION
## What
Fixes a bug on 2nd level browse pages ([example](https://www.gov.uk/browse/business/setting-up)) where the description of 1st level links include an underline as well as the h3. Additionally reduces the size of 2nd level browse page link lists to keep the page a bit less busy.

## Why
To align page design with expected visual behaviour.

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-06-16 at 14 33 01](https://user-images.githubusercontent.com/64783893/122228637-f3370500-ceaf-11eb-9876-e54bb4deedb8.png) | ![Screenshot 2021-06-16 at 14 33 15](https://user-images.githubusercontent.com/64783893/122228664-f92ce600-ceaf-11eb-8fbc-9bf36fc3cdcc.png) |