### PR TITLE
Fix browse analytics location

### DIFF
--- a/app/assets/javascripts/browse-columns.js
+++ b/app/assets/javascripts/browse-columns.js
@@ -289,7 +289,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
       var options = {
         dimension1: sectionTitle,
-        dimension32: navigationPageType
+        dimension32: navigationPageType,
+        location: window.location.href
       }
 
       if (typeof tracker !== 'undefined') {
@@ -298,7 +299,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
       GOVUK.analytics.trackPageview(
         state.path,
-        null,
+        document.title,
         options
       )
     }

--- a/spec/javascripts/browse-columns_spec.js
+++ b/spec/javascripts/browse-columns_spec.js
@@ -226,23 +226,26 @@ describe('browse-columns.js', function () {
     var bc = new window.GOVUK.Modules.BrowseColumns(el)
     bc.init()
     bc.trackPageview(state)
+    var title = document.title
 
     expect(GOVUK.analytics.trackPageview).toHaveBeenCalledTimes(2)
     expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith(
       'foo',
-      null,
+      title,
       {
         dimension1: 'browse',
-        dimension32: 'none'
+        dimension32: 'none',
+        location: String(window.location)
       }
     )
     expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith(
       'foo',
-      null,
+      title,
       {
         dimension1: 'browse',
         dimension32: 'none',
-        trackerName: 'govuk'
+        trackerName: 'govuk',
+        location: String(window.location)
       }
     )
   })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Fixes Google analytics pageviews in the browse page sent on category change after the page has loaded.

This problem is due to the browse pages behaving like a Single Page Application. The `Document location URL` (location) and the page title are set in GA when the page loads but not updated for any further pageviews sent manually by the browse JavaScript if the user navigates to other sections within the browse page.

So if you started from `https://www.gov.uk/browse/citizenship` but then browsed to other sections of the browse page, the location would remain the same, even though the `path` value in the pageview might be something quite different. In the example below, `path` accurately reflects the page/URL that is currently being viewed, whereas location does not.

![Screenshot 2022-01-31 at 15 23 40](https://user-images.githubusercontent.com/861310/151821939-ed576d32-80eb-42ee-b1e9-804b4ce7b583.png)

This fixes this by explicitly setting the `location` value in the options object passed to GA. It also does the same for the document title.

## Visual changes
None.