### PR TITLE
Handle back button navigation for Coronavirus timeline

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -45,23 +45,34 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   CoronavirusLandingPage.prototype.addTimelineCountrySelector = function () {
     var timelineRadios = document.querySelector('.js-change-location')
-    if (timelineRadios) {
-      timelineRadios.addEventListener('submit', function (e) {
-        e.preventDefault()
-      })
-      timelineRadios.addEventListener('change', function (e) {
-        var sections = document.querySelectorAll('.js-covid-timeline')
-        var nation = e.target.value
+    if (!timelineRadios) { return }
 
-        for (var i = 0; i < sections.length; i++) {
-          var show = sections[i].id === 'nation-' + nation
-          if (show) {
-            sections[i].classList.remove('covid-timeline__wrapper--hidden')
-          } else {
-            sections[i].classList.add('covid-timeline__wrapper--hidden')
-          }
-        }
-      })
+    timelineRadios.addEventListener('submit', function (e) {
+      e.preventDefault()
+    })
+
+    timelineRadios.addEventListener('change', this.timelineCountryChangeHandler)
+
+    // Set initial state based of timeline country based on checked inputs.
+    // In Chrome this can set the wrong state as form values may not be restored.
+    this.timelineCountryChangeHandler()
+    // Chromium browsers don't restore form values until after a document is ready
+    // so we can't set initial state until a later event occurs.
+    window.addEventListener('pageshow', this.timelineCountryChangeHandler)
+  }
+
+  CoronavirusLandingPage.prototype.timelineCountryChangeHandler = function () {
+    var sections = document.querySelectorAll('.js-covid-timeline')
+    var checked = document.querySelector('.js-change-location input[name=nation]:checked')
+    var nation = checked ? checked.value : 'england'
+
+    for (var i = 0; i < sections.length; i++) {
+      var show = sections[i].id === 'nation-' + nation
+      if (show) {
+        sections[i].classList.remove('covid-timeline__wrapper--hidden')
+      } else {
+        sections[i].classList.add('covid-timeline__wrapper--hidden')
+      }
     }
   }
 

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -138,6 +138,36 @@ describe('Coronavirus landing page', function () {
       expect(englandSection).toBeVisible()
       expect(northernIrelandSection).toBeHidden()
     })
+
+    it('can initialise to a non England country when they are initially selected', function () {
+      var northernIrelandRadio = $element.find('#radio-1')
+      var englandSection = $element.find('#nation-england')
+      var northernIrelandSection = $element.find('#nation-northern_ireland')
+
+      northernIrelandRadio.prop('checked', true)
+
+      coronavirusLandingPage.start($element)
+
+      expect(englandSection).toBeHidden()
+      expect(northernIrelandSection).toBeVisible()
+    })
+
+    it('can cope with a browser, such as Chrome, that restores form fields late', function () {
+      var northernIrelandRadio = $element.find('#radio-1')
+      var englandSection = $element.find('#nation-england')
+      var northernIrelandSection = $element.find('#nation-northern_ireland')
+
+      coronavirusLandingPage.start($element)
+
+      expect(englandSection).toBeVisible()
+      expect(northernIrelandSection).toBeHidden()
+
+      northernIrelandRadio.prop('checked', true)
+      window.GOVUK.triggerEvent(window, 'pageshow')
+
+      expect(englandSection).toBeHidden()
+      expect(northernIrelandSection).toBeVisible()
+    })
   })
 })
 

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -91,10 +91,8 @@ describe('Coronavirus landing page', function () {
   })
 
   describe('nation selector controls', function () {
-    var nationPickerHtml
-
     beforeEach(function () {
-      nationPickerHtml =
+      var nationPickerHtml =
         '<div>' +
           '<form method="get" target="" class="js-change-location">' +
             '<div class="gem-c-radio govuk-radios__item">' +
@@ -112,7 +110,6 @@ describe('Coronavirus landing page', function () {
       coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage()
       $element = $(nationPickerHtml)
       $('body').append($element)
-      coronavirusLandingPage.start($element)
     })
 
     afterEach(function () {
@@ -120,20 +117,26 @@ describe('Coronavirus landing page', function () {
     })
 
     it('show and hide appropriate sections of the page when the radio buttons change', function () {
-      var radio0 = $element.find('#radio-0')
-      var radio1 = $element.find('#radio-1')
-      var section0 = $element.find('#nation-england')
-      var section1 = $element.find('#nation-northern_ireland')
+      coronavirusLandingPage.start($element)
 
-      window.GOVUK.triggerEvent(radio0[0], 'change')
+      var englandRadio = $element.find('#radio-0')
+      var northernIrelandRadio = $element.find('#radio-1')
+      var englandSection = $element.find('#nation-england')
+      var northernIrelandSection = $element.find('#nation-northern_ireland')
 
-      expect(section0).toBeVisible()
-      expect(section1).toBeHidden()
+      expect(englandSection).toBeVisible()
+      expect(northernIrelandSection).toBeHidden()
 
-      window.GOVUK.triggerEvent(radio1[0], 'change')
+      northernIrelandRadio.prop('checked', true)
+      window.GOVUK.triggerEvent(northernIrelandRadio[0], 'change')
+      expect(englandSection).toBeHidden()
+      expect(northernIrelandSection).toBeVisible()
 
-      expect(section0).toBeHidden()
-      expect(section1).toBeVisible()
+      englandRadio.prop('checked', true)
+      window.GOVUK.triggerEvent(englandRadio[0], 'change')
+
+      expect(englandSection).toBeVisible()
+      expect(northernIrelandSection).toBeHidden()
     })
   })
 })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello: https://trello.com/c/Bn4ekYnO

---

Before:

![Jul-09-2021 19-10-12-before](https://user-images.githubusercontent.com/282717/125119835-89de9680-e0e9-11eb-885d-2001776e40a9.gif)

---

After:

![Jul-09-2021 19-10-12-after](https://user-images.githubusercontent.com/282717/125119851-8f3be100-e0e9-11eb-89d3-1b58ff371cb9.gif)

---

We learnt that there was a UX bug for the Coronavirus timeline if a user
navigated to a back using the browsers back/forward controls.

The experience for a user would be:

- select a constituent country other than England, and see
  the results for that country
- click a link on the page
- click the browser back button
- see that your previously selected country was still selected but that
  the results were for England.

The approach I've taken to resolve this is to make the event handler
no longer understand state from the event and instead read it from the app.
This allows the handler to be called outside of a change event occurring.
I've then updated the code set that the event handler is called during
initialisation which can set the state.

This approach works for Browsers outside the Chrome family, as the form
is set with the restored state before JavaScript initialises. Chrome
however differs and initially renders the form state as per the source
HTML. Once the page reaches a "load" state Chrome then adjusts the form
to restore the previous state. In order to resolve this I've had to put
a listener in for the "pageshow" event that occurs when you navigate to
a page.

A rejected, simpler, approach that I tried was to set the form to
"autocomplete=off". This stops the browser restoring the previous form
state when you navigate by the back button. I found that this had an
undesirable behaviour in Safari where clicking back would set the
country back to England but leave the results as the previous country.
This seems to be because Safari keeps a page existing in memory
initially and doesn't actually reload it on a back button press, however
it will try acknowledge the form autocomplete, while leaving the DOM as
it was previously.