### PR TITLE
Add employing people topic to tree study

### DIFF
--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -5,7 +5,10 @@ class SecondLevelBrowsePageController < ApplicationController
   def show
     setup_content_item_and_navigation_helpers(page)
 
-    @show_recruitment_banner = show_banner?(request.path)
+    if show_banner?(request.path)
+      @show_recruitment_banner = true
+      @study_url = study_url_for(request.path)
+    end
 
     respond_to do |f|
       f.html do

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,7 +1,16 @@
 module RecruitmentBannerHelper
-  TOPICS = ["/browse/business", "/browse/tax"].freeze
+  STUDY_URLS_FOR_TOPICS = {
+    "/browse/business" => "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
+    "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
+    "/browse/employing-people" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr",
+  }.freeze
 
   def show_banner?(path)
-    path.starts_with?(TOPICS.first) || path.starts_with?(TOPICS.last)
+    STUDY_URLS_FOR_TOPICS.keys.any? { |topic| path.starts_with?(topic) }
+  end
+
+  def study_url_for(topic)
+    parent_topic = topic.rpartition("/").first
+    STUDY_URLS_FOR_TOPICS[parent_topic]
   end
 end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -5,7 +5,7 @@
     <%= render "govuk_publishing_components/components/intervention", {
         suggestion_text: "Help improve GOV.UK",
         suggestion_link_text: "Take part in user research",
-        suggestion_link_url: "https://gdsuserresearch.optimalworkshop.com/treejack/lb5eu75l",
+        suggestion_link_url: @study_url,
         new_tab: true,
     } %>
   <% end %>

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -3,11 +3,21 @@ RSpec.describe RecruitmentBannerHelper do
 
   describe "#show_banner?" do
     it "checks that a page should display the banner" do
-      expect(show_banner?("/browse/business")).to be true
+      expect(show_banner?("/browse/employing-people")).to be true
     end
 
     it "checks that a page shows that banner" do
       expect(show_banner?("/browse/stuff")).to be false
+    end
+  end
+
+  describe "#study_url_for" do
+    it "returns common study url" do
+      expect(study_url_for("/browse/tax/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l")
+    end
+
+    it "returns the additional study link" do
+      expect(study_url_for("/browse/employing-people/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/724268fr")
     end
   end
 end


### PR DESCRIPTION
Follows on from #2683. Adding in one more page to display intervention banner to direct users to a tree study for User Research.

[Trello](https://trello.com/c/i6PqMLdp/842-add-banner-to-guidance-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
