### PR TITLE
Revert "Export stats to prometheus on EKS "

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,2 +1,0 @@
-require "govuk_app_config/govuk_prometheus_exporter"
-GovukPrometheusExporter.configure


### PR DESCRIPTION
Reverts alphagov/collections#2684 - this change is causing extra latency for some requests (definitely the organisations controller). This is saturating the worker processes and causing the application to return 5xx errors.