### PR TITLE
Render topical event title, summary and body text

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -1,0 +1,6 @@
+class TopicalEventsController < ApplicationController
+  def show
+    @topical_event = TopicalEvent.find!(request.path)
+    setup_content_item_and_navigation_helpers(@topical_event)
+  end
+end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -33,4 +33,12 @@ class TopicalEvent
       false
     end
   end
+
+  def about_page_url
+    "#{@content_item.content_item_data['base_path']}/about"
+  end
+
+  def about_page_link_text
+    @content_item.content_item_data.dig("details", "about_page_link_text")
+  end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -1,0 +1,12 @@
+class TopicalEvent
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -17,4 +17,8 @@ class TopicalEvent
   def description
     @content_item.content_item_data["description"]
   end
+
+  def body
+    @content_item.content_item_data.dig("details", "body")
+  end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -13,4 +13,8 @@ class TopicalEvent
   def title
     @content_item.content_item_data["title"]
   end
+
+  def description
+    @content_item.content_item_data["description"]
+  end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -9,4 +9,8 @@ class TopicalEvent
     content_item = ContentItem.find!(base_path)
     new(content_item)
   end
+
+  def title
+    @content_item.content_item_data["title"]
+  end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -21,4 +21,16 @@ class TopicalEvent
   def body
     @content_item.content_item_data.dig("details", "body")
   end
+
+  def end_date
+    Date.parse(@content_item.content_item_data.dig("details", "end_date")) if @content_item.content_item_data.dig("details", "end_date")
+  end
+
+  def archived?
+    if end_date && end_date <= Time.zone.today
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -20,5 +20,11 @@
       } do %>
         <%= @topical_event.body&.html_safe %>
     <% end %>
+
+    <% if @topical_event.about_page_link_text %>
+      <p class="govuk-body">
+        <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, html_options: { class: "govuk-link" }) %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -14,5 +14,10 @@
       text: @topical_event.description,
       margin_bottom: 8,
     } %>
+
+    <%= render "govuk_publishing_components/components/govspeak", {
+      } do %>
+        <%= @topical_event.body&.html_safe %>
+    <% end %>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,9 +1,18 @@
 <% content_for :title, @topical_event.title %>
 
+<% content_for :meta_tags do %>
+  <%= tag("meta", name: "description", content: @topical_event.description) if @topical_event.description %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       title: @topical_event.title,
+    } %>
+
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: @topical_event.description,
+      margin_bottom: 8,
     } %>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,5 +1,9 @@
+<% content_for :title, @topical_event.title %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: 'header' %>
+    <%= render "govuk_publishing_components/components/title", {
+      title: @topical_event.title,
+    } %>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: 'header' %>
+  </div>
+</div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -8,6 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       title: @topical_event.title,
+      context: (I18n.t("topical_events.archived") if @topical_event.archived?)
     } %>
 
     <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2,6 +2,37 @@
   "ignored_warnings": [
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 84,
+      "fingerprint": "0ffd823fe221f6cfb9711d2255444c4cc54492bd03be239fdaba0c90bba4fae6",
+      "check_name": "RenderInline",
+      "message": "Unescaped model attribute rendered inline",
+      "file": "app/views/topical_events/show.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross-site_scripting/",
+      "code": "render(text => TopicalEvent.find!(request.path).description, { :margin_bottom => 8 })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "TopicalEventsController",
+          "method": "show",
+          "line": 5,
+          "file": "app/controllers/topical_events_controller.rb",
+          "rendered": {
+            "name": "topical_events/show",
+            "file": "app/views/topical_events/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "topical_events/show"
+      },
+      "user_input": "TopicalEvent.find!(request.path).description",
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "6839f0707a62a6e7efbfc88e217576c072b74172a2e4bd09babf4481c0c0b657",
       "check_name": "CrossSiteScripting",
@@ -359,6 +390,6 @@
       "note": "This comes from the content store and we trust the data there."
     }
   ],
-  "updated": "2022-05-30 13:49:58 +0000",
+  "updated": "2022-05-30 14:29:48 +0000",
   "brakeman_version": "5.2.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -350,6 +350,37 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "db6929b90a4cde731a5169a155241f5be0b4e9dd39ca340009d598f6b54b1938",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/topical_events/show.html.erb",
+      "line": 20,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "TopicalEvent.find!(request.path).body",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "TopicalEventsController",
+          "method": "show",
+          "line": 5,
+          "file": "app/controllers/topical_events_controller.rb",
+          "rendered": {
+            "name": "topical_events/show",
+            "file": "app/views/topical_events/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "topical_events/show"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 84,
       "fingerprint": "fcdb8d748855278e7cb8d9639a2f0a4fd446d022d744162a440d2d967d0a2ae3",
       "check_name": "RenderInline",
@@ -390,6 +421,6 @@
       "note": "This comes from the content store and we trust the data there."
     }
   ],
-  "updated": "2022-05-30 14:29:48 +0000",
+  "updated": "2022-05-30 14:30:31 +0000",
   "brakeman_version": "5.2.2"
 }

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ar:
+  topical_events:
+    archived:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -1,0 +1,4 @@
+---
+az:
+  topical_events:
+    archived:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -1,0 +1,4 @@
+---
+be:
+  topical_events:
+    archived:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -1,0 +1,4 @@
+---
+bg:
+  topical_events:
+    archived:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -1,0 +1,4 @@
+---
+bn:
+  topical_events:
+    archived:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -1,0 +1,4 @@
+---
+cs:
+  topical_events:
+    archived:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -1,0 +1,4 @@
+---
+cy:
+  topical_events:
+    archived:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -1,0 +1,4 @@
+---
+da:
+  topical_events:
+    archived:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -1,0 +1,4 @@
+---
+de:
+  topical_events:
+    archived:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -1,0 +1,4 @@
+---
+dr:
+  topical_events:
+    archived:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -1,0 +1,4 @@
+---
+el:
+  topical_events:
+    archived:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -1,0 +1,4 @@
+---
+en:
+  topical_events:
+    archived: "(Archived)"

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -1,0 +1,4 @@
+---
+es-419:
+  topical_events:
+    archived:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -1,0 +1,4 @@
+---
+es:
+  topical_events:
+    archived:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -1,0 +1,4 @@
+---
+et:
+  topical_events:
+    archived:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -1,0 +1,4 @@
+---
+fa:
+  topical_events:
+    archived:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -1,0 +1,4 @@
+---
+fi:
+  topical_events:
+    archived:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -1,0 +1,4 @@
+---
+fr:
+  topical_events:
+    archived:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -1,0 +1,4 @@
+---
+gd:
+  topical_events:
+    archived:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -1,0 +1,4 @@
+---
+gu:
+  topical_events:
+    archived:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -1,0 +1,4 @@
+---
+he:
+  topical_events:
+    archived:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -1,0 +1,4 @@
+---
+hi:
+  topical_events:
+    archived:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -1,0 +1,4 @@
+---
+hr:
+  topical_events:
+    archived:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -1,0 +1,4 @@
+---
+hu:
+  topical_events:
+    archived:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -1,0 +1,4 @@
+---
+hy:
+  topical_events:
+    archived:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -1,0 +1,4 @@
+---
+id:
+  topical_events:
+    archived:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -1,0 +1,4 @@
+---
+is:
+  topical_events:
+    archived:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -1,0 +1,4 @@
+---
+it:
+  topical_events:
+    archived:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ja:
+  topical_events:
+    archived:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ka:
+  topical_events:
+    archived:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+kk:
+  topical_events:
+    archived:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ko:
+  topical_events:
+    archived:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -1,0 +1,4 @@
+---
+lt:
+  topical_events:
+    archived:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -1,0 +1,4 @@
+---
+lv:
+  topical_events:
+    archived:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ms:
+  topical_events:
+    archived:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -1,0 +1,4 @@
+---
+mt:
+  topical_events:
+    archived:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ne:
+  topical_events:
+    archived:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -1,0 +1,4 @@
+---
+nl:
+  topical_events:
+    archived:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -1,0 +1,4 @@
+---
+'no':
+  topical_events:
+    archived:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+pa-pk:
+  topical_events:
+    archived:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -1,0 +1,4 @@
+---
+pa:
+  topical_events:
+    archived:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -1,0 +1,4 @@
+---
+pl:
+  topical_events:
+    archived:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ps:
+  topical_events:
+    archived:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -1,0 +1,4 @@
+---
+pt:
+  topical_events:
+    archived:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ro:
+  topical_events:
+    archived:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ru:
+  topical_events:
+    archived:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -1,0 +1,4 @@
+---
+si:
+  topical_events:
+    archived:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sk:
+  topical_events:
+    archived:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sl:
+  topical_events:
+    archived:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -1,0 +1,4 @@
+---
+so:
+  topical_events:
+    archived:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sq:
+  topical_events:
+    archived:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sr:
+  topical_events:
+    archived:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sv:
+  topical_events:
+    archived:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -1,0 +1,4 @@
+---
+sw:
+  topical_events:
+    archived:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ta:
+  topical_events:
+    archived:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -1,0 +1,4 @@
+---
+th:
+  topical_events:
+    archived:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+tk:
+  topical_events:
+    archived:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -1,0 +1,4 @@
+---
+tr:
+  topical_events:
+    archived:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+uk:
+  topical_events:
+    archived:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -1,0 +1,4 @@
+---
+ur:
+  topical_events:
+    archived:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -1,0 +1,4 @@
+---
+uz:
+  topical_events:
+    archived:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -1,0 +1,4 @@
+---
+vi:
+  topical_events:
+    archived:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -1,0 +1,4 @@
+---
+yi:
+  topical_events:
+    archived:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -1,0 +1,4 @@
+---
+zh-hk:
+  topical_events:
+    archived:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -1,0 +1,4 @@
+---
+zh-tw:
+  topical_events:
+    archived:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -1,0 +1,4 @@
+---
+zh:
+  topical_events:
+    archived:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
   get "/government/people/:name(.:locale)", to: "people#show"
   get "/government/ministers(.:locale)", to: "ministers#index"
   get "/government/ministers/:name(.:locale)", to: "roles#show"
+  get "/government/topical-events/:name", to: "topical_events#show"
 
   scope :api, defaults: { format: :json } do
     get "/organisations",

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature "Topical Event pages" do
       "base_path" => base_path,
       "title" => "Something very topical",
       "description" => "This event is happening soon",
+      "details" => {
+        "body" => "This is a very important topical event.",
+      },
     }
   end
 
@@ -27,5 +30,10 @@ RSpec.feature "Topical Event pages" do
   it "sets the page meta description" do
     visit base_path
     expect(page).to have_selector("meta[name='description'][content='#{content_item['description']}']", visible: :hidden)
+  end
+
+  it "sets the body text" do
+    visit base_path
+    expect(page).to have_text(content_item.dig("details", "body"))
   end
 end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -4,10 +4,12 @@ RSpec.feature "Topical Event pages" do
   let(:base_path) { "/government/topical-events/something-very-topical" }
   let(:content_item) do
     {
+      "about_page_link_text" => "Read more about this event",
       "base_path" => base_path,
       "title" => "Something very topical",
       "description" => "This event is happening soon",
       "details" => {
+        "about_page_link_text" => "Read more about this event",
         "body" => "This is a very important topical event.",
         "end_date" => "2016-04-28T00:00:00+00:00",
       },
@@ -54,5 +56,10 @@ RSpec.feature "Topical Event pages" do
         expect(page).to have_text("Archived")
       end
     end
+  end
+
+  it "includes a link to the about page" do
+    visit base_path
+    expect(page).to have_link(content_item.dig("details", "about_page_link_text"), href: "#{base_path}/about")
   end
 end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -1,0 +1,14 @@
+require "integration_spec_helper"
+
+RSpec.feature "Topical Event pages" do
+  let(:base_path) { "/government/topical-events/something-very-topical" }
+  let(:content_item) do
+    {
+      "base_path" => base_path,
+    }
+  end
+
+  before do
+    stub_content_store_has_item(base_path, content_item)
+  end
+end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Topical Event pages" do
       "description" => "This event is happening soon",
       "details" => {
         "body" => "This is a very important topical event.",
+        "end_date" => "2016-04-28T00:00:00+00:00",
       },
     }
   end
@@ -35,5 +36,23 @@ RSpec.feature "Topical Event pages" do
   it "sets the body text" do
     visit base_path
     expect(page).to have_text(content_item.dig("details", "body"))
+  end
+
+  context "when the event is current" do
+    it "does not show the archived text" do
+      Timecop.freeze("2016-04-18") do
+        visit base_path
+        expect(page).not_to have_text("Archived")
+      end
+    end
+  end
+
+  context "when the event is archived" do
+    it "shows the archived text" do
+      Timecop.freeze("2016-05-18") do
+        visit base_path
+        expect(page).to have_text("Archived")
+      end
+    end
   end
 end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -5,10 +5,16 @@ RSpec.feature "Topical Event pages" do
   let(:content_item) do
     {
       "base_path" => base_path,
+      "title" => "Something very topical",
     }
   end
 
   before do
     stub_content_store_has_item(base_path, content_item)
+  end
+
+  it "sets the page title" do
+    visit base_path
+    expect(page).to have_title("#{content_item['title']} - GOV.UK")
   end
 end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Topical Event pages" do
     {
       "base_path" => base_path,
       "title" => "Something very topical",
+      "description" => "This event is happening soon",
     }
   end
 
@@ -16,5 +17,15 @@ RSpec.feature "Topical Event pages" do
   it "sets the page title" do
     visit base_path
     expect(page).to have_title("#{content_item['title']} - GOV.UK")
+  end
+
+  it "sets the page description" do
+    visit base_path
+    expect(page).to have_text(content_item["description"])
+  end
+
+  it "sets the page meta description" do
+    visit base_path
+    expect(page).to have_selector("meta[name='description'][content='#{content_item['description']}']", visible: :hidden)
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe TopicalEvent do
       "title" => "Something very topical",
       "description" => "This event is happening soon",
       "details" => {
+        "about_page_link_text" => "Read more about this event",
         "body" => "This is a very important topical event.",
         "end_date" => "2016-04-28T00:00:00+00:00",
       },
@@ -40,5 +41,13 @@ RSpec.describe TopicalEvent do
         expect(topical_event.archived?).to be true
       end
     end
+  end
+
+  it "should have about link link" do
+    expect(topical_event.about_page_url).to eq("#{base_path}/about")
+  end
+
+  it "should have about link text" do
+    expect(topical_event.about_page_link_text).to eq("Read more about this event")
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TopicalEvent do
     {
       "base_path" => base_path,
       "title" => "Something very topical",
+      "description" => "This event is happening soon",
     }
   end
   let(:content_item) { ContentItem.new(api_data) }
@@ -11,5 +12,9 @@ RSpec.describe TopicalEvent do
 
   it "should have a title" do
     expect(topical_event.title).to eq("Something very topical")
+  end
+
+  it "should have a description" do
+    expect(topical_event.description).to eq("This event is happening soon")
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -3,8 +3,13 @@ RSpec.describe TopicalEvent do
   let(:api_data) do
     {
       "base_path" => base_path,
+      "title" => "Something very topical",
     }
   end
   let(:content_item) { ContentItem.new(api_data) }
   let(:topical_event) { described_class.new(content_item) }
+
+  it "should have a title" do
+    expect(topical_event.title).to eq("Something very topical")
+  end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe TopicalEvent do
       "base_path" => base_path,
       "title" => "Something very topical",
       "description" => "This event is happening soon",
+      "details" => {
+        "body" => "This is a very important topical event.",
+      },
     }
   end
   let(:content_item) { ContentItem.new(api_data) }
@@ -16,5 +19,9 @@ RSpec.describe TopicalEvent do
 
   it "should have a description" do
     expect(topical_event.description).to eq("This event is happening soon")
+  end
+
+  it "show have body text" do
+    expect(topical_event.body).to eq("This is a very important topical event.")
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TopicalEvent do
       "description" => "This event is happening soon",
       "details" => {
         "body" => "This is a very important topical event.",
+        "end_date" => "2016-04-28T00:00:00+00:00",
       },
     }
   end
@@ -23,5 +24,21 @@ RSpec.describe TopicalEvent do
 
   it "show have body text" do
     expect(topical_event.body).to eq("This is a very important topical event.")
+  end
+
+  context "when the event is current" do
+    it "does not mark as archived" do
+      Timecop.freeze("2016-04-18") do
+        expect(topical_event.archived?).to be false
+      end
+    end
+  end
+
+  context "when the event is archived" do
+    it "shows the archived text" do
+      Timecop.freeze("2016-05-18") do
+        expect(topical_event.archived?).to be true
+      end
+    end
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe TopicalEvent do
+  let(:base_path) { "/government/topical-events/something-very-topical" }
+  let(:api_data) do
+    {
+      "base_path" => base_path,
+    }
+  end
+  let(:content_item) { ContentItem.new(api_data) }
+  let(:topical_event) { described_class.new(content_item) }
+end


### PR DESCRIPTION
This allows Collections to render Topical Event pages.  It only includes the event's title, summary, body text and archived status.

Other parts of the page will be added in later work.  The horizontal line between the two sections will be added as part of the organisation logos.  The image needs to be added to the content item and will be added to this view separately.

This is dependent on the following PRs being merged (and existing topical events republished to Publishing API):
- https://github.com/alphagov/govuk-content-schemas/pull/1097
- https://github.com/alphagov/whitehall/pull/6583
- https://github.com/alphagov/govuk-content-schemas/pull/1099
- https://github.com/alphagov/whitehall/pull/6588

Router currently points all topical event pages to Whitehall, so this is safe to merge and deploy, despite the page not being fully completed yet.

## Example topical event rendered by Collections
![Screenshot of a topical event on GOV.UK, including the standard GOV.UK header plus the event's title, summary, body and archived status.  The rendering is visually identical to the same features rendered by Whitehall.](https://user-images.githubusercontent.com/6329861/170992978-25a96a64-bad4-4775-89c4-7048c9d5414e.png)

## Example topical event rendered by Whitehall
![Screenshot of a topical event on GOV.UK as it is at the moment.  Compared to the Collections rendered version, there is also an image, social media links and organisation names.](https://user-images.githubusercontent.com/6329861/170993002-cc02de14-b0db-42df-b507-aff08c1ac67e.png)

[Trello card](https://trello.com/c/zpFXy34H)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
