### PR TITLE
Fix context parameter

### DIFF
--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -12,9 +12,7 @@
   <%
     title_params = { title: t("shared.topics.title", title: subtopic.title) }
     if subtopic.parent
-      title_params[:context] = {
-        text: subtopic.parent.title
-      }
+      title_params[:context] = subtopic.parent.title
     end
   %>
   <%= render "govuk_publishing_components/components/title", title_params %>


### PR DESCRIPTION
This is a fix to the context parameter when calling the Title component on subtopic pages. It is no longer possible to pass a href to the title component to wrap the context text, and while we pre-emptively removed the href parameter we left the code here presenting a hash which wound up being rendered.

### Screenshots:

### Before:
<img width="623" alt="Screenshot 2021-08-06 at 15 17 38" src="https://user-images.githubusercontent.com/31649453/128674004-dbb33c50-5f97-471e-aea7-ef5891467221.png"> 

### After:
![image](https://user-images.githubusercontent.com/31649453/128674169-595f798a-b413-44da-a2d4-08b3c7b798c6.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
