### PR TITLE
Add tracking fixes

### DIFF
--- a/app/views/browse/new_show.html.erb
+++ b/app/views/browse/new_show.html.erb
@@ -7,7 +7,7 @@
     content_item: {
       navigation_page_type: "Browse level 1",
       navigation_list_type: page.second_level_pages_curated? ? "curated" : "default",
-      section: yield(:title).downcase.sub!('browse: ', ''),
+      section: page.title.downcase,
     }
   } %>
 <% end %>

--- a/app/views/second_level_browse_page/_new_links.html.erb
+++ b/app/views/second_level_browse_page/_new_links.html.erb
@@ -13,8 +13,6 @@
             dimension114: "#{list_index + 1}.#{index + 1}",
             dimension28: list.count.to_s,
             dimension29: list_item.title,
-            location: list_item.base_path,
-            title: list_item.title,
           },
         },
       ) %>

--- a/app/views/second_level_browse_page/new_show_curated.html.erb
+++ b/app/views/second_level_browse_page/new_show_curated.html.erb
@@ -99,20 +99,18 @@
         %>
       <% end %>
 
-      <div data-module="gem-track-click">
-        <div data-module="toggle-attribute">
-          <%= render "govuk_publishing_components/components/accordion", {
-            track_show_all_clicks: true,
-            track_sections: true,
-            heading_level: 2,
-            data_attributes: {
-              module: "govuk-accordion",
-              track_count: "accordionSection"
-            },
-            items: accordion_contents,
-            margin_bottom: 4,
-          } %>
-        </div>
+      <div data-module="toggle-attribute">
+        <%= render "govuk_publishing_components/components/accordion", {
+          track_show_all_clicks: true,
+          track_sections: true,
+          heading_level: 2,
+          data_attributes: {
+            module: "govuk-accordion",
+            track_count: "accordionSection"
+          },
+          items: accordion_contents,
+          margin_bottom: 4,
+        } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR:
- corrects `dimension1` for Level 1 pageview to be `<level 1 topic name>` eg `births, deaths, marriages and care`
- removes a `gem-track-click` attribute from the accordion wrapper as it's already set on the lists and was making the link click events fire twice; keeping it on the lists (instead of the wrapper) to be more explicit about what it impacts since the 'Show all' button also sets its (button click) tracking with a separate attribute inside the accordion
- removes explicitly setting `location` or `title` on the accordion link clicks; this makes `Document location URL` and `Document Title` flow from the pageview directly so that they are the URL and title of the page the accordion is on (so similar to the current homepage implementation)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
