### PR TITLE
Add ExploreMenuABTestable AB Test code

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -1,0 +1,26 @@
+module AbTests::ExploreMenuAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def explore_menu_test
+    @explore_menu_test ||= GovukAbTesting::AbTest.new(
+      "ExploreMenuAbTestable",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def explore_menu_variant
+    explore_menu_test.requested_variant(request.headers)
+  end
+
+  def set_explore_menu_response
+    explore_menu_variant.configure_response(response) if explore_menu_testable?
+  end
+
+  def explore_menu_testable?
+    explore_menu_variant.variant?("B")
+  end
+end

--- a/app/controllers/ab_tests/slimmer_template_selectable.rb
+++ b/app/controllers/ab_tests/slimmer_template_selectable.rb
@@ -1,0 +1,17 @@
+module AbTests::SlimmerTemplateSelectable
+  def set_gem_layout
+    if explore_menu_testable?
+      slimmer_template "gem_layout_explore_header"
+    else
+      slimmer_template "gem_layout"
+    end
+  end
+
+  def set_gem_layout_full_width
+    if explore_menu_testable?
+      slimmer_template "gem_layout_full_width_explore_header"
+    else
+      slimmer_template "gem_layout_full_width"
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,17 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
-  slimmer_template :gem_layout
+  include AbTests::ExploreMenuAbTestable
+  include AbTests::SlimmerTemplateSelectable
 
   protect_from_forgery with: :exception
 
   before_action :set_expiry
   before_action :restrict_request_formats
+  before_action :set_explore_menu_response
+
+  after_action :set_slimmer_template
+
+  helper_method :explore_menu_variant, :explore_menu_testable?
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
   rescue_from GdsApi::HTTPForbidden, with: :error_403
@@ -38,6 +44,10 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def set_slimmer_template
+    set_gem_layout
+  end
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale

--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -1,7 +1,6 @@
 class BrexitLandingPageController < ApplicationController
   include GovukPersonalisation::AccountConcern
   include Slimmer::Headers
-  slimmer_template :gem_layout_full_width
 
   skip_before_action :set_expiry
   before_action -> { set_expiry(1.minute) }
@@ -18,6 +17,10 @@ class BrexitLandingPageController < ApplicationController
   end
 
 private
+
+  def set_slimmer_template
+    set_gem_layout_full_width
+  end
 
   def taxon
     base_path = request.path

--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,8 +1,6 @@
 require "active_model"
 
 class CoronavirusLandingPageController < ApplicationController
-  slimmer_template :gem_layout_full_width
-
   def show
     @statistics = FetchCoronavirusStatisticsService.call
     if @statistics
@@ -50,6 +48,10 @@ class CoronavirusLandingPageController < ApplicationController
   end
 
 private
+
+  def set_slimmer_template
+    set_gem_layout_full_width
+  end
 
   def content_item
     @content_item ||= ContentItem.find!(request.path)

--- a/app/controllers/dit_landing_page_controller.rb
+++ b/app/controllers/dit_landing_page_controller.rb
@@ -1,12 +1,15 @@
 class DitLandingPageController < ApplicationController
   around_action :switch_locale
-  slimmer_template :gem_layout_full_width
 
   def show
     @presenter = presenter
   end
 
 private
+
+  def set_slimmer_template
+    set_gem_layout_full_width
+  end
 
   def content_item
     ContentItem.find!(request.path)

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -2,8 +2,6 @@ class TaxonsController < ApplicationController
   rescue_from Taxon::InAlphaPhase, with: :error_404
 
   def show
-    slimmer_template :gem_layout_full_width
-
     setup_content_item_and_navigation_helpers(taxon)
 
     redirect_to(url_override, status: :temporary_redirect) and return if url_override.present?
@@ -15,6 +13,10 @@ class TaxonsController < ApplicationController
   end
 
 private
+
+  def set_slimmer_template
+    set_gem_layout_full_width
+  end
 
   def taxon
     @taxon ||= Taxon.find(request.path)

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
-<% content_for :meta_tags %>
 
 <div class="govuk-width-container">
   <%= render(

--- a/app/views/dit_landing_page/_page_header.html.erb
+++ b/app/views/dit_landing_page/_page_header.html.erb
@@ -10,7 +10,7 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="<%= image_url("KBM_twitter.png") %>">
   <meta name="description" content="<%= t("dit_landing_page.meta_description") %>">
-  
+
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
       navigation_page_type: "Taxon Page",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -3,6 +3,7 @@ require "integration_spec_helper"
 RSpec.feature "Coronavirus Pages" do
   include CoronavirusLandingPageSteps
   include CoronavirusContentItemHelper
+  include GovukAbTesting::RspecHelpers
 
   describe "the landing page" do
     before { stub_coronavirus_statistics }
@@ -111,6 +112,19 @@ RSpec.feature "Coronavirus Pages" do
       and_another_coronavirus_subtaxon
       when_i_visit_a_coronavirus_subtaxon_without_a_hub_page
       then_i_am_redirected_to_the_landing_page
+    end
+  end
+
+  context "for AB tests" do
+    before { stub_coronavirus_statistics }
+
+    scenario "AB testing of Explore navigational super menu" do
+      with_variant ExploreMenuAbTestable: "B" do
+        given_there_is_a_content_item
+        when_i_visit_the_coronavirus_landing_page
+
+        expect(page).to have_css('meta[content="ExploreMenuAbTestable:B"]', visible: false)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ Capybara.automatic_label_click = true
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :capybara
+end
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.include GdsApi::TestHelpers::Search


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Shows users in B variant of AB test the new Explore Super Menu header.

Static has a new header that the GOV.UK Explore team want to AB test as part of their beta.
https://github.com/alphagov/static/pull/2540


Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk

## Why 

We are slowly rolling out to users a redesigned header.

## Visual changes

Incoming