### PR TITLE
Add accordion tracking

### DIFF
--- a/app/views/second_level_browse_page/_new_links.html.erb
+++ b/app/views/second_level_browse_page/_new_links.html.erb
@@ -1,10 +1,25 @@
-<ul class="govuk-list">
+<%
+  list_tracking_values = []
+%>
+<ul class="govuk-list" data-module="gem-track-click">
   <% section.each_with_index do |list_item, index| %>
-    <li class="govuk-!-margin-bottom-4"=>
+    <%
+    data_track_options = {
+      "dimension114": 'value',
+      "dimension28": 'value',
+      "dimension29": list_item.title,
+    }
+    list_tracking_values << data_track_options
+    %>
+    <li class="govuk-!-margin-bottom-4">
       <%= link_to(
         list_item.title,
-        list_item.base_path,
+        "#",
         class: "govuk-link",
+        "data-track-category": 'browseClicked',
+        "data-track-action": "contentLink",
+        "data-track-label": list_item.base_path,
+        "data-track-options": list_tracking_values,
       ) %>
     </li>
   <% end %>

--- a/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
@@ -30,8 +30,6 @@
         content: {
           html: contents,
         },
-        data_attributes: {
-        }
       }
       accordion_contents << additional_contents
       %>
@@ -76,6 +74,8 @@
   <div data-module="gem-track-click">
     <div data-module="toggle-attribute">
       <%= render 'govuk_publishing_components/components/accordion', {
+        track_show_all_clicks: true,
+        track_sections: true,
         heading_level: 2,
         data_attributes: {
           module: "govuk-accordion"

--- a/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
@@ -40,13 +40,23 @@
 <% if page.related_topics.any? %>
   <% more_on_this_topic_contents = capture do %>
     <%# Todo: use browse-section partial here - currently the shape of the data is different for the accordion contents %>
-    <ul class="govuk-list">
+    <ul class="govuk-list" data-module="gem-track-click">
       <% page.related_topics.each_with_index do |related_topic, index| %>
-      <li class="govuk-!-margin-bottom-4"=>
+      <li class="govuk-!-margin-bottom-4">
           <%= link_to(
             related_topic.title,
             related_topic.base_path,
             class: "govuk-link",
+            data_attributes: {
+              track_category: 'browseClicked',
+              track_action: "contentLink",
+              track_label: related_topic.base_path,
+              track_options: {
+                dimension114: 'value',
+                dimension28: 'value',
+                dimension29: top_level_browse_page.title,
+              },
+            }
           ) %>
         </li>
       <% end %>


### PR DESCRIPTION
## What

Switch on feature flags for click event tracking for the Accordion on the new [Level 2 Browse Templates ](https://github.com/alphagov/collections/pull/2696)

## Why 

When cookies are accepted and "Show all sections" or a section on the Accordion is clicked then send this event to Google Analytics (GA).

## Visuals 

NA

## Anything else

## Done when

- [x] [Accordion](https://github.com/alphagov/govuk_publishing_components/pull/2693) updated
- [ ] Dependancy in `collections`

### Capture for future update

- [ ] Update other instances
- [ ] Remove bespoke tracking