### PR TITLE
Remove unused styles from coronavirus pages

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -9,34 +9,11 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 }
 
-.covid__page-title {
-  @include govuk-font(48, $weight: bold);
-  margin-bottom: govuk-spacing(5);
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: govuk-spacing(4);
-    margin-bottom: 45px;
-  }
-}
-
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
   border-top: solid govuk-spacing(2) $covid-yellow;
   background-color: $c19-landing-page-header-background;
   color: govuk-colour("white");
-
-  .covid__page-header-link {
-    font-weight: normal;
-
-    &:link,
-    &:visited {
-      color: govuk-colour("white");
-    }
-
-    &:focus {
-      color: $govuk-text-colour;
-    }
-  }
 }
 
 .covid__page-header--business {
@@ -53,10 +30,6 @@ $c19-landing-page-header-background: govuk-colour("blue");
   @include govuk-media-query($until: tablet) {
     margin-bottom: govuk-spacing(3);
   }
-}
-
-.covid__page-header-title-section-break {
-  padding: 0 govuk-spacing(3);
 }
 
 .covid__page-header-content-section {
@@ -111,26 +84,6 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 }
 
-.covid__spaced-list > li {
-  &:nth-child(2n) {
-    margin-bottom: govuk-spacing(5);
-
-    @include govuk-media-query($from: desktop) {
-      margin-bottom: govuk-spacing(4);
-    }
-  }
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.covid__list--header {
-  padding-left: govuk-spacing(4);
-  list-style-type: disc;
-  color: govuk-colour("white");
-}
-
 .covid__list-item-description {
   @include govuk-font(19);
   padding-left: govuk-spacing(6);
@@ -138,51 +91,6 @@ $c19-landing-page-header-background: govuk-colour("blue");
 
 .covid__list-item {
   margin-bottom: govuk-spacing(2);
-}
-
-.covid__video-wrapper {
-  margin-bottom: govuk-spacing(4);
-}
-
-.covid__video-placeholder {
-  position: relative;
-  padding: 110px 0;
-  margin-bottom: govuk-spacing(4);
-  border: solid 2px govuk-colour("black");
-  text-align: center;
-
-  .govuk-body {
-    margin: 0;
-  }
-
-  .covid__bold {
-    font-weight: bold;
-  }
-}
-
-.covid__video-logo {
-  @include govuk-font(19, $weight: bold, $line-height: 1);
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: govuk-spacing(1);
-  padding-top: govuk-spacing(2);
-  padding-left: govuk-spacing(5);
-  padding-right: govuk-spacing(2);
-  margin: govuk-spacing(3);
-  border: solid 1px govuk-colour("black");
-  text-transform: uppercase;
-
-  &:before {
-    content: "";
-    position: absolute;
-    top: 11px;
-    left: 8px;
-    width: 12px;
-    height: 12px;
-    background: govuk-colour("red");
-    border-radius: 100%;
-  }
 }
 
 .covid__list ~ .covid__accordion-heading {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove some unneeded styles from the coronavirus pages. Note that https://github.com/alphagov/collections/pull/2559 should be merged before this PR - I was originally going to include these changes with that, but thought it would be easier to find and revert these changes later if needed, if they were separate.

## Why

General cleanup.

## Visual changes
None (hopefully!)

