### PR TITLE
[WIP] Add intervention banner to Mainstream Browse pages

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -39,8 +39,66 @@
     this.$el.on('click', 'a', this.navigate.bind(this))
 
     $(window).on('popstate', this.popState.bind(this))
+
+    this.initBanner()
   }
   BrowseColumns.prototype = {
+    initBanner: function() {
+      var main = document.getElementById("content")
+      var banner = document.getElementsByClassName("gem-c-intervention")
+
+      if (banner.length === 0) {
+        /*
+          <section class="gem-c-intervention" role="region" aria-label="Intervention" data-module="intervention">
+            <p class="govuk-body">
+              <span class="gem-c-intervention__textwrapper">Help improve GOV.UK</span>
+                <a class="govuk-link gem-c-intervention__suggestion-link" href="/travel-abroad" target="_blank" rel="noopener noreferrer">Sign up to take part in user research (opens in a new tab)</a>
+            </p>
+          </section>
+        */
+        var bannerHTML = document.createElement("SECTION")
+        bannerHTML.classList.add("gem-c-intervention")
+        bannerHTML.setAttribute("role", "region")
+        bannerHTML.setAttribute("aria-label", "region")
+        bannerHTML.setAttribute("data-module", "intervention")
+        bannerHTML.hidden = true
+
+        var pHTML = document.createElement("P")
+        pHTML.classList.add("govuk-body")
+
+        var spanHTML = document.createElement("SPAN")
+        spanHTML.classList.add("gem-c-intervention__textwrapper")
+        var heplImproveText = document.createTextNode("Help improve GOV.UK")
+        spanHTML.appendChild(heplImproveText)
+
+        var aTagHTML = document.createElement("A")
+        aTagHTML.classList.add("govuk-link")
+        aTagHTML.classList.add("gem-c-intervention__suggestion-link")
+        aTagHTML.setAttribute("href", "https://www.optimalworkshop.com/treejack/")
+        aTagHTML.setAttribute("target", "_blank")
+        aTagHTML.setAttribute("rel", "noopener noreferrer external")
+        var aTagText = document.createTextNode("Sign up to take part in user research (opens in a new tab)")
+        aTagHTML.appendChild(aTagText)
+
+        pHTML.appendChild(spanHTML)
+        pHTML.appendChild(aTagHTML)
+
+
+        bannerHTML.appendChild(pHTML)
+
+        main.insertBefore(bannerHTML, main.childNodes[0])
+      }
+    },
+    banner: function(slug) {
+      var topicSlugs = ["benefits", "benefits/manage-your-benefit"]
+      var banner = document.getElementsByClassName("gem-c-intervention")[0]
+
+      if (topicSlugs.some(function(topicSlug) { return slug == topicSlug })) {
+        banner.hidden = false
+      } else {
+        banner.hidden = true
+      }
+    },
     popState: function (e) {
       var state = e.originalEvent.state
       var loadPromise
@@ -338,6 +396,9 @@
         e.preventDefault()
 
         var state = this.parsePathname(e.currentTarget.pathname)
+
+        this.banner(state.slug)
+
         state.title = $target.text()
 
         if (state.path === window.location.pathname) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/image-card';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/inset-text';
+@import 'govuk_publishing_components/components/intervention';
 @import 'govuk_publishing_components/components/inverse-header';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -10,6 +10,14 @@
 
 <h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
+<%#
+<%= render "govuk_publishing_components/components/intervention", {
+  suggestion_text: "Help improve GOV.UK",
+  suggestion_link_text: "Sign up to take part in user research",
+  suggestion_link_url: "/travel-abroad",
+  new_tab: true,
+} %>
+
 <div class="browse-panes root" data-module="gem-track-click">
   <%= render 'top_level_browse_pages',
     top_level_browse_pages: page.top_level_browse_pages %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -11,6 +11,15 @@
 
 <h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
+<% if request.url.include?("/browse/benefits") %>
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help improve GOV.UK",
+    suggestion_link_text: "Sign up to take part in user research",
+    suggestion_link_url: "https://www.optimalworkshop.com/treejack/",
+    new_tab: true,
+  } %>
+<% end %>
+
 <div class="browse-panes section" data-state="section" data-module="gem-track-click">
   <div id="section" class="section-pane pane with-sort">
     <%= render 'second_level_browse_page/second_level_browse_pages',

--- a/app/views/second_level_browse_page/show.html.erb
+++ b/app/views/second_level_browse_page/show.html.erb
@@ -13,6 +13,13 @@
 
 <h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
 
+<%#= render "govuk_publishing_components/components/intervention", {
+  suggestion_text: "Help improve GOV.UK",
+  suggestion_link_text: "Sign up to take part in user research",
+  suggestion_link_url: "/travel-abroad",
+  new_tab: true,
+} %>
+
 <div class="browse-panes subsection" data-state="subsection" data-module="gem-track-click">
   <div id="subsection" class="subsection-pane pane with-sort">
     <%= render 'links', page: page %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -8,7 +8,15 @@
     }
   } %>
 <% end %>
+
 <% content_for :page_class, "topics-page" %>
+
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help improve GOV.UK",
+    suggestion_link_text: "Sign up to take part in user research",
+    suggestion_link_url: "/travel-abroad",
+    new_tab: true,
+  } %>
 
 <header class="page-header group">
   <%= render "govuk_publishing_components/components/title", title: title_with_suffix %>


### PR DESCRIPTION
Injects the intervention banner on certain Mainstream Browse topic pages.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
