### PR TITLE
Fix spacing around timeline tags

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -265,8 +265,19 @@ $c19-landing-page-header-background: govuk-colour("blue");
   display: none;
 }
 
-.covid-timeline__tag {
+.covid-timeline__tag-wrapper {
   margin-left: govuk-spacing(1);
+
+  @include govuk-media-query($until: desktop) {
+    display: block;
+    margin: 0;
+    margin-top: govuk-spacing(1);
+  }
+}
+
+.covid-timeline__tag {
+  margin-right: govuk-spacing(1);
+  margin-bottom: govuk-spacing(1);
 }
 
 .covid-timeline__button-wrapper {

--- a/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_timeline.html.erb
@@ -41,7 +41,9 @@
           <% timeline.each do | item | %>
             <% text = capture do %>
               <%= item["heading"] %>
-              <%= item["tags"] %>
+              <span class="covid-timeline__tag-wrapper">
+                <%= item["tags"] %>
+              </span>
             <% end %>
             <div class="covid-timeline__item">
               <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
For tags appearing next to country specific items on the timeline nation picker:

- apply improved spacing particularly for where multiple country tags are present and wrap onto a second line on mobile
- make tags appear beneath item title, except on desktop

## Why

Visual improvement.

## Visual changes

Desktop:

![Screenshot 2021-07-14 at 09 51 23](https://user-images.githubusercontent.com/861310/125593797-f5ceef56-1000-4679-be01-41576f47211c.png)

Tablet:

![Screenshot 2021-07-14 at 09 50 57](https://user-images.githubusercontent.com/861310/125593835-96b80d8d-e51f-4d64-b328-3870d1c06441.png)

Large mobile:

![Screenshot 2021-07-14 at 09 50 47](https://user-images.githubusercontent.com/861310/125593869-64356132-9c63-4a89-b072-8002c83ac492.png)

Small mobile:

![Screenshot 2021-07-14 at 09 50 30](https://user-images.githubusercontent.com/861310/125593903-caebb1b0-c4ae-45db-904a-ea4e4856763b.png)

Trello card: https://trello.com/c/pNWmLPts/500-nation-picker-display-tags-on-their-own-line-on-mobile
