### PR TITLE
Use new sub heading

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
   <%
-    accordion_contents << {
+    additional_contents = {
       heading: {
         text: section["title"],
       },
@@ -32,6 +32,10 @@
         track_dimension_index: 26
       }
     }
+
+    additional_contents[:summary] = { text: section["sub_heading"] } if section["sub_heading"]
+
+    accordion_contents << additional_contents
   %>
 <% end %>
 <%= render "govuk_publishing_components/components/heading", {

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -25,6 +25,12 @@ RSpec.feature "Coronavirus Pages" do
       then_i_can_see_the_accordions_content
     end
 
+    scenario "has accordions with sub headings" do
+      given_there_is_a_content_item
+      when_i_visit_the_coronavirus_landing_page
+      then_i_can_see_sub_headings_of_accordions
+    end
+
     scenario "shows COVID-19 risk level when risk level is enabled" do
       given_there_is_a_content_item_with_risk_level_element_enabled
       when_i_visit_the_coronavirus_landing_page

--- a/spec/fixtures/content_store/coronavirus_landing_page.json
+++ b/spec/fixtures/content_store/coronavirus_landing_page.json
@@ -70,6 +70,7 @@
     "sections": [
       {
         "title": "How to protect yourself and others",
+        "sub_heading": "accordion sub heading",
         "sub_sections": [
           {
             "title": "",

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -103,6 +103,10 @@ module CoronavirusLandingPageSteps
     expect(page).not_to have_content("Find out when schools are expected to reopen in Scotland, Wales and Northern Ireland")
   end
 
+  def then_i_can_see_sub_headings_of_accordions
+    expect(page).to have_content("accordion sub heading")
+  end
+
   def then_i_can_see_the_business_page
     expect(page).to have_title("Coronavirus (COVID-19): Business support")
     then_i_can_see_the_page_title("Business support")


### PR DESCRIPTION
We have recently introduced the ability for collections publisher to
save subheadings to accordion sections. This shows them on the
coronavirus landing page if they're present.

Trello - https://trello.com/c/0W3i2dN8/645-add-subheading-field-to-subsections-in-coronavirus-publishing-tool

## Visual change

### Before
<img width="678" alt="Screenshot 2021-10-07 at 11 33 30" src="https://user-images.githubusercontent.com/24547207/136368182-dc448580-4ea4-4209-a675-f9cd491a1190.png">


### After
<img width="551" alt="Screenshot 2021-10-06 at 15 58 40" src="https://user-images.githubusercontent.com/24547207/136368062-2ca8be8f-75e5-41c5-b7a9-2b17d9625c39.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
