### PR TITLE
Update CI workflow to use main for reusable workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Build and publish to ECR
+name: CI
 
 on:
   workflow_dispatch:
@@ -12,15 +12,13 @@ on:
       - ".git**"
 
 jobs:
-  build-publish-image-to-ecr:
-    name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@resusable-workflows
+  build-and-publish-image:
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   deploy-to-integration:
-    name: Deploy to integration
-    needs: build-publish-image-to-ecr
-    uses: alphagov/govuk-infrastructure/.github/workflows/deploy-to-eks.yaml@resusable-workflows
+    needs: build-and-publish-image
+    uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     secrets:
       GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
Previously, the git ref for the reusable workflows was changed to refer
to a branch to allow easier development removing the need to merge
changes with main. This commit changes the reference back to main and
removes the job names as the specified in the reusable workflows.