### PR TITLE
Redirect all coronavirus taxons to landing page

### DIFF
--- a/app/controllers/taxons_redirection_controller.rb
+++ b/app/controllers/taxons_redirection_controller.rb
@@ -1,57 +1,13 @@
 # frozen_string_literal: true
 
 class TaxonsRedirectionController < ApplicationController
-  CORONAVIRUS_LANDING_PAGE_PATH = "/coronavirus"
-  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon"
-
-  HUB_PAGE_FROM_CONTENT_ID = {
-    "65666cdf-b177-4d79-9687-b9c32805e450" => "/coronavirus/business-support",
-    "272308f4-05c8-4d0d-abc7-b7c2e3ccd249" => "/coronavirus/education-and-childcare",
-    "b7f57213-4b16-446d-8ded-81955d782680" => "/coronavirus/worker-support",
-  }.freeze
-
   def redirect
-    if is_coronavirus_taxon?
-      redirect_to_landing_page && return
-    else
-      redirect_to_best_coronavirus_page
-    end
+    redirect_to_landing_page && return
   end
 
 private
 
   def redirect_to_landing_page
-    redirect_to(CORONAVIRUS_LANDING_PAGE_PATH, status: :temporary_redirect)
-  end
-
-  def redirect_to_best_coronavirus_page
-    redirect_to(best_coronavirus_page, status: :temporary_redirect)
-  end
-
-  def best_coronavirus_page
-    return HUB_PAGE_FROM_CONTENT_ID[taxon.content_id] if hub_taxon?
-    return HUB_PAGE_FROM_CONTENT_ID[parent_hub_taxons.first] if parent_hub_taxons.any?
-
-    CORONAVIRUS_LANDING_PAGE_PATH
-  end
-
-  def hub_taxon?
-    hub_taxon_content_ids.include?(taxon.content_id)
-  end
-
-  def parent_hub_taxons
-    hub_taxon_content_ids & taxon.parent_taxons.map(&:content_id)
-  end
-
-  def hub_taxon_content_ids
-    HUB_PAGE_FROM_CONTENT_ID.keys
-  end
-
-  def taxon
-    @taxon ||= Taxon.find(request.path)
-  end
-
-  def is_coronavirus_taxon?
-    request.path == CORONAVIRUS_TAXON_PATH
+    redirect_to("/coronavirus", status: :temporary_redirect)
   end
 end

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -98,20 +98,6 @@ RSpec.feature "Coronavirus Pages" do
       then_i_am_redirected_to_the_landing_page
     end
 
-    scenario "redirects taxons to appropriate hub pages" do
-      given_there_is_a_business_content_item
-      and_a_coronavirus_business_taxon
-      when_i_visit_the_coronavirus_business_taxon
-      then_i_am_redirected_to_the_business_hub_page
-    end
-
-    scenario "redirects subtaxons to appropriate hub pages" do
-      given_there_is_a_business_content_item
-      and_a_coronavirus_business_subtaxon
-      when_i_visit_the_coronavirus_business_subtaxon
-      then_i_am_redirected_to_the_business_hub_page
-    end
-
     scenario "redirects subtaxons to the landing page if there is no overriding rule" do
       given_there_is_a_content_item
       and_another_coronavirus_subtaxon

--- a/spec/support/coronavirus_content_item_helper.rb
+++ b/spec/support/coronavirus_content_item_helper.rb
@@ -63,13 +63,6 @@ module CoronavirusContentItemHelper
     end
   end
 
-  def business_taxon_content_item
-    random_taxon_page do |item|
-      item["content_id"] = TaxonsRedirectionController::HUB_PAGE_FROM_CONTENT_ID.key("/coronavirus/business-support")
-      item
-    end
-  end
-
   def business_subtaxon_content_item
     stubbed_business_taxon = business_taxon_content_item.tap do |item|
       item["links"] = {}

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -35,10 +35,6 @@ module CoronavirusLandingPageSteps
     stub_content_store_has_item(EDUCATION_PATH, education_content_item)
   end
 
-  def and_a_coronavirus_business_taxon
-    stub_content_store_has_item(BUSINESS_TAXON_PATH, business_taxon_content_item)
-  end
-
   def and_a_coronavirus_business_subtaxon
     stub_content_store_has_item(BUSINESS_SUBTAXON_PATH, business_subtaxon_content_item)
   end


### PR DESCRIPTION
Trello: https://trello.com/c/ZzFMVDNS
Depends on: https://github.com/alphagov/collections-publisher/pull/1456

# What's changed and why?

We have been given permission to retire the coronavirus hub pages.
The links to the hub pages have already been removed and the content in the hubs as already been added to the accordions.

Now we need to make sure that the coronavirus child taxons are redirected to the landing page. If we didn't add this change, we'd still be redirecting users to the landing page, but there would be one more jump as they hit the redirect for the hub page first.

Also removes the feature tests that test the redirect.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
