### PR TITLE
Remove jQuery from toggle attribute

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,8 +38,3 @@
 //= require modules/toggle-attribute
 //= require modules/coronavirus-landing-page
 //= require modules/track-links
-
-$(document).on('ready', function () {
-  var toggleAttribute = new GOVUK.Modules.ToggleAttribute()
-  toggleAttribute.start($('[data-module=toggle-attribute]'))
-})

--- a/app/assets/javascripts/modules/toggle-attribute.js
+++ b/app/assets/javascripts/modules/toggle-attribute.js
@@ -2,19 +2,19 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  'use strict'
-
-  Modules.ToggleAttribute = function () {
-    this.start = function ($element) {
-      $element.find('[data-toggle-attribute]').click(function (event) {
-        var clicked = event.target
-        var toggleAttribute = clicked.getAttribute('data-toggle-attribute')
-        var current = clicked.getAttribute(toggleAttribute)
-        var closedText = clicked.getAttribute('data-when-closed-text')
-        var openText = clicked.getAttribute('data-when-open-text')
-
-        clicked.setAttribute(toggleAttribute, current === closedText ? openText : closedText)
-      })
-    }
+  function ToggleAttribute ($module) {
+    this.$module = $module
+    this.toggleAttribute = $module.querySelector('[data-toggle-attribute]')
   }
+  ToggleAttribute.prototype.init = function ($element) {
+    this.toggleAttribute.addEventListener('click', function (event) {
+      var clicked = event.target
+      var toggleAttribute = clicked.getAttribute('data-toggle-attribute')
+      var current = clicked.getAttribute(toggleAttribute)
+      var closedText = clicked.getAttribute('data-when-closed-text')
+      var openText = clicked.getAttribute('data-when-open-text')
+      clicked.setAttribute(toggleAttribute, current === closedText ? openText : closedText)
+    })
+  }
+  Modules.ToggleAttribute = ToggleAttribute
 })(window.GOVUK.Modules)

--- a/spec/javascripts/modules/toggle-attribute_spec.js
+++ b/spec/javascripts/modules/toggle-attribute_spec.js
@@ -11,9 +11,9 @@ describe('A toggle attribute module', function () {
     '</div>'
 
   beforeEach(function () {
-    toggle = new GOVUK.Modules.ToggleAttribute()
     $element = $(html)
-    toggle.start($element)
+    toggle = new GOVUK.Modules.ToggleAttribute($element[0])
+    toggle.init()
     clickon = $element.find('#clickon')
   })
 


### PR DESCRIPTION
## What

Remove jQuery from the toggle-attribute file.

## Why

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

## Trello

https://trello.com/c/RBRTymH1/485-remove-jquery-from-collections-modules-toggle-attributejs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
