### PR TITLE
Set brexit landing page template to old style header

### DIFF
--- a/app/controllers/brexit_landing_page_controller.rb
+++ b/app/controllers/brexit_landing_page_controller.rb
@@ -20,7 +20,7 @@ class BrexitLandingPageController < ApplicationController
 private
 
   def set_slimmer_template
-    slimmer_template "gem_layout_full_width"
+    slimmer_template "gem_layout_full_width_old_header"
   end
 
   def taxon


### PR DESCRIPTION
We will be setting the Explore Super Menu Header as the default across GOV.UK, so we need to switch the Brexit landing page to use a specific template from Static that has a header with the Sign in link. This is temporary, while we work on design iterations to add the Accounts related links.

Depends on https://github.com/alphagov/static/pull/2595

Related https://github.com/alphagov/finder-frontend/pull/2633

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
