### PR TITLE
Change the branch reference for reusable workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-publish-image-to-ecr:
-    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@resusable-workflows
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This changes the branch reference for reusable GitHub Action workflow used to build and push the image. This is workflow is contained in another repository and to make development easier, switching the reference from the main branch, so a changes to don't need to be merged to main before testing. This commit should be reverted.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
