### PR TITLE
Remove unnecessary `test` task in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint cucumber test spec jasmine:ci pact:verify]
+task default: %i[lint cucumber spec jasmine:ci pact:verify]


### PR DESCRIPTION
This task isn't running any tests and can be removed:

```
Run options: --seed 29011
# Running:



Finished in 0.000925s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
