### PR TITLE
DO NOT MERGE: Remove link to eu settlement scheme from Brexit landing page

### DIFF
--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -17,8 +17,6 @@ en:
         path: "/visit-europe-1-january-2021"
       - text: living and working in the EU
         path: "/uk-nationals-living-eu"
-      - text: staying in the UK if you’re an EU citizen
-        path: "/staying-uk-eu-citizen"
     comms:
       links:
       - link:


### PR DESCRIPTION
## What

Remove link to EU settlement scheme from the Brexit landing page

## Why

The deadline will have passed for this scheme.

trello: https://trello.com/c/5qtlCy7i/1605-remove-euss-link-from-landing-page-on-30-june

review app: https://govuk-collec-remove-eu--7ppp4v.herokuapp.com/brexit

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
