### PR TITLE
Fix links on 2nd level browse topics pages

### DIFF
--- a/app/views/second_level_browse_page/_new_links.html.erb
+++ b/app/views/second_level_browse_page/_new_links.html.erb
@@ -14,7 +14,7 @@
     <li class="govuk-!-margin-bottom-4">
       <%= link_to(
         list_item.title,
-        "#",
+        list_item.base_path,
         class: "govuk-link",
         "data-track-category": 'browseClicked',
         "data-track-action": "contentLink",

--- a/config/locales/ne/browse.yml
+++ b/config/locales/ne/browse.yml
@@ -2,3 +2,5 @@
 uk:
   browse:
     all_categories:
+    description:
+    title:


### PR DESCRIPTION
## What

Links for content were hard coded to "#" for the second level browse page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
