### PR TITLE
Add tracking attributes for links inside accordions and in A-Z lists

### DIFF
--- a/app/views/second_level_browse_page/_new_links.html.erb
+++ b/app/views/second_level_browse_page/_new_links.html.erb
@@ -1,25 +1,22 @@
-<%
-  list_tracking_values = []
-%>
 <ul class="govuk-list" data-module="gem-track-click">
-  <% section.each_with_index do |list_item, index| %>
-    <%
-    data_track_options = {
-      "dimension114": 'value',
-      "dimension28": 'value',
-      "dimension29": list_item.title,
-    }
-    list_tracking_values << data_track_options
-    %>
+  <% list.each_with_index do |list_item, index| %>
     <li class="govuk-!-margin-bottom-4">
       <%= link_to(
         list_item.title,
         list_item.base_path,
         class: "govuk-link",
-        "data-track-category": 'browseClicked',
-        "data-track-action": "contentLink",
-        "data-track-label": list_item.base_path,
-        "data-track-options": list_tracking_values,
+        data: {
+          track_category: "browseClicked",
+          track_action: "contentLink",
+          track_label: list_item.base_path,
+          track_options: {
+            dimension114: "#{list_index + 1}.#{index + 1}",
+            dimension28: list.count.to_s,
+            dimension29: list_item.title,
+            location: list_item.base_path,
+            title: list_item.title,
+          },
+        },
       ) %>
     </li>
   <% end %>

--- a/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
@@ -4,20 +4,20 @@
   more_on_this_topic_contents = []
 %>
 
-<% page.lists.each_with_index do |section, section_index| %>
+<% page.lists.each_with_index do |list, list_index| %>
 
   <% contents = capture do %>
     <%# Add a heading above the A-Z the list. Add it here so that we can extract the heading text %>
     <% if !curated_order %>
       <%= render "govuk_publishing_components/components/heading", {
-       text: section["title"],
+       text: list["title"],
        font_size: "m",
        margin_bottom: 7,
       }
      %>
     <% end %>
     <%# Render the contents as a list, regardless of whether they'll be in an accordion or as an A-Z list %>
-    <%= render partial: 'new_links', locals: { section: section.contents } %>
+    <%= render partial: 'new_links', locals: { list: list.contents, list_index: list_index } %>
   <% end %>
 
   <%# Generate accordion shaped markup %>
@@ -25,7 +25,7 @@
     <%
       additional_contents = {
         heading: {
-          text: section["title"],
+          text: list["title"],
         },
         content: {
           html: contents,


### PR DESCRIPTION
Add tracking attributes to links on curated pages (pages with accordions) and to links in A-Z lists as per sheet from Performance Analyst.

Also use 'list' instead of 'section' for the related variable names.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
