### PR TITLE
Render featured documents on Topical Event page

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -51,4 +51,16 @@ class TopicalEvent
       }
     end
   end
+
+  def ordered_featured_documents
+    @content_item.content_item_data.dig("details", "ordered_featured_documents").map do |document|
+      {
+        href: document["href"],
+        image_src: document.dig("image", "url"),
+        image_alt: document.dig("image", "alt_text"),
+        heading_text: document["title"],
+        description: document["summary"],
+      }
+    end
+  end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -33,4 +33,26 @@
       } %>
     <% end %>
   </div>
+
+  <div class="govuk-grid-column-full">
+    <% if @topical_event.ordered_featured_documents %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.featured"),
+        padding: true,
+        font_size: "l",
+        border_top: 2,
+        margin_bottom: 4,
+      } %>
+
+      <% @topical_event.ordered_featured_documents.in_groups_of(3, false) do |row| %>
+        <div class="govuk-grid-row">
+          <% row.each do |document| %>
+            <div class="govuk-grid-column-one-third">
+              <%= render "govuk_publishing_components/components/image_card", document %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -2,3 +2,4 @@
 ar:
   topical_events:
     archived:
+    featured:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -2,3 +2,4 @@
 az:
   topical_events:
     archived:
+    featured:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -2,3 +2,4 @@
 be:
   topical_events:
     archived:
+    featured:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -2,3 +2,4 @@
 bg:
   topical_events:
     archived:
+    featured:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -2,3 +2,4 @@
 bn:
   topical_events:
     archived:
+    featured:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -2,3 +2,4 @@
 cs:
   topical_events:
     archived:
+    featured:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -2,3 +2,4 @@
 cy:
   topical_events:
     archived:
+    featured:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -2,3 +2,4 @@
 da:
   topical_events:
     archived:
+    featured:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -2,3 +2,4 @@
 de:
   topical_events:
     archived:
+    featured:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -2,3 +2,4 @@
 dr:
   topical_events:
     archived:
+    featured:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -2,3 +2,4 @@
 el:
   topical_events:
     archived:
+    featured:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -2,3 +2,4 @@
 en:
   topical_events:
     archived: "(Archived)"
+    featured: "Featured"

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -2,3 +2,4 @@
 es-419:
   topical_events:
     archived:
+    featured:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -2,3 +2,4 @@
 es:
   topical_events:
     archived:
+    featured:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -2,3 +2,4 @@
 et:
   topical_events:
     archived:
+    featured:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -2,3 +2,4 @@
 fa:
   topical_events:
     archived:
+    featured:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -2,3 +2,4 @@
 fi:
   topical_events:
     archived:
+    featured:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -2,3 +2,4 @@
 fr:
   topical_events:
     archived:
+    featured:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -2,3 +2,4 @@
 gd:
   topical_events:
     archived:
+    featured:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -2,3 +2,4 @@
 gu:
   topical_events:
     archived:
+    featured:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -2,3 +2,4 @@
 he:
   topical_events:
     archived:
+    featured:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -2,3 +2,4 @@
 hi:
   topical_events:
     archived:
+    featured:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -2,3 +2,4 @@
 hr:
   topical_events:
     archived:
+    featured:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -2,3 +2,4 @@
 hu:
   topical_events:
     archived:
+    featured:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -2,3 +2,4 @@
 hy:
   topical_events:
     archived:
+    featured:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -2,3 +2,4 @@
 id:
   topical_events:
     archived:
+    featured:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -2,3 +2,4 @@
 is:
   topical_events:
     archived:
+    featured:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -2,3 +2,4 @@
 it:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -2,3 +2,4 @@
 ja:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -2,3 +2,4 @@
 ka:
   topical_events:
     archived:
+    featured:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -2,3 +2,4 @@
 kk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -2,3 +2,4 @@
 ko:
   topical_events:
     archived:
+    featured:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -2,3 +2,4 @@
 lt:
   topical_events:
     archived:
+    featured:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -2,3 +2,4 @@
 lv:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -2,3 +2,4 @@
 ms:
   topical_events:
     archived:
+    featured:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -2,3 +2,4 @@
 mt:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -2,3 +2,4 @@
 ne:
   topical_events:
     archived:
+    featured:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -2,3 +2,4 @@
 nl:
   topical_events:
     archived:
+    featured:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -2,3 +2,4 @@
 'no':
   topical_events:
     archived:
+    featured:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -2,3 +2,4 @@
 pa-pk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -2,3 +2,4 @@
 pa:
   topical_events:
     archived:
+    featured:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -2,3 +2,4 @@
 pl:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -2,3 +2,4 @@
 ps:
   topical_events:
     archived:
+    featured:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -2,3 +2,4 @@
 pt:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -2,3 +2,4 @@
 ro:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -2,3 +2,4 @@
 ru:
   topical_events:
     archived:
+    featured:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -2,3 +2,4 @@
 si:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -2,3 +2,4 @@
 sk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -2,3 +2,4 @@
 sl:
   topical_events:
     archived:
+    featured:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -2,3 +2,4 @@
 so:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -2,3 +2,4 @@
 sq:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -2,3 +2,4 @@
 sr:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -2,3 +2,4 @@
 sv:
   topical_events:
     archived:
+    featured:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -2,3 +2,4 @@
 sw:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -2,3 +2,4 @@
 ta:
   topical_events:
     archived:
+    featured:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -2,3 +2,4 @@
 th:
   topical_events:
     archived:
+    featured:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -2,3 +2,4 @@
 tk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -2,3 +2,4 @@
 tr:
   topical_events:
     archived:
+    featured:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -2,3 +2,4 @@
 uk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -2,3 +2,4 @@
 ur:
   topical_events:
     archived:
+    featured:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -2,3 +2,4 @@
 uz:
   topical_events:
     archived:
+    featured:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -2,3 +2,4 @@
 vi:
   topical_events:
     archived:
+    featured:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -2,3 +2,4 @@
 yi:
   topical_events:
     archived:
+    featured:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -2,3 +2,4 @@
 zh-hk:
   topical_events:
     archived:
+    featured:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -2,3 +2,4 @@
 zh-tw:
   topical_events:
     archived:
+    featured:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -2,3 +2,4 @@
 zh:
   topical_events:
     archived:
+    featured:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -57,6 +57,11 @@ RSpec.feature "Topical Event pages" do
     expect(page).to have_link("Twitter", href: "https://www.twitter.com/a-topical-event")
   end
 
+  it "includes links to the featured documents" do
+    visit base_path
+    expect(page).to have_link("A document related to this event", href: "https://www.gov.uk/somewhere")
+  end
+
 private
 
   def fetch_fixture(filename)

--- a/spec/fixtures/content_store/topical_event.json
+++ b/spec/fixtures/content_store/topical_event.json
@@ -6,6 +6,17 @@
     "about_page_link_text": "Read more about this event",
     "body": "This is a very important topical event.",
     "end_date": "2016-04-28T00:00:00+00:00",
+    "ordered_featured_documents": [
+      {
+        "href": "https://www.gov.uk/somewhere",
+        "image": {
+          "url": "https://www.gov.uk/someimage.png",
+          "alt_text": "Alt text for the image"
+        },
+        "title": "A document related to this event",
+        "summary": "Very interesting document content."
+      }
+    ],
     "social_media_links": [
       {
         "href": "https://www.facebook.com/a-topical-event",

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe TopicalEvent do
     ])
   end
 
+  it "should map the social media links" do
+    expect(topical_event.ordered_featured_documents).to eq([
+      {
+        href: "https://www.gov.uk/somewhere",
+        image_src: "https://www.gov.uk/someimage.png",
+        image_alt: "Alt text for the image",
+        heading_text: "A document related to this event",
+        description: "Very interesting document content.",
+      },
+    ])
+  end
+
 private
 
   def fetch_fixture(filename)


### PR DESCRIPTION
This adds the featured document links to the Topical Event pages.

Router currently points all topical event pages to Whitehall, so this is safe to merge and deploy, despite the page not being fully completed yet.

## Example topical event page
![Screenshot showing a topical event page.  There is a section headed 'Featured', which includes a number of image cards.  Each has a image, header (i.e. the document's title) and a summary.  The header links to the document.](https://user-images.githubusercontent.com/6329861/171407175-4371ad91-d99f-49c1-bd76-a18eece85420.png)

[Trello card](https://trello.com/c/WwxYigCm)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
