### PR TITLE
Update accordion GTM analytics tracking

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -55,10 +55,22 @@
 } if heading %>
 <div data-module="gem-track-click gtm-click-tracking">
   <div data-module="toggle-attribute">
+    <%
+      show_all_attributes = {
+        type: "accordion",
+        index: 0,
+        "index-total": number_of_accordion_sections,
+        section: "n/a"
+      }
+    %>
     <%= render 'govuk_publishing_components/components/accordion', {
       heading_level: 3,
       data_attributes: {
         module: "govuk-accordion"
+      },
+      data_attributes_show_all: {
+        "gtm-event-name": "select_content",
+        "gtm-attributes": show_all_attributes.to_json
       },
       items: accordion_contents,
       margin_bottom: 3


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds data attributes to the accordion component on the /coronavirus page, which will be used to track clicks on the 'show/hide all' link.

Depends upon https://github.com/alphagov/govuk_publishing_components/pull/2786 but will fail silently without it.

## Why
We're testing the technical approach of implementing GTM. This is only going to be used for testing.

## Visual changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions
