### PR TITLE
split analytics dimension for browse templates

### DIFF
--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -3,7 +3,8 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      navigation_page_type: "Browse level 0 - default",
+      navigation_page_type: "Browse level 0",
+      navigation_list_type: "default",
       section: "new_browse_page",
     }
   } %>

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -5,8 +5,8 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      # TODO align this naming "level 1" vs "second_level" mismatch
-      navigation_page_type: "Browse level 1 - #{page.second_level_pages_curated? ? "curated" : "default"}",
+      navigation_page_type: "Browse level 1",
+      navigation_list_type: page.second_level_pages_curated? ? "curated" : "default",
       section: "new_browse_page",
     }
   } %>

--- a/app/views/second_level_browse_page/new_show.html.erb
+++ b/app/views/second_level_browse_page/new_show.html.erb
@@ -4,7 +4,8 @@
 <% content_for :meta_tags do %>
   <%= render "govuk_publishing_components/components/meta_tags", {
     content_item: {
-      navigation_page_type: "Second Level Browse",
+      navigation_page_type: "Browse level 2",
+      navigation_list_type: page.lists.curated? ? "curated" : "default",
       section: meta_section,
     }
   } %>


### PR DESCRIPTION
## What

This PR is for splitting the navigation_page_type dimension into navigation_page_type and navigation_list_type.

## Why 
These changes were requested to make analytics better.

## Visual Changes
There should be none.