### PR TITLE
Update the url for the user research survey on the Tax, Business and Employing-People browse pages

### DIFF
--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -6,11 +6,7 @@ class SecondLevelBrowsePageController < ApplicationController
     setup_content_item_and_navigation_helpers(page)
     @dimension26 = count_link_sections(page)
     @dimension27 = count_total_links(page)
-
-    if show_banner?(request.path)
-      @show_recruitment_banner = true
-      @study_url = study_url_for(request.path)
-    end
+    @study_url = study_url_for(request.path)
 
     respond_to do |f|
       f.html do

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,8 +1,8 @@
 module RecruitmentBannerHelper
   STUDY_URLS_FOR_TOPICS = {
-    "/browse/business" => "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
-    "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l",
-    "/browse/employing-people" => "https://gdsuserresearch.optimalworkshop.com/treejack/724268fr-1",
+    "/browse/business" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
+    "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
+    "/browse/employing-people" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
   }.freeze
 
   def show_banner?(path)

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,16 +1,13 @@
 module RecruitmentBannerHelper
+  STUDY_URL_ONE = "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0".freeze
   STUDY_URLS_FOR_TOPICS = {
-    "/browse/business" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
-    "/browse/tax" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
-    "/browse/employing-people" => "https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0",
+    "/browse/business" => STUDY_URL_ONE,
+    "/browse/tax" => STUDY_URL_ONE,
+    "/browse/employing-people" => STUDY_URL_ONE,
   }.freeze
 
-  def show_banner?(path)
-    STUDY_URLS_FOR_TOPICS.keys.any? { |topic| path.starts_with?(topic) }
-  end
-
-  def study_url_for(topic)
-    parent_topic = topic.rpartition("/").first
-    STUDY_URLS_FOR_TOPICS[parent_topic]
+  def study_url_for(path)
+    key = STUDY_URLS_FOR_TOPICS.keys.find { |topic| path.starts_with?(topic) }
+    STUDY_URLS_FOR_TOPICS[key]
   end
 end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,7 +1,7 @@
 <div class="browse__inner <%= page.lists.curated? ? 'browse__inner--curated' : 'browse__inner--alphabetical' %>">
   <h2 tabindex="-1" class="browse__heading js-heading"><%= t("shared.browse.prefix") %> <%= page.title %></h2>
 
-  <% if @show_recruitment_banner %>
+  <% if @study_url %>
     <%= render "govuk_publishing_components/components/intervention", {
         suggestion_text: "Help improve GOV.UK",
         suggestion_link_text: "Take part in user research",

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -1,23 +1,16 @@
 RSpec.describe RecruitmentBannerHelper do
   include RecruitmentBannerHelper
 
-  describe "#show_banner?" do
-    it "checks that a page should display the banner" do
-      expect(show_banner?("/browse/employing-people")).to be true
-    end
-
-    it "checks that a page shows that banner" do
-      expect(show_banner?("/browse/stuff")).to be false
-    end
-  end
-
   describe "#study_url_for" do
-    it "returns common study url" do
-      expect(study_url_for("/browse/tax/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
+    let(:survey_url) { RecruitmentBannerHelper::STUDY_URL_ONE }
+    it "returns STUDY_URL_ONE for business, tax and employing people browse pages" do
+      ["/browse/business/foo", "/browse/tax/foo", "/browse/employing-people/foo"].each do |browse_path|
+        expect(study_url_for(browse_path)).to eq survey_url
+      end
     end
 
-    it "returns the additional study link" do
-      expect(study_url_for("/browse/employing-people/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
+    it "does not return a survey url for other browse pages" do
+      expect(study_url_for("/browse/boring/blah-blah-blah")).to be nil
     end
   end
 end

--- a/spec/helpers/recruitment_banner_helper_spec.rb
+++ b/spec/helpers/recruitment_banner_helper_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe RecruitmentBannerHelper do
 
   describe "#study_url_for" do
     it "returns common study url" do
-      expect(study_url_for("/browse/tax/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/lb5eu75l")
+      expect(study_url_for("/browse/tax/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
     end
 
     it "returns the additional study link" do
-      expect(study_url_for("/browse/employing-people/blah-blah-blah")).to eq("https://gdsuserresearch.optimalworkshop.com/treejack/724268fr-1")
+      expect(study_url_for("/browse/employing-people/blah-blah-blah")).to eq("https://GDSUserResearch.optimalworkshop.com/treejack/724268fr-1-0")
     end
   end
 end


### PR DESCRIPTION
Update the url for the user research survey on the Tax, Business and Employing-People browse pages. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
