### PR TITLE
Add intervention banner on specific mainstream browse and specialist topics

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -48,6 +48,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       this.addLoading(clicked)
       this.getSectionData(state)
+      this.showBanner(state.slug)
     }
   }
 
@@ -190,6 +191,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.updateBreadcrumbs(state)
 
     this.changeColumnVisibility(3)
+    this.showBanner(state.slug)
     this.$subsection.querySelector('.js-heading').focus()
   }
 
@@ -299,6 +301,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         null,
         options
       )
+    }
+  }
+
+  BrowseColumns.prototype.showBanner = function (slug) {
+    var topicSlug = 'visas-immigration'
+    var banner = document.getElementsByClassName('gem-c-intervention')
+
+    if (banner.length > 0) {
+      banner[0].hidden = !slug.startsWith(topicSlug)
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/inverse-header';
+@import 'govuk_publishing_components/components/intervention';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';
 @import 'govuk_publishing_components/components/metadata';

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,8 +1,11 @@
 class SecondLevelBrowsePageController < ApplicationController
+  include RecruitmentBannerHelpers
   enable_request_formats show: [:json]
 
   def show
     setup_content_item_and_navigation_helpers(page)
+
+    @hide_recruitment_banner = hide_banner?(request.path)
 
     respond_to do |f|
       f.html do

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,4 +1,6 @@
 class SubtopicsController < ApplicationController
+  include RecruitmentBannerHelpers
+
   def show
     subtopic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(subtopic)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,6 @@
 class TopicsController < ApplicationController
+  include RecruitmentBannerHelpers
+
   def index
     topic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(topic)

--- a/app/helpers/recruitment_banner_helpers.rb
+++ b/app/helpers/recruitment_banner_helpers.rb
@@ -1,0 +1,7 @@
+module RecruitmentBannerHelpers
+  TOPIC_TO_TEST = "/browse/visas-immigration".freeze
+
+  def hide_banner?(path)
+    !path.starts_with?(TOPIC_TO_TEST)
+  end
+end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,6 +1,14 @@
 <div class="browse__inner <%= page.lists.curated? ? 'browse__inner--curated' : 'browse__inner--alphabetical' %>">
   <h2 tabindex="-1" class="browse__heading js-heading"><%= t("shared.browse.prefix") %> <%= page.title %></h2>
 
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help improve GOV.UK",
+    suggestion_link_text: "Take part in user research",
+    suggestion_link_url: "https://gdsuserresearch.optimalworkshop.com/treejack/35gap0ij",
+    new_tab: true,
+    hide: @hide_recruitment_banner,
+  } %>
+
   <% page.lists.each_with_index do |list, section_index| %>
     <% if page.lists.curated? %>
       <h3 class="browse__list-header"><%= list.title %></h3>

--- a/spec/features/recruitment_banner_spec.rb
+++ b/spec/features/recruitment_banner_spec.rb
@@ -1,0 +1,30 @@
+require "integration_spec_helper"
+
+RSpec.feature "Recruitment banner" do
+  include SearchApiHelpers
+
+  context "Mainstream browse pages" do
+    scenario "browse page is where we want to display recruitment banner" do
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      schema["base_path"] = "/browse/visas-immigration/tourist-short-stay-visas"
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], %w[/browse/visas-immigration/tourist-short-stay-visas], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector(".gem-c-intervention")
+    end
+
+    scenario "browse page is not where we want to display recruitment banner" do
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to_not have_selector(".gem-c-intervention")
+    end
+  end
+end

--- a/spec/helpers/recruitment_banner_helpers_spec.rb
+++ b/spec/helpers/recruitment_banner_helpers_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe RecruitmentBannerHelpers do
+  include RecruitmentBannerHelpers
+
+  describe "#hide_banner?" do
+    it "checks that a page should display the banner" do
+      expect(hide_banner?("/browse/visas-immigration/tourist-short-stay-visas")).to be false
+    end
+
+    it "checks that a page hides that banner" do
+      expect(hide_banner?("/browse/random")).to be true
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## Note 

Depends on https://github.com/alphagov/govuk_publishing_components/pull/2516 (tests will fail until that is released)

## What

Adds the intervention banner component onto select topic pages and the Miller Columns.

## Why

We want to lead users of these specific topics to an online tree testing exercise.

## Visual changes

https://user-images.githubusercontent.com/424772/146251828-0fa2d84a-c7ac-4cb3-afdb-f5a7696f4b36.mov


https://user-images.githubusercontent.com/424772/146252361-4c782b3a-0346-4d2e-bb2c-5be4b1b4f09e.mov


![localhost_3070_topic_dealing-with-hmrc(Moto G4)](https://user-images.githubusercontent.com/424772/146251863-414c6a4a-55d6-43ea-971f-66e2aa30b8f4.png)
![localhost_3070_browse_tax_capital-gains(Moto G4)](https://user-images.githubusercontent.com/424772/146251874-cfe46c61-2b9b-416c-853f-3a8d58d8011b.png)
![localhost_3070_browse_benefits_help-for-carers(Moto G4)](https://user-images.githubusercontent.com/424772/146251886-156b9d4e-9cf8-4f14-95e1-c93624f36333.png)

