### PR TITLE
Fix Explore header being applied to Brexit pages

### DIFF
--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -5,6 +5,7 @@ class BrexitLandingPageController < ApplicationController
   skip_before_action :set_expiry
   before_action -> { set_expiry(1.minute) }
   before_action -> { set_slimmer_headers(remove_search: true, show_accounts: logged_in? ? "signed-in" : "signed-out") }
+  after_action :set_slimmer_template
 
   around_action :switch_locale
   def show
@@ -19,7 +20,7 @@ class BrexitLandingPageController < ApplicationController
 private
 
   def set_slimmer_template
-    set_gem_layout_full_width
+    slimmer_template "gem_layout_full_width"
   end
 
   def taxon


### PR DESCRIPTION
We should exclude the Brexit pages from the Explore Super Menu AB Test as they need to keep the Sign In link.

https://trello.com/c/xjU0uYAt/459-fix-sign-in-link-on-brexit-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
