### PR TITLE
Remove Brexit action link overrides

### DIFF
--- a/app/assets/stylesheets/views/_brexit-landing-page.scss
+++ b/app/assets/stylesheets/views/_brexit-landing-page.scss
@@ -8,14 +8,6 @@ $red: #ff003b;
   .gem-c-translation-nav {
     width: 35%;
   }
-
-  .gem-c-action-link__link {
-    margin-bottom: 0;
-
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(2);
-    }
-  }
 }
 
 .landing-page__section {

--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -43,7 +43,7 @@
       <%= render "govuk_publishing_components/components/action_link", {
         text: t("brexit_landing_page.page_header_links.guidance_for_businesses.text"),
         href: t("brexit_landing_page.page_header_links.guidance_for_businesses.path"),
-        margin_bottom: 4,
+        margin_bottom: 2,
         brexit_icon: true,
         font_size: "m",
         data: {
@@ -58,7 +58,7 @@
         text: t("brexit_landing_page.page_header_links.guidance_for_individuals_and_families.text"),
         href: t("brexit_landing_page.page_header_links.guidance_for_individuals_and_families.path"),
         brexit_icon: true,
-        margin_bottom: 4,
+        margin_bottom: 2,
         font_size: "m",
         data: {
           "module": "gem-track-click",


### PR DESCRIPTION
### What 
Remove Brexit action link overrides.

### Why
These were in place as adjustments before [the Brexit variation of action links](https://components.publishing.service.gov.uk/component-guide/action_link/with_brexit_icon_and_custom_font_size) was developed. Now we need to remove them as they interfere with the component setup and results in a misalignment between the arrow and the text on narrow screens.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![before](https://user-images.githubusercontent.com/788096/125294522-00b7a180-e32d-11eb-8432-b4eaceaff036.jpg)



</td><td valign="top">

![after](https://user-images.githubusercontent.com/788096/125294549-04e3bf00-e32d-11eb-9beb-a6ed61e0423a.jpg)



</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
