### PR TITLE
Remove import of non-existent JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,6 @@
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/govspeak
-//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 //= require govuk_publishing_components/components/error-summary


### PR DESCRIPTION
The intervention banner Javascript was removed in the publishing components gem as that was no longer needed.

See https://github.com/alphagov/govuk_publishing_components/pull/2730 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
