### PR TITLE
Backend logic for the Browse AB test

### DIFF
--- a/app/controllers/ab_tests/new_browse_ab_testable.rb
+++ b/app/controllers/ab_tests/new_browse_ab_testable.rb
@@ -1,0 +1,30 @@
+module AbTests::NewBrowseAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def new_browse_test
+    @new_browse_test ||= GovukAbTesting::AbTest.new(
+      "NewBrowse",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def new_browse_variant
+    new_browse_test.requested_variant(request.headers)
+  end
+
+  def set_new_browse_response_header
+    new_browse_variant.configure_response(response)
+  end
+
+  def new_browse_variant_b?
+    page_under_test? && new_browse_variant.variant?("B")
+  end
+
+  def page_under_test?
+    request.path.starts_with?("/browse")
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
+  include AbTests::NewBrowseAbTestable
+
+  helper_method :new_browse_variant
+  helper_method :page_under_test?
   helper_method :content_item_h
 
   protect_from_forgery with: :exception
 
   before_action :set_expiry
   before_action :restrict_request_formats
+  before_action :set_new_browse_response_header_if_browse_page
 
   slimmer_template "gem_layout"
 
@@ -67,6 +72,10 @@ private
     return true if format == Mime[:html] || format == Mime::ALL
 
     format && self.class.acceptable_formats.fetch(params[:action].to_sym, []).include?(format.to_sym)
+  end
+
+  def set_new_browse_response_header_if_browse_page
+    set_new_browse_response_header if page_under_test?
   end
 
   def error_403

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -6,19 +6,12 @@ class BrowseController < ApplicationController
     @dimension26 = 1
     @dimension27 = page.top_level_browse_pages.count || 0
     setup_content_item_and_navigation_helpers(page)
-    slimmer_template "gem_layout_full_width" if is_variant_b?
-
-    template = is_variant_b? ? :new_index : :index
-
-    render(template, locals: {
-      page: page,
-    })
+    index_html(page)
   end
 
   def show
     page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
     setup_content_item_and_navigation_helpers(page)
-    slimmer_template "gem_layout_full_width" if is_variant_b?
 
     respond_to do |f|
       f.html do
@@ -38,18 +31,22 @@ class BrowseController < ApplicationController
 
 private
 
-  # NOTE: This is just to fake an A/B test - replace with proper A/B test code.
-  # Add a query string with b=true to the URL to force variant B.
-  def is_variant_b?
-    params["b"].present?
+  def show_html(page)
+    template = :show
+    if new_browse_variant_b?
+      slimmer_template "gem_layout_full_width"
+      template = :new_show
+    end
+    render template, locals: { page: page }
   end
 
-  def show_html(page)
-    template = is_variant_b? ? :new_show : :show
-
-    render(template, locals: {
-      page: page,
-    })
+  def index_html(page)
+    template = :index
+    if new_browse_variant_b?
+      slimmer_template "gem_layout_full_width"
+      template = :new_index
+    end
+    render template, locals: { page: page }
   end
 
   def second_level_browse_pages_partial(page)

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -7,7 +7,6 @@ class SecondLevelBrowsePageController < ApplicationController
     @dimension26 = count_link_sections(page)
     @dimension27 = count_total_links(page)
     @study_url = study_url_for(request.path)
-    slimmer_template "gem_layout_full_width" if is_variant_b?
 
     respond_to do |f|
       f.html do
@@ -26,30 +25,19 @@ class SecondLevelBrowsePageController < ApplicationController
 
 private
 
-  # NOTE: This is just to fake an A/B test - replace with proper A/B test code.
-  # Add a query string with b=true to the URL to force variant B.
-  def is_variant_b?
-    params["b"].present?
-  end
-
   def show_html
-    # The defauly template should be 'show' if there's no A/B variant set
     template = :show
 
-    # If the A/B test requires the new layout, then we need to see whether the
-    # page is a curated list or a A to Z list and set the correct template:
-    if is_variant_b? && page.lists.curated?
-      template = :new_show_curated
+    if new_browse_variant_b?
+      slimmer_template "gem_layout_full_width"
+      template = if page.lists.curated?
+                   :new_show_curated
+                 else
+                   :new_show_a_to_z
+                 end
     end
 
-    if is_variant_b? && !page.lists.curated?
-      template = :new_show_a_to_z
-    end
-
-    render(template, locals: {
-      page: page,
-      meta_section: meta_section,
-    })
+    render(template, locals: { page: page, meta_section: meta_section })
   end
 
   def meta_section

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
+  <%= new_browse_variant.analytics_meta_tag.html_safe if page_under_test? %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe BrowseController do
+  include GovukAbTesting::RspecHelpers
+
   describe "GET index" do
     before do
       stub_content_store_has_item(
@@ -45,7 +47,8 @@ RSpec.describe BrowseController do
     end
   end
 
-  context "AB test preparation: New browse templates" do
+  context "AB test: New browse templates" do
+    render_views
     describe "GET index" do
       before do
         stub_content_store_has_item(
@@ -56,10 +59,24 @@ RSpec.describe BrowseController do
         )
       end
 
-      subject { get :index, params: { b: "anything" } }
+      subject { get :index }
 
-      it "renders the new_index template" do
-        expect(subject).to render_template(:new_index)
+      it "with variant B" do
+        with_variant NewBrowse: "B" do
+          expect(subject).to render_template(:new_index)
+        end
+      end
+
+      it "with variant A" do
+        with_variant NewBrowse: "A" do
+          expect(subject).to render_template(:index)
+        end
+      end
+
+      it "with variant Z" do
+        with_variant NewBrowse: "Z" do
+          expect(subject).to render_template(:index)
+        end
       end
     end
 
@@ -68,6 +85,7 @@ RSpec.describe BrowseController do
         stub_content_store_has_item(
           "/browse/benefits",
           base_path: "/browse/benefits",
+          title: "Benefits",
           links: {
             top_level_browse_pages: top_level_browse_pages,
             second_level_browse_pages: second_level_browse_pages,
@@ -75,10 +93,24 @@ RSpec.describe BrowseController do
         )
       end
 
-      subject { get :show, params: { top_level_slug: "benefits", b: "anything" } }
+      subject { get :show, params: { top_level_slug: "benefits" } }
 
-      it "renders the new_show template" do
-        expect(subject).to render_template(:new_show)
+      it "with variant B" do
+        with_variant NewBrowse: "B" do
+          expect(subject).to render_template(:new_show)
+        end
+      end
+
+      it "with variant A" do
+        with_variant NewBrowse: "A" do
+          expect(subject).to render_template(:show)
+        end
+      end
+
+      it "with variant Z" do
+        with_variant NewBrowse: "Z" do
+          expect(subject).to render_template(:show)
+        end
       end
     end
   end

--- a/spec/controllers/second_level_browse_page_controller_spec.rb
+++ b/spec/controllers/second_level_browse_page_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe SecondLevelBrowsePageController do
   include SearchApiHelpers
+  include GovukAbTesting::RspecHelpers
 
   describe "GET second_level_browse_page" do
     describe "for a valid browse page" do
@@ -49,12 +50,12 @@ RSpec.describe SecondLevelBrowsePageController do
     end
   end
 
-  context "AB test preparation: New browse templates" do
+  context "AB test: New browse templates" do
+    render_views
     let :params do
       {
         top_level_slug: "benefits",
         second_level_slug: "entitlement",
-        b: "anything",
       }
     end
 
@@ -89,16 +90,44 @@ RSpec.describe SecondLevelBrowsePageController do
     describe "GET second_level_browse_page for uncurated topic" do
       let(:details) { {} }
 
-      it "renders the new_show_a_to_z template" do
-        expect(subject).to render_template(:new_show_a_to_z)
+      it "with variant B" do
+        with_variant NewBrowse: "B" do
+          expect(subject).to render_template(:new_show_a_to_z)
+        end
+      end
+
+      it "with variant A" do
+        with_variant NewBrowse: "A" do
+          expect(subject).to render_template(:show)
+        end
+      end
+
+      it "with variant Z" do
+        with_variant NewBrowse: "Z" do
+          expect(subject).to render_template(:show)
+        end
       end
     end
 
     describe "GET second_level_browse_page for curated topic" do
       let(:details) { { groups: [{ name: "something", contents: ["/something"] }] } }
 
-      it "renders the new_show_curated template" do
-        expect(subject).to render_template(:new_show_curated)
+      it "with variant B" do
+        with_variant NewBrowse: "B" do
+          expect(subject).to render_template(:new_show_curated)
+        end
+      end
+
+      it "with variant A" do
+        with_variant NewBrowse: "A" do
+          expect(subject).to render_template(:show)
+        end
+      end
+
+      it "with variant Z" do
+        with_variant NewBrowse: "Z" do
+          expect(subject).to render_template(:show)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ Capybara.automatic_label_click = true
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :active_support
+end
+
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.include GdsApi::TestHelpers::Search


### PR DESCRIPTION
## Add AB test logic for the new browse templates

In https://github.com/alphagov/collections/pull/2696 temporary logic was added to the browse controllers so that the new templates are only shown if the url contains a query string with the b param. 

This PR replaces that temp logic with working AB test code.

Currently the CDN config has not been updated to add the header that the logic here is using to switch between variants. As it's absent, all users will be seeing the A (control) variant. We are doing this so that we can validate all is well before we activate the AB test and put it in front of real users. 

### How to view the B variant before we turn the AB test on
To toggle between the variants install [modheader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) and then add a new **Request Header** by clicking the **+**. Enter a `Name` of **govuk-abtest-newbrowse** and a `Value` of **B**

---

- Trello card: https://trello.com/c/ACFzuepy/850-prep-prs-for-ab-test-of-browse-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
