### PR TITLE
Update GHA to enable manual deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+      manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
This updates the deploy GitHub Action workflow to add the ability to trigger
manual one off deploys of specific commits. The workflow now accepts a gitRef
input that can be either commit SHA, branch name or a git tag. If a branch name
is given, the latest commit on that branch is used. The workflow will build the
image for that commit and trigger its deployment to integration. The workflow
is still used to build images and trigger continuous deployment for new
releases. The workflow has also been renamed from CI to Deploy to better
clarify its purpose.
