### PR TITLE
Use locale files for Organisation Type

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,29 +1,11 @@
 module OrganisationHelper
-  ORGANISATION_TYPES = {
-    executive_office: { name: "Executive office" },
-    ministerial_department: { name: "Ministerial department" },
-    non_ministerial_department: { name: "Non-ministerial department" },
-    executive_agency: { name: "Executive agency" },
-    executive_ndpb: { name: "Executive non-departmental public body" },
-    advisory_ndpb: { name: "Advisory non-departmental public body" },
-    tribunal: { name: "Tribunal" },
-    public_corporation: { name: "Public corporation" },
-    independent_monitoring_body: { name: "Independent monitoring body" },
-    adhoc_advisory_group: { name: "Ad-hoc advisory group" },
-    devolved_administration: { name: "Devolved administration" },
-    sub_organisation: { name: "Sub-organisation" },
-    other: { name: "Other" },
-    civil_service: { name: "Civil Service" },
-    court: { name: "Court" },
-  }.freeze
-
   def child_organisation_count(organisation)
     child_orgs = organisation.content_item.content_item_data["links"]["ordered_child_organisations"]
     child_orgs.present? ? child_orgs.count : 0
   end
 
   def organisation_type_name(organisation_type)
-    ORGANISATION_TYPES.dig(organisation_type.to_sym, :name) || ORGANISATION_TYPES[:other][:name]
+    I18n.t("organisations.type.#{organisation_type}", default: I18n.t("organisations.type.other"))
   end
 
   def image_url_by_size(image_url, size)

--- a/app/models/content_store_organisations.rb
+++ b/app/models/content_store_organisations.rb
@@ -5,19 +5,6 @@ class ContentStoreOrganisations
 
   attr_reader :content_item
 
-  DEPARTMENT_TYPE_AND_NAMES = {
-    "executive_office" => "",
-    "ministerial_department" => "Ministerial department",
-    "executive_agency" => "Executive agency",
-    "executive_ndpb" => "Executive non-departmental public body",
-    "advisory_ndpb" => "Advisory non-departmental public body",
-    "other" => "Other",
-    "civil_service" => "Civil Service",
-    "non_ministerial_department" => "Non-ministerial department",
-    "tribunal" => "Tribunal",
-    "public_corporation" => "Public corporation",
-  }.freeze
-
   def initialize(content_item)
     @content_item = content_item
   end
@@ -72,7 +59,7 @@ class ContentStoreOrganisations
   end
 
   def category_name_from_type(category_type)
-    DEPARTMENT_TYPE_AND_NAMES[category_type]
+    I18n.t("organisations.type.#{category_type}")
   end
 
 private


### PR DESCRIPTION
The organisation types are specified in the locale files, but we are instead using hardcoded English text.

This change will mean we will always use the translated name, rather than always using English.

Additionally, it removes two places that hardcoded lists have to be edited if an organisation type is added or removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
