### PR TITLE
Allow links in NHS section

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_nhs_notice.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_nhs_notice.html.erb
@@ -21,12 +21,18 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% nhs_banner["sections"].each do |section| %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: section["heading"],
-        heading_level: 2,
-        font_size: "s",
-        margin_bottom: 4,
-      } if section["heading"].present? %>
+      <% if section["heading"].present? && section["url"].present? %>
+        <p class="govuk-heading-s">
+          <a class="govuk-link" href="<%= section["url"] %>"><%= section["heading"] %></a>
+        </p>
+      <% else %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: section["heading"],
+          heading_level: 3,
+          font_size: "s",
+          margin_bottom: 4,
+        } if section["heading"].present? %>
+      <% end %>
 
       <%= render_govspeak(section["markdown"]) if section["markdown"].present? %>
     <% end %>

--- a/spec/views/coronavirus_landing_page/components/landing_page/nhs_notice.html.erb_spec.rb
+++ b/spec/views/coronavirus_landing_page/components/landing_page/nhs_notice.html.erb_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+
+RSpec.describe "the nhs notice partial" do
+  before do
+    render(
+      "coronavirus_landing_page/components/landing_page/nhs_notice",
+      {
+        nhs_banner: {
+          header: "Hello world",
+          sections: sections,
+        },
+      }.with_indifferent_access,
+    )
+  end
+
+  describe "header" do
+    context "when there is header text" do
+      let(:sections) { [] }
+
+      it "renders the header as an H2 with the text" do
+        expect(rendered).to have_selector("h2", text: "Hello world")
+      end
+    end
+  end
+
+  describe "sections" do
+    context "when there are no sections" do
+      let(:sections) { [] }
+
+      it "renders an empty DIV" do
+        expect(rendered).to have_selector("div.govuk-grid-column-two-thirds", text: "")
+      end
+    end
+
+    describe "markdown" do
+      context "when the markdown is empty" do
+        let(:sections) { [{ markdown: "" }] }
+
+        it "does not render a DIV with the govuk-govspeak class" do
+          expect(rendered).to have_no_selector("div.govuk-govspeak")
+        end
+      end
+
+      context "when the markdown has text" do
+        let(:sections) { [{ markdown: "- List item\n" }] }
+
+        it "renders a DIV with govuk-govspeak" do
+          expect(rendered).to have_selector("div.govuk-govspeak")
+        end
+
+        it "renders the markdown text as HTML" do
+          expect(rendered).to have_selector("li", text: "List item")
+        end
+      end
+    end
+
+    describe "heading" do
+      context "when there is a heading but no URL" do
+        let(:sections) { [{ heading: "Section heading" }] }
+
+        it "renders an H3 with the heading text" do
+          expect(rendered).to have_selector("h3", text: "Section heading")
+        end
+      end
+
+      context "when there is a heading but the URL is empty" do
+        let(:sections) { [{ heading: "Section heading", url: "" }] }
+
+        it "renders a section heading as an H3" do
+          expect(rendered).to have_selector("h3", text: "Section heading")
+        end
+      end
+
+      context "when there is a URL but no heading" do
+        let(:sections) do
+          [{ url: "https://example.com" }]
+        end
+
+        it "does not render a section heading" do
+          expect(rendered).to have_no_selector("p.govuk-heading-s")
+        end
+
+        it "does not render a link" do
+          expect(rendered).to have_no_link("Section heading", href: "https://example.com")
+        end
+      end
+
+      context "when there is a heading and a URL" do
+        let(:sections) do
+          [{ heading: "Section heading", url: "https://example.com" }]
+        end
+
+        it "renders a P styled as an H3" do
+          expect(rendered).to have_selector("p.govuk-heading-s")
+        end
+
+        it "renders a link with the heading text" do
+          expect(rendered).to have_link("Section heading", href: "https://example.com")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

This change allows for a section heading in the NHS notice to be (optionally) made a link. 

## Why

This improves the user experience by allowing simple, clean copy to be created that has a single link to the desired action.

The use of links in headers is not typically done on GOV.UK. It may also create some undesirable accessibility issues. To avoid this situation, we style a `P` element to look like a an `H3` in these cases.

Section headers without a URL are rendered as an `H3` element as before.

## Example YAML (see [coronavirus_landing_page.yml](https://github.com/alphagov/govuk-coronavirus-content/blob/12bacb98cdfa9a96a8f6f344143be0be1361babd/content/coronavirus_landing_page.yml#L33))

```yaml
nhs_banner:
  header: Testing for coronavirus (COVID-19)
  sections:
    - heading: "Testing for coronavirus (COVID-19)"
      url: "https://www.nhs.uk/conditions/coronavirus-covid-19/testing/"
      markdown: "Find out how to get tested, what your test result means and how to report your result.\n"
```

## Screenshots

### Before

<img width="1023" alt="Screenshot 2021-11-01 at 13 40 14" src="https://user-images.githubusercontent.com/44037625/139868860-42c0c061-8ea3-4002-96bd-fab93e6c0d9d.png">

### After

<img width="1023" alt="Screenshot 2021-11-01 at 13 41 08" src="https://user-images.githubusercontent.com/44037625/139868888-e1bdee3e-2c9f-435b-b57b-0d7694da6ffe.png">

[Trello](https://trello.com/c/MRWKzJg6/299-improve-nhs-section-to-allow-for-links)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
