### PR TITLE
Update Italian language translation

### DIFF
--- a/config/locales/it/shared.yml
+++ b/config/locales/it/shared.yml
@@ -7,6 +7,6 @@ it:
       title: Visita GOV.UK
     get_emails: Ricevi e-mail su questo argomento
     language_direction: ltr
-    language_name: Inglese
+    language_name: Italiano
     topics:
       title: "%{title}: informazioni dettagliate"


### PR DESCRIPTION
This text is used in the translation_nav and it should be a translation of the
name of the foreign language. It was a translation of 'English' instead.

https://govuk.zendesk.com/agent/tickets/4966663

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
