### PR TITLE
Change naming variation of "image_card"

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -69,7 +69,7 @@ module Organisations
           href: promotional_feature_link(item["href"]),
           image_src: item["image"]["url"],
           image_alt: item["image"]["alt_text"],
-          extra_links: item["links"].map do |link|
+          extra_details: item["links"].map do |link|
             {
               text: link["title"],
               href: link["href"],

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -84,11 +84,11 @@ module Organisations
         heading_text: person["title"],
         lang: person["locale"],
         heading_level: 0,
-        extra_links_no_indent: true,
+        extra_details_no_indent: true,
       }
 
       if is_person_ministerial?(type)
-        data[:extra_links] = roles.map { |role| formatted_role_link(role) }
+        data[:extra_details] = roles.map { |role| formatted_role_link(role) }
       else
         data[:description] = roles.map { |role| role["title"] }.join(", ")
       end

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/1-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
             image_alt: "Image 1-1",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/1-1",
@@ -137,7 +137,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/2-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
             image_alt: "Image 2-1",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/2-1",
@@ -155,7 +155,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/2-2",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
             image_alt: "Image 2-2",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/2-2",
@@ -181,7 +181,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/3-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
             image_alt: "Image 3-1",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/3-1",
@@ -199,7 +199,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/3-3",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
             image_alt: "Image 3-2",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/3-2",
@@ -218,7 +218,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
             image_alt: "Image 3-3",
             heading_text: "An unexpected title",
-            extra_links: [
+            extra_details: [
               {
                 text: "Single departmental plans",
                 href: "https://www.gov.uk/government/collections/3-3",

--- a/spec/presenters/organisations/people_presenter_spec.rb
+++ b/spec/presenters/organisations/people_presenter_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Organisations::PeoplePresenter do
           heading_text: "Oliver Dowden CBE MP",
           lang: "en",
           heading_level: 0,
-          extra_links_no_indent: true,
-          extra_links: [
+          extra_details_no_indent: true,
+          extra_details: [
             {
               text: "Parliamentary Secretary (Minister for Implementation)",
               href: "/government/ministers/parliamentary-secretary",
@@ -43,8 +43,8 @@ RSpec.describe Organisations::PeoplePresenter do
           heading_text: "The Rt Hon Theresa May MP",
           lang: "en",
           heading_level: 0,
-          extra_links_no_indent: true,
-          extra_links: [
+          extra_details_no_indent: true,
+          extra_details: [
             {
               text: "Prime Minister",
               href: "/government/ministers/prime-minister",
@@ -73,8 +73,8 @@ RSpec.describe Organisations::PeoplePresenter do
           heading_text: "Victoria Atkins MP",
           lang: "en",
           heading_level: 0,
-          extra_links_no_indent: true,
-          extra_links: [
+          extra_details_no_indent: true,
+          extra_details: [
             {
               text: "Minister of State",
               href: "/government/ministers/minister-of-state--61",
@@ -100,8 +100,8 @@ RSpec.describe Organisations::PeoplePresenter do
           heading_text: "Stuart Andrew MP",
           lang: "en",
           heading_level: 0,
-          extra_links_no_indent: true,
-          extra_links: [
+          extra_details_no_indent: true,
+          extra_details: [
             {
               text: "Parliamentary Under Secretary of State",
               href: "/government/ministers/parliamentary-under-secretary-of-state--94",
@@ -165,7 +165,7 @@ RSpec.describe Organisations::PeoplePresenter do
 
     it "displays role as descriptions rather than links" do
       expect(people_presenter.all_people.third[:people][0][:description]).to eq("Cabinet Secretary")
-      expect(people_presenter.all_people.third[:people][0][:extra_links]).to be_nil
+      expect(people_presenter.all_people.third[:people][0][:extra_details]).to be_nil
     end
 
     it "handles non-ministers with multiple roles" do
@@ -185,7 +185,7 @@ RSpec.describe Organisations::PeoplePresenter do
         heading_text: "Sir Jeremy Heywood",
         lang: "en",
         heading_level: 0,
-        extra_links_no_indent: true,
+        extra_details_no_indent: true,
         image_src: "/photo/jeremy-heywood",
       }
 
@@ -197,7 +197,7 @@ RSpec.describe Organisations::PeoplePresenter do
         heading_text: "John Manzoni",
         lang: "en",
         heading_level: 0,
-        extra_links_no_indent: true,
+        extra_details_no_indent: true,
       }
 
       expect(non_important_board_members.all_people.third[:people][0]).to eq(expected_important)


### PR DESCRIPTION
## What 

Rename options within instances of `image_card` 

## Why

A variation of the  [`image_card`](https://components.publishing.service.gov.uk/component-guide/image_card) component has been added, however the naming was confusing this has renamed from `extra_links` to `extra_details`

## Anything else 

Breaking change dependant on `govuk_publishing_components` release

Related PR - https://github.com/alphagov/govuk_publishing_components/pull/2300
