### PR TITLE
Add employing people topic to tree study

### DIFF
--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,7 +1,11 @@
 module RecruitmentBannerHelper
-  TOPICS = ["/browse/business", "/browse/tax"].freeze
+  TOPICS = ["/browse/business", "/browse/tax", "/browse/employing-people"].freeze
 
   def show_banner?(path)
-    path.starts_with?(TOPICS.first) || path.starts_with?(TOPICS.last)
+    TOPICS.each do |topic|
+      return true if path.starts_with?(topic)
+    end
+
+    false
   end
 end

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RecruitmentBannerHelper do
 
   describe "#show_banner?" do
     it "checks that a page should display the banner" do
-      expect(show_banner?("/browse/business")).to be true
+      expect(show_banner?("/browse/employing-people")).to be true
     end
 
     it "checks that a page shows that banner" do


### PR DESCRIPTION
Follows on from #2683. Adding in one more page to display intervention banner to direct users to a tree study for User Research.

[Trello](https://trello.com/c/i6PqMLdp/842-add-banner-to-guidance-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
