### PR TITLE
Add missing tracking to recruitment banner

### DIFF
--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -7,6 +7,13 @@
     suggestion_link_url: "https://gdsuserresearch.optimalworkshop.com/treejack/35gap0ij",
     new_tab: true,
     hide: @hide_recruitment_banner,
+    suggestion_data_attributes: {
+      "track-category": "interventionBanner",
+      "track-action": "interventionClicked",
+      "track-dimension": "Take part in user research",
+      "track-dimension-index": "29",
+      "track-label": "https://gdsuserresearch.optimalworkshop.com/treejack/35gap0ij",
+    },
   } %>
 
   <% page.lists.each_with_index do |list, section_index| %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This was missing from https://github.com/alphagov/collections/pull/2630