### PR TITLE
Add tracking to c19 header links

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -51,7 +51,7 @@
             data: {
               module: "gem-track-click",
               track_category: "pageElementInteraction",
-              track_action: "Announcements",
+              track_action: "Header",
               track_label: header["link"]["href"]
             }
           } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Add tracking to the links in the header section of the coronavirus landing page, and make the tracking already present on the action link beneath them consistent with the new tracking.

## Why
Part of improving our understanding of how users are interacting with this page.

## Visual changes
None.

Trello card: https://trello.com/c/XJ57hQhA/235-add-tracking-to-the-links-in-the-header-on-coronavirus
