### PR TITLE
Align header links centrally on news organisations

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -59,18 +59,6 @@ module Organisations
       end
     end
 
-    def logo_wrapper_class
-      return "govuk-grid-column-two-thirds" if org.is_news_organisation?
-
-      "govuk-grid-column-one-third"
-    end
-
-    def link_wrapper_class
-      return "govuk-grid-column-one-third" if org.is_news_organisation?
-
-      "govuk-grid-column-two-thirds"
-    end
-
     def translation_links
       if org.translations.present? && org.translations.count > 1
         links = []

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -4,7 +4,7 @@
   <h1 class="govuk-visually-hidden"><%= @header.org.title %></h1>
 
   <div class="govuk-grid-row">
-    <div class="<%= @header.logo_wrapper_class %> organisation__margin-bottom">
+    <div class="govuk-grid-column-one-third organisation__margin-bottom">
       <%= render "govuk_publishing_components/components/organisation_logo", {
         organisation: @header.organisation_logo
       } %>
@@ -18,7 +18,7 @@
     </div>
 
     <% if @organisation.is_live? %>
-      <div class="<%= @header.link_wrapper_class %> organisation__margin-bottom">
+      <div class="govuk-grid-column-two-thirds organisation__margin-bottom">
         <%= render "govuk_publishing_components/components/translation_nav", @header.translation_links %>
         <%= render "components/topic-list", @header.ordered_featured_links %>
       </div>


### PR DESCRIPTION
Introduced at https://github.com/alphagov/collections/pull/685/commits/ec8da8bc803cbda2deb28a7683dc03b502f84efa#diff-e1dc10a5537077c2ff786edc2b95d1c11c5b95751ba532cba44a92df77fd9921R51

We had a request to change this styling in a Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/4772599

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
