### PR TITLE
Fix topic-list `line-height`

### DIFF
--- a/app/assets/stylesheets/components/_topic-list.scss
+++ b/app/assets/stylesheets/components/_topic-list.scss
@@ -1,5 +1,5 @@
 .app-c-topic-list__item {
-  @include govuk-font(19, $weight: bold, $line-height: 1.7);
+  @include govuk-font(19, $weight: bold);
 }
 
 .app-c-topic-list > li { // Needed to override `.govuk-list > li`


### PR DESCRIPTION
Use the default `line-height` of `1.25` on topic-list component

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1010" alt="Screenshot 2021-08-19 at 11 21 33" src="https://user-images.githubusercontent.com/788096/130053202-38701bbb-7bfd-45dd-8389-59005376f2d9.png">


</td><td valign="top">

<img width="1010" alt="Screenshot 2021-08-19 at 11 21 53" src="https://user-images.githubusercontent.com/788096/130053220-eb74ff77-48e7-439c-81db-4b7dd63ed7fe.png">


</td></tr>
<tr><td valign="top">

<img width="1010" alt="Screenshot 2021-08-19 at 11 22 44" src="https://user-images.githubusercontent.com/788096/130053276-b39c2c76-59f7-406a-a208-b1869fc3a10f.png">


</td><td valign="top">

<img width="1010" alt="Screenshot 2021-08-19 at 11 22 15" src="https://user-images.githubusercontent.com/788096/130053273-c7313c4e-b90f-476b-bbe7-867e3f70c050.png">

</td></tr>
</table>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
