### PR TITLE
Update GTM analytics attributes

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -32,12 +32,12 @@
         track_dimension_index: 26,
         gtm_event_name: "select_content",
         gtm_attributes: {
-          gtm_ui_type: 'accordion',
-          gtm_ui_text: section["title"],
-          gtm_ui_index: index + 1,
-          gtm_ui_index_total: number_of_accordion_sections,
-          gtm_ui_section: 'n/a',
-          gtm_ui_state: 'n/a',
+          type: 'accordion',
+          text: section["title"],
+          index: index + 1,
+          'index-total': number_of_accordion_sections,
+          section: 'n/a',
+          state: 'n/a',
         }
       }
     }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Update the attributes for the GTM experiment on the coronavirus landing page accordion.

## Why
They were wrong.

## Visual changes
None.