### PR TITLE
Remove min-height attribute

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -114,10 +114,6 @@
         border-left: 1px solid $govuk-border-colour;
         min-height: 950px;
       }
-
-      @include govuk-media-query($from: desktop) {
-        min-height: 700px;
-      }
     }
 
     .pane-inner__title {


### PR DESCRIPTION
## What
Remove `min-height: 700px` styling rule from browse pages.

## Why
To fix a visual bug on 2nd level browse pages.

[Example page](https://www.gov.uk/browse/abroad/travel-abroad)
[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4599722)

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-06-18 at 17 15 32](https://user-images.githubusercontent.com/64783893/122590826-fd950280-d059-11eb-9e63-25357b039b18.png) | ![Screenshot 2021-06-18 at 17 19 38](https://user-images.githubusercontent.com/64783893/122590842-02f24d00-d05a-11eb-8248-f1fb69454062.png) |