### PR TITLE
Remove context link

### DIFF
--- a/app/views/latest_changes/index.html.erb
+++ b/app/views/latest_changes/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :page_title do %>
   <%= render "govuk_publishing_components/components/title", {
         title: t("latest_changes.title"),
-        context: { text: subtopic.title, href: subtopic.base_path }
+        context: subtopic.title,
       } %>
 <% end %>
 

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -4,7 +4,7 @@
 <header class="page-header group">
   <%= render "govuk_publishing_components/components/title", {
         title: t("services_and_information.title"),
-        context: { text: organisation["title"], href: organisation["base_path"] }
+        context: organisation["title"],
       } %>
 </header>
 

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -13,8 +13,7 @@
     title_params = { title: t("shared.topics.title", title: subtopic.title) }
     if subtopic.parent
       title_params[:context] = {
-        text: subtopic.parent.title,
-        href: subtopic.parent.base_path
+        text: subtopic.parent.title
       }
     end
   %>

--- a/spec/features/subtopic_page_spec.rb
+++ b/spec/features/subtopic_page_spec.rb
@@ -76,7 +76,7 @@ RSpec.feature "Subtopic pages" do
     within ".page-header" do
       within ".gem-c-title" do
         expect(page).to have_selector(".gem-c-title__text", text: "Offshore: detailed information")
-        expect(page).to have_selector(".gem-c-title__context-link[href='/topic/oil-and-gas']", text: "Oil and Gas")
+        expect(page).to have_selector(".gem-c-title__context", text: "Oil and Gas")
       end
 
       within ".gem-c-metadata" do
@@ -111,7 +111,7 @@ RSpec.feature "Subtopic pages" do
     within ".page-header" do
       within ".gem-c-title" do
         expect(page).to have_selector(".gem-c-title__text", text: "Offshore")
-        expect(page).to have_selector(".gem-c-title__context-link[href='/topic/oil-and-gas']", text: "Oil and Gas")
+        expect(page).to have_selector(".gem-c-title__context", text: "Oil and Gas")
       end
 
       within ".gem-c-metadata" do
@@ -155,7 +155,7 @@ RSpec.feature "Subtopic pages" do
       within ".page-header" do
         within ".gem-c-title" do
           expect(page).to have_selector(".gem-c-title__text", text: "Latest documents")
-          expect(page).to have_selector(".gem-c-title__context-link[href='/topic/oil-and-gas/offshore']", text: "Offshore")
+          expect(page).to have_selector(".gem-c-title__context", text: "Offshore")
         end
 
         within ".gem-c-metadata" do


### PR DESCRIPTION
This removes the link from the contextual link above the header. The styling of the context text means it's impossible to tell when it is a link or not. The link back to parent content is covered by the existing breadcrumbs anyway so there is no need for it.

No visual changes. 
https://trello.com/c/3ENWcE93/729-confusing-contextual-link-on-some-pages

Trello: https://trello.com/c/3ENWcE93/729-confusing-contextual-link-on-some-pages

Sample URLS:
https://www.gov.uk/government/organisations/medicines-and-healthcare-products-regulatory-agency/services-information
https://www.gov.uk/topic/animal-welfare/pets
https://www.gov.uk/topic/animal-welfare/pets/latest


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
