### PR TITLE
Turn scroll tracking on for covid and brexit pages

### DIFF
--- a/app/views/brexit_landing_page/_page_header.html.erb
+++ b/app/views/brexit_landing_page/_page_header.html.erb
@@ -2,6 +2,7 @@
 <% content_for :title, t("brexit_landing_page.meta_title") %>
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= t("brexit_landing_page.meta_description") %>">
+  <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
 
   <%= render 'govuk_publishing_components/components/machine_readable_metadata', content_item: @content_item, schema: :article %>
 <% end %>

--- a/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_meta_tags.html.erb
@@ -12,6 +12,7 @@
   <meta property="og:title" content="<%= @content_item["title"] %>">
   <meta property="og:description" content="<%= @content_item["description"] %>">
   <meta name="description" content="<%= @content_item["description"] %>">
+  <meta name="govuk:scroll-tracker" content="" data-module="auto-scroll-tracker"/>
 
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Turn on scroll tracking for the `/brexit` and `/coronavirus` pages. 

**NOTE** this change depends on [this change](https://github.com/alphagov/govuk_publishing_components/pull/2543) in the components gem being deployed to `static` at the same time, otherwise duplicate or no scroll tracking events may occur.

## Why
We're retiring the old scroll tracker and migrating all pages that use it to the new one.

## Visual changes
None.

Trello card: https://trello.com/c/sdugtMbX/37-migrate-to-new-scroll-tracker