### PR TITLE
Allow links in covid landing page header

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -75,8 +75,6 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 
   .gem-c-govspeak {
-    color: govuk-colour("white");
-
     li {
       margin: 0 0 govuk-spacing(2);
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,8 +61,8 @@ module ApplicationHelper
     end
   end
 
-  def render_govspeak(content)
-    render "govuk_publishing_components/components/govspeak" do
+  def render_govspeak(content, inverse: false)
+    render "govuk_publishing_components/components/govspeak", inverse: inverse do
       raw(Govspeak::Document.new(content, sanitize: false).to_html)
     end
   end

--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -40,7 +40,7 @@
           } %>
 
           <div class="covid__page-header-content">
-            <%= render_govspeak(header["intro"]) %>
+            <%= render_govspeak(header["intro"], inverse: true) %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- the header section of this page has a blue background and white text, so adding links to the govspeak component wasn't working, they were appearing as the default link style of blue, which was unreadable
- this change to use the new govspeak inverse option allows links to be added that will be automatically styled correctly
- so we can remove the styles that previously made it white also

Note that this PR doesn't actually add any links - it only allows links to be added (which is handled through content). If you want to test that it's working you'll need to manipulate the dom to add a link into the page.

## Visual changes

Before | After
------ | -------
![Screenshot 2021-07-14 at 10 21 44](https://user-images.githubusercontent.com/861310/125598478-eef46271-574a-4349-8763-f8e4ac4c13fa.png) | ![Screenshot 2021-07-14 at 10 21 32](https://user-images.githubusercontent.com/861310/125598501-10bf4b7b-57de-41cf-8eb8-21145d0f32d7.png)

Trello card: https://trello.com/c/o7kekKgI/471-not-to-do-until-we-have-approval-link-styling-within-coronavirus-header-markdown