### PR TITLE
Landing page redesign

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_country_guidance.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_guidance.html.erb
@@ -1,0 +1,17 @@
+<% guidance ||= nil %>
+
+<div
+  class="govuk-body"
+  data-module="gem-track-click"
+  data-track-category="pageElementInteraction"
+  data-track-action="AccordionClick"
+  data-track-links-only>
+
+  <% if guidance.present? && guidance["links"].present? %>
+      <ul class="govuk-list">
+      <% guidance["links"].map do |link| %>
+        <li><%= link_to(link["label"], link["url"], class: "govuk-link") %></li>
+      <% end %>
+      </ul>
+  <% end %>
+</div>

--- a/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_country_section.html.erb
@@ -10,15 +10,4 @@
   <% if guidance.present? && guidance["intro"].present? %>
     <%= render_govspeak(guidance["intro"]) %>
   <% end %>
-
-  <% if guidance.present? && guidance["links"].present? %>
-    <%
-      guidance_links = guidance["links"].map do | link |
-        link_to(link["label"], link["url"], class: "govuk-link")
-      end
-    %>
-    <p class="govuk-body">
-      <%= "#{guidance["text"]} #{guidance_links.to_sentence(last_word_connector: " and ")}".html_safe %>
-    </p>
-  <% end %>
 </div>

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -19,16 +19,6 @@
     <%= render partial: 'coronavirus_landing_page/components/landing_page/timeline', locals: { details: details } %>
   </section>
 
-  <section class="covid__section"
-           aria-label="notice"
-           role="region"
-           data-module="gem-track-click"
-           data-track-category="pageElementInteraction"
-           data-track-action="callOutBox"
-           data-track-links-only>
-           <%= render "coronavirus_landing_page/components/landing_page/nhs_notice", { nhs_banner: details.nhs_banner } %>
-  </section>
-
   <section class="covid__section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -20,8 +20,10 @@
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {
           text: details.sections_heading,
+          margin_bottom: 3,
           font_size: "m"
         } %>
+        <%= render partial: 'coronavirus_landing_page/components/shared/country_guidance', locals: { guidance: details.additional_country_guidance } %>
       </div>
 
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -15,10 +15,6 @@
 } %>
 
 <div class="govuk-width-container covid__page" data-module="coronavirus-landing-page">
-  <section class="covid__section covid__section--first">
-    <%= render partial: 'coronavirus_landing_page/components/landing_page/timeline', locals: { details: details } %>
-  </section>
-
   <section class="covid__section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -34,13 +34,6 @@
   </section>
 
   <section class="covid__section">
-    <%= render partial: 'coronavirus_landing_page/components/landing_page/statistics_section', locals: {
-      topic_section: details.statistics_section,
-      statistics: @statistics,
-    } %>
-  </section>
-
-  <section class="covid__section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -15,7 +15,7 @@
 } %>
 
 <div class="govuk-width-container covid__page" data-module="coronavirus-landing-page">
-  <section class="covid__section">
+  <section class="covid__section covid__section--first">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -45,10 +45,6 @@
   </section>
 
   <section class="covid__section">
-    <%= render partial: 'coronavirus_landing_page/components/landing_page/announcements_section', locals: { details: details } %>
-  </section>
-
-  <section class="covid__section">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {

--- a/spec/controllers/coronavirus_landing_page_controller_spec.rb
+++ b/spec/controllers/coronavirus_landing_page_controller_spec.rb
@@ -44,45 +44,5 @@ RSpec.describe CoronavirusLandingPageController do
         expect(response.headers["Cache-Control"]).to eq("max-age=#{30.seconds}, public")
       end
     end
-
-    context "when testing national_applicability" do
-      render_views
-
-      it "shows timeline for England" do
-        get :show, params: { nation: "england" }
-
-        expect(response.body).to have_selector("#nation-england:not(.covid-timeline__wrapper--hidden)")
-        expect(response.body).to have_selector(".covid-timeline__wrapper--hidden", count: 3)
-      end
-
-      it "shows timeline for Northern Ireland" do
-        get :show, params: { nation: "northern_ireland" }
-
-        expect(response.body).to have_selector("#nation-northern_ireland:not(.covid-timeline__wrapper--hidden)")
-        expect(response.body).to have_selector(".covid-timeline__wrapper--hidden", count: 3)
-      end
-
-      it "shows timeline for Scotland" do
-        get :show, params: { nation: "scotland" }
-
-        expect(response.body).to have_selector("#nation-scotland:not(.covid-timeline__wrapper--hidden)")
-        expect(response.body).to have_selector(".covid-timeline__wrapper--hidden", count: 3)
-      end
-
-      it "shows timeline for Wales" do
-        get :show, params: { nation: "wales" }
-
-        expect(response.body).to have_selector("#nation-wales:not(.covid-timeline__wrapper--hidden)")
-        expect(response.body).to have_selector(".covid-timeline__wrapper--hidden", count: 3)
-      end
-
-      it "shows no content text when there are no timeline entries for a nation" do
-        stub_content_store_has_item("/coronavirus", coronavirus_content_item_with_timeline_national_applicability_without_wales)
-        get :show, params: { nation: "wales" }
-
-        expect(response.body).to have_content(I18n.t("coronavirus_landing_page.show.timeline.no_updates.body", nation: "Wales"))
-        expect(response.body).to match(I18n.t("coronavirus_landing_page.show.timeline.no_updates.wales.additional_country_guidance_html"))
-      end
-    end
   end
 end

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "Coronavirus Pages" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
-      then_i_can_see_the_timeline
       then_i_can_see_the_accordions
       and_i_can_see_links_to_search
       and_there_are_metatags
@@ -28,25 +27,6 @@ RSpec.feature "Coronavirus Pages" do
       when_i_visit_the_coronavirus_landing_page
       then_the_special_announcement_schema_is_rendered
       and_the_faqpage_schema_is_rendered
-    end
-
-    describe "selecting timeline for country" do
-      scenario "with javascript", js: true do
-        given_there_is_a_content_item
-        when_i_visit_the_coronavirus_landing_page
-        then_i_can_see_the_timeline_for_england
-        when_i_click_on_wales
-        then_i_can_see_the_timeline_for_wales
-      end
-
-      scenario "without javascript" do
-        given_there_is_a_content_item
-        when_i_visit_the_coronavirus_landing_page
-        then_i_can_see_the_timeline_for_england
-        when_i_click_on_wales
-        and_i_submit_my_nation
-        then_i_can_see_the_timeline_for_wales
-      end
     end
   end
 

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature "Coronavirus Pages" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page
       then_i_can_see_the_header_section
-      then_i_can_see_the_nhs_banner
       then_i_can_see_the_timeline
       then_i_can_see_the_accordions
       and_i_can_see_links_to_search

--- a/spec/features/coronavirus_landing_page_spec.rb
+++ b/spec/features/coronavirus_landing_page_spec.rb
@@ -23,18 +23,6 @@ RSpec.feature "Coronavirus Pages" do
       then_i_can_see_sub_headings_of_accordions
     end
 
-    scenario "shows COVID-19 risk level when risk level is enabled" do
-      given_there_is_a_content_item_with_risk_level_element_enabled
-      when_i_visit_the_coronavirus_landing_page
-      then_i_can_see_the_risk_level
-    end
-
-    scenario "does not show COVID-19 risk level when risk level is not enabled" do
-      given_there_is_a_content_item
-      when_i_visit_the_coronavirus_landing_page
-      then_i_can_not_see_the_risk_level
-    end
-
     scenario "renders machine readable content" do
       given_there_is_a_content_item
       when_i_visit_the_coronavirus_landing_page

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -66,10 +66,6 @@ module CoronavirusLandingPageSteps
     expect(page).to have_selector(".covid__page-header h1", text: title)
   end
 
-  def then_i_can_see_the_nhs_banner
-    expect(page).to have_selector("[data-track-action='callOutBox']", text: "If you have no symptoms")
-  end
-
   def then_i_can_see_the_timeline
     expect(page).to have_selector("h2", text: "Recent and upcoming changes")
 

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -110,14 +110,6 @@ module CoronavirusLandingPageSteps
     expect(page).to have_link("Guidance", href: "/search/all?level_one_taxon=495afdb6-47be-4df1-8b38-91c8adb1eefc&topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest")
   end
 
-  def then_i_can_see_the_risk_level
-    expect(page).to have_selector('[data-module="govspeak"]', text: "COVID-19 alert level")
-  end
-
-  def then_i_can_not_see_the_risk_level
-    expect(page).not_to have_selector('[data-module="govspeak"]', text: "COVID-19 alert level")
-  end
-
   def then_the_special_announcement_schema_is_rendered
     special_announcement_schema = find_schema("SpecialAnnouncement")
     expect(special_announcement_schema["name"]).to eq("Coronavirus (COVID-19): what you need to do")

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -66,32 +66,6 @@ module CoronavirusLandingPageSteps
     expect(page).to have_selector(".covid__page-header h1", text: title)
   end
 
-  def then_i_can_see_the_timeline
-    expect(page).to have_selector("h2", text: "Recent and upcoming changes")
-
-    expect(page).to have_selector("#nation-england .gem-c-heading", text: "18 September")
-    expect(page).to have_selector("#nation-england .gem-c-govspeak", text: "If you live, work or travel in the North East, you need to follow different covid rules")
-
-    expect(page).to have_selector("#nation-england .gem-c-heading", text: "15 September")
-    expect(page).to have_selector("#nation-england .gem-c-govspeak", text: "If you live, work or visit Bolton, you need to follow different covid rules")
-
-    expect(page).to have_selector("#nation-scotland .gem-c-heading", text: "14 September")
-    expect(page).to have_selector("#nation-scotland .gem-c-govspeak", text: "People must not meet in groups larger than 6 in England. There are exceptions to this ‘rule of 6’")
-
-    expect(page).to have_selector("#nation-wales .gem-c-heading", text: "24 July")
-    expect(page).to have_selector("#nation-wales .gem-c-govspeak", text: "Face coverings are mandatory in shops")
-  end
-
-  def then_i_can_see_the_timeline_for_england
-    expect(page).to have_selector("#nation-england:not(.covid-timeline__wrapper--hidden)")
-    expect(page).to have_selector(".covid-timeline__wrapper--hidden", count: 3, visible: false)
-  end
-
-  def then_i_can_see_the_timeline_for_wales
-    expect(page).to have_selector("#nation-wales:not(.covid-timeline__wrapper--hidden)")
-    expect(page).to have_selector(".covid-timeline__wrapper--hidden", count: 3, visible: false)
-  end
-
   def then_i_can_see_the_accordions
     expect(page).to have_selector("h2", text: "Guidance and support")
   end


### PR DESCRIPTION
Trello: https://trello.com/c/zxAAM52Y

# What's changed?

1. Stop rendering the following on the landing page:
   - NHS Box
   - Announcements section
   - Timeline entries section
   - Statistics section
2. Move the DA links from the bottom of the accordion section to underneath the title in the first column.

# Expected changes

Rendered version 👉  https://govuk-collec-landing-pa-rtxotv.herokuapp.com/coronavirus

|Before|After|
|:------|:----|
|![screenshot-www gov uk-2022 03 30-16_25_54](https://user-images.githubusercontent.com/5793815/160872203-2e6646ca-ce25-46bb-b59e-253cfcfd6e7c.png)|![screenshot-localhost_3070-2022 03 30-17_44_38](https://user-images.githubusercontent.com/5793815/160888185-da8c156b-94fd-4b70-8bb3-a1d9e69ff1a2.png)|




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
