### PR TITLE
Add the Knowledge Graph to users of the org api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,3 +26,4 @@ Please [add your application to this list](https://github.com/alphagov/collectio
 - [Signon](https://github.com/alphagov/signon/blob/53302a17ccfedca9914d15937a040d6b586dbebd/lib/organisations_fetcher.rb#L24)
 - [Support API](https://github.com/alphagov/support-api/blob/e6f4b9db213c6dd7b75aef832f12bf1da7070d4d/lib/organisation_importer.rb#L67)
 - [Transition config](https://github.com/alphagov/transition-config/blob/5c6e76f76646ff5e4db62b77bf6681d92d86f503/lib/redirector/organisations.rb#L9)
+- [Knowledge graph](https://github.com/alphagov/govuk-knowledge-graph/blob/9f51774c1cbaf9a9fe4121f94249940ff3446b7c/src/data/extract_organisation_api.py)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

As [requested](https://github.com/alphagov/collections/blob/main/docs/api.md), this adds an application to the list of users of the Organisations API.