### PR TITLE
SPIKE:  New Coronavirus Statistics on Landing Page

### DIFF
--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -12,6 +12,7 @@ class FetchCoronavirusStatisticsService
                           :percent_of_second_vaccine,
                           :percent_of_second_vaccine_date,
                           :total_current_week_cases,
+                          :total_current_week_admissions,
                           keyword_init: true)
 
   def self.call
@@ -103,6 +104,11 @@ private
     last_7_days_cases = data.first(7).map { |day_cases| day_cases["newPositiveTests"] }
     if last_7_days_cases.compact.size == 7
       parsed[:total_current_week_cases] = last_7_days_cases.inject(:+)
+    end
+
+    last_7_days_admissions = data.first(7).map { |day_cases| day_cases["hospitalAdmissions"] }
+    if last_7_days_admissions.compact.size == 7
+      parsed[:total_current_week_admissions] = last_7_days_admissions.inject(:+)
     end
 
     parsed

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -15,6 +15,8 @@ class FetchCoronavirusStatisticsService
                           :total_current_week_admissions,
                           :cases_percentage_change,
                           :admissions_percentage_change,
+                          :total_cases_change,
+                          :total_admissions_change,
                           keyword_init: true)
 
   def self.call
@@ -117,13 +119,15 @@ private
       previous_week_cases = data[7..13].map { |day_cases| day_cases["newPositiveTests"] }
       if parsed[:total_current_week_cases] && previous_week_cases && previous_week_cases.compact.size == 7
         total_previous_week_cases = previous_week_cases.inject(:+)
-        parsed[:cases_percentage_change] = ((parsed[:total_current_week_cases] - total_previous_week_cases) / total_previous_week_cases) * 100
+        parsed[:total_cases_change] = parsed[:total_current_week_cases] - total_previous_week_cases
+        parsed[:cases_percentage_change] = ((parsed[:total_current_week_cases] - total_previous_week_cases) / total_previous_week_cases.to_f) * 100
       end
 
       previous_week_admissions = data[7..13].map { |day_cases| day_cases["hospitalAdmissions"] }
       if parsed[:total_current_week_admissions] && previous_week_admissions && previous_week_admissions.compact.size == 7
         total_previous_week_admissions = previous_week_admissions.inject(:+)
-        parsed[:admissions_percentage_change] = ((parsed[:total_current_week_admissions] - total_previous_week_admissions) / total_previous_week_admissions) * 100
+        parsed[:total_admissions_change] = parsed[:total_current_week_admissions] - total_previous_week_admissions
+        parsed[:admissions_percentage_change] = ((parsed[:total_current_week_admissions] - total_previous_week_admissions) / total_previous_week_admissions.to_f) * 100
       end
     end
 

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -7,6 +7,10 @@ class FetchCoronavirusStatisticsService
                           :hospital_admissions_date,
                           :new_positive_tests,
                           :new_positive_tests_date,
+                          :percent_of_first_vaccine,
+                          :percent_of_first_vaccine_date,
+                          :percent_of_second_vaccine,
+                          :percent_of_second_vaccine_date,
                           keyword_init: true)
 
   def self.call
@@ -57,6 +61,8 @@ private
           "cumulativeVaccinations" => "cumPeopleVaccinatedFirstDoseByPublishDate",
           "hospitalAdmissions" => "newAdmissions",
           "newPositiveTests" => "newCasesByPublishDate",
+          "percentageFirstVaccine" => "cumVaccinationFirstDoseUptakeByPublishDatePercentage",
+          "percentageSecondVaccine" => "cumVaccinationSecondDoseUptakeByPublishDatePercentage",
         }.to_json,
       })
     end
@@ -81,6 +87,16 @@ private
     if (latest_tests = data.find { |d| d["newPositiveTests"] })
       parsed[:new_positive_tests] = latest_tests["newPositiveTests"]
       parsed[:new_positive_tests_date] = Date.parse(latest_tests["date"])
+    end
+
+    if (latest_first_dose_percentage = data.find { |d| d["percentageFirstVaccine"] })
+      parsed[:percent_of_first_vaccine] = latest_first_dose_percentage["percentageFirstVaccine"]
+      parsed[:percent_of_first_vaccine_date] = Date.parse(latest_tests["date"])
+    end
+
+    if (latest_second_dose_percentage = data.find { |d| d["percentageSecondVaccine"] })
+      parsed[:percent_of_second_vaccine] = latest_second_dose_percentage["percentageSecondVaccine"]
+      parsed[:percent_of_second_vaccine_date] = Date.parse(latest_tests["date"])
     end
 
     parsed

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -11,6 +11,7 @@ class FetchCoronavirusStatisticsService
                           :percent_of_first_vaccine_date,
                           :percent_of_second_vaccine,
                           :percent_of_second_vaccine_date,
+                          :total_current_week_cases,
                           keyword_init: true)
 
   def self.call
@@ -97,6 +98,11 @@ private
     if (latest_second_dose_percentage = data.find { |d| d["percentageSecondVaccine"] })
       parsed[:percent_of_second_vaccine] = latest_second_dose_percentage["percentageSecondVaccine"]
       parsed[:percent_of_second_vaccine_date] = Date.parse(latest_tests["date"])
+    end
+
+    last_7_days_cases = data.first(7).map { |day_cases| day_cases["newPositiveTests"] }
+    if last_7_days_cases.compact.size == 7
+      parsed[:total_current_week_cases] = last_7_days_cases.inject(:+)
     end
 
     parsed

--- a/app/services/fetch_coronavirus_statistics_service.rb
+++ b/app/services/fetch_coronavirus_statistics_service.rb
@@ -105,25 +105,29 @@ private
       parsed[:percent_of_second_vaccine_date] = Date.parse(latest_tests["date"])
     end
 
-    current_week_cases = data.first(7).map { |day_cases| day_cases["newPositiveTests"] }
+    cases_data = data.select { |d| d["newPositiveTests"].present? }
+
+    current_week_cases = cases_data.first(7).map { |day_cases| day_cases["newPositiveTests"] }
     if current_week_cases.compact.size == 7
       parsed[:total_current_week_cases] = current_week_cases.inject(:+)
     end
 
-    current_week_admissions = data.first(7).map { |day_cases| day_cases["hospitalAdmissions"] }
+    admissions_data = data.select { |d| d["hospitalAdmissions"].present? }
+
+    current_week_admissions = admissions_data.first(7).map { |day_cases| day_cases["hospitalAdmissions"] }
     if current_week_admissions && current_week_admissions.compact.size == 7
       parsed[:total_current_week_admissions] = current_week_admissions.inject(:+)
     end
 
     if data.size >= 13
-      previous_week_cases = data[7..13].map { |day_cases| day_cases["newPositiveTests"] }
+      previous_week_cases = cases_data[7..13].map { |day_cases| day_cases["newPositiveTests"] }
       if parsed[:total_current_week_cases] && previous_week_cases && previous_week_cases.compact.size == 7
         total_previous_week_cases = previous_week_cases.inject(:+)
         parsed[:total_cases_change] = parsed[:total_current_week_cases] - total_previous_week_cases
         parsed[:cases_percentage_change] = ((parsed[:total_current_week_cases] - total_previous_week_cases) / total_previous_week_cases.to_f) * 100
       end
 
-      previous_week_admissions = data[7..13].map { |day_cases| day_cases["hospitalAdmissions"] }
+      previous_week_admissions = admissions_data[7..13].map { |day_cases| day_cases["hospitalAdmissions"] }
       if parsed[:total_current_week_admissions] && previous_week_admissions && previous_week_admissions.compact.size == 7
         total_previous_week_admissions = previous_week_admissions.inject(:+)
         parsed[:total_admissions_change] = parsed[:total_current_week_admissions] - total_previous_week_admissions

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -39,7 +39,7 @@
   <% if statistics && statistics.percent_of_first_vaccine %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
       title: "People vaccinated, percent of total population - 1st dose",
-      statistic: number_with_delimiter(statistics.percent_of_first_vaccine),
+      statistic: number_to_percentage(statistics.percent_of_first_vaccine, precision: 1),
       statistic_meaning: "people have received their first dose",
       last_updated_date: statistics.percent_of_first_vaccine_date,
       guidance_link: "",
@@ -49,7 +49,7 @@
   <% if statistics && statistics.percent_of_second_vaccine %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
       title: "People vaccinated, percent of total population - 2nd dose",
-      statistic: number_with_delimiter(statistics.percent_of_second_vaccine),
+      statistic: number_to_percentage(statistics.percent_of_second_vaccine, precision: 1),
       statistic_meaning: "people have received their second dose",
       last_updated_date: statistics.percent_of_second_vaccine_date,
       guidance_link: "",

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -66,6 +66,16 @@
     } %>
   <% end %>
 
+  <% if statistics && statistics.total_cases_change %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People testing positive - Last 7 days Total change",
+      statistic: number_with_delimiter(statistics.total_cases_change),
+      statistic_meaning: "total change in people testing positive with COVID-19 in the last 7 days",
+      last_updated_date: statistics.new_positive_tests_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
   <% if statistics && statistics.cases_percentage_change %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
       title: "People testing positive - Last 7 days Percentage change",
@@ -82,6 +92,16 @@
       statistic: number_with_delimiter(statistics.total_current_week_admissions),
       statistic_meaning: "new patients have been admitted to hospital in the last 7 days",
       last_updated_date: statistics.hospital_admissions_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
+  <% if statistics && statistics.total_admissions_change %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People admitted to hospital - Last 7 days Total change",
+      statistic: number_with_delimiter(statistics.total_admissions_change),
+      statistic_meaning: "total change in new patients have been admitted to hospital in the last 7 days",
+      last_updated_date: statistics.new_positive_tests_date,
       guidance_link: "",
     } %>
   <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -101,7 +101,7 @@
       title: "People admitted to hospital - Last 7 days Total change",
       statistic: number_with_delimiter(statistics.total_admissions_change),
       statistic_meaning: "total change in new patients have been admitted to hospital in the last 7 days",
-      last_updated_date: statistics.new_positive_tests_date,
+      last_updated_date: statistics.hospital_admissions_date,
       guidance_link: "",
     } %>
   <% end %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -56,6 +56,16 @@
     } %>
   <% end %>
 
+  <% if statistics && statistics.total_current_week_cases %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People testing positive - Last 7 days",
+      statistic: number_with_delimiter(statistics.total_current_week_cases),
+      statistic_meaning: "people tested positive with COVID-19 in the last 7 days",
+      last_updated_date: statistics.new_positive_tests_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
   <ul class="govuk-list">
     <% topic_section["links"].each do | link | %>
       <li class="covid__topic-list-item">

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -66,11 +66,31 @@
     } %>
   <% end %>
 
+  <% if statistics && statistics.cases_percentage_change %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People testing positive - Last 7 days Percentage change",
+      statistic: number_to_percentage(statistics.cases_percentage_change, precision: 1),
+      statistic_meaning: "percentage change in people testing positive with COVID-19 in the last 7 days",
+      last_updated_date: statistics.new_positive_tests_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
   <% if statistics && statistics.total_current_week_admissions %>
     <%= render "coronavirus_landing_page/components/landing_page/statistic", {
       title: "People admitted to hospital - Last 7 days",
       statistic: number_with_delimiter(statistics.total_current_week_admissions),
       statistic_meaning: "new patients have been admitted to hospital in the last 7 days",
+      last_updated_date: statistics.hospital_admissions_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
+  <% if statistics && statistics.admissions_percentage_change %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People admitted to hospital - Last 7 days Percentage change",
+      statistic: number_to_percentage(statistics.admissions_percentage_change, precision: 1),
+      statistic_meaning: "percentage change in new patients have been admitted to hospital in the last 7 days",
       last_updated_date: statistics.hospital_admissions_date,
       guidance_link: "",
     } %>

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -66,6 +66,16 @@
     } %>
   <% end %>
 
+  <% if statistics && statistics.total_current_week_admissions %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People admitted to hospital - Last 7 days",
+      statistic: number_with_delimiter(statistics.total_current_week_admissions),
+      statistic_meaning: "new patients have been admitted to hospital in the last 7 days",
+      last_updated_date: statistics.hospital_admissions_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
   <ul class="govuk-list">
     <% topic_section["links"].each do | link | %>
       <li class="covid__topic-list-item">

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -36,6 +36,26 @@
     } %>
   <% end %>
 
+  <% if statistics && statistics.percent_of_first_vaccine %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People vaccinated, percent of total population - 1st dose",
+      statistic: number_with_delimiter(statistics.percent_of_first_vaccine),
+      statistic_meaning: "people have received their first dose",
+      last_updated_date: statistics.percent_of_first_vaccine_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
+  <% if statistics && statistics.percent_of_second_vaccine %>
+    <%= render "coronavirus_landing_page/components/landing_page/statistic", {
+      title: "People vaccinated, percent of total population - 2nd dose",
+      statistic: number_with_delimiter(statistics.percent_of_second_vaccine),
+      statistic_meaning: "people have received their second dose",
+      last_updated_date: statistics.percent_of_second_vaccine_date,
+      guidance_link: "",
+    } %>
+  <% end %>
+
   <ul class="govuk-list">
     <% topic_section["links"].each do | link | %>
       <li class="covid__topic-list-item">

--- a/spec/services/fetch_coronavirus_statistics_service_spec.rb
+++ b/spec/services/fetch_coronavirus_statistics_service_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe FetchCoronavirusStatisticsService do
       body = {
         data: [
           { "date" => "2021-03-18", "cumulativeVaccinations" => nil, "hospitalAdmissions" => nil, "newPositiveTests" => 6303 },
-          { "date" => "2021-03-17", "cumulativeVaccinations" => 25_735_472, "hospitalAdmissions" => nil, "newPositiveests" => 5758 },
-          { "date" => "2021-03-16", "cumulativeVaccinations" => 25_273_226, "hospitalAdmissions" => nil, "newPositiveests" => 5294 },
-          { "date" => "2021-03-15", "cumulativeVaccinations" => 24_839_906, "hospitalAdmissions" => nil, "newPositiveests" => 5089 },
-          { "date" => "2021-03-14", "cumulativeVaccinations" => 24_453_221, "hospitalAdmissions" => 426, "newPositiveests" => 4618 },
-          { "date" => "2021-03-13", "cumulativeVaccinations" => 24_196_211, "hospitalAdmissions" => 460, "newPositiveests" => 5534 },
+          { "date" => "2021-03-17", "cumulativeVaccinations" => 25_735_472, "hospitalAdmissions" => nil, "newPositiveTests" => 5758 },
+          { "date" => "2021-03-16", "cumulativeVaccinations" => 25_273_226, "hospitalAdmissions" => nil, "newPositiveTests" => 5294 },
+          { "date" => "2021-03-15", "cumulativeVaccinations" => 24_839_906, "hospitalAdmissions" => nil, "newPositiveTests" => 5089 },
+          { "date" => "2021-03-14", "cumulativeVaccinations" => 24_453_221, "hospitalAdmissions" => 426, "newPositiveTests" => 4618 },
+          { "date" => "2021-03-13", "cumulativeVaccinations" => 24_196_211, "hospitalAdmissions" => 460, "newPositiveTests" => 5534 },
         ],
       }
 
@@ -51,6 +51,27 @@ RSpec.describe FetchCoronavirusStatisticsService do
           hospital_admissions_date: nil,
           new_positive_tests: 6303,
           new_positive_tests_date: Date.new(2021, 3, 18),
+        )
+      end
+
+      it "gets total number of cases for the last week (7 days)" do
+        body = {
+          data: [
+            { "date" => "2021-03-18", "cumulativeVaccinations" => nil, "hospitalAdmissions" => nil, "newPositiveTests" => 6303 },
+            { "date" => "2021-03-17", "cumulativeVaccinations" => 25_735_472, "hospitalAdmissions" => nil, "newPositiveTests" => 5758 },
+            { "date" => "2021-03-16", "cumulativeVaccinations" => 25_273_226, "hospitalAdmissions" => nil, "newPositiveTests" => 5294 },
+            { "date" => "2021-03-15", "cumulativeVaccinations" => 24_839_906, "hospitalAdmissions" => nil, "newPositiveTests" => 5089 },
+            { "date" => "2021-03-14", "cumulativeVaccinations" => 24_453_221, "hospitalAdmissions" => 426, "newPositiveTests" => 4618 },
+            { "date" => "2021-03-13", "cumulativeVaccinations" => 24_196_211, "hospitalAdmissions" => 460, "newPositiveTests" => 5534 },
+            { "date" => "2021-03-12", "cumulativeVaccinations" => 24_196_211, "hospitalAdmissions" => 460, "newPositiveTests" => 1234 },
+          ],
+        }
+
+        stub_request(:get, /coronavirus.data.gov.uk/)
+          .to_return(status: 200, body: body.to_json)
+
+        expect(described_class.call).to have_attributes(
+          total_current_week_cases: 33_830,
         )
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/cKIalHvC

# Screenshots

<img width="671" alt="Screenshot 2021-09-10 at 16 26 00" src="https://user-images.githubusercontent.com/5793815/132878570-c2c76d2f-c9c7-4c01-9606-7b8abb8313e0.png">
<img width="668" alt="Screenshot 2021-09-10 at 16 26 23" src="https://user-images.githubusercontent.com/5793815/132878590-101415ed-6471-41da-82ec-8efdfbf22f24.png">
<img width="760" alt="Screenshot 2021-09-15 at 13 58 52" src="https://user-images.githubusercontent.com/5793815/133437796-8475d744-f3d0-4ec4-b6ca-b0756dc2f158.png">


Disclaimer: 
1. Screenshots do not reflect the final design, they only prove that the data can be displayed.
2. The hospital admissions screenshot was added much later so does not match the screenshot from coronavirus.data.gov.uk 👇 

# Comparision data from coronavirus.data.gov.uk
<img width="1312" alt="Screenshot 2021-09-10 at 16 58 55" src="https://user-images.githubusercontent.com/5793815/132882941-f6e16852-2b74-4c6d-ba04-31b6182e161d.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
