### PR TITLE
Define available locales

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,73 @@ module Collections
     config.i18n.default_locale = :en
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
     config.i18n.fallbacks = true
+    config.i18n.available_locales = %i[
+      ar
+      az
+      be
+      bg
+      bn
+      cs
+      cy
+      da
+      de
+      dr
+      el
+      en
+      es
+      es-419
+      et
+      fa
+      fi
+      fr
+      gd
+      gu
+      he
+      hi
+      hr
+      hu
+      hy
+      id
+      is
+      it
+      ja
+      ka
+      kk
+      ko
+      lt
+      lv
+      ms
+      mt
+      nl
+      no
+      pa
+      pa-pk
+      pl
+      ps
+      pt
+      ro
+      ru
+      si
+      sk
+      sl
+      so
+      sq
+      sr
+      sv
+      sw
+      ta
+      th
+      tk
+      tr
+      uk
+      ur
+      uz
+      vi
+      yi
+      zh
+      zh-hk
+      zh-tw
+    ]
 
     config.assets.prefix = "/assets/collections/"
 

--- a/config/locales/ar/corona_virus_landing_page.yml
+++ b/config/locales/ar/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ar:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ar/coronavirus_landing_page.yml
+++ b/config/locales/ar/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ar:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/az/corona_virus_landing_page.yml
+++ b/config/locales/az/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-az:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/az/coronavirus_landing_page.yml
+++ b/config/locales/az/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+az:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/be/corona_virus_landing_page.yml
+++ b/config/locales/be/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-be:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/be/coronavirus_landing_page.yml
+++ b/config/locales/be/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+be:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/bg/corona_virus_landing_page.yml
+++ b/config/locales/bg/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-bg:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/bg/coronavirus_landing_page.yml
+++ b/config/locales/bg/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+bg:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/bn/corona_virus_landing_page.yml
+++ b/config/locales/bn/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-bn:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/bn/coronavirus_landing_page.yml
+++ b/config/locales/bn/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+bn:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/cs/corona_virus_landing_page.yml
+++ b/config/locales/cs/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-cs:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/cs/coronavirus_landing_page.yml
+++ b/config/locales/cs/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+cs:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/cy/corona_virus_landing_page.yml
+++ b/config/locales/cy/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-cy:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/cy/coronavirus_landing_page.yml
+++ b/config/locales/cy/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+cy:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/da/corona_virus_landing_page.yml
+++ b/config/locales/da/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-da:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/da/coronavirus_landing_page.yml
+++ b/config/locales/da/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+da:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/de/corona_virus_landing_page.yml
+++ b/config/locales/de/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-de:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/de/coronavirus_landing_page.yml
+++ b/config/locales/de/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+de:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/dr/corona_virus_landing_page.yml
+++ b/config/locales/dr/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-dr:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/dr/coronavirus_landing_page.yml
+++ b/config/locales/dr/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+dr:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/el/corona_virus_landing_page.yml
+++ b/config/locales/el/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-el:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/el/coronavirus_landing_page.yml
+++ b/config/locales/el/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+el:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/es-419/corona_virus_landing_page.yml
+++ b/config/locales/es-419/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-es-419:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/es-419/coronavirus_landing_page.yml
+++ b/config/locales/es-419/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+es-419:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/es/corona_virus_landing_page.yml
+++ b/config/locales/es/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-es:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/es/coronavirus_landing_page.yml
+++ b/config/locales/es/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+es:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/et/corona_virus_landing_page.yml
+++ b/config/locales/et/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-et:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/et/coronavirus_landing_page.yml
+++ b/config/locales/et/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+et:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/fa/corona_virus_landing_page.yml
+++ b/config/locales/fa/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-fa:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/fa/coronavirus_landing_page.yml
+++ b/config/locales/fa/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+fa:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/fi/corona_virus_landing_page.yml
+++ b/config/locales/fi/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-fi:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/fi/coronavirus_landing_page.yml
+++ b/config/locales/fi/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+fi:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/fr/corona_virus_landing_page.yml
+++ b/config/locales/fr/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-fr:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/fr/coronavirus_landing_page.yml
+++ b/config/locales/fr/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+fr:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/gd/corona_virus_landing_page.yml
+++ b/config/locales/gd/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-gd:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/gd/coronavirus_landing_page.yml
+++ b/config/locales/gd/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+gd:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/gu/corona_virus_landing_page.yml
+++ b/config/locales/gu/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-gu:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/gu/coronavirus_landing_page.yml
+++ b/config/locales/gu/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+gu:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/he/corona_virus_landing_page.yml
+++ b/config/locales/he/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-he:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/he/coronavirus_landing_page.yml
+++ b/config/locales/he/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+he:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/hi/corona_virus_landing_page.yml
+++ b/config/locales/hi/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-hi:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/hi/coronavirus_landing_page.yml
+++ b/config/locales/hi/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+hi:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/hr/corona_virus_landing_page.yml
+++ b/config/locales/hr/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-hr:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/hr/coronavirus_landing_page.yml
+++ b/config/locales/hr/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+hr:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/hu/corona_virus_landing_page.yml
+++ b/config/locales/hu/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-hu:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/hu/coronavirus_landing_page.yml
+++ b/config/locales/hu/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+hu:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/hy/corona_virus_landing_page.yml
+++ b/config/locales/hy/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-hy:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/hy/coronavirus_landing_page.yml
+++ b/config/locales/hy/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+hy:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/id/corona_virus_landing_page.yml
+++ b/config/locales/id/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-id:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/id/coronavirus_landing_page.yml
+++ b/config/locales/id/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+id:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/is/corona_virus_landing_page.yml
+++ b/config/locales/is/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-is:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/is/coronavirus_landing_page.yml
+++ b/config/locales/is/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+is:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/it/corona_virus_landing_page.yml
+++ b/config/locales/it/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-it:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/it/coronavirus_landing_page.yml
+++ b/config/locales/it/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+it:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ja/corona_virus_landing_page.yml
+++ b/config/locales/ja/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ja:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ja/coronavirus_landing_page.yml
+++ b/config/locales/ja/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ja:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ka/corona_virus_landing_page.yml
+++ b/config/locales/ka/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ka:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ka/coronavirus_landing_page.yml
+++ b/config/locales/ka/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ka:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/kk/corona_virus_landing_page.yml
+++ b/config/locales/kk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-kk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/kk/coronavirus_landing_page.yml
+++ b/config/locales/kk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+kk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ko/corona_virus_landing_page.yml
+++ b/config/locales/ko/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ko:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ko/coronavirus_landing_page.yml
+++ b/config/locales/ko/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ko:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/lt/corona_virus_landing_page.yml
+++ b/config/locales/lt/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-lt:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/lt/coronavirus_landing_page.yml
+++ b/config/locales/lt/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+lt:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/lv/corona_virus_landing_page.yml
+++ b/config/locales/lv/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-lv:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/lv/coronavirus_landing_page.yml
+++ b/config/locales/lv/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+lv:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ms/corona_virus_landing_page.yml
+++ b/config/locales/ms/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ms:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ms/coronavirus_landing_page.yml
+++ b/config/locales/ms/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ms:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/mt/corona_virus_landing_page.yml
+++ b/config/locales/mt/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-mt:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/mt/coronavirus_landing_page.yml
+++ b/config/locales/mt/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+mt:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/nl/corona_virus_landing_page.yml
+++ b/config/locales/nl/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-nl:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/nl/coronavirus_landing_page.yml
+++ b/config/locales/nl/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+nl:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/no/corona_virus_landing_page.yml
+++ b/config/locales/no/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-'no':
-  corona_virus_landing_page:
-    title:

--- a/config/locales/no/coronavirus_landing_page.yml
+++ b/config/locales/no/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+'no':
+  coronavirus_landing_page:
+    title:

--- a/config/locales/pa-pk/corona_virus_landing_page.yml
+++ b/config/locales/pa-pk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-pa-pk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/pa-pk/coronavirus_landing_page.yml
+++ b/config/locales/pa-pk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+pa-pk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/pa/corona_virus_landing_page.yml
+++ b/config/locales/pa/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-pa:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/pa/coronavirus_landing_page.yml
+++ b/config/locales/pa/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+pa:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/pl/corona_virus_landing_page.yml
+++ b/config/locales/pl/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-pl:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/pl/coronavirus_landing_page.yml
+++ b/config/locales/pl/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+pl:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ps/corona_virus_landing_page.yml
+++ b/config/locales/ps/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ps:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ps/coronavirus_landing_page.yml
+++ b/config/locales/ps/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ps:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/pt/corona_virus_landing_page.yml
+++ b/config/locales/pt/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-pt:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/pt/coronavirus_landing_page.yml
+++ b/config/locales/pt/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+pt:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ro/corona_virus_landing_page.yml
+++ b/config/locales/ro/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ro:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ro/coronavirus_landing_page.yml
+++ b/config/locales/ro/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ro:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ru/corona_virus_landing_page.yml
+++ b/config/locales/ru/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ru:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ru/coronavirus_landing_page.yml
+++ b/config/locales/ru/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ru:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/si/corona_virus_landing_page.yml
+++ b/config/locales/si/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-si:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/si/coronavirus_landing_page.yml
+++ b/config/locales/si/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+si:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sk/corona_virus_landing_page.yml
+++ b/config/locales/sk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sk/coronavirus_landing_page.yml
+++ b/config/locales/sk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sl/corona_virus_landing_page.yml
+++ b/config/locales/sl/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sl:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sl/coronavirus_landing_page.yml
+++ b/config/locales/sl/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sl:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/so/corona_virus_landing_page.yml
+++ b/config/locales/so/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-so:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/so/coronavirus_landing_page.yml
+++ b/config/locales/so/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+so:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sq/corona_virus_landing_page.yml
+++ b/config/locales/sq/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sq:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sq/coronavirus_landing_page.yml
+++ b/config/locales/sq/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sq:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sr/corona_virus_landing_page.yml
+++ b/config/locales/sr/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sr:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sr/coronavirus_landing_page.yml
+++ b/config/locales/sr/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sr:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sv/corona_virus_landing_page.yml
+++ b/config/locales/sv/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sv:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sv/coronavirus_landing_page.yml
+++ b/config/locales/sv/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sv:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/sw/corona_virus_landing_page.yml
+++ b/config/locales/sw/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-sw:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/sw/coronavirus_landing_page.yml
+++ b/config/locales/sw/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+sw:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ta/corona_virus_landing_page.yml
+++ b/config/locales/ta/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ta:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ta/coronavirus_landing_page.yml
+++ b/config/locales/ta/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ta:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/th/corona_virus_landing_page.yml
+++ b/config/locales/th/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-th:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/th/coronavirus_landing_page.yml
+++ b/config/locales/th/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+th:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/tk/corona_virus_landing_page.yml
+++ b/config/locales/tk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-tk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/tk/coronavirus_landing_page.yml
+++ b/config/locales/tk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+tk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/tr/corona_virus_landing_page.yml
+++ b/config/locales/tr/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-tr:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/tr/coronavirus_landing_page.yml
+++ b/config/locales/tr/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+tr:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/uk/corona_virus_landing_page.yml
+++ b/config/locales/uk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-uk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/uk/coronavirus_landing_page.yml
+++ b/config/locales/uk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+uk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/ur/corona_virus_landing_page.yml
+++ b/config/locales/ur/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-ur:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/ur/coronavirus_landing_page.yml
+++ b/config/locales/ur/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+ur:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/uz/corona_virus_landing_page.yml
+++ b/config/locales/uz/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-uz:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/uz/coronavirus_landing_page.yml
+++ b/config/locales/uz/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+uz:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/vi/corona_virus_landing_page.yml
+++ b/config/locales/vi/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-vi:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/vi/coronavirus_landing_page.yml
+++ b/config/locales/vi/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+vi:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/zh-hk/corona_virus_landing_page.yml
+++ b/config/locales/zh-hk/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-zh-hk:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/zh-hk/coronavirus_landing_page.yml
+++ b/config/locales/zh-hk/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+zh-hk:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/zh-tw/corona_virus_landing_page.yml
+++ b/config/locales/zh-tw/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-zh-tw:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/zh-tw/coronavirus_landing_page.yml
+++ b/config/locales/zh-tw/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+zh-tw:
+  coronavirus_landing_page:
+    title:

--- a/config/locales/zh/corona_virus_landing_page.yml
+++ b/config/locales/zh/corona_virus_landing_page.yml
@@ -1,4 +1,0 @@
----
-zh:
-  corona_virus_landing_page:
-    title:

--- a/config/locales/zh/coronavirus_landing_page.yml
+++ b/config/locales/zh/coronavirus_landing_page.yml
@@ -1,0 +1,4 @@
+---
+zh:
+  coronavirus_landing_page:
+    title:


### PR DESCRIPTION
Defines the locales actually in use, in the application. This has been
done as a prerequisite for the Rails Translation Manager changes [1].

[1]: alphagov/rails_translation_manager#12

Trello:
https://trello.com/c/Ma1ygjNc/2567-add-automated-tests-to-check-translations-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
