### PR TITLE
Order a persons role by seniority

### DIFF
--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -64,6 +64,7 @@ module Organisations
         .map { |ra| ra["links"]["role"].first }
         .select { |role| allowed_role_content_ids.include?(role["content_id"]) }
         .select { |role| expected_document_type(type).include?(role["document_type"]) }
+        .sort_by { |role| role["details"]["seniority"] }
     end
 
     def formatted_role_link(role)
@@ -75,7 +76,6 @@ module Organisations
 
     def formatted_person_data(person, type)
       roles = current_roles(person, type)
-
       data = {
         brand: @org.brand,
         href: person["base_path"],

--- a/spec/presenters/organisations/people_presenter_spec.rb
+++ b/spec/presenters/organisations/people_presenter_spec.rb
@@ -61,6 +61,34 @@ RSpec.describe Organisations::PeoplePresenter do
       expect(people_presenter.all_people.first[:people][2]).to eq(expected[:people])
     end
 
+    it "orders minister roles by seniority" do
+      expected = {
+        title: "Our ministers",
+        people: {
+          brand: "attorney-generals-office",
+          href: "/government/people/victoria-atkins",
+          image_src: "/photo/victoria-atkins",
+          description: nil,
+          metadata: nil,
+          heading_text: "Victoria Atkins MP",
+          lang: "en",
+          heading_level: 0,
+          extra_links_no_indent: true,
+          extra_links: [
+            {
+              text: "Minister of State",
+              href: "/government/ministers/minister-of-state--61",
+            },
+            {
+              text: "Minister for Afghan Resettlement",
+              href: "/government/ministers/minister-for-afghan-resettlement",
+            },
+          ],
+        },
+      }
+      expect(people_presenter.all_people.first[:people][3]).to eq(expected[:people])
+    end
+
     it "returns minister without image if no image available" do
       expected = {
         title: "Our ministers",

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -79,7 +79,7 @@ module OrganisationHelpers
     }
   end
 
-  def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil, content_id: nil)
+  def current_role_appointment(title:, base_path: nil, payment_type: nil, document_type: nil, content_id: nil, seniority: nil)
     {
       details: {
         current: true,
@@ -91,7 +91,7 @@ module OrganisationHelpers
             title: title,
             base_path: base_path,
             document_type: document_type,
-            details: { role_payment_type: payment_type },
+            details: { role_payment_type: payment_type, seniority: seniority },
           }.compact,
         ],
       },
@@ -131,6 +131,8 @@ module OrganisationHelpers
           { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
           { content_id: "849f0fdc-6393-49fa-9661-9afdfb40615c" },
           { content_id: "3f4bbf6c-741e-4207-9135-63d1c8f39c28" },
+          { content_id: "ac6e554d-f7d2-4c15-8a0c-91eedc1e3c31" },
+          { content_id: "6d8eb1a6-41f2-4381-9c06-de697c0ff2c5" },
         ],
         ordered_ministers: [
           {
@@ -193,6 +195,35 @@ module OrganisationHelpers
                   title: "Minister for the Civil Service",
                   base_path: "/government/ministers/minister-for-the-civil-service",
                   document_type: "ministerial_role",
+                ),
+              ],
+            },
+          },
+          {
+            title: "Victoria Atkins MP",
+            locale: "en",
+            base_path: "/government/people/victoria-atkins",
+            details: {
+              image: {
+                url: "/photo/victoria-atkins",
+                alt_text: "Victoria Atkins MP",
+              },
+            },
+            links: {
+              role_appointments: [
+                current_role_appointment(
+                  content_id: "6d8eb1a6-41f2-4381-9c06-de697c0ff2c5",
+                  title: "Minister for Afghan Resettlement",
+                  base_path: "/government/ministers/minister-for-afghan-resettlement",
+                  document_type: "ministerial_role",
+                  seniority: 100,
+                ),
+                current_role_appointment(
+                  content_id: "ac6e554d-f7d2-4c15-8a0c-91eedc1e3c31",
+                  title: "Minister of State",
+                  base_path: "/government/ministers/minister-of-state--61",
+                  document_type: "ministerial_role",
+                  seniority: 99,
                 ),
               ],
             },


### PR DESCRIPTION
## What
Order a persons role by seniority 

## How
Whitehall has a concept of [role seniority](https://github.com/alphagov/whitehall/blob/main/db/schema.rb#L909) which it uses to determine the order of roles displayed on the [government/ministers page](https://www.gov.uk/government/ministers). Where 1 is high and 100 is low. We would like to make sure that when collections renders the
[organisations/org_name page](https://govuk-collec-rename-com-l6cefi.herokuapp.com/government/organisations/ministry-of-justice) that the roles under each person are in order
of seniority.

## Why
External request

## Before

<img width="292" alt="Screenshot 2021-09-24 at 15 54 22" src="https://user-images.githubusercontent.com/17908089/134695766-3c4732a1-21ab-49a4-9edb-505f7d83421b.png">


## After

<img width="305" alt="Screenshot 2021-09-24 at 15 53 36" src="https://user-images.githubusercontent.com/17908089/134695671-0262faf5-16d4-4864-b393-50f1c5f3cf18.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

