### PR TITLE
Remove the details element from the nation picker

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -51,9 +51,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       })
       timelineRadios.addEventListener('change', function (e) {
         var sections = document.querySelectorAll('.js-covid-timeline')
-        var currentNation = document.querySelector('.js-current-nation')
         var nation = e.target.value
-        currentNation.innerHTML = nation.replace('_', ' ')
 
         for (var i = 0; i < sections.length; i++) {
           var show = sections[i].id === 'nation-' + nation

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -261,11 +261,6 @@ $c19-landing-page-header-background: govuk-colour("blue");
   margin-bottom: govuk-spacing(1);
 }
 
-.covid-timeline__nation {
-  font-weight: bold;
-  text-transform: capitalize;
-}
-
 .covid-timeline__wrapper--hidden {
   display: none;
 }

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -270,7 +270,7 @@ $c19-landing-page-header-background: govuk-colour("blue");
 }
 
 .covid-timeline__button-wrapper {
-  margin-top: govuk-spacing(4);
+  margin-top: -(govuk-spacing(2));
 
   .js-enabled & {
     display: none;

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -14,26 +14,17 @@
         <%=t("coronavirus_landing_page.show.timeline.controls.status_html", nation: details.selected_nation.titleize) %>
       </p>
 
-      <%= render "govuk_publishing_components/components/details", {
-        title: t("coronavirus_landing_page.show.timeline.controls.change"),
-        data_attributes: {
-          track_category: "pageElementInteraction",
-          track_action: "TimelineNation",
-          module: "govuk-details",
-        }
-      } do %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "nation",
-          heading: t("coronavirus_landing_page.show.timeline.radio.heading"),
-          margin_bottom: 0,
-          items: details.timeline_nations_items
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "nation",
+        heading: t("coronavirus_landing_page.show.timeline.radio.heading"),
+        margin_bottom: 0,
+        items: details.timeline_nations_items
+      } %>
+      <div class="covid-timeline__button-wrapper">
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("coronavirus_landing_page.show.timeline.button.text")
         } %>
-        <div class="covid-timeline__button-wrapper">
-          <%= render "govuk_publishing_components/components/button", {
-            text: t("coronavirus_landing_page.show.timeline.button.text")
-          } %>
-        </div>
-      <% end %>
+      </div>
     <% end %>
 
     <div aria-live="polite">

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -10,10 +10,6 @@
       method: :get,
       class: "js-change-location" do |f| %>
 
-      <p class="govuk-body">
-        <%=t("coronavirus_landing_page.show.timeline.controls.status_html", nation: details.selected_nation.titleize) %>
-      </p>
-
       <%= render "govuk_publishing_components/components/radio", {
         name: "nation",
         heading: t("coronavirus_landing_page.show.timeline.radio.heading"),

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -13,12 +13,13 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "nation",
         heading: t("coronavirus_landing_page.show.timeline.radio.heading"),
-        margin_bottom: 0,
+        margin_bottom: 7,
         items: details.timeline_nations_items
       } %>
       <div class="covid-timeline__button-wrapper">
         <%= render "govuk_publishing_components/components/button", {
-          text: t("coronavirus_landing_page.show.timeline.button.text")
+          text: t("coronavirus_landing_page.show.timeline.button.text"),
+          margin_bottom: 7
         } %>
       </div>
     <% end %>

--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -8,7 +8,6 @@ en:
           text: View
         controls:
           status_html: "Showing updates for <span class='js-current-nation covid-timeline__nation'>%{nation}</span>."
-          change: Change to another nation
         radio:
           heading: Choose location
         updates:

--- a/config/locales/en/coronavirus_landing_page.yml
+++ b/config/locales/en/coronavirus_landing_page.yml
@@ -6,8 +6,6 @@ en:
       timeline:
         button:
           text: View
-        controls:
-          status_html: "Showing updates for <span class='js-current-nation covid-timeline__nation'>%{nation}</span>."
         radio:
           heading: Choose location
         updates:

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -96,7 +96,6 @@ describe('Coronavirus landing page', function () {
     beforeEach(function () {
       nationPickerHtml =
         '<div>' +
-          '<p>Showing updates for <span class="js-current-nation">England</span></p>' +
           '<form method="get" target="" class="js-change-location">' +
             '<div class="gem-c-radio govuk-radios__item">' +
               '<input type="radio" name="nation" id="radio-0" value="england" class="govuk-radios__input" checked="">' +
@@ -121,7 +120,6 @@ describe('Coronavirus landing page', function () {
     })
 
     it('show and hide appropriate sections of the page when the radio buttons change', function () {
-      var status = $element.find('.js-current-nation')
       var radio0 = $element.find('#radio-0')
       var radio1 = $element.find('#radio-1')
       var section0 = $element.find('#nation-england')
@@ -131,13 +129,11 @@ describe('Coronavirus landing page', function () {
 
       expect(section0).toBeVisible()
       expect(section1).toBeHidden()
-      expect(status.text()).toBe('england')
 
       window.GOVUK.triggerEvent(radio1[0], 'change')
 
       expect(section0).toBeHidden()
       expect(section1).toBeVisible()
-      expect(status.text()).toBe('northern ireland')
     })
   })
 })

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -84,7 +84,6 @@ module CoronavirusLandingPageSteps
   end
 
   def when_i_click_on_wales
-    find("span", text: "Change to another nation").click
     choose "Wales"
   end
 

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -6,10 +6,6 @@ module CoronavirusLandingPageSteps
   include GdsApi::TestHelpers::ContentItemHelpers
   include SearchApiHelpers
 
-  def self.included(mod)
-    mod.include(ActionView::Helpers::SanitizeHelper)
-  end
-
   CORONAVIRUS_PATH = "/coronavirus".freeze
   BUSINESS_PATH = "/coronavirus/business-support".freeze
   EDUCATION_PATH = "/coronavirus/education".freeze
@@ -141,13 +137,11 @@ module CoronavirusLandingPageSteps
   end
 
   def then_i_can_see_the_timeline_for_england
-    expect(page).to have_content(strip_tags(I18n.t("coronavirus_landing_page.show.timeline.controls.status_html", nation: "England")))
     expect(page).to have_selector("#nation-england:not(.covid-timeline__wrapper--hidden)")
     expect(page).to have_selector(".covid-timeline__wrapper--hidden", count: 3, visible: false)
   end
 
   def then_i_can_see_the_timeline_for_wales
-    expect(page).to have_content(strip_tags(I18n.t("coronavirus_landing_page.show.timeline.controls.status_html", nation: "Wales")))
     expect(page).to have_selector("#nation-wales:not(.covid-timeline__wrapper--hidden)")
     expect(page).to have_selector(".covid-timeline__wrapper--hidden", count: 3, visible: false)
   end


### PR DESCRIPTION
Trello cards:
- https://trello.com/c/PSKxvsS3
- https://trello.com/c/eE62ythU

# What's changed?

Remove the details component that show/hides the radio button and button components in the nation picker in the timeline.

# Why?

The original plan was to change the "Change to another nation" text to instead list the other nations that the user hadn't picked, e.g. "Change to England, Scotland, or Wales" etc.

However, the nation names in the link would need to be dynamically updated, which could be confusing without testing, and also looks odd when the details tab is opened.

There is a concern that leaving the text as it is will mean that user's won't intuitively understand what is being hidden in the detail. So the decision was made to remove the details component completely.

We can add back the details component later on when we're more certain it won't cause users an issue.

# Things to do
- [x] Sort out margin between radio buttons / button and timeline
 
With Javascript enabled:

![Screenshot 2021-07-06 at 13 17 59](https://user-images.githubusercontent.com/861310/124598628-bc279400-de5c-11eb-9b3f-ae53f0745355.png)

With Javascript disabled:

![Screenshot 2021-07-06 at 13 17 51](https://user-images.githubusercontent.com/861310/124598656-c0ec4800-de5c-11eb-9b36-ce984fcc41d3.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
