### PR TITLE
Set landing page og image to default

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
@@ -19,10 +19,5 @@
     }
   } %>
 
-  <% if corona_opengraph_images %>
-    <meta property="og:image" content="<%= image_url("hands-face-space-social.png") %>" />
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="<%= image_url("hands-face-space-social.png") %>">
-  <% end %>
   <link rel="canonical" href="<%= page_url %>">
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove the landing page specific og:image for sharing on the coronavirus landing page, to default back to the standard GOV.UK crown image.

## Why

The icons have been removed.

## Visual changes

None on the page, but social media sharing should no longer look like this:

![Screenshot 2021-07-26 at 11 31 59](https://user-images.githubusercontent.com/861310/126975383-3ed16e33-80c0-43d9-9a67-2c9ee3827343.png)

and look more like this:

![Screenshot 2021-07-26 at 11 33 27](https://user-images.githubusercontent.com/861310/126975408-03e9c75b-b9f3-4d8c-9c3b-fca096d3d359.png)

(images mocked up using Slack - this can't be properly tested until the change goes live)

Trello card: https://trello.com/c/Ty8vLAbT/525-meta-image-update