### PR TITLE
Fix flaky person test

### DIFF
--- a/spec/features/person_spec.rb
+++ b/spec/features/person_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Person page" do
   end
 
   def stub_person_page_content_item(base_path, name)
-    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person").merge(
+    content_item.merge!(
       "title" => name,
       "base_path" => base_path,
     )
@@ -43,5 +43,9 @@ RSpec.feature "Person page" do
         reject_content_purpose_supergroup: "other",
       })
       .to_return(body: { results: [] }.to_json)
+  end
+
+  def content_item
+    @content_item ||= GovukSchemas::RandomExample.for_schema(frontend_schema: "person")
   end
 end


### PR DESCRIPTION
This test intermittently fails in CI with:

```
​1) Person page displays the person page
   ​Failure/Error: expect(page).to have_title("Rufus Scrimgeour - GOV.UK")

   ​NoMethodError:
     ​undefined method `match?' for nil:NilClass
```

I think this could be because we're trying to load a "Random" content
item before each test run. The hope is that memoizing the content item
will mean that that the `title` is already set before the page loads.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
