### PR TITLE
Add missing styles to hardcoded paragraph on organisation page

### DIFF
--- a/config/locales/ar/organisations.yml
+++ b/config/locales/ar/organisations.yml
@@ -565,7 +565,7 @@ ar:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: اطلع على جميع بيانات الشفافية وحرية تداول المعلومات
         title: الشفافية وحرية تداول المعلومات
-    errors_or_omissions_html: <p>أخطاء أو حالات إغفال؟ <a class="govuk-link" href="/contact/govuk">أخبرنا هنا</a>. للحصول على القوائم الرسمية للهيئات العامة غير التابعة للإدارات <a class="govuk-link" href="/government/collections/public-bodies">اطلع على الهيئات العامة</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">أخطاء أو حالات إغفال؟ <a class="govuk-link" href="/contact/govuk">أخبرنا هنا</a>. للحصول على القوائم الرسمية للهيئات العامة غير التابعة للإدارات <a class="govuk-link" href="/government/collections/public-bodies">اطلع على الهيئات العامة</a>.</p>
     featured: متميّز
     foi:
       contact_form: نموذج الاتصال المخصص لحرية تبادل المعلومات

--- a/config/locales/az/organisations.yml
+++ b/config/locales/az/organisations.yml
@@ -269,7 +269,7 @@ az:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Şəffaflıq və məlumat əldə etmə azadlığı üzrə bütün buraxılışları nəzərdən keçirin
         title: Şəffaflıq və məlumat əldə etmə azadlığı buraxılışları
-    errors_or_omissions_html: <p>Xətalar və ya səhlənkarlıqlar? <a class="govuk-link" href="/contact/govuk">Bizə burada bildirin</a>. Yarımüstəqil qeyri-hökumət təşkilatlarının rəsmi siyahıları üçün <a class="govuk-link" href="/government/collections/public-bodies">dövlət qurumlarını nəzərdən keçirin</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Xətalar və ya səhlənkarlıqlar? <a class="govuk-link" href="/contact/govuk">Bizə burada bildirin</a>. Yarımüstəqil qeyri-hökumət təşkilatlarının rəsmi siyahıları üçün <a class="govuk-link" href="/government/collections/public-bodies">dövlət qurumlarını nəzərdən keçirin</a>.</p>
     featured: Seçilmiş
     foi:
       contact_form: Məlumat əldə etmə azadlığı üzrə əlaqə forması

--- a/config/locales/be/organisations.yml
+++ b/config/locales/be/organisations.yml
@@ -417,7 +417,7 @@ be:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Глядзець усё аб празрыстасцi і волi інфармацыі
         title: Празрыстасць і воля інфармацыі
-    errors_or_omissions_html: <p>Памылкі або недагляды? <a class="govuk-link" href="/contact/govuk">Раскажыце нам тут</a>. Для афіцыйных спісаў пазаведамасных дзяржаўных органаў <a class="govuk-link" href="/government/collections/public-bodies">глядзi дзяржаўныя органы</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Памылкі або недагляды? <a class="govuk-link" href="/contact/govuk">Раскажыце нам тут</a>. Для афіцыйных спісаў пазаведамасных дзяржаўных органаў <a class="govuk-link" href="/government/collections/public-bodies">глядзi дзяржаўныя органы</a>.</p>
     featured: Падборка
     foi:
       contact_form: Кантактавая форма FOI

--- a/config/locales/bg/organisations.yml
+++ b/config/locales/bg/organisations.yml
@@ -269,7 +269,7 @@ bg:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Вижте всички издания за прозрачността и свободата на информация
         title: Издания за прозрачността и свободата на информация
-    errors_or_omissions_html: <p>Грешки или пропуски? <a class="govuk-link" href="/contact/govuk">Разкажете ни тук</a>. За официални списъци на публични органи, които не са министерства, <a class="govuk-link" href="/government/collections/public-bodies">вижте публични органи</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Грешки или пропуски? <a class="govuk-link" href="/contact/govuk">Разкажете ни тук</a>. За официални списъци на публични органи, които не са министерства, <a class="govuk-link" href="/government/collections/public-bodies">вижте публични органи</a>.</p>
     featured: Избрани
     foi:
       contact_form: Формуляр за контакт за свобода на информацията

--- a/config/locales/bn/organisations.yml
+++ b/config/locales/bn/organisations.yml
@@ -269,7 +269,7 @@ bn:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: সকল স্বচ্ছতা ও তথ্যের স্বাধীনতা বিষয়ক প্রকাশনা দেখুন
         title: স্বচ্ছতা ও তথ্যের স্বাধীনতা বিষয়ক প্রকাশনা
-    errors_or_omissions_html: <p>ত্রুটি বা বর্জন? <a class="govuk-link" href="/contact/govuk">আমাদেরকে এখানে বলুন</a>। নন-ডিপার্টমেন্টাল সরকারি প্রতিষ্ঠানগুলোর দাপ্তরিক তালিকার জন্য <a class="govuk-link" href="/government/collections/public-bodies">সরকারি প্রতিষ্ঠানসমূহ দেখুন</a>।</p>
+    errors_or_omissions_html: <p class="govuk-body">ত্রুটি বা বর্জন? <a class="govuk-link" href="/contact/govuk">আমাদেরকে এখানে বলুন</a>। নন-ডিপার্টমেন্টাল সরকারি প্রতিষ্ঠানগুলোর দাপ্তরিক তালিকার জন্য <a class="govuk-link" href="/government/collections/public-bodies">সরকারি প্রতিষ্ঠানসমূহ দেখুন</a>।</p>
     featured: ফিচারকৃত
     foi:
       contact_form: FOI যোগাযোগের ফর্ম

--- a/config/locales/cs/organisations.yml
+++ b/config/locales/cs/organisations.yml
@@ -343,7 +343,7 @@ cs:
           path: "/search/transparency-and-freedom-of-information-releases?organizations[]=%{organisation}&parent=%{organisation}"
           text: Podívejte se na všechny zprávy o transparentnosti a svobodě informací
         title: Transparentnost a svoboda informací
-    errors_or_omissions_html: <p>Chyby nebo opomenutí? <a class="govuk-link" href="/contact/govuk">Sdělte nám to zde</a>. Oficiální seznamy neveřejných subjektů <a class="govuk-link" href="/government/collections/public-bodies">viz veřejné subjekty</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Chyby nebo opomenutí? <a class="govuk-link" href="/contact/govuk">Sdělte nám to zde</a>. Oficiální seznamy neveřejných subjektů <a class="govuk-link" href="/government/collections/public-bodies">viz veřejné subjekty</a>.</p>
     featured: Doporučené stránky
     foi:
       contact_form: Kontaktní formulář FOI

--- a/config/locales/cy/organisations.yml
+++ b/config/locales/cy/organisations.yml
@@ -565,7 +565,7 @@ cy:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Gweld yr holl wybodaeth a ryddhawyd o dan FOI a thryloywder
         title: Gwybodaeth a ryddhawyd o dan FOI a thryloywder
-    errors_or_omissions_html: <p>Gwallau neu hepgoriadau? <a class="govuk-link" href="/contact/govuk">Rhowch wybod i ni yma</a>. I weld rhestrau swyddogol o gyrff cyhoeddus anadrannol <a class="govuk-link" href="/government/collections/public-bodies">gweler cyrff cyhoeddus</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Gwallau neu hepgoriadau? <a class="govuk-link" href="/contact/govuk">Rhowch wybod i ni yma</a>. I weld rhestrau swyddogol o gyrff cyhoeddus anadrannol <a class="govuk-link" href="/government/collections/public-bodies">gweler cyrff cyhoeddus</a>.</p>
     featured: Dangosir
     foi:
       contact_form: Ffurflen gysylltu FOI

--- a/config/locales/da/organisations.yml
+++ b/config/locales/da/organisations.yml
@@ -281,7 +281,7 @@ da:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Se al gennemsigtighed og informationsfrihed
         title: Gennemsigtighed og informationsfrihed frigives
-    errors_or_omissions_html: <p>Fejl eller udeladelser? <a class="govuk-link" href="/contact/govuk">Tell os her</a>. For officielle lister over ikke-departementale offentlige organer <a class="govuk-link" href="/government/collections/public-bodies">se offentlige organer</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Fejl eller udeladelser? <a class="govuk-link" href="/contact/govuk">Tell os her</a>. For officielle lister over ikke-departementale offentlige organer <a class="govuk-link" href="/government/collections/public-bodies">se offentlige organer</a>.</p>
     featured: Fremhævede
     foi:
       contact_form: kontaktformular for informationsfrihed

--- a/config/locales/de/organisations.yml
+++ b/config/locales/de/organisations.yml
@@ -269,7 +269,7 @@ de:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Alle Veröffentlichungen zur Transparenz und Informationsfreiheit anzeigen
         title: Veröffentlichungen zu Transparenz und Informationsfreiheit
-    errors_or_omissions_html: <p>Fehler oder Auslassungen? <a class="govuk-link" href="/contact/govuk">Berichten Sie uns hier</a>. Offizielle Listen von nichtbehördlichen öffentlichen Einrichtungen finden Sie unter <a class="govuk-link" href="/government/collections/public-bodies">Öffentliche Einrichtungen</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Fehler oder Auslassungen? <a class="govuk-link" href="/contact/govuk">Berichten Sie uns hier</a>. Offizielle Listen von nichtbehördlichen öffentlichen Einrichtungen finden Sie unter <a class="govuk-link" href="/government/collections/public-bodies">Öffentliche Einrichtungen</a>.</p>
     featured: Vorgestellt
     foi:
       contact_form: Informationsfreiheit-Kontaktformular

--- a/config/locales/dr/organisations.yml
+++ b/config/locales/dr/organisations.yml
@@ -270,7 +270,7 @@ dr:
           text: تمام آزادی و شفافیت انتشار معلومات را مشاهده نمایید
         title: شفافیت و آزادی انتشار معلومات
     errors_or_omissions_html: |-
-      <p>خطا ها و فروگذاری ها؟
+      <p class="govuk-body">خطا ها و فروگذاری ها؟
       <a class="govuk-link" href="/contact/govuk">اینجا بگویید</a>.
       برای لست هایی رسمی نهاد هایی عامهء غیر اداری<a class="govuk-link" href="/government/collections/public-bodies">نهاد هایی عامه را مشاهده نمایید</a>.</p>
     featured: ویژه

--- a/config/locales/el/organisations.yml
+++ b/config/locales/el/organisations.yml
@@ -269,7 +269,7 @@ el:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Δείτε όλες τις εκδόσεις για την διαφάνεια και ελευθερία πληροφόρησης
         title: Εκδόσεις για τη διαφάνεια και ελευθερία πληροφόρησης
-    errors_or_omissions_html: <p>Λάθη ή παραλείψεις; <a class="govuk-link" href="/contact/govuk">Πείτε μας εδώ</a>. Για επίσημους καταλόγους μη υπηρεσιακών δημόσιων φορέων <a class="govuk-link" href="/government/collections/public-bodies">δείτε τους δημόσιους οργανισμούς</a> .</p>
+    errors_or_omissions_html: <p class="govuk-body">Λάθη ή παραλείψεις; <a class="govuk-link" href="/contact/govuk">Πείτε μας εδώ</a>. Για επίσημους καταλόγους μη υπηρεσιακών δημόσιων φορέων <a class="govuk-link" href="/government/collections/public-bodies">δείτε τους δημόσιους οργανισμούς</a> .</p>
     featured: Προτεινόμενα
     foi:
       contact_form: Φόρμα επικοινωνίας ελευθερία της πληροφόρησης

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -272,7 +272,7 @@ en:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: See all transparency and freedom of information releases
         title: Transparency and freedom of information releases
-    errors_or_omissions_html: <p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
     featured: Featured
     foi:
       contact_form: FOI contact form

--- a/config/locales/es-419/organisations.yml
+++ b/config/locales/es-419/organisations.yml
@@ -269,7 +269,7 @@ es-419:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Ver todos los artículos sobre transparencia y libertad de información
         title: Transparencia y libertad de información
-    errors_or_omissions_html: <p>¿Errores u omisiones?<a class="govuk-link" href="/contact/govuk">Díganoslo aquí</a>. Para las listas oficiales de organismos públicos no departamentales <a class="govuk-link" href="/government/collections/public-bodies">ver organismos públicos</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">¿Errores u omisiones?<a class="govuk-link" href="/contact/govuk">Díganoslo aquí</a>. Para las listas oficiales de organismos públicos no departamentales <a class="govuk-link" href="/government/collections/public-bodies">ver organismos públicos</a>.</p>
     featured: Destacado
     foi:
       contact_form: Formulario de contacto FOI

--- a/config/locales/es/organisations.yml
+++ b/config/locales/es/organisations.yml
@@ -269,7 +269,7 @@ es:
           path: "/search/transparency-and-freedency-of-information-releases?organizations[]=%{organization}&parent=%{organization}"
           text: Ver todos los comunicados de transparencia y libertad de información
         title: Transparencia y libertad de información
-    errors_or_omissions_html: <p>¿Errores u omisiones? <a class="govuk-link" href="/contact/govuk">Díganoslo aquí</a>. Para un listado oficial de los organismos públicos no departamentales <a class="govuk-link" href="/government/collections/public-bodies">public bodies</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">¿Errores u omisiones? <a class="govuk-link" href="/contact/govuk">Díganoslo aquí</a>. Para un listado oficial de los organismos públicos no departamentales <a class="govuk-link" href="/government/collections/public-bodies">public bodies</a>.</p>
     featured: Destacados
     foi:
       contact_form: Formulario de contacto según la Ley de Libertad de Información

--- a/config/locales/et/organisations.yml
+++ b/config/locales/et/organisations.yml
@@ -269,7 +269,7 @@ et:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Vaata kogu teabe avaldamise läbipaistvust ja vabadust
         title: Teabe avaldamise läbipaistvus ja vabadus
-    errors_or_omissions_html: <p> Vead või väljajätmised? <a class="govuk-link" href="/contact/govuk">Rääkige meile siin</a>. Osakonnaväliste avalike asutuste ametlikud loendid <a class="govuk-link" href="/government/collections/public-bodies">vaata avalikke asutusi</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body"> Vead või väljajätmised? <a class="govuk-link" href="/contact/govuk">Rääkige meile siin</a>. Osakonnaväliste avalike asutuste ametlikud loendid <a class="govuk-link" href="/government/collections/public-bodies">vaata avalikke asutusi</a>.</p>
     featured: Soovitatavad
     foi:
       contact_form: FOI kontaktivorm

--- a/config/locales/fa/organisations.yml
+++ b/config/locales/fa/organisations.yml
@@ -269,7 +269,7 @@ fa:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: مشاهده تمام موارد منتشر شده مربوط به شفافیت و آزادی اطلاعات
         title: موارد منتشر شده مربوط به شفافیت و آزادی اطلاعات
-    errors_or_omissions_html: <p>موارد خطا یا حذف وجود دارد؟ <a class="govuk-link" href="/contact/govuk">از اینجا به ما بگویید</a>. برای اطلاع از لیست رسمی نهادهای عمومی غیر وزارتی <a class="govuk-link" href="/government/collections/public-bodies">نهادهای عمومی را مشاهده کنید</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">موارد خطا یا حذف وجود دارد؟ <a class="govuk-link" href="/contact/govuk">از اینجا به ما بگویید</a>. برای اطلاع از لیست رسمی نهادهای عمومی غیر وزارتی <a class="govuk-link" href="/government/collections/public-bodies">نهادهای عمومی را مشاهده کنید</a>.</p>
     featured: برجسته
     foi:
       contact_form: فرم تماس آزادی اطلاعات

--- a/config/locales/fi/organisations.yml
+++ b/config/locales/fi/organisations.yml
@@ -269,7 +269,7 @@ fi:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Katso kaikki avoimuus ja tiedon vapaus
         title: Avoimuus ja tiedonvälityksen vapaus
-    errors_or_omissions_html: <p>Virheitä tai puutteita? <a class="govuk-link" href="/contact/govuk">Kerro meille täällä</a>. Muiden kuin ministeriöiden julkisten elinten virallisia luetteloita varten <a class="govuk-link" href="/government/collections/public-bodies">katso julkisyhteisöt</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Virheitä tai puutteita? <a class="govuk-link" href="/contact/govuk">Kerro meille täällä</a>. Muiden kuin ministeriöiden julkisten elinten virallisia luetteloita varten <a class="govuk-link" href="/government/collections/public-bodies">katso julkisyhteisöt</a>.</p>
     featured: Suositeltava
     foi:
       contact_form: Tiedonvälityksen vapaus yhteydenottolomake

--- a/config/locales/fr/organisations.yml
+++ b/config/locales/fr/organisations.yml
@@ -269,7 +269,7 @@ fr:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Afficher tous les communiqués sur la transparence et l'accès à l'information
         title: Transparence et accès à l'information
-    errors_or_omissions_html: <p>Erreurs ou omissions ? <a class="govuk-link" href="/contact/govuk">Dites-nous ici</a>. Pour les listes officielles des organismes publics non ministériels <a class="govuk-link" href="/government/collections/public-bodies">voir les organismes publics</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Erreurs ou omissions ? <a class="govuk-link" href="/contact/govuk">Dites-nous ici</a>. Pour les listes officielles des organismes publics non ministériels <a class="govuk-link" href="/government/collections/public-bodies">voir les organismes publics</a>.</p>
     featured: Mis en exergue
     foi:
       contact_form: Formulaire de contact sur l'accès à l'information

--- a/config/locales/gd/organisations.yml
+++ b/config/locales/gd/organisations.yml
@@ -417,7 +417,7 @@ gd:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Féach gach rud faoi thrédhearcacht agus saoirse faisnéise
         title: Preaseisiúintí maidir le trédhearcacht agus saoirse faisnéise
-    errors_or_omissions_html: <p>Earráidí nó easnaimh? <a class="govuk-link" href="/contact/govuk">Labhair linn anseo</a>. Le haghaidh fógraí oifigiúla ó chomhlachtaí poiblí neamhrannacha <a class="govuk-link" href="/government/collections/public-bodies">féach comhlachtaí poiblí</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Earráidí nó easnaimh? <a class="govuk-link" href="/contact/govuk">Labhair linn anseo</a>. Le haghaidh fógraí oifigiúla ó chomhlachtaí poiblí neamhrannacha <a class="govuk-link" href="/government/collections/public-bodies">féach comhlachtaí poiblí</a>.</p>
     featured: Réadmhaoin
     foi:
       contact_form: Bileog teagmhála SF

--- a/config/locales/gu/organisations.yml
+++ b/config/locales/gu/organisations.yml
@@ -269,7 +269,7 @@ gu:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: તમામ પારદર્શિતા-અને-માહિતી જારી કરવાની સ્વતંત્રતા જુઓ
         title: પારદર્શિતા-અને-માહિતી જારી કરવાની સ્વતંત્રતા
-    errors_or_omissions_html: <p>ભૂલો અથવા બાદબાકી?<a class="govuk-link" href="/contact/govuk">અમને અહીં જણાવો</a>.બિન-વિભાગીય જાહેર સંસ્થાઓની અધિકૃત યાદીઓ માટે<a class="govuk-link" href="/government/collections/public-bodies">જાહેર સંસ્થાઓ જુઓ</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">ભૂલો અથવા બાદબાકી?<a class="govuk-link" href="/contact/govuk">અમને અહીં જણાવો</a>.બિન-વિભાગીય જાહેર સંસ્થાઓની અધિકૃત યાદીઓ માટે<a class="govuk-link" href="/government/collections/public-bodies">જાહેર સંસ્થાઓ જુઓ</a>.</p>
     featured: ફીચર્ડ
     foi:
       contact_form: માહિતીની સ્વતંત્રતા સંપર્ક પત્રક

--- a/config/locales/he/organisations.yml
+++ b/config/locales/he/organisations.yml
@@ -269,7 +269,7 @@ he:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: ראה את כל השקיפות וחופש המידע שפורסם
         title: שקיפות וחופש פרסומי מידע
-    errors_or_omissions_html: <p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. לרשימות רשמיות של גופים ציבוריים שאינם מחלקתיים <a class="govuk-link" href="/government/collections/public-bodies">ראו גופים ציבורייםs</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. לרשימות רשמיות של גופים ציבוריים שאינם מחלקתיים <a class="govuk-link" href="/government/collections/public-bodies">ראו גופים ציבורייםs</a>.</p>
     featured: מוצגים
     foi:
       contact_form: טופס יצירת קשר של חופש מידע

--- a/config/locales/hi/organisations.yml
+++ b/config/locales/hi/organisations.yml
@@ -269,7 +269,7 @@ hi:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: सभी पारदर्शिता और सूचना जारी करने की आज़ादी देखें
         title: पारदर्शिता और सूचना जारी करने की आज़ादी
-    errors_or_omissions_html: <p>त्रुटियां या चूक? <a class="govuk-link" href="/contact/govuk">हमें यहां बताएं</a>। For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">सार्वजनिक निकाय देखें</a>।</p>
+    errors_or_omissions_html: <p class="govuk-body">त्रुटियां या चूक? <a class="govuk-link" href="/contact/govuk">हमें यहां बताएं</a>। For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">सार्वजनिक निकाय देखें</a>।</p>
     featured: फीचर्ड
     foi:
       contact_form: एफओआई संपर्क प्रपत्र

--- a/config/locales/hr/organisations.yml
+++ b/config/locales/hr/organisations.yml
@@ -417,7 +417,7 @@ hr:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Pogledajte sve objave o transparentnosti i slobodi informacija
         title: Transparentnost i sloboda objavljivanja informacija
-    errors_or_omissions_html: <p>Pogreške ili propusti? <a class="govuk-link" href="/contact/govuk">Recite nam ovdje</a>. Za službene popise javnih tijela koja nisu odjela <a class="govuk-link" href="/government/collections/public-bodies">pogledajte javna tijela</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Pogreške ili propusti? <a class="govuk-link" href="/contact/govuk">Recite nam ovdje</a>. Za službene popise javnih tijela koja nisu odjela <a class="govuk-link" href="/government/collections/public-bodies">pogledajte javna tijela</a>.</p>
     featured: Istaknuto
     foi:
       contact_form: Kontakt forma za Slobodu Informacija

--- a/config/locales/hu/organisations.yml
+++ b/config/locales/hu/organisations.yml
@@ -269,7 +269,7 @@ hu:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Tekintsen meg minden átláthatósággal és az információközlés szabadságával kapcsolatos információt
         title: Átláthatóság és az információközlés szabadsága
-    errors_or_omissions_html: <p>Hibák vagy hiányosságok? <a class="govuk-link" href="/contact/govuk">Mondja el nekünk</a>. A nem minisztériumként működő hivatalos szervek hivatalos listájáért tekintse meg a <a class="govuk-link" href="/government/collections/public-bodies">hivatalos szerveket</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Hibák vagy hiányosságok? <a class="govuk-link" href="/contact/govuk">Mondja el nekünk</a>. A nem minisztériumként működő hivatalos szervek hivatalos listájáért tekintse meg a <a class="govuk-link" href="/government/collections/public-bodies">hivatalos szerveket</a>.</p>
     featured: Kiemelt
     foi:
       contact_form: Információszabadság - kapcsolatfelvételi űrlap

--- a/config/locales/hy/organisations.yml
+++ b/config/locales/hy/organisations.yml
@@ -269,7 +269,7 @@ hy:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Դիտել տեղեկատվության ազատության և թափանցիկության բոլոր հրապարակումներ
         title: Տեղեկատվության ազատության և թափանցիկության հրապարակումներ
-    errors_or_omissions_html: <p>Կա՞ն սխալներ կամ բացթողումներ։<a class="govuk-link" href="/contact/govuk">Նշեք այստեղ</a>։ Ոչ գերատեսչական հասարակական կազմակերպությունների պաշտոնական ցանկերի համար <a class="govuk-link" href="/government/collections/public-bodies">դիտել հասարակական կազմակերպությունները</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Կա՞ն սխալներ կամ բացթողումներ։<a class="govuk-link" href="/contact/govuk">Նշեք այստեղ</a>։ Ոչ գերատեսչական հասարակական կազմակերպությունների պաշտոնական ցանկերի համար <a class="govuk-link" href="/government/collections/public-bodies">դիտել հասարակական կազմակերպությունները</a>.</p>
     featured: Հայտնի
     foi:
       contact_form: Տեղեկատվության ազատության (FOI) կոնտակտային ձև

--- a/config/locales/id/organisations.yml
+++ b/config/locales/id/organisations.yml
@@ -195,7 +195,7 @@ id:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Lihat semua transparansi dan kebebasan rilis informasi
         title: Transparansi dan kebebasan rilis informasi
-    errors_or_omissions_html: <p>Kesalahan atau pengabaian? <a class="govuk-link" href="/contact/govuk">Beri tahu kami di sini</a>. Untuk daftar pejabat dari lembaga publik non-pemerintah <a class="govuk-link" href="/government/collections/public-bodies">lihat lembaga publik</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Kesalahan atau pengabaian? <a class="govuk-link" href="/contact/govuk">Beri tahu kami di sini</a>. Untuk daftar pejabat dari lembaga publik non-pemerintah <a class="govuk-link" href="/government/collections/public-bodies">lihat lembaga publik</a>.</p>
     featured: Unggulan
     foi:
       contact_form: Formulir kontak Kebebasan Informasi

--- a/config/locales/is/organisations.yml
+++ b/config/locales/is/organisations.yml
@@ -269,7 +269,7 @@ is:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Sjá alla útgáfu vegna gagnsæis og upplýsingafrelsi
         title: Útgáfa vegna gagnsæis og upplýsingafrelsi
-    errors_or_omissions_html: <p>Villur eða yfirsjónir? <a class="govuk-link" href="/contact/govuk">Segðu okkur hér</a>. Fyrir opinbera lista yfir opinberar stofnar sem tilheyra ekki ráðuneytum <a class="govuk-link" href="/government/collections/public-bodies">sjá opinberar stofnanir</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Villur eða yfirsjónir? <a class="govuk-link" href="/contact/govuk">Segðu okkur hér</a>. Fyrir opinbera lista yfir opinberar stofnar sem tilheyra ekki ráðuneytum <a class="govuk-link" href="/government/collections/public-bodies">sjá opinberar stofnanir</a>.</p>
     featured: Valið
     foi:
       contact_form: FOI eyðublað til að hafa samband

--- a/config/locales/it/organisations.yml
+++ b/config/locales/it/organisations.yml
@@ -269,7 +269,7 @@ it:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Vedi tutte le pubblicazioni su trasparenza e libertà di diffusione delle informazioni
         title: Trasparenza e libertà di diffusione delle informazioni
-    errors_or_omissions_html: "<p>Errori o omissioni? <a class=”govuk-link” href=”/contact/govuk”>Comunicacelo qui</a>. Per gli elenchi ufficiali degli enti pubblici non dipartimentali <a class=”govuk-link” href=”/government/collections/public-bodies”>vedere enti pubblici</a>.</p>"
+    errors_or_omissions_html: "<p class=”govuk-body”>Errori o omissioni? <a class=”govuk-link” href=”/contact/govuk”>Comunicacelo qui</a>. Per gli elenchi ufficiali degli enti pubblici non dipartimentali <a class=”govuk-link” href=”/government/collections/public-bodies”>vedere enti pubblici</a>.</p>"
     featured: In primo piano
     foi:
       contact_form: Modulo di contratto per la libertà d’informazione

--- a/config/locales/ja/organisations.yml
+++ b/config/locales/ja/organisations.yml
@@ -195,7 +195,7 @@ ja:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: すべての情報公開の透明性と自由を見る
         title: 情報公開の透明性と自由
-    errors_or_omissions_html: <p>誤字脱字がありますか。 <a class="govuk-link" href="/contact/govuk">こちら教えてください</a>。非省庁公共団体の公式リストについては、<a class="govuk-link" href="/government/collections/public-bodies">公共団体をご覧ください</a>。</p>
+    errors_or_omissions_html: <p class="govuk-body">誤字脱字がありますか。 <a class="govuk-link" href="/contact/govuk">こちら教えてください</a>。非省庁公共団体の公式リストについては、<a class="govuk-link" href="/government/collections/public-bodies">公共団体をご覧ください</a>。</p>
     featured: 特徴
     foi:
       contact_form: FOI（情報の自由）お問い合わせフォーム

--- a/config/locales/ka/organisations.yml
+++ b/config/locales/ka/organisations.yml
@@ -269,7 +269,7 @@ ka:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: იხილეთ ინფორმაციის გამჭვირვალობა და თავისუფლება
         title: ინფორმაციის გამჭვირვალობა და თავისუფლება
-    errors_or_omissions_html: <p>შეცდომები და გამოტოვებული ადგილები? <a class="govuk-link" href="/contact/govuk">მოგვწერეთ აქ</a>. არასამთავრობო უწყებრივი ორგანოების ოფიციალური სიებისათვის <a class="govuk-link" href="/government/collections/public-bodies">საჯარო ორგანოების ნახვა</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">შეცდომები და გამოტოვებული ადგილები? <a class="govuk-link" href="/contact/govuk">მოგვწერეთ აქ</a>. არასამთავრობო უწყებრივი ორგანოების ოფიციალური სიებისათვის <a class="govuk-link" href="/government/collections/public-bodies">საჯარო ორგანოების ნახვა</a>.</p>
     featured: რჩეული
     foi:
       contact_form: ინფორმაციის თავისუფლების საკონტაქტო ფორმა

--- a/config/locales/kk/organisations.yml
+++ b/config/locales/kk/organisations.yml
@@ -269,7 +269,7 @@ kk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Барлық ақпарат шығарылымдарының ашықтығы мен еркіндігін қараңыз
         title: Ақпарат шығарылымының ашықтығы мен еркіндігі
-    errors_or_omissions_html: <p>Қателер немесе қалып кеткендер бар ма? <a class="govuk-link" href="/contact/govuk">Осы жерде айтыңыз</a>. Ведомстволық емес мемлекеттік органдардың ресми тізімдерін алу үшін<a class="govuk-link" href="/government/collections/public-bodies">мемлекеттік органдарды қараңыз</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Қателер немесе қалып кеткендер бар ма? <a class="govuk-link" href="/contact/govuk">Осы жерде айтыңыз</a>. Ведомстволық емес мемлекеттік органдардың ресми тізімдерін алу үшін<a class="govuk-link" href="/government/collections/public-bodies">мемлекеттік органдарды қараңыз</a>.</p>
     featured: Таңдаулы
     foi:
       contact_form: FOI байланысу формасы

--- a/config/locales/ko/organisations.yml
+++ b/config/locales/ko/organisations.yml
@@ -195,7 +195,7 @@ ko:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: 모든 정보 공개의 투명성 및 자유 보기
         title: 정보 공개의 투명성 및 자유
-    errors_or_omissions_html: <p>오류 또는 생략된 내용이 있습니까? <a class="govuk-link" href="/contact/govuk">여기에 말씀해 주십시오</a>. 비부처 공공기관의 공식 목록은 <a class="govuk-link" href="/government/collections/public-bodies">공공기관을 참조하십시오</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">오류 또는 생략된 내용이 있습니까? <a class="govuk-link" href="/contact/govuk">여기에 말씀해 주십시오</a>. 비부처 공공기관의 공식 목록은 <a class="govuk-link" href="/government/collections/public-bodies">공공기관을 참조하십시오</a>.</p>
     featured: 특집
     foi:
       contact_form: FOI 콘택트 폼

--- a/config/locales/lt/organisations.yml
+++ b/config/locales/lt/organisations.yml
@@ -343,7 +343,7 @@ lt:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Peržiūrėti visus pranešimus apie skaidrumą ir informacijos laisvę
         title: Pranešimai apie skaidrumą ir informacijos laisvę
-    errors_or_omissions_html: <p>Radote klaidų ar pastebėjote, kad pateikta ne visa informacija? <a class="govuk-link" href="/contact/govuk">Nurodykite mums čia</a>. Oficialus ne departamentinių viešųjų įstaigų sąrašas <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Radote klaidų ar pastebėjote, kad pateikta ne visa informacija? <a class="govuk-link" href="/contact/govuk">Nurodykite mums čia</a>. Oficialus ne departamentinių viešųjų įstaigų sąrašas <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
     featured: Rodomas
     foi:
       contact_form: Kontaktinės forma dėl informacijos laisvės

--- a/config/locales/lv/organisations.yml
+++ b/config/locales/lv/organisations.yml
@@ -269,7 +269,7 @@ lv:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Skatīt visas caurredzamības un informācijas atklātības publikācijas
         title: Caurredzamība un informācijas atklātības publikācijas
-    errors_or_omissions_html: <p>Kļūdas vai izlaista informācija? <a class="govuk-link" href="/contact/govuk">Pastāstiet mums šeit</a>. Oficiālos nevalstisko sabiedrisko organizāciju sarakstus <a class="govuk-link" href="/government/collections/public-bodies">skatiet sabiedrisko organizāciju sadaļā</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Kļūdas vai izlaista informācija? <a class="govuk-link" href="/contact/govuk">Pastāstiet mums šeit</a>. Oficiālos nevalstisko sabiedrisko organizāciju sarakstus <a class="govuk-link" href="/government/collections/public-bodies">skatiet sabiedrisko organizāciju sadaļā</a>.</p>
     featured: Ieteikts
     foi:
       contact_form: Informācijas atklātības saziņas veidlapa

--- a/config/locales/ms/organisations.yml
+++ b/config/locales/ms/organisations.yml
@@ -195,7 +195,7 @@ ms:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Lihat semua hebahan ketelusan dan kebebasan maklumat
         title: Hebahan ketelusan dan kebebasan maklumat
-    errors_or_omissions_html: <p>Kesilapan atau butiran tidak dimasukkan? <a class="govuk-link" href="/contact/govuk">Beritahu kami di sini</a>. Untuk senarai rasmi badan awam bukan jabatan <a class="govuk-link" href="/government/collections/public-bodies">lihat badan awam</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Kesilapan atau butiran tidak dimasukkan? <a class="govuk-link" href="/contact/govuk">Beritahu kami di sini</a>. Untuk senarai rasmi badan awam bukan jabatan <a class="govuk-link" href="/government/collections/public-bodies">lihat badan awam</a>.</p>
     featured: Paparan
     foi:
       contact_form: Borang hubungan Kebebasan Maklumat (FOI)

--- a/config/locales/mt/organisations.yml
+++ b/config/locales/mt/organisations.yml
@@ -417,7 +417,7 @@ mt:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Ara r-rilaxxi kollha dwar trasparency u l-libertà tal-informazzjoni
         title: Rilaxxi dwar trasparenza u l-libertà tal-informazzjoni
-    errors_or_omissions_html: <p>Żbalji jew ommissjonijiet? <a class="govuk-link" href="/contact/govuk">Għidilna hawn</a>. Għal listi uffiċjali ta'  korpi pubbliċi mingħajr dipartiment <a class="govuk-link" href="/government/collections/public-bodies">pamatyti viešąsias įstaigas</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Żbalji jew ommissjonijiet? <a class="govuk-link" href="/contact/govuk">Għidilna hawn</a>. Għal listi uffiċjali ta'  korpi pubbliċi mingħajr dipartiment <a class="govuk-link" href="/government/collections/public-bodies">pamatyti viešąsias įstaigas</a>.</p>
     featured: Dehru
     foi:
       contact_form: Formola ta' Kuntatt għall-Libertà tal-Informazzjoni

--- a/config/locales/nl/organisations.yml
+++ b/config/locales/nl/organisations.yml
@@ -269,7 +269,7 @@ nl:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Bekijk alle transparantie en vrijheid van informatieberichten
         title: Transparantie en vrijheid van informatie
-    errors_or_omissions_html: <p>Fouten of omissies? <a class="govuk-link" href="/contact/govuk">Vel ons hier</a>. Voor de officiële lijsten van niet-overheidsinstellingen <a class="govuk-link" href="/overheid/collecties/publieke-organisaties">zie publieke-organisaties</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Fouten of omissies? <a class="govuk-link" href="/contact/govuk">Vel ons hier</a>. Voor de officiële lijsten van niet-overheidsinstellingen <a class="govuk-link" href="/overheid/collecties/publieke-organisaties">zie publieke-organisaties</a>.</p>
     featured: Aanbevolen
     foi:
       contact_form: Vrijheid van informatie contact formulier

--- a/config/locales/no/organisations.yml
+++ b/config/locales/no/organisations.yml
@@ -269,7 +269,7 @@
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Se alle skriv om åpenhet og informasjonsfrihet
         title: Skriv om åpenhet og informasjonsfrihet
-    errors_or_omissions_html: <p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">Fortell oss her</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">se offentlige organer</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">Fortell oss her</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">se offentlige organer</a>.</p>
     featured: Utvalgt
     foi:
       contact_form: Kontaktskjema for åpenhet og informasjonsfrihet (FOI)

--- a/config/locales/pa-pk/organisations.yml
+++ b/config/locales/pa-pk/organisations.yml
@@ -269,7 +269,7 @@ pa-pk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: خبراں دی آزادی تے شفافیت بارے جاری کیتا گیا سب کُج ویکھو
         title: خبراں دی آزادی تے شفافیت بارے جاری کیتا گیا
-    errors_or_omissions_html: <p>غلطی یا کوتاہی <a class="govuk-link" href="/contact/govuk">سانوں ایتھے دسو</a>. غیر عوامی اداریاں دی سرکاری فہرست<a class="govuk-link" href="/government/collections/public-bodies">عوامی اداریاں بارے ویکھو</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">غلطی یا کوتاہی <a class="govuk-link" href="/contact/govuk">سانوں ایتھے دسو</a>. غیر عوامی اداریاں دی سرکاری فہرست<a class="govuk-link" href="/government/collections/public-bodies">عوامی اداریاں بارے ویکھو</a>.</p>
     featured: نُمایاں کیتا گیا
     foi:
       contact_form: 'رابطے دا FOI فارم '

--- a/config/locales/pa/organisations.yml
+++ b/config/locales/pa/organisations.yml
@@ -269,7 +269,7 @@ pa:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: ਸਾਰੀ ਪਾਰਦਰਸ਼ਤਾ ਅਤੇ ਜਾਣਕਾਰੀ ਜਾਰੀ ਕਰਨ ਦੀ ਆਜ਼ਾਦੀ ਵੇਖੋ
         title: ਪਾਰਦਰਸ਼ਤਾ ਅਤੇ ਜਾਣਕਾਰੀ ਜਾਰੀ ਕਰਨ ਦੀ ਆਜ਼ਾਦੀ
-    errors_or_omissions_html: <p>Errors or omissions? <a class="govuk-link" href="/contact/govuk">ਸਾਨੂੰ ਇੱਥੇ ਦੱਸੋ</a>.ਗੈਰ -ਵਿਭਾਗੀ ਜਨਤਕ ਸੰਸਥਾਵਾਂ ਦੀਆਂ ਅਧਿਕਾਰਤ ਸੂਚੀਆਂ ਲਈ <a class="govuk-link" href="/government/collections/public-bodies">ਜਨਤਕ ਸੰਸਥਾਵਾਂ ਵੇਖੋ</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">ਸਾਨੂੰ ਇੱਥੇ ਦੱਸੋ</a>.ਗੈਰ -ਵਿਭਾਗੀ ਜਨਤਕ ਸੰਸਥਾਵਾਂ ਦੀਆਂ ਅਧਿਕਾਰਤ ਸੂਚੀਆਂ ਲਈ <a class="govuk-link" href="/government/collections/public-bodies">ਜਨਤਕ ਸੰਸਥਾਵਾਂ ਵੇਖੋ</a>.</p>
     featured: ਫੀਚਰਡ
     foi:
       contact_form: FOI ਸੰਪਰਕ ਫਾਰਮ

--- a/config/locales/pl/organisations.yml
+++ b/config/locales/pl/organisations.yml
@@ -417,7 +417,7 @@ pl:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Zobacz wszystkie publikacje na temat przerzystości i wolności informacji
         title: Publikacje na temat przerzystości i wolności informacji
-    errors_or_omissions_html: <p>Błędy lub przeoczenia? <a class="govuk-link" href="/contact/govuk">Powiedz nam tutaj</a>. Aby uzyskać oficjalny wykaz pozaministerialnych organów publicznych <a class="govuk-link" href="/government/collections/public-bodies">zobacz organy publiczne</a>.</p>.
+    errors_or_omissions_html: <p class="govuk-body">Błędy lub przeoczenia? <a class="govuk-link" href="/contact/govuk">Powiedz nam tutaj</a>. Aby uzyskać oficjalny wykaz pozaministerialnych organów publicznych <a class="govuk-link" href="/government/collections/public-bodies">zobacz organy publiczne</a>.</p>.
     featured: Polecane
     foi:
       contact_form: Formularz zgłoszeniowy dot. wolności informacji

--- a/config/locales/ps/organisations.yml
+++ b/config/locales/ps/organisations.yml
@@ -269,7 +269,7 @@ ps:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: د معلوماتو خپریدو ټول شفافیت او ازادي وګورئ
         title: د معلوماتو د خپریدو شفافیت او آزادي
-    errors_or_omissions_html: <p> اشتباه یا تیروتنه؟ <a class="govuk-link" href="/contact/govuk"> موږ ته دلته ووایاست </a>. د غیر ډیپارټمنټ عامه ادارو رسمي لیستونو لپاره <a class="govuk-link" href="/government/collections/public-bodies"> عامه ادارې وګورئ </a>. </p>
+    errors_or_omissions_html: <p class="govuk-body"> اشتباه یا تیروتنه؟ <a class="govuk-link" href="/contact/govuk"> موږ ته دلته ووایاست </a>. د غیر ډیپارټمنټ عامه ادارو رسمي لیستونو لپاره <a class="govuk-link" href="/government/collections/public-bodies"> عامه ادارې وګورئ </a>. </p>
     featured: ځانګړی شوی
     foi:
       contact_form: د د معلوماتو د آزادۍ قانون تماس فورمه

--- a/config/locales/pt/organisations.yml
+++ b/config/locales/pt/organisations.yml
@@ -269,7 +269,7 @@ pt:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Ver todos os comunicados de transparência e liberdade de informação
         title: Comunicados de transparência e liberdade de informação
-    errors_or_omissions_html: <p>Encontrou erros ou emissões? <a class="govuk-link" href="/contact/govuk">Diga-nos aqui</a>. Para listas oficiais de organismos públicos não departamentais,<a class="govuk-link" href="/government/collections/public-bodies">veja os organismos públicos</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Encontrou erros ou emissões? <a class="govuk-link" href="/contact/govuk">Diga-nos aqui</a>. Para listas oficiais de organismos públicos não departamentais,<a class="govuk-link" href="/government/collections/public-bodies">veja os organismos públicos</a>.</p>
     featured: Destaque
     foi:
       contact_form: Formulário de contacto da Liberdade de Informação

--- a/config/locales/ro/organisations.yml
+++ b/config/locales/ro/organisations.yml
@@ -343,7 +343,7 @@ ro:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Vedeți toate comunicările de informațiile cu privire la transparență și libertate
         title: Transparența și libertatea comunicării de informații
-    errors_or_omissions_html: <p>Erori sau omisiuni? <a class="govuk-link" href="/contact/govuk">Spuneți-ne aici</a>. Pentru liste oficiale ale organismelor publice neministeriale, <a class="govuk-link" href="/government/collections/public-bodies">consultați organismele publice</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Erori sau omisiuni? <a class="govuk-link" href="/contact/govuk">Spuneți-ne aici</a>. Pentru liste oficiale ale organismelor publice neministeriale, <a class="govuk-link" href="/government/collections/public-bodies">consultați organismele publice</a>.</p>
     featured: Prezentat
     foi:
       contact_form: Formular de contact pentru libertatea informației

--- a/config/locales/ru/organisations.yml
+++ b/config/locales/ru/organisations.yml
@@ -417,7 +417,7 @@ ru:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Посмотрите все новые редакции закона о свободе распространения и прозрачности информации
         title: Новые редакции закона о свободе распространения и прозрачности информации
-    errors_or_omissions_html: <p>Ошибки? <a class="govuk-link" href="/contact/govuk">Расскажите нам здесь</a>. Официальный список автономных неправительственных организаций <a class="govuk-link" href="/government/collections/public-bodies">посмотрите государственные органы</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Ошибки? <a class="govuk-link" href="/contact/govuk">Расскажите нам здесь</a>. Официальный список автономных неправительственных организаций <a class="govuk-link" href="/government/collections/public-bodies">посмотрите государственные органы</a>.</p>
     featured: Подборка
     foi:
       contact_form: Форма обратной связи по свободе распространения информации

--- a/config/locales/sk/organisations.yml
+++ b/config/locales/sk/organisations.yml
@@ -343,7 +343,7 @@ sk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Pozrite si všetky informácie o transparentnosti a slobode informácií
         title: Transparentnosť a slobodné zverejňovanie informácií
-    errors_or_omissions_html: <p>Chyby alebo opomenutia? <a class="govuk-link" href="/contact/govuk">Oznámte nám ich tu</a>. Oficiálne zoznamy verejných orgánov, <a class="govuk-link" href="/government/collections/public-bodies">ktoré nie sú ministerstvami, nájdete na stránke verejných orgánov</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Chyby alebo opomenutia? <a class="govuk-link" href="/contact/govuk">Oznámte nám ich tu</a>. Oficiálne zoznamy verejných orgánov, <a class="govuk-link" href="/government/collections/public-bodies">ktoré nie sú ministerstvami, nájdete na stránke verejných orgánov</a>.</p>
     featured: Odporúčané
     foi:
       contact_form: Kontaktný formulár FOI

--- a/config/locales/sl/organisations.yml
+++ b/config/locales/sl/organisations.yml
@@ -417,7 +417,7 @@ sl:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Poglej vse objave o transparentnosti in svobodi informacij
         title: Objave o transparentnosti in svobodi informacij
-    errors_or_omissions_html: <p>Napake ali izpusti? <a class="govuk-link" href="/contact/govuk">Povejte nam tu</a>. Uradne nevladne javne organizacije najdete <a class="govuk-link" href="/government/collections/public-bodies">na</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Napake ali izpusti? <a class="govuk-link" href="/contact/govuk">Povejte nam tu</a>. Uradne nevladne javne organizacije najdete <a class="govuk-link" href="/government/collections/public-bodies">na</a>.</p>
     featured: Vključeno
     foi:
       contact_form: Kontaktni obrazec prostega dostopa do informacij

--- a/config/locales/so/organisations.yml
+++ b/config/locales/so/organisations.yml
@@ -269,7 +269,7 @@ so:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Fiiri dhamaan daah furnaanta iyo xoriyada baahinta macluumaadka
         title: Daah furnaanta iyo xoriyada baahinta macluumaadka
-    errors_or_omissions_html: <p>Qaladaadka ama katagista? <a class="govuk-link" href="/contact/govuk">Noogu sheg halkan</a>. Liiska rasmiga ah ee haayada dadweynaha <a class="govuk-link" href="/government/collections/public-bodies">fiiri haayadaha dadweynaha</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Qaladaadka ama katagista? <a class="govuk-link" href="/contact/govuk">Noogu sheg halkan</a>. Liiska rasmiga ah ee haayada dadweynaha <a class="govuk-link" href="/government/collections/public-bodies">fiiri haayadaha dadweynaha</a>.</p>
     featured: Muuqday
     foi:
       contact_form: Foomka xidhiidhka FOI

--- a/config/locales/sq/organisations.yml
+++ b/config/locales/sq/organisations.yml
@@ -269,7 +269,7 @@ sq:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Shihni të gjithë transparencën dhe lirinë e publikimit të informacionit
         title: Transparenca dhe liria e publikimit të informacionit
-    errors_or_omissions_html: <p>Gabime apo heqje? <a class="govuk-link" href="/contact/govuk">Na tregoni këtu</a>. Për listat zyrtare të organeve publike jo departamentale <a class="govuk-link" href="/government/collections/public-bodies">shihni organet publike</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Gabime apo heqje? <a class="govuk-link" href="/contact/govuk">Na tregoni këtu</a>. Për listat zyrtare të organeve publike jo departamentale <a class="govuk-link" href="/government/collections/public-bodies">shihni organet publike</a>.</p>
     featured: Paraqitur
     foi:
       contact_form: Formulari i kontaktit për FOI

--- a/config/locales/sr/organisations.yml
+++ b/config/locales/sr/organisations.yml
@@ -343,7 +343,7 @@ sr:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Pogledajte sve iz kategorije Odgovori na zahteve o transparentnosti i pristupu informacijama od javnog značaja
         title: Odgovori na zahteve o transparentnosti i pristupu informacijama od javnog značaja
-    errors_or_omissions_html: <p>Greške ili propusti? <a class="govuk-link" href="/contact/govuk">Obavestite nas ovde</a>. Zvanične liste neresornih javnih tela <a class="govuk-link" href="/government/collections/public-bodies">potražite u kategoriji Javna tela</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Greške ili propusti? <a class="govuk-link" href="/contact/govuk">Obavestite nas ovde</a>. Zvanične liste neresornih javnih tela <a class="govuk-link" href="/government/collections/public-bodies">potražite u kategoriji Javna tela</a>.</p>
     featured: Istaknuto
     foi:
       contact_form: Kontakt obrazac za pristup informacijama od javnog značaja

--- a/config/locales/sv/organisations.yml
+++ b/config/locales/sv/organisations.yml
@@ -269,7 +269,7 @@ sv:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Se alla offentliggöranden om öppenhet och informationsfrihet
         title: Offentliggöranden om öppenhet och informationsfrihet
-    errors_or_omissions_html: <p>Fel eller utelämnanden? <a class="govuk-link" href="/contact/govuk">Berätta för oss här</a>. För officiella förteckningar över offentliga organ utanför ministeriet <a class="govuk-link" href="/government/collections/public-bodies">se offentliga organ</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Fel eller utelämnanden? <a class="govuk-link" href="/contact/govuk">Berätta för oss här</a>. För officiella förteckningar över offentliga organ utanför ministeriet <a class="govuk-link" href="/government/collections/public-bodies">se offentliga organ</a>.</p>
     featured: Utvalda
     foi:
       contact_form: Kontaktformulär för FOI

--- a/config/locales/sw/organisations.yml
+++ b/config/locales/sw/organisations.yml
@@ -269,7 +269,7 @@ sw:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Angalia taarifa zote za uwazi na uhuru wa kupata habari
         title: Taarifa za uwazi na uhuru wa kupata habari
-    errors_or_omissions_html: <p>Je, kuna hitilafu au kutojumuishwa kwa maelezo yoyote? <a class="govuk-link" href="/contact/govuk">Tufahamishe hapa</a>. Ili upate orodha rasmi ya mashirika ya serikali yasiyo ya kiidara <a class="govuk-link" href="/government/collections/public-bodies">angalia mashirika ya serikali</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Je, kuna hitilafu au kutojumuishwa kwa maelezo yoyote? <a class="govuk-link" href="/contact/govuk">Tufahamishe hapa</a>. Ili upate orodha rasmi ya mashirika ya serikali yasiyo ya kiidara <a class="govuk-link" href="/government/collections/public-bodies">angalia mashirika ya serikali</a>.</p>
     featured: Yanayoangaziwa
     foi:
       contact_form: Fomu ya mawasiliano ya FOI

--- a/config/locales/ta/organisations.yml
+++ b/config/locales/ta/organisations.yml
@@ -269,7 +269,7 @@ ta:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: அனைத்து வெளிப்படைத்தன்மை மற்றும் தகவல் சுதந்திர வெளியீடுகளைக் காண்க
         title: வெளிப்படைத்தன்மை மற்றும் தகவல் சுதந்திர வெளியீடுகள்
-    errors_or_omissions_html: <p>பிழைகள் அல்லது விடுதல்கள்? <a class="govuk-link" href="/contact/govuk">இங்கே எங்களிடம் சொல்லுங்கள்</a>. துறைசாரா பொது நிறுவனங்களின் அதிகாரப்பூர்வ பட்டியலுக்கு <a class="govuk-link" href="/government/collections/public-bodies">பொது நிறுவனங்களைக் காண்க</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">பிழைகள் அல்லது விடுதல்கள்? <a class="govuk-link" href="/contact/govuk">இங்கே எங்களிடம் சொல்லுங்கள்</a>. துறைசாரா பொது நிறுவனங்களின் அதிகாரப்பூர்வ பட்டியலுக்கு <a class="govuk-link" href="/government/collections/public-bodies">பொது நிறுவனங்களைக் காண்க</a>.</p>
     featured: சிறப்புக் கூறுகளமைந்தது
     foi:
       contact_form: தகவல் சுதந்திரத் தொடர்புப் படிவம்

--- a/config/locales/th/organisations.yml
+++ b/config/locales/th/organisations.yml
@@ -195,7 +195,7 @@ th:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: ดูข่าวประชาสัมพันธ์เกี่ยวกับความโปร่งใสและเสรีภาพด้านข้อมูลข่าวสารทั้งหมด
         title: ความโปร่งใสและเสรีภาพในการเผยแพร่ข้อมูล
-    errors_or_omissions_html: <p>ข้อผิดพลาดหรือการละเว้น? <a class="govuk-link" href="/contact/govuk">บอกเราที่นี่</a> สำหรับรายชื่ออย่างเป็นทางการขององค์กรอิสระ (non–departmental public bodies – NDPB) <a class="govuk-link" href="/government/collections/public-bodies">ดูองค์กรอิสระ</a></p>
+    errors_or_omissions_html: <p class="govuk-body">ข้อผิดพลาดหรือการละเว้น? <a class="govuk-link" href="/contact/govuk">บอกเราที่นี่</a> สำหรับรายชื่ออย่างเป็นทางการขององค์กรอิสระ (non–departmental public bodies – NDPB) <a class="govuk-link" href="/government/collections/public-bodies">ดูองค์กรอิสระ</a></p>
     featured: รายการเด่น
     foi:
       contact_form: แบบฟอร์มติดต่อ FOI

--- a/config/locales/tk/organisations.yml
+++ b/config/locales/tk/organisations.yml
@@ -269,7 +269,7 @@ tk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Maglumatlaryň aç-açanlygy we erkinlige derediň
         title: Maglumatlaryň aç-açanlygy we erkinligi
-    errors_or_omissions_html: <p>Ýalňyşlyklar ýa-da galdyryp gitmeler? <a class="govuk-link" href="/contact/govuk">Bize şu ýerde aýdyň</a>. Bölüm däl jemgyýetçilik guramalarynyň resmi sanawlary üçin <a class="govuk-link" href="/government/collections/public-bodies">jemgyýetçilik guramalaryna serediň</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Ýalňyşlyklar ýa-da galdyryp gitmeler? <a class="govuk-link" href="/contact/govuk">Bize şu ýerde aýdyň</a>. Bölüm däl jemgyýetçilik guramalarynyň resmi sanawlary üçin <a class="govuk-link" href="/government/collections/public-bodies">jemgyýetçilik guramalaryna serediň</a>.</p>
     featured: Aýratynlyk
     foi:
       contact_form: FOI habarlaşmak üçin forma

--- a/config/locales/tr/organisations.yml
+++ b/config/locales/tr/organisations.yml
@@ -269,7 +269,7 @@ tr:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Tüm bilgi edinme şeffaflığı ve özgürlüğü açıklamalarına bakın
         title: Bilgi edinme açıklamalarının şeffaflığı ve özgürlüğü
-    errors_or_omissions_html: <p>Hatalar veya eksiklikler mi var? <a class="govuk-link" href="/contact/govuk">Buradan bize söyleyin</a>. Müdürlük dışı kamu kurumlarının resmi listeleri için <a class="govuk-link" href="/government/collections/public-bodies">kamu kurumlarına bakın</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Hatalar veya eksiklikler mi var? <a class="govuk-link" href="/contact/govuk">Buradan bize söyleyin</a>. Müdürlük dışı kamu kurumlarının resmi listeleri için <a class="govuk-link" href="/government/collections/public-bodies">kamu kurumlarına bakın</a>.</p>
     featured: Öne çıkan
     foi:
       contact_form: Bilgi Edinme Özgürlüğü irtibat formu

--- a/config/locales/uk/organisations.yml
+++ b/config/locales/uk/organisations.yml
@@ -417,7 +417,7 @@ uk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Переглянути всі дані прозорості та свободи інформації
         title: Прозорість та свобода інформації
-    errors_or_omissions_html: <p>Помилки або упущення? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. Для отримання офіційних списків невідомчих державних органів <a class="govuk-link" href="/government/collections/public-bodies">зверніться до державних органів</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Помилки або упущення? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. Для отримання офіційних списків невідомчих державних органів <a class="govuk-link" href="/government/collections/public-bodies">зверніться до державних органів</a>.</p>
     featured: Рекомендовано
     foi:
       contact_form: Форма зв'язку щодо свободи інформації

--- a/config/locales/ur/organisations.yml
+++ b/config/locales/ur/organisations.yml
@@ -269,7 +269,7 @@ ur:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: معلومات کے اجراء کی تمام شفافیت اور آزادی دیکھیں
         title: معلومات کے اجراء کی شفافیت اور آزادی
-    errors_or_omissions_html: <p>نقائص یا چوک؟ <a class="govuk-link" href="/contact/govuk">ہمیں یہاں پر آگاہ کریں</a>۔ غیر محکماتی عوامی دھڑوں کے لیے <a class="govuk-link" href="/government/collections/public-bodies">عوامی دھڑے دیکھیں</a>۔</p>
+    errors_or_omissions_html: <p class="govuk-body">نقائص یا چوک؟ <a class="govuk-link" href="/contact/govuk">ہمیں یہاں پر آگاہ کریں</a>۔ غیر محکماتی عوامی دھڑوں کے لیے <a class="govuk-link" href="/government/collections/public-bodies">عوامی دھڑے دیکھیں</a>۔</p>
     featured: فیچرڈ
     foi:
       contact_form: FOI رابطے کا فارم

--- a/config/locales/uz/organisations.yml
+++ b/config/locales/uz/organisations.yml
@@ -269,7 +269,7 @@ uz:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Шаффофлик ва маълумотларни ошкор қилиш эркинлиги ҳақидаги барча маълумотларни кўриш
         title: Шаффофлик ва маълумотларни ошкор қилиш эркинлиги
-    errors_or_omissions_html: <p>Хатоликлар ёки камчиликлар? <a class="govuk-link" href="/contact/govuk">Шу ерда сўзлаб беринг</a>. Ноидоравий давлат органларнинг расмий рўйхати <a class="govuk-link" href="/government/collections/public-bodies">давлат органлари рўйхатида тақдим этилган</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Хатоликлар ёки камчиликлар? <a class="govuk-link" href="/contact/govuk">Шу ерда сўзлаб беринг</a>. Ноидоравий давлат органларнинг расмий рўйхати <a class="govuk-link" href="/government/collections/public-bodies">давлат органлари рўйхатида тақдим этилган</a>.</p>
     featured: Тавсия қилинган
     foi:
       contact_form: Маълумотларга эркин кириш ахборотлари бўйича қайта алоқа шакли

--- a/config/locales/vi/organisations.yml
+++ b/config/locales/vi/organisations.yml
@@ -195,7 +195,7 @@ vi:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: Xem tất cả các công bố theo luật về tính minh bạch và tự do thông tin
         title: Công bố theo luật về tính minh bạch và tự do thông tin
-    errors_or_omissions_html: <p>Có lỗi hoặc thiếu sót? <a class="govuk-link" href="/contact/govuk">Hãy cho chúng tôi biết tại đây</a>. Để biết danh sách chính thức của các cơ quan công quyền không thuộc ban/bộ, <a class="govuk-link" href="/government/collections/public-bodies">xem các cơ quan công quyền</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body">Có lỗi hoặc thiếu sót? <a class="govuk-link" href="/contact/govuk">Hãy cho chúng tôi biết tại đây</a>. Để biết danh sách chính thức của các cơ quan công quyền không thuộc ban/bộ, <a class="govuk-link" href="/government/collections/public-bodies">xem các cơ quan công quyền</a>.</p>
     featured: Đặc biệt
     foi:
       contact_form: Biểu mẫu liên hệ FOI

--- a/config/locales/zh-hk/organisations.yml
+++ b/config/locales/zh-hk/organisations.yml
@@ -269,7 +269,7 @@ zh-hk:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: 查閱全部資訊發佈透明度及自由
         title: 資訊發佈透明度及自由
-    errors_or_omissions_html: <p>有出錯或是遺漏？<a class="govuk-link" href="/contact/govuk">請在此處告知我們</a>。如要了解非部門公共機構名單，請 <a class="govuk-link" href="/government/collections/public-bodies">參閱公共機構</a>。</p>
+    errors_or_omissions_html: <p class="govuk-body">有出錯或是遺漏？<a class="govuk-link" href="/contact/govuk">請在此處告知我們</a>。如要了解非部門公共機構名單，請 <a class="govuk-link" href="/government/collections/public-bodies">參閱公共機構</a>。</p>
     featured: 特載內容
     foi:
       contact_form: FOI 聯絡表

--- a/config/locales/zh-tw/organisations.yml
+++ b/config/locales/zh-tw/organisations.yml
@@ -269,7 +269,7 @@ zh-tw:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: 查看透明度與資訊自由的發布
         title: 透明度與資訊自由的發布
-    errors_or_omissions_html: <p>錯誤或遺漏？<a class="govuk-link" href="/contact/govuk">從這裡通知我們</a>.有關非政府部門公共機構的官方列表 <a class="govuk-link" href="/government/collections/public-bodies">查看公共機構</a>。</p>
+    errors_or_omissions_html: <p class="govuk-body">錯誤或遺漏？<a class="govuk-link" href="/contact/govuk">從這裡通知我們</a>.有關非政府部門公共機構的官方列表 <a class="govuk-link" href="/government/collections/public-bodies">查看公共機構</a>。</p>
     featured: 特色
     foi:
       contact_form: 資訊自由聯繫表

--- a/config/locales/zh/organisations.yml
+++ b/config/locales/zh/organisations.yml
@@ -195,7 +195,7 @@ zh:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: 查看信息发布的全部透明度和自由
         title: 信息发布的透明度和自由
-    errors_or_omissions_html: <p>错误或遗漏？<a class="govuk-link" href="/contact/govuk">Tell us here</a>.如要查看非部门公共机构的正式名单 <a class="govuk-link" href="/government/collections/public-bodies">查看公共机构</a>。</p>
+    errors_or_omissions_html: <p class="govuk-body">错误或遗漏？<a class="govuk-link" href="/contact/govuk">Tell us here</a>.如要查看非部门公共机构的正式名单 <a class="govuk-link" href="/government/collections/public-bodies">查看公共机构</a>。</p>
     featured: 特征
     foi:
       contact_form: FOI联系表单


### PR DESCRIPTION
## What
Add missing styles to hardcoded paragraph on organisation page

## Why

All paragraphs must have the `govuk-body` class to be styled properly (otherwise they fallback on browser's default styles)
Ideally the paragraph wouldn't be hardcoded in the locale, but not in scope for this PR.

## Visual changes
### Before
<img width="1024" alt="Screenshot 2022-03-04 at 12 17 12" src="https://user-images.githubusercontent.com/788096/156762127-ee37f603-fd77-4363-a264-8816725c9e87.png">


### After
<img width="1024" alt="Screenshot 2022-03-04 at 12 17 31" src="https://user-images.githubusercontent.com/788096/156762139-905d4b0d-fcc9-458a-96ed-fa9668269866.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
