### PR TITLE
DO NOT MERGE - Display accordion sub-headings on /coronavirus

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -18,6 +18,9 @@
       heading: {
         text: section["title"],
       },
+      summary: {
+        text: section["sub_heading"],
+      },
       content: {
         html: content,
       },


### PR DESCRIPTION
#Why?

A need has been identified in that the title of the accordion needs to be short and doesn’t work hard enough to explain what users will get inside the accordion. Therefore we want to update accordions to include sub headings. This is already an option on the accordion component, as shown in the [accordion component documentation](https://components.publishing.service.gov.uk/component-guide/accordion/with_summary). 

#What?
The aim of this task is to amend the [component on the frontend](https://github.com/alphagov/collections/blob/fb66d59732b42134464e83c4e4bc59e832de6b24/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb#L17-L35) to pass in a [summary argument](https://components.publishing.service.gov.uk/component-guide/accordion/with_summary).

There is a [corresponding backend task](https://trello.com/c/0W3i2dN8/938-add-sub-heading-field-to-sub-sections-in-coronavirus-publishing-tool) to add making the accordion heading publishable using the coronavirus publishing tool. Once this is deployed and the sub_headings data has been updated, the data will be accessible using: `section["sub_heading"]`.

The sub headings are optional, so the accordion needs to be able to handle no data being found. 

[Trello](https://trello.com/c/KnAUn3al/646-display-accordion-sub-headings-on-coronavirus)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
