### PR TITLE
Add Rails Translation Manager as development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem "pact", require: false
   gem "pact_broker-client"
   gem "pry-byebug"
+  gem "rails_translation_manager"
   gem "rspec-rails"
   gem "rubocop-govuk"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,6 +357,9 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
+    rails_translation_manager (0.1.0)
+      activesupport
+      rails-i18n
     railties (6.1.3.2)
       actionpack (= 6.1.3.2)
       activesupport (= 6.1.3.2)
@@ -550,6 +553,7 @@ DEPENDENCIES
   pry-byebug
   rails (= 6.1.3.2)
   rails-controller-testing
+  rails_translation_manager
   rinku
   rspec-rails
   rubocop-govuk


### PR DESCRIPTION
This will allow us to export the translation keys that need translating.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/ifbyj6pJ)