### PR TITLE
Add FAQPage schema to Brexit landing page

### DIFF
--- a/app/views/brexit_landing_page/_schema.html.erb
+++ b/app/views/brexit_landing_page/_schema.html.erb
@@ -1,0 +1,32 @@
+<%
+  trade_markup = I18n.t("brexit_landing_page.trade_deal_links").reduce("") do |memo, trade_link|
+    memo += "<p><a href='#{trade_link[:path]}'>#{trade_link[:text]}</a></p><p>#{trade_link[:explainer]}</p>"
+  end
+%>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "name": "<%= presenter.title %>",
+  "description": "<p><%= t("brexit_landing_page.page_header_explainer") %></p>\n<ul>\n  <li><a href='<%= t("brexit_landing_page.page_header_links.guidance_for_businesses.path") %>'><%= t("brexit_landing_page.page_header_links.guidance_for_businesses.text") %></a></li>    \n<li><a href='<%= t("brexit_landing_page.page_header_links.guidance_for_individuals_and_families.path") %>'><%= t("brexit_landing_page.page_header_links.guidance_for_individuals_and_families.text") %></a></li>  </ul>\n",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "<%= t("brexit_landing_page.take_action_heading") %>",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p><%= t("brexit_landing_page.take_action_explainer") %></p><p><a href='<%= t("brexit_landing_page.take_action_start_now_link") %>'><%= t("brexit_landing_page.take_action_start_now") %></a></p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "<%= t("brexit_landing_page.trade_deal_heading") %>",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<%= trade_markup.html_safe %>"
+      }
+    }
+  ]
+}
+</script>

--- a/app/views/brexit_landing_page/show.html.erb
+++ b/app/views/brexit_landing_page/show.html.erb
@@ -20,3 +20,7 @@
     }
   ) %>
 </div>
+
+<%= render partial: 'schema', locals: {
+  presenter: presented_taxon,
+} %>

--- a/spec/features/brexit_landing_page_spec.rb
+++ b/spec/features/brexit_landing_page_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Brexit landing page" do
       then_i_can_see_the_header_section
       and_i_can_see_the_explore_topics_section
       and_there_is_metadata
+      and_the_faqpage_schema_is_rendered
     end
 
     it "has tracking on all links" do

--- a/spec/support/brexit_landing_page_steps.rb
+++ b/spec/support/brexit_landing_page_steps.rb
@@ -83,4 +83,17 @@ module BrexitLandingPageSteps
       )
     end
   end
+
+  def and_the_faqpage_schema_is_rendered
+    faq_schema = find_schema("FAQPage")
+    expect(faq_schema["name"]).to eq("Brexit")
+    expect(faq_schema["description"]).to include("Find out how new Brexit rules apply to things like travel and doing business with Europe.")
+  end
+
+  def find_schema(schema_name)
+    schema_sections = page.find_all("script[type='application/ld+json']", visible: false)
+    schemas = schema_sections.map { |section| JSON.parse(section.text(:all)) }
+
+    schemas.detect { |schema| schema["@type"] == schema_name }
+  end
 end


### PR DESCRIPTION
Approximating the [/brexit](https://govuk-collec-brexit-dat-orwhxy.herokuapp.com/brexit) page content in [FAQPage schema format](https://schema.org/FAQPage)

Tested in:
- https://validator.schema.org/
- https://search.google.com/test/rich-results

https://trello.com/c/eq8JyhvX/1731-resolve-the-issue-of-the-brexit-landing-page-title-appearing-as-brexit-checker-in-google

## Google result previews

![Screenshot 2021-09-15 at 09 40 52](https://user-images.githubusercontent.com/773037/133400673-150fb7d6-55f7-433f-b380-438b4d2148c4.png)
![Screenshot 2021-09-15 at 09 40 43](https://user-images.githubusercontent.com/773037/133400680-07587cb7-5dcc-468a-abe2-50981319bfd3.png)
