### PR TITLE
Show all documents in "latest from" list

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -51,7 +51,6 @@ module Organisations
           count: 3,
           order: "-public_timestamp",
           filter_organisations: @org.slug,
-          reject_content_purpose_supergroup: "other",
           fields: %w[title link content_store_document_type public_timestamp],
         },
         metric_key: "organisations.search.request_time",

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -53,7 +53,6 @@ module OrganisationHelpers
 
     url = build_search_api_query_url(
       filter_organisations: organisation_slug,
-      reject_content_purpose_supergroup: "other",
       count: 3,
     )
 
@@ -61,12 +60,12 @@ module OrganisationHelpers
   end
 
   def stub_search_api_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other")
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
   end
 
   def stub_search_api_latest_content_with_acronym(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp&reject_content_purpose_supergroup=other")
+    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
   end
 


### PR DESCRIPTION
It's confusing that the "latest from" list does not show the same
results as the search it links to.  The search does not exclude the
"other" supergroup, so let's not exclude it here either.

---

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4784939)
