### PR TITLE
Move link in statistics section

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_statistics_section.html.erb
@@ -4,21 +4,6 @@
   font_size: "m"
 } %>
 
-<% link = topic_section["links"].shift %>
-<p class="govuk-body govuk-!-margin-bottom-6">
-  <%= link_to(
-    link["label"].html_safe,
-    link["url"],
-    class: 'govuk-link',
-    data: {
-      module: "gem-track-click",
-      track_category: "pageElementInteraction",
-      track_action: "Statistics",
-      track_label: link["url"],
-    },
-  ) %>
-</p>
-
 <% if statistics %>
   <div class="govuk-grid-row">
     <% if statistics.new_positive_tests %>


### PR DESCRIPTION
Trello: https://trello.com/c/6aHbUNVu

# Whats' changed and why?
Moves "Daily summary of COVID-19 testing, cases and vaccinations" link
in the statistics section on Coronavirus landing page back to its
original position at the bottom of the statistics section as its being
missed by users.

# Expected changes
## Before
<img width="1033" alt="Screenshot 2021-12-24 at 10 40 09" src="https://user-images.githubusercontent.com/5793815/147347647-88c84b7b-6a49-49a5-b982-bd8923d868d4.png">

## After
<img width="1033" alt="Screenshot 2021-12-24 at 10 39 43" src="https://user-images.githubusercontent.com/5793815/147347640-fcbdd41c-4878-4705-8ee6-ea5f8d24535c.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
