### PR TITLE
Add recruitment banner on specific mainstream browse pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,6 +6,7 @@
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/error-summary

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/image-card';
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/inset-text';
+@import 'govuk_publishing_components/components/intervention';
 @import 'govuk_publishing_components/components/inverse-header';
 @import 'govuk_publishing_components/components/label';
 @import 'govuk_publishing_components/components/lead-paragraph';

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,8 +1,11 @@
 class SecondLevelBrowsePageController < ApplicationController
+  include RecruitmentBannerHelper
   enable_request_formats show: [:json]
 
   def show
     setup_content_item_and_navigation_helpers(page)
+
+    @show_recruitment_banner = show_banner?(request.path)
 
     respond_to do |f|
       f.html do

--- a/app/controllers/subtopics_controller.rb
+++ b/app/controllers/subtopics_controller.rb
@@ -1,4 +1,6 @@
 class SubtopicsController < ApplicationController
+  include RecruitmentBannerHelper
+
   def show
     subtopic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(subtopic)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,4 +1,6 @@
 class TopicsController < ApplicationController
+  include RecruitmentBannerHelper
+
   def index
     topic = Topic.find(request.path)
     setup_content_item_and_navigation_helpers(topic)

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,11 +1,7 @@
-module RecruitmentBannerHelpers
+module RecruitmentBannerHelper
   TOPICS = ["/browse/business", "/browse/tax"].freeze
 
   def show_banner?(path)
     path.starts_with?(TOPICS.first) || path.starts_with?(TOPICS.last)
-  end
-
-  def hide_banner?(path)
-    !show_banner?(path)
   end
 end

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,0 +1,11 @@
+module RecruitmentBannerHelpers
+  TOPICS = ["/browse/business", "/browse/tax"].freeze
+
+  def show_banner?(path)
+    path.starts_with?(TOPICS.first) || path.starts_with?(TOPICS.last)
+  end
+
+  def hide_banner?(path)
+    !show_banner?(path)
+  end
+end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,6 +1,15 @@
 <div class="browse__inner <%= page.lists.curated? ? 'browse__inner--curated' : 'browse__inner--alphabetical' %>">
   <h2 tabindex="-1" class="browse__heading js-heading"><%= t("shared.browse.prefix") %> <%= page.title %></h2>
 
+  <% if @show_recruitment_banner %>
+    <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: "https://gdsuserresearch.optimalworkshop.com/treejack/lb5eu75l",
+        new_tab: true,
+    } %>
+  <% end %>
+
   <% page.lists.each_with_index do |list, section_index| %>
     <% if page.lists.curated? %>
       <h3 class="browse__list-header"><%= list.title %></h3>

--- a/spec/features/recruitment_banner_spec.rb
+++ b/spec/features/recruitment_banner_spec.rb
@@ -1,0 +1,30 @@
+require "integration_spec_helper"
+
+RSpec.feature "Recruitment banner" do
+  include SearchApiHelpers
+
+  context "Mainstream browse pages" do
+    scenario "browse page is where we want to display recruitment banner" do
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      schema["base_path"] = "/browse/business/foo"
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], %w[/browse/business/foo], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector(".gem-c-intervention")
+    end
+
+    scenario "browse page is not where we want to display recruitment banner" do
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to_not have_selector(".gem-c-intervention")
+    end
+  end
+end

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -1,15 +1,5 @@
-RSpec.describe RecruitmentBannerHelpers do
-  include RecruitmentBannerHelpers
-
-  describe "#hide_banner?" do
-    it "checks that a page should display the banner" do
-      expect(hide_banner?("/browse/business")).to be false
-    end
-
-    it "checks that a page hides that banner" do
-      expect(hide_banner?("/browse/stuff")).to be true
-    end
-  end
+RSpec.describe RecruitmentBannerHelper do
+  include RecruitmentBannerHelper
 
   describe "#show_banner?" do
     it "checks that a page should display the banner" do

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe RecruitmentBannerHelpers do
+  include RecruitmentBannerHelpers
+
+  describe "#hide_banner?" do
+    it "checks that a page should display the banner" do
+      expect(hide_banner?("/browse/business")).to be false
+    end
+
+    it "checks that a page hides that banner" do
+      expect(hide_banner?("/browse/stuff")).to be true
+    end
+  end
+
+  describe "#show_banner?" do
+    it "checks that a page should display the banner" do
+      expect(show_banner?("/browse/business")).to be true
+    end
+
+    it "checks that a page shows that banner" do
+      expect(show_banner?("/browse/stuff")).to be false
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR is entirely based on the excellent work of @chao-xian https://github.com/alphagov/collections/pull/2630

Final commit wip.

https://trello.com/c/qPhlRiUx/779-launch-and-monitor-the-recruitment-banner-for-money-tax