### PR TITLE
Use new_links partial in the refactored 2nd level browse templates

### DIFF
--- a/app/views/second_level_browse_page/_new_links.html.erb
+++ b/app/views/second_level_browse_page/_new_links.html.erb
@@ -1,3 +1,5 @@
+<% track_action ||= "contentLink" %>
+
 <ul class="govuk-list" data-module="gem-track-click">
   <% list.each_with_index do |list_item, index| %>
     <li class="govuk-!-margin-bottom-4">
@@ -8,12 +10,12 @@
         data: {
           track_category: "browseClicked",
           track_count: "contentLink",
-          track_action: "contentLink",
+          track_action: track_action,
           track_label: list_item.base_path,
           track_options: {
-            dimension114: "#{list_index + 1}.#{index + 1}",
             dimension28: list.count.to_s,
             dimension29: list_item.title,
+            dimension114: "#{list_index + 1}.#{index + 1}",
           },
         },
       ) %>

--- a/app/views/second_level_browse_page/new_show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/new_show_a_to_z.html.erb
@@ -56,27 +56,7 @@
           } %>
         </div>
 
-        <ul class="govuk-list" data-module="gem-track-click">
-          <% page.related_topics.each_with_index do |related_topic, index| %>
-          <li class="govuk-!-margin-bottom-4">
-              <%= link_to(
-                related_topic.title,
-                related_topic.base_path,
-                class: "govuk-link",
-                data: {
-                  track_category: "browseClicked",
-                  track_action: "moreLink",
-                  track_label: related_topic.base_path,
-                  track_options: {
-                    dimension28: page.related_topics.count.to_s,
-                    dimension29: related_topic.title,
-                    dimension114: "#{page.lists.count + 1}.#{index + 1}",
-                  },
-                }
-              ) %>
-            </li>
-          <% end %>
-        </ul>
+        <%= render partial: "new_links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink" } %>
       <% end %>
     </div>
   </div>

--- a/app/views/second_level_browse_page/new_show_curated.html.erb
+++ b/app/views/second_level_browse_page/new_show_curated.html.erb
@@ -60,28 +60,7 @@
       %>
       <% if page.related_topics.any? %>
         <% more_on_this_topic_contents = capture do %>
-          <ul class="govuk-list" data-module="gem-track-click">
-            <% page.related_topics.each_with_index do |related_topic, index| %>
-            <li class="govuk-!-margin-bottom-4">
-                <%= link_to(
-                  related_topic.title,
-                  related_topic.base_path,
-                  class: "govuk-link",
-                  data: {
-                    track_category: "browseClicked",
-                    track_count: "contentLink",
-                    track_action: "moreLink",
-                    track_label: related_topic.base_path,
-                    track_options: {
-                      dimension28: page.related_topics.count.to_s,
-                      dimension29: related_topic.title,
-                      dimension114: "#{page.lists.count + 1}.#{index + 1}",
-                    },
-                  },
-                ) %>
-              </li>
-            <% end %>
-          </ul>
+          <%= render partial: "new_links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink" } %>
         <% end %>
 
         <%

--- a/app/views/shared/_topic_page_breadcrumbs.html.erb
+++ b/app/views/shared/_topic_page_breadcrumbs.html.erb
@@ -1,7 +1,7 @@
 <%
   column_two_thirds ||= false
 
-  column_classes = %w()
+  column_classes = %w[]
   column_classes << (column_two_thirds ? "govuk-grid-column-full" : "govuk-grid-column-two-thirds")
 %>
 


### PR DESCRIPTION
This PR addresses the suggested changes made in https://github.com/alphagov/collections/pull/2696#discussion_r864672508 and https://github.com/alphagov/collections/pull/2696#discussion_r830989865. 

Square brackets are now used in `_topic_page_breadcrumbs` partial. Where new_links could be used in the new templates, it has been used (with a small change made to accept a different value for `track_action` which is the only difference between the partial and the markup it is replacing.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
