### PR TITLE
Make JS tests pass in Internet Explorer 10+

### DIFF
--- a/spec/javascripts/modules/track-links_spec.js
+++ b/spec/javascripts/modules/track-links_spec.js
@@ -34,6 +34,10 @@ describe('Track links', function () {
     element.innerHTML = html
     element = element.firstElementChild
 
+    element.addEventListener('click', function (e) {
+      e.preventDefault()
+    })
+
     var tracker = new GOVUK.Modules.TrackLinks()
     tracker.start([element])
   })
@@ -43,7 +47,8 @@ describe('Track links', function () {
   })
 
   it('track events sends href as label', function () {
-    element.querySelector('a[href="/government/news/chancellor-outlines-winter-economy-plan"]').dispatchEvent(new Event('click'))
+    var link = element.querySelector('a[href="/government/news/chancellor-outlines-winter-economy-plan"]')
+    window.GOVUK.triggerEvent(link, 'click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'pageElementInteraction', 'Timeline', {
@@ -54,7 +59,8 @@ describe('Track links', function () {
   })
 
   it('track events sends external href', function () {
-    element.querySelector('a[href="https://covid19.nhs.uk/"]').dispatchEvent(new Event('click'))
+    var link = element.querySelector('a[href="https://covid19.nhs.uk/"]')
+    window.GOVUK.triggerEvent(link, 'click')
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'pageElementInteraction', 'Timeline', {

--- a/spec/javascripts/organisation-list-filter_spec.js
+++ b/spec/javascripts/organisation-list-filter_spec.js
@@ -65,6 +65,11 @@ describe('organisation-list-filter.js', function () {
     GOVUK.filter.init()
   })
 
+  afterAll(function () {
+    $('#organisations_search_results').remove()
+    $('form[data-filter="form"]').remove()
+  })
+
   afterEach(function (done) {
     setTimeout(function () {
       $('[data-filter="form"] input').val('')


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix a test that was preventing the jasmine Javascript test suite from finishing in IE10+. This fortunately confirms that all of the JS tests pass in IE10+, so no further work is required.

## Why
Part of a wider change to make sure our JS tests pass in browsers that we support.

## Visual changes
None.

Trello card: https://trello.com/c/CAkmuuTK/424-make-js-tests-pass-in-all-browsers
