### PR TITLE
Add colour contrast documentation for new grey

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -330,7 +330,16 @@ $transition-speed: .4s;
   }
 }
 
-// New background colour for the topic pages:
+// This dark grey is the background colour for the topic pages.
+//
+// White text on this background gives a contrast ratio of 13.35 - this meets AA
+// and AAA for body and large text.
+//
+// The focus state's yellow gives a contrast ratio of 9.91 - this meets the AA
+// requirement for active user interface components (AAA requirement is not
+// defined for this).
+//
+// Requirements source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
 $topic-page-header-background-colour: #263135;
 
 // This isn't proper BEM - but the convention is to have the view name as the


### PR DESCRIPTION
## What

Add comment explaining the colour contrast results for the use of the new darker grey.

## Why

So we can show that the new background colour meets the [WCAG 2.1 AA colour contrast requirements][1] - [MDN provides a slightly easier to read summary][2].

## Visual differences

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


[1]: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum
[2]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast
