### PR TITLE
Add print stylesheet for organisation logo component

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -3,6 +3,7 @@
 @import 'govuk_publishing_components/components/print/button';
 @import 'govuk_publishing_components/components/print/contents-list';
 @import 'govuk_publishing_components/components/print/govspeak';
+@import 'govuk_publishing_components/components/print/organisation-logo';
 @import 'govuk_publishing_components/components/print/step-by-step-nav';
 @import 'govuk_publishing_components/components/print/step-by-step-nav-header';
 @import 'govuk_publishing_components/components/print/title';


### PR DESCRIPTION
## What

Adds the print stylesheet for the organisation logo component.

Reliant on alphagov/govuk_publishing_components#2371 being released.


## Why

When a page containing the organisation logo is printed, the logo is printed out at the native dimensions of the image - this means that if an image is used that too large it can overwhelm the printed page.

## Visual changes

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/1732331/137769094-69bfbd36-59e2-440c-84f8-83bb22d2b229.png) | ![](https://user-images.githubusercontent.com/1732331/137769172-a5793d3d-1865-4519-9633-3a01aa234db5.png) |


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
