### PR TITLE
Class `.visuallyhidden` no longer works

### DIFF
--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -2,14 +2,14 @@
   <% if presented_taxon.renders_as_accordion? %>
     <%= render "govuk_publishing_components/components/subscription_links", {
       email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "#{t("shared.get_emails")} <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
+      email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
       feed_link: whitehall_atom_url,
       feed_link_box_value: whitehall_atom_url
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/subscription_links", {
       email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "#{t("shared.get_emails")} <span class='visuallyhidden'>#{presented_taxon.title}</span>".html_safe,
+      email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
     } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The class `visuallyhidden` from the old govuk template no longer does anything since we've switched to the new templates. This means that some text which uses this class and is supposed to be visually hidden is visible.

<img width="1442" alt="Screenshot 2022-01-21 at 17 00 27" src="https://user-images.githubusercontent.com/7116819/150570893-eaae00b1-19ad-4a1e-a18d-796c9c219044.png">



Replace remaining instances of `visuallyhidden` with the equivalent `govuk-visually-hidden` class.


-----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
