### PR TITLE
Add DRCF digital market research label

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -74,6 +74,9 @@ en:
         draft_text:
           one: Draft text
           other: Draft texts
+        drcf_digital_markets_research:
+          one: DRCF digital markets research
+          other: DRCF digital markets research
         drug_safety_update:
           one: Drug Safety Update
           other: Drug Safety Updates


### PR DESCRIPTION
Trello: https://trello.com/c/0LHrDag7/157-create-new-specialist-finder-for-competition-and-markets-authority

This is a new document type introduced in https://github.com/alphagov/govuk-content-schemas/pull/1085

Before:
![Screenshot 2022-02-25 at 16 30 44](https://user-images.githubusercontent.com/282717/155751875-dcb06e42-1a62-4152-adaf-ad8c03780b67.png)


After:
![Screenshot 2022-02-25 at 16 30 51](https://user-images.githubusercontent.com/282717/155751866-e89c7e5a-0462-474b-a3b9-100dc45dc43b.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
