### PR TITLE
Bump Rails Translation Manager version and enable Dependabot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
         dependency-type: direct
       - dependency-name: plek
         dependency-type: direct
+      - dependency-name: rails_translation_manager
+        dependency-type: direct
       - dependency-name: rubocop-govuk
         dependency-type: direct
       - dependency-name: slimmer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
+    csv (3.2.1)
     cucumber (4.1.0)
       builder (~> 3.2, >= 3.2.3)
       cucumber-core (~> 7.1, >= 7.1.0)
@@ -371,8 +372,9 @@ GEM
     rails-i18n (6.0.0)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 7)
-    rails_translation_manager (1.1.0)
+    rails_translation_manager (1.1.2)
       activesupport
+      csv (~> 3.2)
       i18n-tasks
       rails-i18n
     railties (6.1.4.1)
@@ -499,7 +501,7 @@ GEM
     table_print (1.5.7)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    terminal-table (3.0.1)
+    terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.1.0)
     thread_safe (0.3.6)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello:
https://trello.com/c/rFcKFuXv/2521-add-railstranslationmanager-to-dependabot-configuration