### PR TITLE
Changes to resolve axe issues for browse pages

### DIFF
--- a/app/views/browse/new_index.erb
+++ b/app/views/browse/new_index.erb
@@ -44,6 +44,7 @@
         },
         description: top_level_browse_page.description,
       }
-    end
+    end,
+    sub_heading_level: 2,
   } %>
 <% end %>

--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -48,6 +48,7 @@
         },
         description: second_level_browse_page.description,
       }
-    end
+    end,
+    sub_heading_level: 2,
   } %>
 <% end %>


### PR DESCRIPTION
This branch contains resolutions to one of two issues that were flagged up by the axe DevTool.

1. Change the heading level of the cards to heading level 2 so that there is not a decrease in level of more than 1 when going from the header of the page to the cards of the new templates.
