### PR TITLE
Remove jQuery from coronavirus landing page JS

### DIFF
--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -1,3 +1,5 @@
+//= require govuk_publishing_components/vendor/polyfills/closest
+
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 

--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -2,11 +2,11 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function CoronavirusLandingPage () {}
+  function CoronavirusLandingPage ($module) {
+    this.module = $module
+  }
 
-  CoronavirusLandingPage.prototype.start = function ($element) {
-    this.module = $element[0]
-
+  CoronavirusLandingPage.prototype.init = function () {
     // Confirm the user is on the coronavirus landing page
     if (this.checkOnLandingPage()) {
       this.globarBarSeen()

--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -5,17 +5,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   function CoronavirusLandingPage () {}
 
   CoronavirusLandingPage.prototype.start = function ($element) {
-    var $this = this
+    this.module = $element[0]
+
     // Confirm the user is on the coronavirus landing page
     if (this.checkOnLandingPage()) {
       this.globarBarSeen()
     }
 
-    // Ensure that the "Open/Close all" element exists when attaching the event listeners for tracking
-    $(document).ready(function () {
-      $this.addAccordionOpenAllTracking($element)
-      $this.addTimelineCountrySelector()
-    })
+    this.addAccordionOpenAllTracking()
+    this.addTimelineCountrySelector()
   }
 
   CoronavirusLandingPage.prototype.checkOnLandingPage = function () {
@@ -32,15 +30,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  CoronavirusLandingPage.prototype.addAccordionOpenAllTracking = function ($element) {
-    $element.find('.gem-c-accordion__open-all').on('click', function (e) {
-      var expanded = $(e.target).attr('aria-expanded') === 'true'
-      var label = expanded ? 'Expand all' : 'Collapse all'
-      var action = expanded ? 'accordionOpened' : 'accordionClosed'
-      var options = { transport: 'beacon', label: label }
+  // we want to track the accordion show/hide all control but this is added dynamically
+  // after page load by the accordion component, so we attach the event listener to the
+  // accordion parent element then filter click events to only track that control
+  CoronavirusLandingPage.prototype.addAccordionOpenAllTracking = function () {
+    var accordions = this.module.querySelectorAll('.gem-c-accordion')
+    for (var i = 0; i < accordions.length; i++) {
+      accordions[i].addEventListener('click', function (e) {
+        var clicked = e.target.closest('button')
+        if (clicked && clicked.classList.contains('gem-c-accordion__open-all')) {
+          var expanded = clicked.getAttribute('aria-expanded') === 'true'
+          var label = expanded ? 'Expand all' : 'Collapse all'
+          var action = expanded ? 'accordionOpened' : 'accordionClosed'
+          var options = { transport: 'beacon', label: label }
 
-      GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
-    })
+          GOVUK.analytics.trackEvent('pageElementInteraction', action, options)
+        }
+      })
+    }
   }
 
   CoronavirusLandingPage.prototype.addTimelineCountrySelector = function () {

--- a/app/assets/javascripts/modules/organisation-list-filter.js
+++ b/app/assets/javascripts/modules/organisation-list-filter.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-var */
+//= require govuk_publishing_components/vendor/polyfills/closest
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};

--- a/spec/javascripts/modules/coronavirus-landing-page_spec.js
+++ b/spec/javascripts/modules/coronavirus-landing-page_spec.js
@@ -23,15 +23,15 @@ describe('Coronavirus landing page', function () {
   var $element
 
   beforeEach(function () {
-    coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage()
     $element = $(html)
+    coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage($element[0])
     GOVUK.approveAllCookieTypes()
   })
 
   it('sets global_bar_seen to automatically hide if on /coronavirus', function () {
     GOVUK.cookie('global_bar_seen', JSON.stringify({ count: 0, version: 1 }))
     spyOn(coronavirusLandingPage, 'checkOnLandingPage').and.returnValue(true)
-    coronavirusLandingPage.start($element)
+    coronavirusLandingPage.init()
 
     expect(parseCookie(GOVUK.cookie('global_bar_seen')).count).toBe(999)
   })
@@ -39,7 +39,7 @@ describe('Coronavirus landing page', function () {
   it('only sets global_bar_seen if on /coronavirus', function () {
     GOVUK.cookie('global_bar_seen', JSON.stringify({ count: 0, version: 1 }))
     spyOn(coronavirusLandingPage, 'checkOnLandingPage').and.returnValue(false)
-    coronavirusLandingPage.start($element)
+    coronavirusLandingPage.init()
 
     expect(parseCookie(GOVUK.cookie('global_bar_seen')).count).not.toBe(999)
     expect(parseCookie(GOVUK.cookie('global_bar_seen')).version).toBe(1)
@@ -59,7 +59,7 @@ describe('Coronavirus landing page', function () {
         $(e.target).attr('aria-expanded', expanded ? 'false' : 'true')
       })
 
-      coronavirusLandingPage.start($element)
+      coronavirusLandingPage.init()
     })
 
     it('tracks expanding', function () {
@@ -107,9 +107,9 @@ describe('Coronavirus landing page', function () {
           '<div id="nation-england" class="js-covid-timeline">England</div>' +
           '<div id="nation-northern_ireland" class="js-covid-timeline">Northern Ireland</div>' +
         '</div>'
-      coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage()
       $element = $(nationPickerHtml)
       $('body').append($element)
+      coronavirusLandingPage = new GOVUK.Modules.CoronavirusLandingPage($element[0])
     })
 
     afterEach(function () {
@@ -117,7 +117,7 @@ describe('Coronavirus landing page', function () {
     })
 
     it('show and hide appropriate sections of the page when the radio buttons change', function () {
-      coronavirusLandingPage.start($element)
+      coronavirusLandingPage.init()
 
       var englandRadio = $element.find('#radio-0')
       var northernIrelandRadio = $element.find('#radio-1')
@@ -146,7 +146,7 @@ describe('Coronavirus landing page', function () {
 
       northernIrelandRadio.prop('checked', true)
 
-      coronavirusLandingPage.start($element)
+      coronavirusLandingPage.init()
 
       expect(englandSection).toBeHidden()
       expect(northernIrelandSection).toBeVisible()
@@ -157,7 +157,7 @@ describe('Coronavirus landing page', function () {
       var englandSection = $element.find('#nation-england')
       var northernIrelandSection = $element.find('#nation-northern_ireland')
 
-      coronavirusLandingPage.start($element)
+      coronavirusLandingPage.init()
 
       expect(englandSection).toBeVisible()
       expect(northernIrelandSection).toBeHidden()


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove jQuery from the JS for the coronavirus landing page, and restructure the code slightly. Also converts it into a GOVUK Frontend 'init' module, rather than a 'start' module.

## Why

We're removing jQuery across GOV.UK, and there was also some tidying needed on this particular file.

## Visual changes

None.

Trello card: https://trello.com/c/GmHGdvoH/72-convert-coronavirus-landing-page-javascript-to-follow-a-more-conventional-module-approach-without-jquery
