### PR TITLE
Clean-up JavaScript imports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,26 +1,6 @@
 //= require govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind
 
-//= require govuk_publishing_components/vendor/polyfills/closest
-//= require govuk_publishing_components/vendor/polyfills/common
-//= require govuk_publishing_components/vendor/polyfills/indexOf
-
-// The `gem_layout` template from Static provides cookie-functions,
-// header-navigation, and track-click from the the components `lib` folder - so
-// they're not required here.
-
-//= require govuk_publishing_components/lib/current-location
-//= require govuk_publishing_components/lib/initial-focus
-//= require govuk_publishing_components/lib/primary-links
-//= require govuk_publishing_components/lib/select
-//= require govuk_publishing_components/lib/toggle-input-class-on-focus
-//= require govuk_publishing_components/lib/toggle
-//= require govuk_publishing_components/lib/track-click
-//= require govuk_publishing_components/lib/trigger-event
-
-//= require govuk_publishing_components/lib/govspeak/barchart-enhancement
-//= require govuk_publishing_components/lib/govspeak/magna-charta
-//= require govuk_publishing_components/lib/govspeak/youtube-link-enhancement
-
+//= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/details
@@ -29,7 +9,6 @@
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/analytics/explicit-cross-domain-links
 
 //= require support
 //= require browse-columns

--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -3,4 +3,4 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/lib/cookie-functions
 //= require govuk_publishing_components/lib/header-navigation
-//= require govuk_publishing_components/lib/track-click
+//= require govuk_publishing_components/analytics


### PR DESCRIPTION
Simplify JavaScript imports and follow convention as [documented in the components library](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).
This means:
- we can use `govuk_publishing_components/lib` which contains all the listed `lib` files and `vendor/polyfills`
- since `govuk_publishing_components/analytics` (including `explicit-cross-domain-links`) are already required by static there's no need to add any analytics-related scripts at the application level

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
