### PR TITLE
Remove conditional from A/B test meta tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
-  <%= explore_menu_variant.analytics_meta_tag.html_safe if explore_menu_testable? %>
+  <%= explore_menu_variant.analytics_meta_tag.html_safe %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: @content_item %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>


### PR DESCRIPTION
## What

Remove the conditional from the explore variant meta tag.

## Why

This was only being output on the page when on the "B" side of the test; the meta tag should be added to the page for all sides of the test so it can be picked up by analytics and the browser extension.

## Visual changes

None.

https://trello.com/c/8Y8tYYzk

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
