### PR TITLE
Render social media links on Topical Event page

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -41,4 +41,14 @@ class TopicalEvent
   def about_page_link_text
     @content_item.content_item_data.dig("details", "about_page_link_text")
   end
+
+  def social_media_links
+    @content_item.content_item_data.dig("details", "social_media_links").map do |social_media_link|
+      {
+        href: social_media_link["href"],
+        text: social_media_link["title"],
+        icon: social_media_link["service_type"],
+      }
+    end
+  end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -26,5 +26,11 @@
         <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, html_options: { class: "govuk-link" }) %>
       </p>
     <% end %>
+
+    <% if @topical_event.social_media_links %>
+      <%= render "govuk_publishing_components/components/share_links", {
+        links: @topical_event.social_media_links,
+      } %>
+    <% end %>
   </div>
 </div>

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -1,32 +1,8 @@
 require "integration_spec_helper"
 
 RSpec.feature "Topical Event pages" do
-  let(:base_path) { "/government/topical-events/something-very-topical" }
-  let(:content_item) do
-    {
-      "about_page_link_text" => "Read more about this event",
-      "base_path" => base_path,
-      "title" => "Something very topical",
-      "description" => "This event is happening soon",
-      "details" => {
-        "about_page_link_text" => "Read more about this event",
-        "body" => "This is a very important topical event.",
-        "end_date" => "2016-04-28T00:00:00+00:00",
-        "social_media_links" => [
-          {
-            "href" => "https://www.facebook.com/a-topical-event",
-            "title" => "Facebook",
-            "service_type" => "facebook",
-          },
-          {
-            "href" => "https://www.twitter.com/a-topical-event",
-            "title" => "Twitter",
-            "service_type" => "twitter",
-          },
-        ],
-      },
-    }
-  end
+  let(:content_item) { fetch_fixture("topical_event") }
+  let(:base_path) { content_item["base_path"] }
 
   before do
     stub_content_store_has_item(base_path, content_item)
@@ -79,5 +55,14 @@ RSpec.feature "Topical Event pages" do
     visit base_path
     expect(page).to have_link("Facebook", href: "https://www.facebook.com/a-topical-event")
     expect(page).to have_link("Twitter", href: "https://www.twitter.com/a-topical-event")
+  end
+
+private
+
+  def fetch_fixture(filename)
+    json = File.read(
+      Rails.root.join("spec", "fixtures", "content_store", "#{filename}.json"),
+    )
+    JSON.parse(json)
   end
 end

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -12,6 +12,18 @@ RSpec.feature "Topical Event pages" do
         "about_page_link_text" => "Read more about this event",
         "body" => "This is a very important topical event.",
         "end_date" => "2016-04-28T00:00:00+00:00",
+        "social_media_links" => [
+          {
+            "href" => "https://www.facebook.com/a-topical-event",
+            "title" => "Facebook",
+            "service_type" => "facebook",
+          },
+          {
+            "href" => "https://www.twitter.com/a-topical-event",
+            "title" => "Twitter",
+            "service_type" => "twitter",
+          },
+        ],
       },
     }
   end
@@ -61,5 +73,11 @@ RSpec.feature "Topical Event pages" do
   it "includes a link to the about page" do
     visit base_path
     expect(page).to have_link(content_item.dig("details", "about_page_link_text"), href: "#{base_path}/about")
+  end
+
+  it "includes links to the social media accounts" do
+    visit base_path
+    expect(page).to have_link("Facebook", href: "https://www.facebook.com/a-topical-event")
+    expect(page).to have_link("Twitter", href: "https://www.twitter.com/a-topical-event")
   end
 end

--- a/spec/fixtures/content_store/topical_event.json
+++ b/spec/fixtures/content_store/topical_event.json
@@ -1,0 +1,22 @@
+{
+  "base_path": "/government/topical-events/something-very-topical",
+  "title": "Something very topical",
+  "description": "This event is happening soon",
+  "details": {
+    "about_page_link_text": "Read more about this event",
+    "body": "This is a very important topical event.",
+    "end_date": "2016-04-28T00:00:00+00:00",
+    "social_media_links": [
+      {
+        "href": "https://www.facebook.com/a-topical-event",
+        "title": "Facebook",
+        "service_type": "facebook"
+      },
+      {
+        "href": "https://www.twitter.com/a-topical-event",
+        "title": "Twitter",
+        "service_type": "twitter"
+      }
+    ]
+  }
+}

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -1,30 +1,7 @@
 RSpec.describe TopicalEvent do
-  let(:base_path) { "/government/topical-events/something-very-topical" }
-  let(:api_data) do
-    {
-      "base_path" => base_path,
-      "title" => "Something very topical",
-      "description" => "This event is happening soon",
-      "details" => {
-        "about_page_link_text" => "Read more about this event",
-        "body" => "This is a very important topical event.",
-        "end_date" => "2016-04-28T00:00:00+00:00",
-        "social_media_links" => [
-          {
-            "href" => "https://www.facebook.com/a-topical-event",
-            "title" => "Facebook",
-            "service_type" => "facebook",
-          },
-          {
-            "href" => "https://www.twitter.com/a-topical-event",
-            "title" => "Twitter",
-            "service_type" => "twitter",
-          },
-        ],
-      },
-    }
-  end
+  let(:api_data) { fetch_fixture("topical_event") }
   let(:content_item) { ContentItem.new(api_data) }
+  let(:base_path) { content_item.base_path }
   let(:topical_event) { described_class.new(content_item) }
 
   it "should have a title" do
@@ -76,5 +53,14 @@ RSpec.describe TopicalEvent do
         icon: "twitter",
       },
     ])
+  end
+
+private
+
+  def fetch_fixture(filename)
+    json = File.read(
+      Rails.root.join("spec", "fixtures", "content_store", "#{filename}.json"),
+    )
+    JSON.parse(json)
   end
 end

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe TopicalEvent do
         "about_page_link_text" => "Read more about this event",
         "body" => "This is a very important topical event.",
         "end_date" => "2016-04-28T00:00:00+00:00",
+        "social_media_links" => [
+          {
+            "href" => "https://www.facebook.com/a-topical-event",
+            "title" => "Facebook",
+            "service_type" => "facebook",
+          },
+          {
+            "href" => "https://www.twitter.com/a-topical-event",
+            "title" => "Twitter",
+            "service_type" => "twitter",
+          },
+        ],
       },
     }
   end
@@ -49,5 +61,20 @@ RSpec.describe TopicalEvent do
 
   it "should have about link text" do
     expect(topical_event.about_page_link_text).to eq("Read more about this event")
+  end
+
+  it "should map the social media links" do
+    expect(topical_event.social_media_links).to eq([
+      {
+        href: "https://www.facebook.com/a-topical-event",
+        text: "Facebook",
+        icon: "facebook",
+      },
+      {
+        href: "https://www.twitter.com/a-topical-event",
+        text: "Twitter",
+        icon: "twitter",
+      },
+    ])
   end
 end


### PR DESCRIPTION
This adds the social media links to the Topical Event pages.

Router currently points all topical event pages to Whitehall, so this is safe to merge and deploy, despite the page not being fully completed yet.

## Example topical event page
![Screenshot showing a topical event page rendered by Collections.  Under the body, there are links to Facebook and Twitter.  The links include the icons for the social media sites.](https://user-images.githubusercontent.com/6329861/171198669-8e70952f-f36c-4373-8987-fdaabe913a04.png)

[Trello card](https://trello.com/c/mXhNcdFk)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
