### PR TITLE
Add reset to lists on Coronavirus landing page

### DIFF
--- a/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/hub/_guidance_section.html.erb
@@ -9,7 +9,7 @@
             font_size: 19,
             margin_bottom: 5
           } %>
-          <ul class="covid__list govuk-!-margin-bottom-8">
+          <ul class="govuk-list covid__list govuk-!-margin-bottom-8">
             <% guidance["list"].each do | item | %>
               <li class="covid__list-item">
                 <%= render 'govuk_publishing_components/components/action_link', {

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -7,7 +7,7 @@
       margin_bottom: 4,
     } %>
   <% end %>
-  <ul class="covid__list">
+  <ul class="govuk-list covid__list">
     <% sub_section["list"].each do | item | %>
       <li class="covid__list-item">
         <% if item["featured_link"] %>


### PR DESCRIPTION
## What

Add `govuk-list` to override the browser default padding and margin to the lists on the Coronavirus landing page.

## Why

The global CSS reset was been removed with the move to using `gem_layout` and the public layout component - this caused the lists to fall back to the browsers default padding and margin, which meant that the alignment of the lists was not correct.

## Visual differences
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/122250440-92b0c380-cec1-11eb-8b69-fa1be3e8e530.png) | ![image](https://user-images.githubusercontent.com/1732331/122250320-7745b880-cec1-11eb-9f9f-7d27bc04a6b2.png) |

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
