### PR TITLE
Add missing translations

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -320,13 +320,18 @@ en:
       adhoc_advisory_group: Ad-hoc advisory group
       advisory_ndpb: Advisory non-departmental public body
       civil_service: Civil service
+      court: Court
+      devolved_administration: Devolved administration
       executive_agency: Executive agency
       executive_ndpb: Executive non-departmental public body
+      executive_office: Executive office
       independent_monitoring_body: Independent monitoring body
+      ministerial_department: Ministerial department
       non_ministerial_department: Non-ministerial department
       other: Other
       public_corporation: Public corporation
       tribunal: Tribunal
+      sub_organisation: Sub organisation
     view_all: view all
     view_less: view less
     what_we_do: What %{title} does


### PR DESCRIPTION
These are missing and were causing translation errors in the development
environment and relying on I18n to fallback to the key names in
production.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
