### PR TITLE
Add language name and direction for Nepali

### DIFF
--- a/config/locales/ne/shared.yml
+++ b/config/locales/ne/shared.yml
@@ -6,7 +6,7 @@ ne:
       prefix:
       title:
     get_emails:
-    language_direction:
-    language_name:
+    language_direction: ltr
+    language_name: नेपाली
     topics:
       title:


### PR DESCRIPTION
This appeared to be missing from the locale files.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
