### PR TITLE
Adjust behaviour of ToggleAttribute

### DIFF
--- a/app/assets/javascripts/modules/toggle-attribute.js
+++ b/app/assets/javascripts/modules/toggle-attribute.js
@@ -4,17 +4,27 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   function ToggleAttribute ($module) {
     this.$module = $module
-    this.toggleAttribute = $module.querySelector('[data-toggle-attribute]')
   }
-  ToggleAttribute.prototype.init = function ($element) {
-    this.toggleAttribute.addEventListener('click', function (event) {
-      var clicked = event.target
-      var toggleAttribute = clicked.getAttribute('data-toggle-attribute')
-      var current = clicked.getAttribute(toggleAttribute)
-      var closedText = clicked.getAttribute('data-when-closed-text')
-      var openText = clicked.getAttribute('data-when-open-text')
-      clicked.setAttribute(toggleAttribute, current === closedText ? openText : closedText)
-    })
+
+  ToggleAttribute.prototype.init = function () {
+    this.$module.addEventListener('click', function (event) {
+      var target = event.target
+      var toggleAttribute
+
+      // traverse up node tree to check parent elements for data-toggle-attribute
+      do {
+        toggleAttribute = target.getAttribute('data-toggle-attribute')
+        if (toggleAttribute) break
+        target = target.parentNode
+      } while (target && target !== this.$module)
+
+      if (!toggleAttribute) return
+
+      var current = target.getAttribute(toggleAttribute)
+      var closedText = target.getAttribute('data-when-closed-text')
+      var openText = target.getAttribute('data-when-open-text')
+      target.setAttribute(toggleAttribute, current === closedText ? openText : closedText)
+    }.bind(this))
   }
   Modules.ToggleAttribute = ToggleAttribute
 })(window.GOVUK.Modules)

--- a/spec/javascripts/modules/toggle-attribute_spec.js
+++ b/spec/javascripts/modules/toggle-attribute_spec.js
@@ -1,31 +1,35 @@
 describe('A toggle attribute module', function () {
   'use strict'
 
-  var $element
-  var toggle
-  var clickon
-  var html =
-    '<div id="element" data-module="toggle-attribute">' +
-      '<div id="clickon" data-toggle-attribute="data-state" data-when-closed-text="closed" data-when-open-text="open" data-state="closed">' +
-      '</div>' +
-    '</div>'
+  var element
 
   beforeEach(function () {
-    $element = $(html)
-    toggle = new GOVUK.Modules.ToggleAttribute($element[0])
+    element = document.createElement('div')
+    element.innerHTML =
+      '<div id="unnested-click" data-toggle-attribute="data-state" data-when-closed-text="closed" data-when-open-text="open" data-state="closed"></div>' +
+      '<div id="nested-click" data-toggle-attribute="data-state" data-when-closed-text="closed" data-when-open-text="open" data-state="closed">' +
+        '<button type="button"><span>Toggler</span></button>' +
+      '</div>'
+    var toggle = new GOVUK.Modules.ToggleAttribute(element)
     toggle.init()
-    clickon = $element.find('#clickon')
-  })
-
-  afterEach(function () {
-    $(document).off()
   })
 
   it('sets the state to open when clicked and back again', function () {
-    expect(clickon).toHaveAttr('data-state', 'closed')
-    clickon.click()
-    expect(clickon).toHaveAttr('data-state', 'open')
-    clickon.click()
-    expect(clickon).toHaveAttr('data-state', 'closed')
+    var unnested = element.querySelector('#unnested-click')
+
+    expect(unnested).toHaveAttr('data-state', 'closed')
+    unnested.click()
+    expect(unnested).toHaveAttr('data-state', 'open')
+    unnested.click()
+    expect(unnested).toHaveAttr('data-state', 'closed')
+  })
+
+  it('can handle a click on a nested element', function () {
+    var nested = element.querySelector('#nested-click')
+    var span = nested.querySelector('span')
+
+    expect(nested).toHaveAttr('data-state', 'closed')
+    span.click()
+    expect(nested).toHaveAttr('data-state', 'open')
   })
 })


### PR DESCRIPTION
Trello: https://trello.com/c/71ehy3NG/562-fix-action-value-for-ga-event-for-accordion-opens-on-coronavirus-hubs

This module wasn't behaving correctly for a couple of reasons:

1) It wasn't finding multiple elements with [data-toggle-attribute]
   because it was using querySelector (as opposed to querySelectorAll)
2) The elements with [data-toggle-attribute] were being removed from the
   DOM and replaced with button elements [1], which meant any elements
   set on them lost their event handlers.

To resolve these issues I have placed a click event handler on the
module itself. Whenever an element within the module is clicked this
event will be triggered, it then resolves whether that element has a
[data-toggle-attribute] attribute or a parent with it to then execute
the code.

This change has been done to fix the problem that our accordions are
sending accordionClosed events each time they are opened or closed -
using this toggleAttributes module will change that attribute when they
are clicked before a later event handler to send the event.

This process to track accordion clicks is rather unusual and fragile and
should really be re-considered, the ideal would probably be to have a
custom event triggered from the accordion that can be listened to, or to
bake in analytic tracking into the accordion itself.

[1]: https://github.com/alphagov/govuk_publishing_components/blob/fe80e8b591bcec1f1855cb34d8601137a36f782c/app/assets/javascripts/govuk_publishing_components/components/accordion.js#L144-L153

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
