### PR TITLE
Spike to visualise browse powered by topics

### DIFF
--- a/app/controllers/browsetopics_controller.rb
+++ b/app/controllers/browsetopics_controller.rb
@@ -1,0 +1,51 @@
+class BrowsetopicsController < ApplicationController
+  enable_request_formats show: [:json]
+
+  def index
+    page = MainstreamBrowseTopicPage.find("/topic")
+    setup_content_item_and_navigation_helpers(page)
+
+    render :index,
+           locals: {
+             page: page,
+           }
+  end
+
+  def show
+    page =
+      MainstreamBrowseTopicPage.find("/topic/#{params[:topic_slug]}")
+    setup_content_item_and_navigation_helpers(page)
+
+    respond_to do |f|
+      f.html do
+        show_html(page)
+      end
+      f.json do
+        render json: {
+          content_id: page.content_id,
+          navigation_page_type: "First Level Browse",
+          breadcrumbs: breadcrumb_content,
+          html: second_level_browse_pages_partial(page),
+        }
+      end
+    end
+  end
+
+private
+
+  def show_html(page)
+    render :show,
+           locals: {
+             page: page,
+           }
+  end
+
+  def second_level_browse_pages_partial(page)
+    render_partial(
+      "second_level_browse_page/_second_level_browse_pages",
+      title: page.title,
+      second_level_browse_pages: page.second_level_browse_pages,
+      curated_order: page.second_level_pages_curated?,
+    )
+  end
+end

--- a/app/controllers/second_level_browse_topics_controller.rb
+++ b/app/controllers/second_level_browse_topics_controller.rb
@@ -1,0 +1,41 @@
+class SecondLevelBrowseTopicsController < ApplicationController
+  enable_request_formats show: [:json]
+
+  def show
+    setup_content_item_and_navigation_helpers(page)
+
+    respond_to do |f|
+      f.html do
+        show_html
+      end
+      f.json do
+        render json: {
+          content_id: page.content_id,
+          navigation_page_type: "Second Level Browse",
+          breadcrumbs: breadcrumb_content,
+          html: render_partial("_links", page: page),
+        }
+      end
+    end
+  end
+
+private
+
+  def show_html
+    render :show,
+           locals: {
+             page: page,
+             meta_section: meta_section,
+           }
+  end
+
+  def meta_section
+    page.active_top_level_browse_page.title.downcase
+  end
+
+  def page
+    @page ||= MainstreamBrowseTopicPage.find(
+      "/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
+    )
+  end
+end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -15,7 +15,7 @@ class ContentItem
     @content_item_data = content_item_data
   end
 
-  %i[base_path title description content_id document_type locale cache_control].each do |field|
+  %i[title description content_id document_type locale cache_control].each do |field|
     define_method field do
       @content_item_data[field.to_s]
     end
@@ -32,6 +32,10 @@ class ContentItem
   def public_cache
     public_cache = @content_item_data.dig("cache_control", "public")
     public_cache.nil? ? true : public_cache
+  end
+
+  def base_path
+    @content_item_data["base_path"].gsub("topic", "browsetopics")
   end
 
   def linked_items(field)

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -69,7 +69,8 @@ private
 
   def filter_name
     if @tag_type == "section"
-      :filter_mainstream_browse_page_content_ids
+      # :filter_mainstream_browse_page_content_ids
+      :filter_topic_content_ids
     else
       :filter_topic_content_ids
     end

--- a/app/models/mainstream_browse_topic_page.rb
+++ b/app/models/mainstream_browse_topic_page.rb
@@ -1,0 +1,76 @@
+class MainstreamBrowseTopicPage
+  attr_reader :content_item
+
+  delegate(
+    :content_id,
+    :base_path,
+    :title,
+    :description,
+    :linked_items,
+    :details,
+    :to_hash,
+    to: :content_item,
+  )
+
+  def self.find(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def top_level_browse_pages
+    # linked_items("top_level_browse_pages")
+    # We could store all the top level topics on child topics to save this additional fetch.
+    @top_level_browse_pages ||= ContentItem.find!("/topic").linked_items("children")
+
+  end
+
+  def active_top_level_browse_page
+    linked_items("parent").first
+  end
+
+  def child_topic?
+    linked_items("parent").any?
+  end
+
+  def siblings
+    me = ContentItem.find!(slug.gsub("browsetopics", "topic"))
+    p = me.linked_items("parent").first
+    path = p.base_path.gsub("browsetopics", "topic")
+    parent = ContentItem.find!(path)
+    parent.linked_items("children")
+  end
+
+  def second_level_browse_pages
+    links = linked_items("children")
+
+    if second_level_pages_curated?
+      links.sort_by do |link|
+        details["ordered_second_level_browse_pages"].index(link.content_id)
+      end
+    else
+      links
+    end
+  end
+
+  def second_level_pages_curated?
+    #not present on the topic content item, so would need to be added.
+    # details["second_level_ordering"] == "curated"
+    false
+  end
+
+  def lists
+    @lists ||= ListSet.new("section", @content_item.content_id, details["groups"])
+  end
+
+  def related_topics
+    linked_items("related_topics")
+  end
+
+  def slug
+    base_path
+  end
+end

--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -6,7 +6,7 @@ class Breadcrumbs
 
   def breadcrumbs
     ordered_parents = all_parents.map do |parent|
-      { title: parent.fetch("title"), url: parent.fetch("base_path") }
+      { title: parent.fetch("title"), url: parent.fetch("base_path").gsub("topic", "browsetopics") }
     end
 
     ordered_parents << { title: I18n.t("shared.breadcrumbs_home"), url: "/" }

--- a/app/views/browsetopics/_top_level_browse_pages.erb
+++ b/app/views/browsetopics/_top_level_browse_pages.erb
@@ -1,0 +1,27 @@
+<div id="root" class="browse__root-pane">
+  <h2 class="govuk-visually-hidden" tabindex="-1"><%= t("browse.all_categories") %></h2>
+  <ul class="browse__list">
+    <% top_level_browse_pages.each_with_index do |page, index| %>
+      <%
+        link_classes = %w[browse__link]
+        link_classes << (browsing_in_top_level_page?(page) ? "browse__link--active" : "browse__link--inactive")
+      %>
+      <li>
+        <%= link_to(
+          page.title,
+          page.base_path,
+          data: {
+            track_category: 'firstLevelBrowseLinkClicked',
+            track_action: "#{index + 1}",
+            track_label: page.base_path,
+            track_options: {
+              dimension28: top_level_browse_pages.count.to_s,
+              dimension29: page.title,
+            },
+          },
+          class: link_classes,
+        ) %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/browsetopics/index.html.erb
+++ b/app/views/browsetopics/index.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t("browse.all_categories") %>
+<% content_for :meta_tags do %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Browse Index",
+    }
+  } %>
+<% end %>
+
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
+
+<div class="browse" data-module="browse-columns gem-track-click">
+  <div id="subsection" class="browse__subsection-pane"></div>
+  <div id="section" class="browse__section-pane"></div>
+  <%= render 'top_level_browse_pages',
+    top_level_browse_pages: page.top_level_browse_pages %>
+</div>

--- a/app/views/browsetopics/show.html.erb
+++ b/app/views/browsetopics/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
+<%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "First Level Browse",
+    }
+  } %>
+<% end %>
+
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
+
+<div class="browse <%= 'browse--two-columns' if page.second_level_browse_pages %>" data-state="section" data-module="browse-columns gem-track-click">
+  <div id="subsection" class="browse__subsection-pane"></div>
+  <div id="section" class="browse__section-pane">
+    <%= render 'second_level_browse_topics/second_level_browse_pages',
+          title: yield(:title),
+          second_level_browse_pages: page.second_level_browse_pages,
+          curated_order: page.second_level_pages_curated? %>
+  </div>
+
+  <%= render 'browsetopics/top_level_browse_pages',
+        top_level_browse_pages: page.top_level_browse_pages %>
+</div>

--- a/app/views/second_level_browse_topics/_links.html.erb
+++ b/app/views/second_level_browse_topics/_links.html.erb
@@ -1,0 +1,61 @@
+<div class="browse__inner <%= page.lists.curated? ? 'browse__inner--curated' : 'browse__inner--alphabetical' %>">
+  <h2 tabindex="-1" class="browse__heading js-heading"><%= t("shared.browse.prefix") %> <%= page.title %></h2>
+
+  <% page.lists.each_with_index do |list, section_index| %>
+    <% if page.lists.curated? %>
+      <h3 class="browse__list-header"><%= list.title %></h3>
+    <% else %>
+      <h3 class="browse__sort-order"><%= list.title %></h3>
+    <% end %>
+    <ul class="browse__list">
+      <% list.contents.each_with_index do |list_item, index| %>
+        <li>
+          <%= link_to(
+            list_item.title,
+            list_item.base_path,
+            data: {
+              track_category: 'thirdLevelBrowseLinkClicked',
+              track_action: "#{section_index + 1}.#{index + 1}",
+              track_label: list_item.base_path,
+              track_options: {
+                dimension28: list.contents.count.to_s,
+                dimension29: list_item.title,
+              },
+            },
+            class: "browse__normal-link govuk-link",
+          ) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if page.related_topics.any? %>
+    <div class="browse__detailed-guidance">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("second_level_browse.detailed_guidance"),
+        heading_level: 2,
+        margin_bottom: 3,
+      } %>
+      <ul class="browse__list">
+        <% page.related_topics.each_with_index do |related_topic, index| %>
+          <li>
+            <%= link_to(
+              related_topic.title,
+              related_topic.base_path,
+              data: {
+                track_category: 'thirdLevelBrowseLinkClicked',
+                track_action: "#{page.lists.count + 1}.#{index + 1}",
+                track_label: related_topic.base_path,
+                track_options: {
+                  dimension28: page.related_topics.count.to_s,
+                  dimension29: related_topic.title,
+                },
+              },
+              class: "browse__normal-link govuk-link",
+            ) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/second_level_browse_topics/_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_topics/_second_level_browse_pages.html.erb
@@ -1,0 +1,32 @@
+<div class="browse__inner <%= curated_order ? "browse__inner--curated" : "browse__inner--alphabetical" %>">
+  <h2 tabindex="-1" class="browse__heading js-heading"><%= t("shared.browse.prefix") %> <%= title.sub(t("shared.browse.prefix"), "") %></h2>
+  <% unless curated_order %>
+    <h3 class="browse__sort-order"><%= t("second_level_browse.a_to_z") %></h3>
+  <% end %>
+  <ul class="browse__list">
+    <% second_level_browse_pages.each_with_index do |browse_page, index| %>
+      <%
+        link_classes = %w[browse__link]
+        link_classes << (browsing_in_second_level_page?(browse_page) ? "browse__link--active" : "browse__link--inactive")
+      %>
+      <li>
+        <%= link_to(
+          "#{browse_page.base_path.gsub('/topic', '')}",
+          data: {
+            track_category: "secondLevelBrowseLinkClicked",
+            track_action: "#{index + 1}",
+            track_label: browse_page.base_path,
+            track_options: {
+              dimension28: second_level_browse_pages.count.to_s,
+              dimension29: browse_page.title,
+            },
+          },
+          class: link_classes,
+        ) do %>
+          <h3 class="browse__title"><%= browse_page.title %></h3>
+          <p class="browse__description"> description attribute needs adding to the topic schema</p>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/second_level_browse_topics/show.html.erb
+++ b/app/views/second_level_browse_topics/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
+<% top_level_title = "#{t("shared.browse.prefix")} #{page.active_top_level_browse_page.title}" %>
+<%= render 'shared/tag_meta', tag: page %>
+<% content_for :meta_tags do %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Second Level Browse",
+      section: meta_section,
+    }
+  } %>
+<% end %>
+
+<h1 class="govuk-visually-hidden"><%= t("shared.browse.title") %></h1>
+
+<div class="browse browse--three-columns" data-state="subsection" data-module="browse-columns gem-track-click">
+  <div id="subsection" class="browse__subsection-pane">
+    <%= render 'links', page: page %>
+  </div>
+
+  <div id="section" class="browse__section-pane">
+
+    <%= render 'second_level_browse_pages',
+      title: top_level_title,
+      second_level_browse_pages: page.siblings,
+      curated_order: page.second_level_pages_curated? %>
+  </div>
+
+  <%= render 'browsetopics/top_level_browse_pages', top_level_browse_pages: page.top_level_browse_pages %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
     get ":second_level_slug", on: :member, to: "second_level_browse_page#show"
   end
 
+  resources :browsetopics, only: %i[index show], param: :topic_slug do
+    get ":subtopic_slug", on: :member, to: "second_level_browse_topics#show"
+  end
+
   resources :topics, only: %i[index show], path: :topic, param: :topic_slug do
     get ":subtopic_slug", on: :member, to: "subtopics#show"
   end


### PR DESCRIPTION
Things to note:

- mainstream_browse_page content items contain a list of all top level browse categories in the attribute
`top_level_browse_pages`. But topic content_items do not contain a list of all the topic categories. I've
added an additional page fetch for the "/topic" content item which contains all the topic categories in
it's "children" attribute but obviously that's just a hack, we should add the list to all topic content items
when they're published.

- mainstram_browse_page content items contain a representation of their parent, children, and siblings.
Topics only contain their parent and child categories. To get this prototype functioning, I've added an addiontal
page fetch. ie when we are on browsetopics/topic/subtopic, the subtopic content item doesn't know who it's siblings are.
So I fetch the parent in order to get the list of siblings. We should add the siblings for subtopics to all topic
content items when they're published.

- There's a concept of links having a curated order, or an alphabetical order. This prototype does not respect the curated
order, because the second_level_ordering attribute is not present on the topic content item.

- Not all topics have a populated details["groups"] attribute.
eg topic/benefits-credits/child-benefit does
but topic/business-enterprise/business-auditing-accounting-reporting

If the groups aren't set, we just show anything tagged to the topic via
https://github.com/alphagov/collections/blob/ac1003904ef6770778ec606e80da14a370e42d7c/app/models/list_set.rb#L43

This is the same behaviour as on /browse at the moment. But just FYI.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Trello https://trello.com/c/uux5bshi/756-prototype-a-representation-of-a-browse-topic-from-within-specialist-topic

## Review App
https://govuk-collec-topic-spik-hy1lrn.herokuapp.com/browsetopics/benefits-credits