### PR TITLE
Add GA4 analytics tracking attributes to accordion

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -6,7 +6,7 @@
   accordion_contents = []
   number_of_accordion_sections = accordions.length
 %>
-<% accordions.each do | section | %>
+<% accordions.each_with_index do | section, index | %>
   <% content = capture do %>
     <%# this element captures an override from the accordion that the last item has margin 0 %>
     <div class="covid__accordion-inner">
@@ -29,7 +29,16 @@
         track_action: "accordionClosed",
         track_label: section["title"],
         track_dimension: number_of_accordion_sections,
-        track_dimension_index: 26
+        track_dimension_index: 26,
+        gtm_event_name: "select_content",
+        gtm_attributes: {
+          gtm_ui_type: 'accordion',
+          gtm_ui_text: section["title"],
+          gtm_ui_index: index + 1,
+          gtm_ui_index_total: number_of_accordion_sections,
+          gtm_ui_section: 'n/a',
+          gtm_ui_state: 'n/a',
+        }
       }
     }
 
@@ -42,9 +51,9 @@
   text: heading,
   padding: heading_padding,
   border_top: border_top,
-  font_size: "m"  
+  font_size: "m"
 } if heading %>
-<div data-module="gem-track-click">
+<div data-module="gem-track-click gtm-click-tracking">
   <div data-module="toggle-attribute">
     <%= render 'govuk_publishing_components/components/accordion', {
       heading_level: 3,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Preliminary attempt to try to get GTM code working on integration. Note that this should only work on integration, where we have enabled the `dataLayer` using the [GTM component](https://components.publishing.service.gov.uk/component-guide/google_tag_manager_script). Applies to the accordion on the `/coronavirus` page.

Currently incomplete as we want `data-gtm-ui-state` to reflect the status of the accordion item when clicked (opened or closed) and this has not been implemented yet.

## Why
We want to experiment to see if we can get some data events to work and show up in GA.

## Visual changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions
