### PR TITLE
Add event listeners to feed

### DIFF
--- a/app/assets/javascripts/modules/feeds.js
+++ b/app/assets/javascripts/modules/feeds.js
@@ -7,9 +7,15 @@
 
   window.GOVUK.feeds = {
     init: function () {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        window.GOVUK.analytics.trackEvent('feed', 'initialize', {})
+      }
       $('.js-feed').on('click', window.GOVUK.feeds.toggle)
     },
     toggle: function (e) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        window.GOVUK.analytics.trackEvent('feed', 'toggle', {})
+      }
       e.preventDefault()
       var panel = $(e.target).siblings('.js-feed-panel')
       panel.toggle()


### PR DESCRIPTION
We have a suspicion that the feed is never actually used. This adds an event listener to it so that we can know for sure.

This is part of a wider effort to remove jQuery from our stack

Trello - https://trello.com/c/ybtss04a/484-remove-jquery-from-collections-modules-feedsjs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
