### PR TITLE
Display correct translation for "email"

### DIFF
--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -21,7 +21,12 @@
         <div class="<%= contact[:post_addresses].any? ? "govuk-grid-column-one-half" : "govuk-grid-column-two-thirds" %>">
           <% if contact[:email_addresses].any? %>
             <div class="organisation__margin-bottom">
-              <p <%= "lang=en" if contact[:locale] != "en" %>><%= t('organisations.contact.email', locale: :en) %></p>
+              <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>
+                <p><%= t('organisations.contact.email') %></p>
+              <% else %>
+                <p lang="en"><%= t('organisations.contact.email') %></p>
+              <% end %>
+
               <% contact[:email_addresses].each do |email| %>
                 <p><%= email.html_safe %></p>
               <% end %>


### PR DESCRIPTION
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4836551

# What's changed and why?
A change was made to always set the translation for "email" to the english
version for "FOI Contacts" as they come from Whitehall and are unreliable:
https://github.com/alphagov/collections/pull/1857/commits/b321aaeb285b6da0ffd7fafd21b5902621278a01

However this also had the effect of not translating the text in the contacts block.
This was odd as "telephone" would be translated, but "email" is not.
See: https://www.gov.uk/government/organisations/land-registry.cy

# Expected changes
## Before
<img width="409" alt="Screenshot 2022-01-12 at 17 11 53" src="https://user-images.githubusercontent.com/5793815/149188497-ad9e7b17-31e3-4bd3-89c9-799bcc8ba717.png">

## After
<img width="409" alt="Screenshot 2022-01-12 at 17 11 35" src="https://user-images.githubusercontent.com/5793815/149188523-c530aed5-70a1-4932-abdb-c4f060e4aa0d.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
