### PR TITLE
Remove encoding from locale files

### DIFF
--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -40,7 +40,7 @@
             icon: "twitter"
           },
           {
-            href: "mailto:?body=https://www.gov.uk#{CGI.escape(request.fullpath)}/&subject=#{t('brexit_landing_page.email_mailto_subject')}",
+            href: "mailto:?body=https://www.gov.uk#{CGI.escape(request.fullpath)}/&subject=#{CGI.escape(t('brexit_landing_page.email_mailto_subject'))}",
             text: "Email",
             icon: "email"
           },
@@ -50,7 +50,7 @@
             icon: "whatsapp"
           },
           {
-            href: "http://www.linkedin.com/shareArticle?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}&title=#{t('brexit_landing_page.email_mailto_subject')}",
+            href: "http://www.linkedin.com/shareArticle?url=https%3A%2F%2Fwww.gov.uk#{CGI.escape(request.fullpath)}&title=#{CGI.escape(t('brexit_landing_page.email_mailto_subject'))}",
             text: "LinkedIn",
             icon: "linkedin"
           },

--- a/config/locales/cy/brexit_landing_page.yml
+++ b/config/locales/cy/brexit_landing_page.yml
@@ -57,7 +57,7 @@ cy:
       read_transcript:
     comms_header: Cyhoeddiadau
     data_list_title:
-    email_mailto_subject: Dechrau%20newydd%20y%20DU:%20Ymlaen%20â%20ni-%20GOV.UK
+    email_mailto_subject: "Dechrau newydd y DU: Ymlaen â ni- GOV.UK"
     guidance_header: Newidiadau i fusnesau a dinasyddion
     meta_description: Darganfyddwch sut mae’r rheolau newydd yn effeithio arnoch chi
     meta_title: Brexit

--- a/config/locales/en/brexit_landing_page.yml
+++ b/config/locales/en/brexit_landing_page.yml
@@ -59,7 +59,7 @@ en:
       read_transcript: Read the transcript for this video
     comms_header: Announcements
     data_list_title: 'Brexit landing page: %{header}'
-    email_mailto_subject: UK's%20new%20start:%20let's%20get%20going-%20GOV.UK
+    email_mailto_subject: "UK's new start: let's get going- GOV.UK"
     guidance_header: Changes for businesses and citizens
     meta_description: Find out how new Brexit rules apply to things like travel and doing business with Europe. Use the Brexit checker to get a personalised list of actions.
     meta_title: Brexit


### PR DESCRIPTION
Removes `%20` (encoding for a space) from the locale files and instead encodes the string at runtime.

This will make it easier for the translators to understand the meaning of this string when we request translations.

[Trello card](https://trello.com/c/ifbyj6pJ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
