### PR TITLE
Fix tracking on statistics

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -46,8 +46,14 @@
           <%= link_to(
             topic_section.dig("tests", "guidance_link", "label"),
             topic_section.dig("tests", "guidance_link", "url"),
-            class: 'govuk-link')
-          %>
+            class: 'govuk-link',
+            data: {
+              module: "gem-track-click",
+              track_category: "pageElementInteraction",
+              track_action: "Statistics",
+              track_label: topic_section.dig("tests", "guidance_link", "url"),
+            },
+          ) %>
           <br/>
           <span class="covid-statistics__latest">
             <%= topic_section.dig("updated_date") %> <%= statistics.new_positive_tests_date.strftime("%d %B %Y") %>
@@ -82,8 +88,14 @@
           <%= link_to(
             topic_section.dig("admissions", "guidance_link", "label"),
             topic_section.dig("admissions", "guidance_link", "url"),
-            class: 'govuk-link')
-          %>
+            class: 'govuk-link',
+            data: {
+              module: "gem-track-click",
+              track_category: "pageElementInteraction",
+              track_action: "Statistics",
+              track_label: topic_section.dig("admissions", "guidance_link", "url"),
+            },
+          ) %>
           <br/>
           <span class="covid-statistics__latest">
             <%= topic_section.dig("updated_date") %> <%= statistics.hospital_admissions_date.strftime("%d %B %Y") %>
@@ -118,8 +130,14 @@
           <%= link_to(
             topic_section.dig("vaccinations", "guidance_link", "label"),
             topic_section.dig("vaccinations", "guidance_link", "url"),
-            class: 'govuk-link')
-          %>
+            class: 'govuk-link',
+            data: {
+              module: "gem-track-click",
+              track_category: "pageElementInteraction",
+              track_action: "Statistics",
+              track_label: topic_section.dig("vaccinations", "guidance_link", "url"),
+            },
+          ) %>
           <br/>
           <span class="covid-statistics__latest">
             <%= topic_section.dig("updated_date") %> <%= statistics.cumulative_vaccinations_date.strftime("%d %B %Y") %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds the `gem-track-click` tracking script to the new links on the redesigned statistics section on the coronavirus landing page. Specifically, the three 'all' links.

![Screenshot 2021-11-22 at 11 09 50](https://user-images.githubusercontent.com/861310/142851338-32d63e60-43da-48b7-86c8-5a7727707a9a.png)


## Why
I forgot to do it when these new links were added.

## Visual changes
None.

Trello card: https://trello.com/c/VbBHekq8/382-add-pageelementinteraction-tracking-events-to-the-statistics-section