### PR TITLE
Simplify 'More on this topic' heading on A-Z topics page

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -399,14 +399,10 @@ $topic-page-header-background-colour: #263135;
 }
 
 .topic-page__more-on-this-topic {
-  border-top-style: solid;
-  border-top-width: 2px;
-  border-top-color: $govuk-text-colour;
-  @include govuk-responsive-padding(3, "top");
-  @include govuk-responsive-margin(6, "top");
-  @include govuk-responsive-margin(4, "bottom");
+  margin-top: govuk-spacing(4);
 
   @include govuk-media-query($from: "tablet") {
-    @include govuk-responsive-margin(7, "top");
+    margin-top: govuk-spacing(7);
+    margin-bottom: govuk-spacing(1);
   }
 }

--- a/app/views/second_level_browse_page/new_show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/new_show_a_to_z.html.erb
@@ -51,7 +51,8 @@
               text: "More on this topic",
               heading_level: 2,
               font_size: "m",
-              margin_bottom: 1,
+              border_top: 2,
+              padding: true,
           } %>
         </div>
 


### PR DESCRIPTION
We want this heading to duplicate the 'More on this topic' one on the current homepage. However unlike that heading,
use the heading component to set the top border and padding. The visual style shouldn't change.

## Before (desktop):

![Screenshot 2022-05-05 at 18 07 17](https://user-images.githubusercontent.com/5007934/166980714-9fd8a309-efb3-4227-b9f9-043799782398.png)


## Before (mobile):
![Screenshot 2022-05-05 at 18 07 09](https://user-images.githubusercontent.com/5007934/166980733-c6c0e01d-0c56-4091-9555-8a55d32cbf52.png)

## After (desktop):

![Screenshot 2022-05-05 at 18 38 51](https://user-images.githubusercontent.com/5007934/166981166-b9f6a557-6a2d-4f40-b665-ecf570820f84.png)

## After (mobile):
![Screenshot 2022-05-05 at 18 39 45](https://user-images.githubusercontent.com/5007934/166981314-074be9d8-8caa-43bc-883f-99b4bf97f9f7.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
