### PR TITLE
Remove jQ from track link file

### DIFF
--- a/app/assets/javascripts/modules/track-links.js
+++ b/app/assets/javascripts/modules/track-links.js
@@ -4,27 +4,26 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  Modules.TrackLinks = function () {
-    this.start = function (element) {
-      var category = element[0].getAttribute('data-track-category')
-      var action = element[0].getAttribute('data-track-action')
-      var links = element[0].getElementsByTagName('a')
+  Modules.TrackLinks = function (element) {
+    this.category = element.getAttribute('data-track-category')
+    this.action = element.getAttribute('data-track-action')
+    this.links = element.getElementsByTagName('a')
+  }
 
-      if (!category) return
+  Modules.TrackLinks.prototype.init = function () {
+    if (!this.category) return
 
-      for (var i = 0; i < links.length; i++) {
-        var link = links[i]
-        link.addEventListener('click', function (e) {
-          var options = {
-            transport: 'beacon',
-            label: e.target.getAttribute('href')
-          }
+    for (var i = 0; i < this.links.length; i++) {
+      var link = this.links[i]
+      link.addEventListener('click', function (e) {
+        var options = {
+          transport: 'beacon',
+          label: e.target.getAttribute('href')
+        }
+        if (!this.action) this.action = e.target.innerText
 
-          if (!action) action = e.target.innerText
-
-          GOVUK.analytics.trackEvent(category, action, options)
-        })
-      }
+        GOVUK.analytics.trackEvent(this.category, this.action, options)
+      }.bind(this))
     }
   }
 })(window.GOVUK.Modules)

--- a/spec/javascripts/modules/track-links_spec.js
+++ b/spec/javascripts/modules/track-links_spec.js
@@ -38,8 +38,8 @@ describe('Track links', function () {
       e.preventDefault()
     })
 
-    var tracker = new GOVUK.Modules.TrackLinks()
-    tracker.start([element])
+    var tracker = new GOVUK.Modules.TrackLinks(element)
+    tracker.init()
   })
 
   afterEach(function () {


### PR DESCRIPTION
## What

Remove jQuery from the track-link file.

## Why

We're using an old and unsupported version of jQuery for browser support reasons. Rather than upgrade, it's far better to remove our dependence.

jQuery makes writing JavaScript easier, but it doesn't do anything that you can't do with vanilla JavaScript, because it's all written in JavaScript.

Once it's removed, we no longer have to worry about upgrading it, and users don't have to download the jQuery library when they visit GOV.UK.

## Trello

https://trello.com/c/T3iJDYst/486-remove-jquery-from-collections-modules-track-linksjs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
