### PR TITLE
🚧 Add new topic templates

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/big-number";
 @import "govuk_publishing_components/components/breadcrumbs";
 @import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/cards";
 @import "govuk_publishing_components/components/contents-list";
 @import "govuk_publishing_components/components/contextual-sidebar";
 @import "govuk_publishing_components/components/details";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,6 +1,7 @@
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/print/accordion";
 @import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/cards";
 @import "govuk_publishing_components/components/print/contents-list";
 @import "govuk_publishing_components/components/print/govspeak";
 @import "govuk_publishing_components/components/print/organisation-logo";

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -335,7 +335,9 @@ $transition-speed: .4s;
 // be run as an A/B test, we need to use a different class name for each view.
 .topic-page__breadcrumb-wrapper,
 .topic-page__header-wrapper {
-  background-color: govuk-colour("dark-grey");
+  $topic-page-header-background: #263135;
+
+  background-color: $topic-page-header-background;
 }
 
 .topic-page__breadcrumb-wrapper {

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -329,3 +329,53 @@ $transition-speed: .4s;
     }
   }
 }
+
+// This isn't proper BEM - but the convention is to have the view name as the
+// block part of the class name. Because we need to keep `browse` so this can
+// be run as an A/B test, we need to use a different class name for each view.
+.topic-page__breadcrumb-wrapper,
+.topic-page__header-wrapper {
+  background-color: govuk-colour("dark-grey");
+}
+
+.topic-page__breadcrumb-wrapper {
+  // Setting the overflow to auto is required to prevent the breadcrumb
+  // component's margin from collapsing.
+  overflow: auto;
+
+  // We want to show a constrained width blue bar _within_ the grey header.
+  // But:
+  //  * The full width coronavirus banner currently shows the blue bar - but
+  // this is only visible when JavaScript is available.
+  //  * A full width layout template doesn't include the blue bar.
+  //
+  // So we need to add a blue bar manually to this template - but only when
+  // JavaScript is unavailable.
+  //
+  // When the coronavirus banner is turned off, there will be some work to turn
+  // this on for both JS and non-JS visitors in a way that doesn't break any
+  // future banner or the emergency banner.
+  &:before {
+    background-color: $govuk-brand-colour;
+    content: "";
+    display: block;
+    margin: auto;
+    max-width: 960px;
+    height: govuk-spacing(2);
+
+    .js-enabled & {
+      content: none;
+    }
+  }
+}
+
+// The header spacings are a work in progress.
+.topic-page__header-wrapper {
+  padding-bottom: 40px;
+  padding-top: 10px;
+
+  @include govuk-media-query($from: "tablet") {
+    padding-bottom: 50px;
+    padding-top: 30px;
+  }
+}

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -330,14 +330,15 @@ $transition-speed: .4s;
   }
 }
 
+// New background colour for the topic pages:
+$topic-page-header-background-colour: #263135;
+
 // This isn't proper BEM - but the convention is to have the view name as the
 // block part of the class name. Because we need to keep `browse` so this can
 // be run as an A/B test, we need to use a different class name for each view.
 .topic-page__breadcrumb-wrapper,
 .topic-page__header-wrapper {
-  $topic-page-header-background: #263135;
-
-  background-color: $topic-page-header-background;
+  background-color: $topic-page-header-background-colour;
 }
 
 .topic-page__breadcrumb-wrapper {
@@ -374,7 +375,13 @@ $transition-speed: .4s;
 // The header spacings are a work in progress.
 .topic-page__header-wrapper {
   padding-bottom: govuk-spacing(7);
-  padding-top: 0;
+
+  // A tiny white seam sometimes appears, despite there being no gap between
+  // this element and the previous element. This shifts the element up by a
+  // pixel to prevent the seam from appearing and adds padding to reposition the
+  // content.
+  border-top: 1px solid $topic-page-header-background-colour;
+  margin-top: -1px;
 
   @include govuk-media-query($from: "tablet") {
     padding-bottom: govuk-spacing(8);

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -373,11 +373,20 @@ $transition-speed: .4s;
 
 // The header spacings are a work in progress.
 .topic-page__header-wrapper {
-  padding-bottom: 40px;
-  padding-top: 10px;
+  padding-bottom: govuk-spacing(7);
+  padding-top: 0;
 
   @include govuk-media-query($from: "tablet") {
-    padding-bottom: 50px;
-    padding-top: 30px;
+    padding-bottom: govuk-spacing(8);
+    padding-top: govuk-spacing(6);
   }
+}
+
+.topic-page__heading {
+  color: govuk-colour("white");
+  margin-bottom: govuk-spacing(6);
+}
+
+.topic-page__description {
+  margin-bottom: govuk-spacing(2);
 }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -6,40 +6,50 @@ class BrowseController < ApplicationController
     @dimension26 = 1
     @dimension27 = page.top_level_browse_pages.count || 0
     setup_content_item_and_navigation_helpers(page)
+    slimmer_template "gem_layout_full_width" if is_variant_b?
 
-    render :index,
-           locals: {
-             page: page,
-           }
+    template = is_variant_b? ? :new_index : :index
+
+    render(template, locals: {
+      page: page,
+    })
   end
 
   def show
-    page =
-      MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
+    page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
     setup_content_item_and_navigation_helpers(page)
+    slimmer_template "gem_layout_full_width" if is_variant_b?
 
     respond_to do |f|
       f.html do
         show_html(page)
       end
+
       f.json do
-        render json: {
+        render(json: {
           content_id: page.content_id,
           navigation_page_type: "First Level Browse",
           breadcrumbs: breadcrumb_content,
           html: second_level_browse_pages_partial(page),
-        }
+        })
       end
     end
   end
 
 private
 
+  # NOTE: This is just to fake an A/B test - replace with proper A/B test code.
+  # Add a query string with b=true to the URL to force variant B.
+  def is_variant_b?
+    params["b"].present?
+  end
+
   def show_html(page)
-    render :show,
-           locals: {
-             page: page,
-           }
+    template = is_variant_b? ? :new_show : :show
+
+    render(template, locals: {
+      page: page,
+    })
   end
 
   def second_level_browse_pages_partial(page)

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -4,6 +4,7 @@
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
       navigation_page_type: "Browse level 0 - uncurated",
+      section: "new_browse_page",
     }
   } %>
 <% end %>

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -1,0 +1,67 @@
+<% content_for :title, t("browse.all_categories") %>
+
+<% content_for :meta_tags do %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Browse Index",
+    }
+  } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <div class="topic-page__breadcrumb-wrapper">
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/breadcrumbs", {
+            breadcrumbs: [
+              {
+                title: "Home",
+                url: "/"
+              },
+            ],
+            collapse_on_mobile: true,
+            inverse: true,
+          } %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="topic-page__header-wrapper">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "xl",
+          heading_level: 1,
+          inverse: true,
+          margin_bottom: 6,
+          text: t("browse.title"),
+        } %>
+        <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
+          <%= t("browse.description") %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-padding-top-9">
+      <%= render "govuk_publishing_components/components/cards", {
+        items: page.top_level_browse_pages.map do |top_level_browse_page|
+          {
+            link: {
+              text: top_level_browse_page.title,
+              path: top_level_browse_page.base_path,
+            },
+            description: top_level_browse_page.description,
+          }
+        end
+      } %>
+    </div>
+  </div>
+</div>

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -33,14 +33,10 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= render "govuk_publishing_components/components/heading", {
-          font_size: "xl",
-          heading_level: 1,
-          inverse: true,
-          margin_bottom: 6,
-          text: t("browse.title"),
-        } %>
-        <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
+        <h1 class="topic-page__heading govuk-heading-xl">
+          <%= t("browse.title") %>
+        </h1>
+        <p class="topic-page__description gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
           <%= t("browse.description") %>
         </p>
       </div>

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -3,7 +3,7 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      navigation_page_type: "Browse level 0 - uncurated",
+      navigation_page_type: "Browse level 0 - default",
       section: "new_browse_page",
     }
   } %>

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -3,7 +3,7 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      navigation_page_type: "Browse Index",
+      navigation_page_type: "Browse level 0 - uncurated",
     }
   } %>
 <% end %>

--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -46,13 +46,22 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-top-9">
+    <div class="govuk-grid-column-full govuk-!-padding-top-9" data-module="gem-track-click">
       <%= render "govuk_publishing_components/components/cards", {
         items: page.top_level_browse_pages.map do |top_level_browse_page|
           {
             link: {
               text: top_level_browse_page.title,
               path: top_level_browse_page.base_path,
+              data_attributes: {
+                track_category: 'browseClicked',
+                track_action: "topicsLink",
+                track_label: top_level_browse_page.base_path,
+                track_dimension: top_level_browse_page.title,
+                track_options: {
+                  dimension29: top_level_browse_page.title,
+                },
+              }
             },
             description: top_level_browse_page.description,
           }

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -52,13 +52,23 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-top-9">
+    <div class="govuk-grid-column-full govuk-!-padding-top-9"  data-module="gem-track-click">
       <%= render "govuk_publishing_components/components/cards", {
-        items: page.second_level_browse_pages.map do |second_level_browse_page|
+        items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
           {
             link: {
               text: second_level_browse_page.title,
               path: second_level_browse_page.base_path,
+              data_attributes: {
+                track_category: 'browseClicked',
+                track_action: "topicsLink",
+                track_label: second_level_browse_page.base_path,
+                track_dimension: second_level_browse_page.title,
+                track_options: {
+                  dimension28: index + 1,
+                  dimension29: second_level_browse_page.title,
+                },
+              }
             },
             description: second_level_browse_page.description,
           }

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -39,13 +39,9 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= render "govuk_publishing_components/components/heading", {
-          font_size: "xl",
-          heading_level: 1,
-          inverse: true,
-          margin_bottom: 6,
-          text: page.title,
-        } %>
+        <h1 class="topic-page__heading govuk-heading-xl">
+          <%= page.title %>
+        </h1>
         <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
           <%= page.description %>
         </p>

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -23,10 +23,6 @@
                 title: "Home",
                 url: "/"
               },
-              {
-                title: "Topics",
-                url: "/browse"
-              },
             ],
             collapse_on_mobile: true,
             inverse: true,

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -6,7 +6,7 @@
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
       # TODO align this naming "level 1" vs "second_level" mismatch
-      navigation_page_type: "Browse level 1 - #{page.second_level_pages_curated? ? "curated" : "uncurated"}",
+      navigation_page_type: "Browse level 1 - #{page.second_level_pages_curated? ? "curated" : "default"}",
       section: "new_browse_page",
     }
   } %>

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -21,6 +21,10 @@
                 title: "Home",
                 url: "/"
               },
+              {
+                title: "Topics",
+                url: "/browse"
+              },
             ],
             collapse_on_mobile: true,
             inverse: true,

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -5,7 +5,8 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      navigation_page_type: "First Level Browse",
+      # TODO align this naming "level 1" vs "second_level" mismatch
+      navigation_page_type: "Browse level 1 - #{page.second_level_pages_curated? ? "curated" : "uncurated"}",
     }
   } %>
 <% end %>
@@ -52,7 +53,7 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-top-9"  data-module="gem-track-click">
+    <div class="govuk-grid-column-full govuk-!-padding-top-9" data-module="gem-track-click">
       <%= render "govuk_publishing_components/components/cards", {
         items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
           {

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -7,6 +7,7 @@
     content_item: {
       # TODO align this naming "level 1" vs "second_level" mismatch
       navigation_page_type: "Browse level 1 - #{page.second_level_pages_curated? ? "curated" : "uncurated"}",
+      section: "new_browse_page",
     }
   } %>
 <% end %>

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -1,0 +1,69 @@
+<% content_for :title, "#{t("shared.browse.prefix")} #{page.title}" %>
+
+<%= render 'shared/tag_meta', tag: page %>
+
+<% content_for :meta_tags do %>
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "First Level Browse",
+    }
+  } %>
+<% end %>
+
+<% content_for :breadcrumbs do %>
+  <div class="topic-page__breadcrumb-wrapper">
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/breadcrumbs", {
+            breadcrumbs: [
+              {
+                title: "Home",
+                url: "/"
+              },
+            ],
+            collapse_on_mobile: true,
+            inverse: true,
+          } %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<div class="topic-page__header-wrapper">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: "xl",
+          heading_level: 1,
+          inverse: true,
+          margin_bottom: 6,
+          text: page.title,
+        } %>
+        <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
+          <%= page.description %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-!-padding-top-9">
+      <%= render "govuk_publishing_components/components/cards", {
+        items: page.second_level_browse_pages.map do |second_level_browse_page|
+          {
+            link: {
+              text: second_level_browse_page.title,
+              path: second_level_browse_page.base_path,
+            },
+            description: second_level_browse_page.description,
+          }
+        end
+      } %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,14 @@
+<%
+  main_classes = %w[content]
+  main_classes << (yield :page_class)
+  lang = params["locale"]
+
+  if content_item_h
+    unless (!content_item_h["locale"] || content_item_h["locale"].eql?("en"))
+      lang = content_item_h["locale"]
+    end
+  end
+%>
 <!DOCTYPE html>
 <html>
 <head>
@@ -21,13 +32,16 @@
         <%= render 'breadcrumbs' %>
       <% end %>
     <% end %>
-    <% if content_item_h %>
-      <main id="content" role="main" class="content <%= yield :page_class %>" <%= "lang=#{content_item_h["locale"]}" unless !content_item_h["locale"] || content_item_h["locale"].eql?("en") %>>
-    <% else %>
-      <main id="content" role="main" class="content <%= yield :page_class %>" <%= "lang=#{params["locale"]}" if params["locale"] %>>
+    <%=
+      content_tag(:main,
+        id: "content",
+        role: "main",
+        class: main_classes,
+        lang: lang,
+       ) do
+    %>
+      <%= yield %>
     <% end %>
-    <%= yield %>
-    </main>
   </div>
 </body>
 </html>

--- a/config/locales/ar/browse.yml
+++ b/config/locales/ar/browse.yml
@@ -2,3 +2,5 @@
 ar:
   browse:
     all_categories: جميع الفئات
+    description: 
+    title: 

--- a/config/locales/az/browse.yml
+++ b/config/locales/az/browse.yml
@@ -2,3 +2,5 @@
 az:
   browse:
     all_categories: Bütün kateqoriyalar
+    description:
+    title:

--- a/config/locales/be/browse.yml
+++ b/config/locales/be/browse.yml
@@ -2,3 +2,5 @@
 be:
   browse:
     all_categories: Усе катэгорыі
+    description:
+    title:

--- a/config/locales/bg/browse.yml
+++ b/config/locales/bg/browse.yml
@@ -2,3 +2,5 @@
 bg:
   browse:
     all_categories: Всички категории
+    description:
+    title:

--- a/config/locales/bn/browse.yml
+++ b/config/locales/bn/browse.yml
@@ -2,3 +2,5 @@
 bn:
   browse:
     all_categories: সকল শ্রেণিবিভাগ
+    description:
+    title:

--- a/config/locales/cs/browse.yml
+++ b/config/locales/cs/browse.yml
@@ -2,3 +2,5 @@
 cs:
   browse:
     all_categories: Všechny kategorie
+    description:
+    title:

--- a/config/locales/cy/browse.yml
+++ b/config/locales/cy/browse.yml
@@ -2,3 +2,5 @@
 cy:
   browse:
     all_categories: Pob categori
+    description:
+    title:

--- a/config/locales/da/browse.yml
+++ b/config/locales/da/browse.yml
@@ -2,3 +2,5 @@
 da:
   browse:
     all_categories: Alle kategorier
+    description:
+    title:

--- a/config/locales/de/browse.yml
+++ b/config/locales/de/browse.yml
@@ -2,3 +2,5 @@
 de:
   browse:
     all_categories: Alle Kategorien
+    description:
+    title:

--- a/config/locales/dr/browse.yml
+++ b/config/locales/dr/browse.yml
@@ -2,3 +2,5 @@
 dr:
   browse:
     all_categories: تمام کتگوری ها
+    description:
+    title:

--- a/config/locales/el/browse.yml
+++ b/config/locales/el/browse.yml
@@ -2,3 +2,5 @@
 el:
   browse:
     all_categories: Όλες οι κατηγορίες
+    description:
+    title:

--- a/config/locales/en/browse.yml
+++ b/config/locales/en/browse.yml
@@ -2,3 +2,5 @@
 en:
   browse:
     all_categories: All categories
+    description: Find information and services.
+    title: Topics

--- a/config/locales/es-419/browse.yml
+++ b/config/locales/es-419/browse.yml
@@ -2,3 +2,5 @@
 es-419:
   browse:
     all_categories: Todas las categorías
+    description:
+    title:

--- a/config/locales/es/browse.yml
+++ b/config/locales/es/browse.yml
@@ -2,3 +2,5 @@
 es:
   browse:
     all_categories: Todas las categorías
+    description:
+    title:

--- a/config/locales/et/browse.yml
+++ b/config/locales/et/browse.yml
@@ -2,3 +2,5 @@
 et:
   browse:
     all_categories: Kõik kategooriad
+    description:
+    title:

--- a/config/locales/fa/browse.yml
+++ b/config/locales/fa/browse.yml
@@ -2,3 +2,5 @@
 fa:
   browse:
     all_categories: تمام دسته‌بندی‌ها
+    description:
+    title:

--- a/config/locales/fi/browse.yml
+++ b/config/locales/fi/browse.yml
@@ -2,3 +2,5 @@
 fi:
   browse:
     all_categories: Kaikki kategoriat
+    description:
+    title:

--- a/config/locales/fr/browse.yml
+++ b/config/locales/fr/browse.yml
@@ -2,3 +2,5 @@
 fr:
   browse:
     all_categories: Toutes catégories
+    description:
+    title:

--- a/config/locales/gd/browse.yml
+++ b/config/locales/gd/browse.yml
@@ -2,3 +2,5 @@
 gd:
   browse:
     all_categories: Gach cineál táirgí
+    description:
+    title:

--- a/config/locales/gu/browse.yml
+++ b/config/locales/gu/browse.yml
@@ -2,3 +2,5 @@
 gu:
   browse:
     all_categories: તમામ શ્રેણીઓ
+    description:
+    title:

--- a/config/locales/he/browse.yml
+++ b/config/locales/he/browse.yml
@@ -2,3 +2,5 @@
 he:
   browse:
     all_categories: כל הקטגוריות
+    description:
+    title:

--- a/config/locales/hi/browse.yml
+++ b/config/locales/hi/browse.yml
@@ -2,3 +2,5 @@
 hi:
   browse:
     all_categories: सभी वर्ग
+    description:
+    title:

--- a/config/locales/hr/browse.yml
+++ b/config/locales/hr/browse.yml
@@ -2,3 +2,5 @@
 hr:
   browse:
     all_categories: Sve kategorije
+    description:
+    title:

--- a/config/locales/hu/browse.yml
+++ b/config/locales/hu/browse.yml
@@ -2,3 +2,5 @@
 hu:
   browse:
     all_categories: Minden kategória
+    description:
+    title:

--- a/config/locales/hy/browse.yml
+++ b/config/locales/hy/browse.yml
@@ -2,3 +2,5 @@
 hy:
   browse:
     all_categories: Բոլոր կատեգորիաները
+    description:
+    title:

--- a/config/locales/id/browse.yml
+++ b/config/locales/id/browse.yml
@@ -2,3 +2,5 @@
 id:
   browse:
     all_categories: Semua kategori
+    description:
+    title:

--- a/config/locales/is/browse.yml
+++ b/config/locales/is/browse.yml
@@ -2,3 +2,5 @@
 is:
   browse:
     all_categories: Allir flokkar
+    description:
+    title:

--- a/config/locales/it/browse.yml
+++ b/config/locales/it/browse.yml
@@ -2,3 +2,5 @@
 it:
   browse:
     all_categories: Tutte le categorie
+    description:
+    title:

--- a/config/locales/ja/browse.yml
+++ b/config/locales/ja/browse.yml
@@ -2,3 +2,5 @@
 ja:
   browse:
     all_categories: すべてのカテゴリ
+    description:
+    title:

--- a/config/locales/ka/browse.yml
+++ b/config/locales/ka/browse.yml
@@ -2,3 +2,5 @@
 ka:
   browse:
     all_categories: ყველა კატეგორია
+    description:
+    title:

--- a/config/locales/kk/browse.yml
+++ b/config/locales/kk/browse.yml
@@ -2,3 +2,5 @@
 kk:
   browse:
     all_categories: Барлық санаттар
+    description:
+    title:

--- a/config/locales/ko/browse.yml
+++ b/config/locales/ko/browse.yml
@@ -2,3 +2,5 @@
 ko:
   browse:
     all_categories: 모든 범주
+    description:
+    title:

--- a/config/locales/lt/browse.yml
+++ b/config/locales/lt/browse.yml
@@ -2,3 +2,5 @@
 lt:
   browse:
     all_categories: Visos kategorijos
+    description:
+    title:

--- a/config/locales/lv/browse.yml
+++ b/config/locales/lv/browse.yml
@@ -2,3 +2,5 @@
 lv:
   browse:
     all_categories: Visas kategorijas
+    description:
+    title:

--- a/config/locales/ms/browse.yml
+++ b/config/locales/ms/browse.yml
@@ -2,3 +2,5 @@
 ms:
   browse:
     all_categories: Semua kategori
+    description:
+    title:

--- a/config/locales/mt/browse.yml
+++ b/config/locales/mt/browse.yml
@@ -2,3 +2,5 @@
 mt:
   browse:
     all_categories: Kategoriji kollha
+    description:
+    title:

--- a/config/locales/nl/browse.yml
+++ b/config/locales/nl/browse.yml
@@ -2,3 +2,5 @@
 nl:
   browse:
     all_categories: Alle categorieën
+    description:
+    title:

--- a/config/locales/no/browse.yml
+++ b/config/locales/no/browse.yml
@@ -2,3 +2,5 @@
 'no':
   browse:
     all_categories: Alle kategorier
+    description:
+    title:

--- a/config/locales/pa-pk/browse.yml
+++ b/config/locales/pa-pk/browse.yml
@@ -2,3 +2,5 @@
 pa-pk:
   browse:
     all_categories: سارے گروہ
+    description:
+    title:

--- a/config/locales/pa/browse.yml
+++ b/config/locales/pa/browse.yml
@@ -2,3 +2,5 @@
 pa:
   browse:
     all_categories: ਸਾਰੀਆਂ ਸ਼੍ਰੇਣੀਆਂ
+    description:
+    title:

--- a/config/locales/pl/browse.yml
+++ b/config/locales/pl/browse.yml
@@ -2,3 +2,5 @@
 pl:
   browse:
     all_categories: Wszystkie kategorie
+    description:
+    title:

--- a/config/locales/ps/browse.yml
+++ b/config/locales/ps/browse.yml
@@ -2,3 +2,5 @@
 ps:
   browse:
     all_categories: ټولې کټګورۍ
+    description:
+    title:

--- a/config/locales/pt/browse.yml
+++ b/config/locales/pt/browse.yml
@@ -2,3 +2,5 @@
 pt:
   browse:
     all_categories: Todas as categorias
+    description:
+    title:

--- a/config/locales/ro/browse.yml
+++ b/config/locales/ro/browse.yml
@@ -2,3 +2,5 @@
 ro:
   browse:
     all_categories: Toate categoriile
+    description:
+    title:

--- a/config/locales/ru/browse.yml
+++ b/config/locales/ru/browse.yml
@@ -2,3 +2,5 @@
 ru:
   browse:
     all_categories: Все категории
+    description:
+    title:

--- a/config/locales/si/browse.yml
+++ b/config/locales/si/browse.yml
@@ -2,3 +2,5 @@
 si:
   browse:
     all_categories: සියලු ප්රවර්ග
+    description:
+    title:

--- a/config/locales/sk/browse.yml
+++ b/config/locales/sk/browse.yml
@@ -2,3 +2,5 @@
 sk:
   browse:
     all_categories: Všetky kategórie
+    description:
+    title:

--- a/config/locales/sl/browse.yml
+++ b/config/locales/sl/browse.yml
@@ -2,3 +2,5 @@
 sl:
   browse:
     all_categories: Vse kategorije
+    description:
+    title:

--- a/config/locales/so/browse.yml
+++ b/config/locales/so/browse.yml
@@ -2,3 +2,5 @@
 so:
   browse:
     all_categories: Dhamaan qeybaha
+    description:
+    title:

--- a/config/locales/sq/browse.yml
+++ b/config/locales/sq/browse.yml
@@ -2,3 +2,5 @@
 sq:
   browse:
     all_categories: Të gjitha kategoritë
+    description:
+    title:

--- a/config/locales/sr/browse.yml
+++ b/config/locales/sr/browse.yml
@@ -2,3 +2,5 @@
 sr:
   browse:
     all_categories: Sve kategorije
+    description:
+    title:

--- a/config/locales/sv/browse.yml
+++ b/config/locales/sv/browse.yml
@@ -2,3 +2,5 @@
 sv:
   browse:
     all_categories: Alla kategorier
+    description:
+    title:

--- a/config/locales/sw/browse.yml
+++ b/config/locales/sw/browse.yml
@@ -2,3 +2,5 @@
 sw:
   browse:
     all_categories: Aina zote
+    description:
+    title:

--- a/config/locales/ta/browse.yml
+++ b/config/locales/ta/browse.yml
@@ -2,3 +2,5 @@
 ta:
   browse:
     all_categories: அனைத்து வகையினங்கள்
+    description:
+    title:

--- a/config/locales/th/browse.yml
+++ b/config/locales/th/browse.yml
@@ -2,3 +2,5 @@
 th:
   browse:
     all_categories: ทุกหมวดหมู่
+    description:
+    title:

--- a/config/locales/tk/browse.yml
+++ b/config/locales/tk/browse.yml
@@ -2,3 +2,5 @@
 tk:
   browse:
     all_categories: Ähli toparlar
+    description:
+    title:

--- a/config/locales/tr/browse.yml
+++ b/config/locales/tr/browse.yml
@@ -2,3 +2,5 @@
 tr:
   browse:
     all_categories: Tüm kategoriler
+    description:
+    title:

--- a/config/locales/uk/browse.yml
+++ b/config/locales/uk/browse.yml
@@ -2,3 +2,5 @@
 uk:
   browse:
     all_categories: Всі категорії
+    description:
+    title:

--- a/config/locales/ur/browse.yml
+++ b/config/locales/ur/browse.yml
@@ -2,3 +2,5 @@
 ur:
   browse:
     all_categories: تمام زمرہ جات
+    description:
+    title:

--- a/config/locales/uz/browse.yml
+++ b/config/locales/uz/browse.yml
@@ -2,3 +2,5 @@
 uz:
   browse:
     all_categories: Барча тоифалар
+    description:
+    title:

--- a/config/locales/vi/browse.yml
+++ b/config/locales/vi/browse.yml
@@ -2,3 +2,5 @@
 vi:
   browse:
     all_categories: Tất cả danh mục
+    description:
+    title:

--- a/config/locales/yi/browse.yml
+++ b/config/locales/yi/browse.yml
@@ -2,3 +2,5 @@
 yi:
   browse:
     all_categories:
+    description:
+    title:

--- a/config/locales/zh-hk/browse.yml
+++ b/config/locales/zh-hk/browse.yml
@@ -2,3 +2,5 @@
 zh-hk:
   browse:
     all_categories: 所有種類
+    description:
+    title:

--- a/config/locales/zh-tw/browse.yml
+++ b/config/locales/zh-tw/browse.yml
@@ -2,3 +2,5 @@
 zh-tw:
   browse:
     all_categories: 所有類別
+    description:
+    title:

--- a/config/locales/zh/browse.yml
+++ b/config/locales/zh/browse.yml
@@ -2,3 +2,5 @@
 zh:
   browse:
     all_categories: 全部分类
+    description:
+    title:


### PR DESCRIPTION
Edit: 

**Please don't push any more changes to this PR, we're now working in https://github.com/alphagov/collections/pull/2696 which contains all the work from this PR. We'll probably close this PR shortly to tidy up.**

🚧 Work in progress 🚧

## What

Adds the new topic page templates for the 0th (`/browse`) and 1st (eg `/browse/benefits`) level of the topics.

This is hidden behind a flag to fake the A/B test mechanism - append `?b=true` to the URL to view the new topic pages.

## Why

The topic pages are undergoing a set of A/B tests, and the templates need to be present and usable for this test to take place.

## Visual differences

...


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


[1]: https://github.com/alphagov/govuk_publishing_components/pull/2624

## Done when

- [x] [PR #2679](https://github.com/alphagov/govuk_publishing_components/pull/2679) complete.
- [x] [Dependancy](https://github.com/alphagov/collections/pull/2707) update in `collections`
- [x] [PR #2689, Analytics update complete](https://github.com/alphagov/govuk_publishing_components/pull/2689)
- [x] Dependancy update in `collections`

### Preview link

https://govuk-collec-add-topic--fzeco1.herokuapp.com/browse?b=true