### PR TITLE
Remove jq from feed

### DIFF
--- a/app/assets/javascripts/modules/feeds.js
+++ b/app/assets/javascripts/modules/feeds.js
@@ -14,7 +14,11 @@
     },
     toggle: function (e) {
       e.preventDefault()
-      var panel = $(e.target).siblings('.js-feed-panel')
+
+      var panel = Array.prototype.filter.call(e.target.parentNode.children, function (child) {
+        return child !== e.target
+      }).querySelectorAll('js-feed-panel')
+
       panel.toggle()
       panel.querySelector('input')
     }

--- a/app/assets/javascripts/modules/feeds.js
+++ b/app/assets/javascripts/modules/feeds.js
@@ -16,7 +16,7 @@
       e.preventDefault()
       var panel = $(e.target).siblings('.js-feed-panel')
       panel.toggle()
-      panel.find('input').select()
+      panel.querySelector('input')
     }
   }
 

--- a/app/assets/javascripts/modules/feeds.js
+++ b/app/assets/javascripts/modules/feeds.js
@@ -7,7 +7,10 @@
 
   window.GOVUK.feeds = {
     init: function () {
-      $('.js-feed').on('click', window.GOVUK.feeds.toggle)
+      var jsFeed = document.getElementById('js-feed')
+      if (jsFeed) {
+        jsFeed.addEventListener('click', window.GOVUK.feeds.toggle)
+      }
     },
     toggle: function (e) {
       e.preventDefault()


### PR DESCRIPTION
## What
Remove jQuery from the feed file.

## Why
We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

## Trello 

https://trello.com/c/ybtss04a/484-remove-jquery-from-collections-modules-feedsjs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
