### PR TITLE
Apply the big number component to the covid landing page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@ $govuk-new-link-styles: true;
 // @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/accordion';
 @import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/big-number';
 @import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/contents-list';

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -289,8 +289,3 @@ $c19-landing-page-header-background: govuk-colour("blue");
 .covid-statistics__statistic-wrapper {
   margin-bottom: govuk-spacing(5);
 }
-
-.covid-statistics__statistic-value {
-  @include govuk-font(80, $weight: bold);
-  margin-bottom: 0;
-}

--- a/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistic.html.erb
@@ -6,9 +6,10 @@
       margin_bottom: 1
     } %>
 
-  <p class="covid-statistics__statistic-value govuk-body">
-    <%= statistic %>
-  </p>
+  
+  <%= render "govuk_publishing_components/components/big_number", {
+    number: statistic,
+  } %>
   <p class="govuk-body"><%= statistic_meaning %></p>
 
   <p class="govuk-body-s">


### PR DESCRIPTION
## What
Adds the [big number component](https://components.publishing.service.gov.uk/component-guide/big_number) to the [covid landing page](https://www.gov.uk/coronavirus), replacing the statistics near the bottom of the page. 

## Why
To ensure we don't have repeating implementations of the same pattern across govuk.

## Visual changes
| Before | After |
| --- | --- |
| ![Screenshot 2021-09-30 at 18 04 17](https://user-images.githubusercontent.com/64783893/135500734-09bba07c-03d7-43d7-bcae-2e194cf7204f.png) | ![Screenshot 2021-09-30 at 18 04 25](https://user-images.githubusercontent.com/64783893/135500763-ff816f72-f6d7-4528-b05a-0756de159fad.png) |
