### PR TITLE
Add 'Special Health Authority' organisation type

### DIFF
--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -11,6 +11,7 @@ module Organisations
       executive_agency
       executive_ndpb
       advisory_ndpb
+      special_health_authority
       tribunal
       public_corporation
       independent_monitoring_body

--- a/config/locales/ar/organisations.yml
+++ b/config/locales/ar/organisations.yml
@@ -626,6 +626,7 @@ ar:
       non_ministerial_department: إدارة غير وزارية
       other: أخرى
       public_corporation: مؤسسة عامة
+      special_health_authority:
       sub_organisation:
       tribunal: هيئة قضائية
     view_all: عرض الكل

--- a/config/locales/az/organisations.yml
+++ b/config/locales/az/organisations.yml
@@ -330,6 +330,7 @@ az:
       non_ministerial_department: Nazirliklə əlaqəli olmayan departament
       other: Digər
       public_corporation: Dövlət korporasiyası
+      special_health_authority:
       sub_organisation:
       tribunal: Məhkəmə kollegiyası
     view_all: hamısını nəzərdən keçirin

--- a/config/locales/be/organisations.yml
+++ b/config/locales/be/organisations.yml
@@ -478,6 +478,7 @@ be:
       non_ministerial_department: Немiнiстэрскi дэпартамент
       other: Іншае
       public_corporation: Дзяржаўная карпарацыя
+      special_health_authority:
       sub_organisation:
       tribunal: Трыбунал
     view_all: паказаць усё

--- a/config/locales/bg/organisations.yml
+++ b/config/locales/bg/organisations.yml
@@ -330,6 +330,7 @@ bg:
       non_ministerial_department: Отдел, който не е министерство
       other: Други
       public_corporation: Публична компания
+      special_health_authority:
       sub_organisation:
       tribunal: Арбитраж
     view_all: покажи всички

--- a/config/locales/bn/organisations.yml
+++ b/config/locales/bn/organisations.yml
@@ -330,6 +330,7 @@ bn:
       non_ministerial_department: মন্ত্রণালয়-বহির্ভূত বিভাগ
       other: অন্যান্য
       public_corporation: পাবলিক কর্পোরেশন
+      special_health_authority:
       sub_organisation:
       tribunal: ট্রাইব্যুনাল
     view_all: সবগুলো দেখান

--- a/config/locales/cs/organisations.yml
+++ b/config/locales/cs/organisations.yml
@@ -404,6 +404,7 @@ cs:
       non_ministerial_department: Neministerské oddělení
       other: Jiné
       public_corporation: Veřejnoprávní korporace
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunál
     view_all: zobrazit všechno

--- a/config/locales/cy/organisations.yml
+++ b/config/locales/cy/organisations.yml
@@ -571,7 +571,7 @@ cy:
       contact_form: Ffurflen gysylltu FOI
       foi_exemption_html: 'Nid yw''r sefydliad hwn yn dod o dan y Ddeddf Rhyddid Gwybodaeth. I weld pa sefydliadau sydd wedi''u cynnwys, gweler <a href="%{foi_url}" class="govuk-link brand__color">y ddeddfwriaeth</a>.
 
-'
+        '
       freedom_of_information_act: Deddf Rhyddid Gwybodaeth
       freedom_of_information_requests: Ceisiadau Rhyddid Gwybodaeth
       make_an_foi_request: Gwneud cais Rhyddid Gwybodaeth
@@ -626,6 +626,7 @@ cy:
       non_ministerial_department: Adran anweinidogol
       other: Arall
       public_corporation: Corfforaeth gyhoeddus
+      special_health_authority:
       sub_organisation:
       tribunal: Tribiwnlys
     view_all: gweld popeth

--- a/config/locales/da/organisations.yml
+++ b/config/locales/da/organisations.yml
@@ -342,6 +342,7 @@ da:
       non_ministerial_department: Ikke-ministeriel afdeling
       other: Anden
       public_corporation: Offentligt selskab
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: se alle

--- a/config/locales/de/organisations.yml
+++ b/config/locales/de/organisations.yml
@@ -330,6 +330,7 @@ de:
       non_ministerial_department: Nichtministerielle Abteilung
       other: Andere
       public_corporation: Öffentliches Unternehmen
+      special_health_authority:
       sub_organisation:
       tribunal: Gerichtshof
     view_all: alle anzeigen

--- a/config/locales/dr/organisations.yml
+++ b/config/locales/dr/organisations.yml
@@ -333,6 +333,7 @@ dr:
       non_ministerial_department: دیپارتمنت غیر وزیری
       other: موارد دیگر
       public_corporation: شرکت سهامی عامه
+      special_health_authority:
       sub_organisation:
       tribunal: دادگاه
     view_all: مشاهدهء همه موارد

--- a/config/locales/el/organisations.yml
+++ b/config/locales/el/organisations.yml
@@ -330,6 +330,7 @@ el:
       non_ministerial_department: Μη υπουργικό τμήμα
       other: Άλλο
       public_corporation: Δημόσια επιχείρηση
+      special_health_authority:
       sub_organisation:
       tribunal: Δικαστήριο
     view_all: εμφάνιση όλων

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -330,6 +330,7 @@ en:
       non_ministerial_department: Non-ministerial department
       other: Other
       public_corporation: Public corporation
+      special_health_authority: Special health authority
       sub_organisation: Sub organisation
       tribunal: Tribunal
     view_all: view all

--- a/config/locales/es-419/organisations.yml
+++ b/config/locales/es-419/organisations.yml
@@ -330,6 +330,7 @@ es-419:
       non_ministerial_department: Departamento no ministerial
       other: Otros
       public_corporation: Empresa pública
+      special_health_authority:
       sub_organisation:
       tribunal: Juzgado
     view_all: ver todo

--- a/config/locales/es/organisations.yml
+++ b/config/locales/es/organisations.yml
@@ -328,6 +328,7 @@ es:
       non_ministerial_department: Departamento no ministerial
       other: Otros
       public_corporation: Corporación pública
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: ver todo

--- a/config/locales/et/organisations.yml
+++ b/config/locales/et/organisations.yml
@@ -330,6 +330,7 @@ et:
       non_ministerial_department: Ministeeriumiväline osakond
       other: Muu
       public_corporation: Avalik ettevõte
+      special_health_authority:
       sub_organisation:
       tribunal: Kohus
     view_all: vaata kõiki

--- a/config/locales/fa/organisations.yml
+++ b/config/locales/fa/organisations.yml
@@ -330,6 +330,7 @@ fa:
       non_ministerial_department: دپارتمان غیر وزارتی
       other: سایر
       public_corporation: شرکت عمومی
+      special_health_authority:
       sub_organisation:
       tribunal: دادگاه
     view_all: مشاهده همه

--- a/config/locales/fi/organisations.yml
+++ b/config/locales/fi/organisations.yml
@@ -330,6 +330,7 @@ fi:
       non_ministerial_department: Muu kuin ministeriön yksikkö
       other: Muut
       public_corporation: Julkinen osakeyhtiö
+      special_health_authority:
       sub_organisation:
       tribunal: Tuomioistuin
     view_all: näytä kaikki

--- a/config/locales/fr/organisations.yml
+++ b/config/locales/fr/organisations.yml
@@ -328,6 +328,7 @@ fr:
       non_ministerial_department: Département non ministériel
       other: Autre
       public_corporation: Société publique
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: tout afficher

--- a/config/locales/gd/organisations.yml
+++ b/config/locales/gd/organisations.yml
@@ -478,6 +478,7 @@ gd:
       non_ministerial_department: Roinn neamh-aireachta
       other: Eile
       public_corporation: Cuideachta phoiblí
+      special_health_authority:
       sub_organisation:
       tribunal: Cúirt
     view_all: Taispeáin gach rud

--- a/config/locales/gu/organisations.yml
+++ b/config/locales/gu/organisations.yml
@@ -328,6 +328,7 @@ gu:
       non_ministerial_department: બિન-મંત્રી વિભાગ
       other: અન્ય
       public_corporation: પબ્લિક કોર્પોરેશન
+      special_health_authority:
       sub_organisation:
       tribunal: ટ્રિબ્યુનલ
     view_all: બધા જુઓ

--- a/config/locales/he/organisations.yml
+++ b/config/locales/he/organisations.yml
@@ -330,6 +330,7 @@ he:
       non_ministerial_department: לא מחלקת שרים
       other: אחר
       public_corporation: תאגיד ציבורי
+      special_health_authority:
       sub_organisation:
       tribunal: 'בית דין '
     view_all: הצג הכל

--- a/config/locales/hi/organisations.yml
+++ b/config/locales/hi/organisations.yml
@@ -328,6 +328,7 @@ hi:
       non_ministerial_department: गैर-मंत्रालयी विभाग
       other: अन्य
       public_corporation: सार्वजनिक निगम
+      special_health_authority:
       sub_organisation:
       tribunal: न्यायाधिकरण
     view_all: सभी देखें

--- a/config/locales/hr/organisations.yml
+++ b/config/locales/hr/organisations.yml
@@ -476,6 +476,7 @@ hr:
       non_ministerial_department: Odjel koji nije ministarski
       other: Ostalo
       public_corporation: Javna korporacija
+      special_health_authority:
       sub_organisation:
       tribunal: Sud
     view_all: vidi sve

--- a/config/locales/hu/organisations.yml
+++ b/config/locales/hu/organisations.yml
@@ -330,6 +330,7 @@ hu:
       non_ministerial_department: Nem minisztériumi részleg
       other: Egyéb
       public_corporation: Állami vállalat
+      special_health_authority:
       sub_organisation:
       tribunal: Bíróság
     view_all: mind megtekintése

--- a/config/locales/hy/organisations.yml
+++ b/config/locales/hy/organisations.yml
@@ -330,6 +330,7 @@ hy:
       non_ministerial_department: Ոչ նախարարական գերատեսչություն
       other: Այլ
       public_corporation: Հասարակական կորպորացիա
+      special_health_authority:
       sub_organisation:
       tribunal: Տրիբունալ
     view_all: ցույց տալ  բոլորը

--- a/config/locales/id/organisations.yml
+++ b/config/locales/id/organisations.yml
@@ -256,6 +256,7 @@ id:
       non_ministerial_department: Departemen non-kementerian
       other: Lainnya
       public_corporation: Korporasi publik
+      special_health_authority:
       sub_organisation:
       tribunal: Persidangan
     view_all: lihat semua

--- a/config/locales/is/organisations.yml
+++ b/config/locales/is/organisations.yml
@@ -330,6 +330,7 @@ is:
       non_ministerial_department: Deild sem hefur ekki ráðherra
       other: Annað
       public_corporation: Opinbert fyrirtæki
+      special_health_authority:
       sub_organisation:
       tribunal: Dómstóll
     view_all: sjá allt

--- a/config/locales/it/organisations.yml
+++ b/config/locales/it/organisations.yml
@@ -330,6 +330,7 @@ it:
       non_ministerial_department: Dipartimento non ministeriale
       other: Altro
       public_corporation: Azienda pubblica
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunale
     view_all: visualizza tutto

--- a/config/locales/ja/organisations.yml
+++ b/config/locales/ja/organisations.yml
@@ -201,7 +201,7 @@ ja:
       contact_form: FOI（情報の自由）お問い合わせフォーム
       foi_exemption_html: 'この組織は情報公開法の対象外です。含まれている組織を確認するには、<ahref = "％{foi_url}" class = "govuk-linkbrand__color">法律</a>をご覧ください。
 
-'
+        '
       freedom_of_information_act: 情報自由（FOI）法
       freedom_of_information_requests: 情報の自由の要求
       make_an_foi_request: FOIの要求を行う
@@ -256,6 +256,7 @@ ja:
       non_ministerial_department: 非閣僚部門
       other: その他
       public_corporation: 公共団体
+      special_health_authority:
       sub_organisation:
       tribunal: 審判所
     view_all: すべて表示

--- a/config/locales/ka/organisations.yml
+++ b/config/locales/ka/organisations.yml
@@ -328,6 +328,7 @@ ka:
       non_ministerial_department: არასამთავრობო მინისტრის განყოფილება
       other: სხვა
       public_corporation: საზოგადოებრივი კორპორაცია
+      special_health_authority:
       sub_organisation:
       tribunal: ტრიბუნალი
     view_all: ყველას ნახვა

--- a/config/locales/kk/organisations.yml
+++ b/config/locales/kk/organisations.yml
@@ -330,6 +330,7 @@ kk:
       non_ministerial_department: Министрлік емес бөлім
       other: Басқа
       public_corporation: Ашық акционерлік қоғамы
+      special_health_authority:
       sub_organisation:
       tribunal: Сот орны
     view_all: барлығын қарау

--- a/config/locales/ko/organisations.yml
+++ b/config/locales/ko/organisations.yml
@@ -256,6 +256,7 @@ ko:
       non_ministerial_department: 비부처
       other: 기타
       public_corporation: 공공 기관
+      special_health_authority:
       sub_organisation:
       tribunal: 법원
     view_all: 모두 보기

--- a/config/locales/lt/organisations.yml
+++ b/config/locales/lt/organisations.yml
@@ -404,6 +404,7 @@ lt:
       non_ministerial_department: Ne ministerijai priklausantis departamentas
       other: Kita
       public_corporation: Viešoji korporacija
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunolas
     view_all: žiūrėti viską

--- a/config/locales/lv/organisations.yml
+++ b/config/locales/lv/organisations.yml
@@ -330,6 +330,7 @@ lv:
       non_ministerial_department: Ar ministrijām nesaistīts departaments
       other: Cits
       public_corporation: Valsts uzņēmums
+      special_health_authority:
       sub_organisation:
       tribunal: Šķīrējtiesa
     view_all: skatīt visu

--- a/config/locales/ms/organisations.yml
+++ b/config/locales/ms/organisations.yml
@@ -256,6 +256,7 @@ ms:
       non_ministerial_department: Jabatan bukan kementerian
       other: Lain-lain
       public_corporation: Perbadanan awam
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: lihat semua

--- a/config/locales/mt/organisations.yml
+++ b/config/locales/mt/organisations.yml
@@ -476,6 +476,7 @@ mt:
       non_ministerial_department: Dipartiment mhux ministerjali
       other: Oħrajn
       public_corporation: Korporazzjoni Pubblika
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: ara kollox

--- a/config/locales/nl/organisations.yml
+++ b/config/locales/nl/organisations.yml
@@ -330,6 +330,7 @@ nl:
       non_ministerial_department: Niet-ministeriële dienst
       other: Andere
       public_corporation: Overheidsbedrijf
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunaal
     view_all: alles bekijken

--- a/config/locales/no/organisations.yml
+++ b/config/locales/no/organisations.yml
@@ -330,6 +330,7 @@
       non_ministerial_department: Ikke-ministeriell avdeling
       other: Annen
       public_corporation: Offentlig selskap
+      special_health_authority:
       sub_organisation:
       tribunal: Nemnd
     view_all: se alt

--- a/config/locales/pa-pk/organisations.yml
+++ b/config/locales/pa-pk/organisations.yml
@@ -275,7 +275,7 @@ pa-pk:
       contact_form: 'رابطے دا FOI فارم '
       foi_exemption_html: 'ایہ ادارہ معلومات دی آزادی دے قانون دے تحت نہیں ہوندا۔ ایہ ویکھن لئی کہ کہیڑے ادارے ایندے وچ شامل نیں ایہ ویکھو <a href="%{foi_url}" class="govuk-link brand__color">قانونی سازی</a>.
 
-'
+        '
       freedom_of_information_act: معلومات دی آزادی  (FOI)  دا قانون
       freedom_of_information_requests: معلومات دی آزادی دیاں درخواستاں
       make_an_foi_request: اک FOI دی درخواست دیوؤ
@@ -332,6 +332,7 @@ pa-pk:
       non_ministerial_department: بغیر وزیر دا محکمہ
       other: ہور دوجے
       public_corporation: عوامی تعاون
+      special_health_authority:
       sub_organisation:
       tribunal: عدالت
     view_all: ساریاں نوں ویکھو

--- a/config/locales/pa/organisations.yml
+++ b/config/locales/pa/organisations.yml
@@ -330,6 +330,7 @@ pa:
       non_ministerial_department: ਗੈਰ-ਮੰਤਰੀ ਵਿਭਾਗ
       other: ਹੋਰ
       public_corporation: ਜਨਤਕ ਨਿਗਮ
+      special_health_authority:
       sub_organisation:
       tribunal: ਟ੍ਰਿਬਿਊਨਲ
     view_all: ਸਭ ਵੇਖੋ

--- a/config/locales/pl/organisations.yml
+++ b/config/locales/pl/organisations.yml
@@ -478,6 +478,7 @@ pl:
       non_ministerial_department: Departament pozaministerialny
       other: Inne
       public_corporation: Korporacja publiczna
+      special_health_authority:
       sub_organisation:
       tribunal: Trybunał
     view_all: Zobacz wszystko

--- a/config/locales/ps/organisations.yml
+++ b/config/locales/ps/organisations.yml
@@ -330,6 +330,7 @@ ps:
       non_ministerial_department: بې وزله څانګه
       other: نور
       public_corporation: عامه شرکت
+      special_health_authority:
       sub_organisation:
       tribunal: محکمه
     view_all: ټول وګوری

--- a/config/locales/pt/organisations.yml
+++ b/config/locales/pt/organisations.yml
@@ -330,6 +330,7 @@ pt:
       non_ministerial_department: Departamento não ministerial
       other: Outro
       public_corporation: Empresa pública
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: ver tudo

--- a/config/locales/ro/organisations.yml
+++ b/config/locales/ro/organisations.yml
@@ -404,6 +404,7 @@ ro:
       non_ministerial_department: Departament neministerial
       other: Altele
       public_corporation: Corporație publică
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: vizualizați pe toate

--- a/config/locales/ru/organisations.yml
+++ b/config/locales/ru/organisations.yml
@@ -476,6 +476,7 @@ ru:
       non_ministerial_department: Неминистерский государственный департамент
       other: Другое
       public_corporation: Государственная корпорация
+      special_health_authority:
       sub_organisation:
       tribunal: Арбитраж
     view_all: Посмотреть все

--- a/config/locales/si/organisations.yml
+++ b/config/locales/si/organisations.yml
@@ -330,6 +330,7 @@ si:
       non_ministerial_department: අමාත්යාංශ නොවන දෙපාර්තමේන්තුව
       other: වෙනත්
       public_corporation: රාජ්ය සංස්ථාව
+      special_health_authority:
       sub_organisation:
       tribunal: විනිශ්චය මණ්ඩලය
     view_all: සියලු බලන්න

--- a/config/locales/sk/organisations.yml
+++ b/config/locales/sk/organisations.yml
@@ -404,6 +404,7 @@ sk:
       non_ministerial_department: Oddelenie, ktoré nie je ministerstvom
       other: Iné
       public_corporation: Verejnoprávna korporácia
+      special_health_authority:
       sub_organisation:
       tribunal: Súd
     view_all: zobraziť všetko

--- a/config/locales/sl/organisations.yml
+++ b/config/locales/sl/organisations.yml
@@ -478,6 +478,7 @@ sl:
       non_ministerial_department: Neministrski oddelek
       other: Drugo
       public_corporation: Javna družba
+      special_health_authority:
       sub_organisation:
       tribunal: Sodišče
     view_all: Prikaži vse

--- a/config/locales/so/organisations.yml
+++ b/config/locales/so/organisations.yml
@@ -330,6 +330,7 @@ so:
       non_ministerial_department: Waaxda ka madaxabanaan wasiirada
       other: Midkale
       public_corporation: Sirkada dadweynaha
+      special_health_authority:
       sub_organisation:
       tribunal: Maxkamad
     view_all: fiiri dhamaan

--- a/config/locales/sq/organisations.yml
+++ b/config/locales/sq/organisations.yml
@@ -328,6 +328,7 @@ sq:
       non_ministerial_department: Departamenti jo ministror
       other: Tjetër
       public_corporation: Korporatë publike
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunali
     view_all: shih të gjitha

--- a/config/locales/sr/organisations.yml
+++ b/config/locales/sr/organisations.yml
@@ -404,6 +404,7 @@ sr:
       non_ministerial_department: Odeljenje bez feljtona
       other: Drugo
       public_corporation: Javno preduzeće
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: prikaži sve

--- a/config/locales/sv/organisations.yml
+++ b/config/locales/sv/organisations.yml
@@ -330,6 +330,7 @@ sv:
       non_ministerial_department: Icke-ministeriell avdelning
       other: Annan
       public_corporation: Offentligt bolag
+      special_health_authority:
       sub_organisation:
       tribunal: Tribunal
     view_all: Visa alla

--- a/config/locales/sw/organisations.yml
+++ b/config/locales/sw/organisations.yml
@@ -330,6 +330,7 @@ sw:
       non_ministerial_department: Idara isiyo na waziri
       other: Nyingine
       public_corporation: Shirika la umma
+      special_health_authority:
       sub_organisation:
       tribunal: Mahakama
     view_all: angalia zote

--- a/config/locales/ta/organisations.yml
+++ b/config/locales/ta/organisations.yml
@@ -330,6 +330,7 @@ ta:
       non_ministerial_department: அமைச்சரவைசாராத் துறை
       other: பிற
       public_corporation: பொதுக் குழுமம்
+      special_health_authority:
       sub_organisation:
       tribunal: தீர்ப்பாயம்
     view_all: அனைத்தையும் காண்க

--- a/config/locales/th/organisations.yml
+++ b/config/locales/th/organisations.yml
@@ -256,6 +256,7 @@ th:
       non_ministerial_department: หน่วยงานราชการที่ไม่ขึ้นกับกระทรวง
       other: อื่น ๆ
       public_corporation: องค์การมหาชน
+      special_health_authority:
       sub_organisation:
       tribunal: ทางศาล
     view_all: ดูทั้งหมด

--- a/config/locales/tk/organisations.yml
+++ b/config/locales/tk/organisations.yml
@@ -330,6 +330,7 @@ tk:
       non_ministerial_department: Ministrlik däl bölüm
       other: Beýleki
       public_corporation: Jemgyýetçilik korporasiýasy
+      special_health_authority:
       sub_organisation:
       tribunal: Kazyýet
     view_all: ählisini görmek

--- a/config/locales/tr/organisations.yml
+++ b/config/locales/tr/organisations.yml
@@ -330,6 +330,7 @@ tr:
       non_ministerial_department: Bakanlık dışı müdürlük
       other: Diğer
       public_corporation: Kamu kurumu
+      special_health_authority:
       sub_organisation:
       tribunal: Mahkeme
     view_all: hepsini gör

--- a/config/locales/uk/organisations.yml
+++ b/config/locales/uk/organisations.yml
@@ -478,6 +478,7 @@ uk:
       non_ministerial_department: Неміністерський відділ
       other: Інше
       public_corporation: Державна корпорація
+      special_health_authority:
       sub_organisation:
       tribunal: Арбітражний суд
     view_all: дивитись все

--- a/config/locales/ur/organisations.yml
+++ b/config/locales/ur/organisations.yml
@@ -330,6 +330,7 @@ ur:
       non_ministerial_department: غیر وزارتی محکمہ
       other: دیگر
       public_corporation: عوامی کارپوریشن
+      special_health_authority:
       sub_organisation:
       tribunal: ٹریبیونل
     view_all: تمام کو دیکھیں

--- a/config/locales/uz/organisations.yml
+++ b/config/locales/uz/organisations.yml
@@ -330,6 +330,7 @@ uz:
       non_ministerial_department: Новазирлик департаменти
       other: Бошқалар
       public_corporation: Давлат корпорацияси
+      special_health_authority:
       sub_organisation:
       tribunal: Трибунал
     view_all: Барчасини кўриш

--- a/config/locales/vi/organisations.yml
+++ b/config/locales/vi/organisations.yml
@@ -256,6 +256,7 @@ vi:
       non_ministerial_department: Bộ phận không thuộc bộ
       other: Khác
       public_corporation: Công ty đại chúng
+      special_health_authority:
       sub_organisation:
       tribunal: Tòa án
     view_all: xem tất cả

--- a/config/locales/yi/organisations.yml
+++ b/config/locales/yi/organisations.yml
@@ -328,6 +328,7 @@ yi:
       non_ministerial_department:
       other:
       public_corporation:
+      special_health_authority:
       sub_organisation:
       tribunal:
     view_all:

--- a/config/locales/zh-hk/organisations.yml
+++ b/config/locales/zh-hk/organisations.yml
@@ -328,6 +328,7 @@ zh-hk:
       non_ministerial_department: 非內閣部門
       other: 其他
       public_corporation: 公共機構
+      special_health_authority:
       sub_organisation:
       tribunal: 法庭
     view_all: 查閱全部內容

--- a/config/locales/zh-tw/organisations.yml
+++ b/config/locales/zh-tw/organisations.yml
@@ -330,6 +330,7 @@ zh-tw:
       non_ministerial_department: 非內閣部會
       other: 其他
       public_corporation: 公營企業
+      special_health_authority:
       sub_organisation:
       tribunal: 審裁處
     view_all: 查看全部

--- a/config/locales/zh/organisations.yml
+++ b/config/locales/zh/organisations.yml
@@ -254,6 +254,7 @@ zh:
       non_ministerial_department: 非部长级部门
       other: 其它
       public_corporation: 公营公司
+      special_health_authority:
       sub_organisation:
       tribunal: 法庭
     view_all: 查看全部


### PR DESCRIPTION
Adds the 'Special Health Authority' organisation type.

This is dependent on https://github.com/alphagov/collections/pull/2636 being merged, as this PR doesn't update the hardcoded lists of organisation types that https://github.com/alphagov/collections/pull/2636 removes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/GArvRPWm)