### PR TITLE
Add a helper to generate accordion content markup

### DIFF
--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,5 +1,7 @@
 class SecondLevelBrowsePageController < ApplicationController
   include RecruitmentBannerHelper
+  include AccordionItemsHelper
+
   enable_request_formats show: [:json]
 
   def show

--- a/app/helpers/accordion_items_helper.rb
+++ b/app/helpers/accordion_items_helper.rb
@@ -1,0 +1,13 @@
+module AccordionItemsHelper
+  def accordion_items(section_title:, section_contents:, accordion_contents:)
+    section_contents = {
+      heading: {
+        text: section_title,
+      },
+      content: {
+        html: section_contents,
+      },
+    }
+    accordion_contents << section_contents
+  end
+end

--- a/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
+++ b/app/views/second_level_browse_page/_new_second_level_browse_pages.html.erb
@@ -22,17 +22,7 @@
 
   <%# Generate accordion shaped markup %>
   <% if curated_order %>
-    <%
-      additional_contents = {
-        heading: {
-          text: list["title"],
-        },
-        content: {
-          html: contents,
-        },
-      }
-      accordion_contents << additional_contents
-      %>
+    <% accordion_items(section_title: list["title"], section_contents: contents, accordion_contents: accordion_contents) %>
   <% end %>
 <% end %>
 
@@ -67,19 +57,8 @@
 <% if curated_order %>
   <%# For curated pages, render the markup using an accordion %>
   <% if page.related_topics.any? %>
-    <%# Insert 'More on this topic markup into the accordion' %>
-    <%
-      additional_contents = {
-        heading: {
-          # To do: Add to translations file
-          text: 'More on this topic',
-        },
-        content: {
-          html: more_on_this_topic_contents,
-        }
-      }
-      accordion_contents << additional_contents
-    %>
+    <%# Insert 'More on this topic' markup into the accordion items %>
+    <% accordion_items(section_title: "More on this topic", section_contents: more_on_this_topic_contents, accordion_contents: accordion_contents) %>
   <% end %>
   <div data-module="gem-track-click">
     <div data-module="toggle-attribute">

--- a/spec/helpers/accordion_items_helper_spec.rb
+++ b/spec/helpers/accordion_items_helper_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe AccordionItemsHelper do
+  include AccordionItemsHelper
+
+  accordion_contents = []
+
+  content = "<p>Some content</p>"
+
+  let(:result) do
+    accordion_items(section_title: "More on this topic", section_contents: content, accordion_contents: accordion_contents)
+  end
+
+  let(:expected) do
+    [{
+      heading: {
+        text: "More on this topic",
+      },
+      content: {
+        html: "<p>Some content</p>",
+      },
+    }]
+  end
+
+  it "provides the content in the format expected by the accordion component" do
+    expect(result).to eq(expected)
+  end
+end


### PR DESCRIPTION
Add a helper to generate the accordion shaped markup (following documentation [here](https://components.publishing.service.gov.uk/component-guide/accordion)) instead of duplicating the code for doing it multiple times inside the new browse templates. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
