### PR TITLE
Remove data-track-count from accordion component parameters

### DIFF
--- a/app/views/second_level_browse_page/new_show_curated.html.erb
+++ b/app/views/second_level_browse_page/new_show_curated.html.erb
@@ -85,7 +85,6 @@
           heading_level: 2,
           data_attributes: {
             module: "govuk-accordion",
-            track_count: "accordionSection"
           },
           items: accordion_contents,
           margin_bottom: 4,


### PR DESCRIPTION
## What

Remove data-track-count from the parameters of the `govuk_publishing_components` accordion.

## Why

Passing data-attributes to the accordion adds those attributes to the container of the accordions that the accordion component renders. This means that analytics will count the container itself and the accordions within the container instead of only counting the accordions. Therefore we need to remove it from the parameters of the accordion component but keep it on each of the accordion_contents to get the correct count of accordions on the page.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
