### PR TITLE
Send AB test header response back for all variants

### DIFF
--- a/app/controllers/ab_tests/explore_menu_ab_testable.rb
+++ b/app/controllers/ab_tests/explore_menu_ab_testable.rb
@@ -17,10 +17,10 @@ module AbTests::ExploreMenuAbTestable
   end
 
   def set_explore_menu_response
-    explore_menu_variant.configure_response(response) if explore_menu_testable?
+    explore_menu_variant.configure_response(response)
   end
 
-  def explore_menu_testable?
+  def explore_menu_variant_b?
     explore_menu_variant.variant?("B")
   end
 end

--- a/app/controllers/ab_tests/slimmer_template_selectable.rb
+++ b/app/controllers/ab_tests/slimmer_template_selectable.rb
@@ -1,6 +1,6 @@
 module AbTests::SlimmerTemplateSelectable
   def set_gem_layout
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "gem_layout_explore_header"
     else
       slimmer_template "gem_layout"
@@ -8,7 +8,7 @@ module AbTests::SlimmerTemplateSelectable
   end
 
   def set_gem_layout_full_width
-    if explore_menu_testable?
+    if explore_menu_variant_b?
       slimmer_template "gem_layout_full_width_explore_header"
     else
       slimmer_template "gem_layout_full_width"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
   after_action :set_slimmer_template
 
-  helper_method :explore_menu_variant, :explore_menu_testable?
+  helper_method :explore_menu_variant, :explore_menu_variant_b?
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
   rescue_from GdsApi::HTTPForbidden, with: :error_403

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -119,11 +119,25 @@ RSpec.feature "Coronavirus Pages" do
     before { stub_coronavirus_statistics }
 
     scenario "AB testing of Explore navigational super menu" do
+      with_variant ExploreMenuAbTestable: "A" do
+        given_there_is_a_content_item
+        when_i_visit_the_coronavirus_landing_page
+
+        expect(page).to have_css('meta[content="ExploreMenuAbTestable:A"]', visible: false)
+      end
+
       with_variant ExploreMenuAbTestable: "B" do
         given_there_is_a_content_item
         when_i_visit_the_coronavirus_landing_page
 
         expect(page).to have_css('meta[content="ExploreMenuAbTestable:B"]', visible: false)
+      end
+
+      with_variant ExploreMenuAbTestable: "Z" do
+        given_there_is_a_content_item
+        when_i_visit_the_coronavirus_landing_page
+
+        expect(page).to have_css('meta[content="ExploreMenuAbTestable:Z"]', visible: false)
       end
     end
   end


### PR DESCRIPTION
We need the variant header to be sent for every variant otherwise Fastly doesn't know how to cache them properly.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
