### PR TITLE
[WIP] - split country guidance

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_country_guidance.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_guidance.html.erb
@@ -1,0 +1,17 @@
+<% guidance ||= nil %>
+
+<div
+  class="govuk-body"
+  data-module="gem-track-click"
+  data-track-category="pageElementInteraction"
+  data-track-action="AccordionClick"
+  data-track-links-only>
+
+  <% if guidance.present? && guidance["links"].present? %>
+      <ul class="govuk-list">
+      <% guidance["links"].map do |link| %>
+        <li><%= link_to(link["label"], link["url"], class: "govuk-link") %></li>
+      <% end %>
+      </ul>
+  <% end %>
+</div>

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -10,15 +10,4 @@
   <% if guidance.present? && guidance["intro"].present? %>
     <%= render_govspeak(guidance["intro"]) %>
   <% end %>
-
-  <% if guidance.present? && guidance["links"].present? %>
-    <%
-      guidance_links = guidance["links"].map do | link |
-        link_to(link["label"], link["url"], class: "govuk-link")
-      end
-    %>
-    <p class="govuk-body">
-      <%= "#{guidance["text"]} #{guidance_links.to_sentence(last_word_connector: " and ")}".html_safe %>
-    </p>
-  <% end %>
 </div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -34,8 +34,10 @@
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {
           text: details.sections_heading,
+          margin_bottom: 3,
           font_size: "m"
         } %>
+        <%= render partial: 'coronavirus_landing_page/components/shared/country_guidance', locals: { guidance: details.additional_country_guidance } %>
       </div>
 
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Trello: https://trello.com/c/Jw3N26VF

Spikes into moving the DA links from the bottom of the Guidance and Support section, so underneath the section title in the "first" column.

split country_section to show the guidance links to devolved administrations
below the section title in the first column.

![screenshot-localhost_3070-2022 03 28-14_46_58](https://user-images.githubusercontent.com/5793815/160414071-d7020808-e7d5-46dd-8e74-dd635e7ec0c3.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
