### PR TITLE
Replaced archived govuk-content-schema-test-helpers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem "uglifier"
 
 group :test do
   gem "cucumber-rails", require: false
-  gem "govuk-content-schema-test-helpers"
   gem "govuk_schemas"
   gem "i18n-coverage"
   gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_ab_testing (2.4.2)
     govuk_app_config (4.6.0)
       logstasher (~> 2.1)
@@ -519,7 +517,6 @@ DEPENDENCIES
   faraday
   gds-api-adapters
   govspeak
-  govuk-content-schema-test-helpers
   govuk_ab_testing
   govuk_app_config
   govuk_document_types

--- a/spec/features/step_nav_page_spec.rb
+++ b/spec/features/step_nav_page_spec.rb
@@ -1,15 +1,8 @@
 require "integration_spec_helper"
-require "govuk-content-schema-test-helpers"
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "frontend" # or 'publisher_v2'
-  config.project_root = Rails.root
-end
 
 RSpec.feature "Step by step nav pages" do
   before do
-    sample = GovukContentSchemaTestHelpers::Examples.new.get("step_by_step_nav", "learn_to_drive_a_car")
-    content_item = JSON.parse(sample)
+    content_item = GovukSchemas::Example.find("step_by_step_nav", example_name: "learn_to_drive_a_car")
     stub_content_store_has_item(content_item["base_path"], content_item)
 
     visit content_item["base_path"]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello: https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem

# What's changed?
Replaces the govuk-content-schema-test-helpers gem with the govuk_schemas gem to validate content item schemas.

# Why?
[govuk-content-schema-test-helpers] has been archived and there is a concern that it no longer receives any security updates. The advice in the govuk-content-schema-test-helpers repo is to replace it with the govuk_schemas gem.

[govuk-content-schema-test-helpers]: https://github.com/alphagov/govuk-content-schema-test-helpers