### PR TITLE
Remove active_model dependency from controller

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -1,5 +1,3 @@
-require "active_model"
-
 class CoronavirusLandingPageController < ApplicationController
   slimmer_template "gem_layout_full_width"
 


### PR DESCRIPTION
Active model was added in https://github.com/alphagov/collections/commit/da96d36d0116c5cca474b55757e876bb940cbf86 to support the live stream section.
The live stream was removed in May 2021 (see https://github.com/alphagov/collections/pull/2374), so this dependency is no longer required.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
