### PR TITLE
Render document lists on Topical Event page

### DIFF
--- a/app/helpers/topical_events_helper.rb
+++ b/app/helpers/topical_events_helper.rb
@@ -1,0 +1,31 @@
+module TopicalEventsHelper
+  def search_url(content_type, slug)
+    base_path(content_type) + query_params(content_type, slug).to_param
+  end
+
+private
+
+  def base_path(content_type)
+    { publication: "/search/all?",
+      consultation: "/search/policy-papers-and-consultations?",
+      announcement: "/search/news-and-communications?" }[content_type]
+  end
+
+  def query_params(content_type, slug)
+    case content_type
+    when :publication
+      {
+        topical_events: [slug],
+      }
+    when :consultation
+      {
+        content_store_document_type: %w[open_consultations closed_consultations],
+        topical_events: [slug],
+      }
+    when :announcement
+      {
+        topical_events: [slug],
+      }
+    end
+  end
+end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -3,6 +3,7 @@ class TopicalEvent
 
   def initialize(content_item)
     @content_item = content_item
+    @documents_service = TopicalEventsDocuments.new(slug)
   end
 
   def self.find!(base_path)
@@ -81,5 +82,28 @@ class TopicalEvent
 
     advice = ContentItem.find!("/foreign-travel-advice/afghanistan").to_hash
     [advice.slice("base_path", "title")]
+  end
+
+  def publications
+    @publications ||= @documents_service.fetch_related_documents_with_format({ filter_format: "publication" })
+  end
+
+  def consultations
+    @consultations ||= @documents_service.fetch_related_documents_with_format({ filter_format: "consultation" })
+  end
+
+  def announcements
+    announcement_document_types = %w[
+      press_release
+      news_article
+      news_story
+      fatality_notice
+      speech
+      written_statement
+      oral_statement
+      authored_article
+      government_response
+    ]
+    @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_store_document_type: announcement_document_types })
   end
 end

--- a/app/services/search_api_fields.rb
+++ b/app/services/search_api_fields.rb
@@ -13,4 +13,15 @@ module SearchApiFields
                           description
                           display_type
                           public_timestamp].freeze
+
+  TOPICAL_EVENTS_SEARCH_FIELDS = %w[display_type
+                                    title
+                                    link
+                                    public_timestamp
+                                    format
+                                    content_store_document_type
+                                    description
+                                    content_id
+                                    organisations
+                                    document_collections].freeze
 end

--- a/app/services/topical_events_documents.rb
+++ b/app/services/topical_events_documents.rb
@@ -1,0 +1,41 @@
+class TopicalEventsDocuments
+  include SearchApiFields
+
+  def initialize(slug)
+    @slug = slug
+  end
+
+  def fetch_related_documents_with_format(filter_format)
+    search_response = Services.search_api.search(default_search_options.merge(filter_format))
+    format_results(search_response)
+  end
+
+private
+
+  def default_search_options
+    { filter_topical_events: [@slug],
+      count: 3,
+      order: "-public_timestamp",
+      fields: TOPICAL_EVENTS_SEARCH_FIELDS }
+  end
+
+  def display_type(document)
+    key = document.fetch("display_type", nil) || document.fetch("content_store_document_type", "")
+    key.humanize
+  end
+
+  def format_results(search_response)
+    search_response["results"].map do |document|
+      {
+        link: {
+          text: document["title"],
+          path: document["link"],
+        },
+        metadata: {
+          public_updated_at: Time.zone.parse(document["public_timestamp"]),
+          document_type: display_type(document),
+        },
+      }
+    end
+  end
+end

--- a/app/views/topical_events/_document_list_from_search_api.html.erb
+++ b/app/views/topical_events/_document_list_from_search_api.html.erb
@@ -1,0 +1,32 @@
+<section id="<%= heading.downcase.parameterize %>" class="document-block">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: heading,
+    padding: true,
+    font_size: 27,
+    margin_bottom: 3,
+  } %>
+
+    <%= render "govuk_publishing_components/components/document_list", {
+      items: documents,
+      margin_bottom: 6,
+    } %>
+
+  <p class="govuk-body">
+    <%=
+      link_to(
+        "See all #{heading.downcase}",
+        link_to,
+        class: "govuk-link",
+        data: {
+          track_category: 'navPolicyAreaLinkClicked',
+          track_action: "#{heading}",
+          track_label: link_to,
+          track_options: {
+            dimension28: documents.size.to_s,
+            dimension29: "See all #{heading.downcase}"
+          }
+        }
+      )
+    %>
+  </p>
+</section>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -69,47 +69,9 @@
       } %>
     <% end %>
 
-    <% if @topical_event.publications.any? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.publications"),
-        padding: true,
-        font_size: 27,
-        margin_bottom: 3,
-      } %>
-
-      <%= render "govuk_publishing_components/components/document_list", {
-        items: @topical_event.publications,
-        margin_bottom: 6,
-      } %>
-    <% end %>
-
-    <% if @topical_event.consultations.any? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.consultations"),
-        padding: true,
-        font_size: 27,
-        margin_bottom: 3,
-      } %>
-
-      <%= render "govuk_publishing_components/components/document_list", {
-        items: @topical_event.consultations,
-        margin_bottom: 6,
-      } %>
-    <% end %>
-
-    <% if @topical_event.announcements.any? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.announcements"),
-        padding: true,
-        font_size: 27,
-        margin_bottom: 3,
-      } %>
-
-      <%= render "govuk_publishing_components/components/document_list", {
-        items: @topical_event.announcements,
-        margin_bottom: 6,
-      } %>
-    <% end %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.publications"), link_to: search_url(:publication, @topical_event.slug) }) if @topical_event.publications.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.consultations"), link_to: search_url(:consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.announcements"), link_to: search_url(:announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -58,6 +58,58 @@
         </div>
       <% end %>
     <% end %>
+
+    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.documents"),
+        padding: true,
+        font_size: "l",
+        border_top: 2,
+        margin_bottom: 3,
+      } %>
+    <% end %>
+
+    <% if @topical_event.publications.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.publications"),
+        padding: true,
+        font_size: 27,
+        margin_bottom: 3,
+      } %>
+
+      <%= render "govuk_publishing_components/components/document_list", {
+        items: @topical_event.publications,
+        margin_bottom: 6,
+      } %>
+    <% end %>
+
+    <% if @topical_event.consultations.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.consultations"),
+        padding: true,
+        font_size: 27,
+        margin_bottom: 3,
+      } %>
+
+      <%= render "govuk_publishing_components/components/document_list", {
+        items: @topical_event.consultations,
+        margin_bottom: 6,
+      } %>
+    <% end %>
+
+    <% if @topical_event.announcements.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.announcements"),
+        padding: true,
+        font_size: 27,
+        margin_bottom: 3,
+      } %>
+
+      <%= render "govuk_publishing_components/components/document_list", {
+        items: @topical_event.announcements,
+        margin_bottom: 6,
+      } %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ar:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 az:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 be:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 bg:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 bn:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 cs:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 cy:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 da:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 de:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 dr:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 el:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -1,10 +1,10 @@
 ---
 en:
   topical_events:
+    announcements: "Announcements"
     archived: "(Archived)"
     consultations: "Consultations"
     documents: "Documents"
-    announcements: "Announcements"
     featured: "Featured"
     headings:
       travel_advice: "Travel Advice"

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -2,6 +2,10 @@
 en:
   topical_events:
     archived: "(Archived)"
+    consultations: "Consultations"
+    documents: "Documents"
+    announcements: "Announcements"
     featured: "Featured"
     headings:
       travel_advice: "Travel Advice"
+    publications: "Publications"

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 es-419:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 es:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 et:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 fa:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 fi:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 fr:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 gd:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 gu:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 he:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 hi:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 hr:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 hu:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 hy:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 id:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 is:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 it:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ja:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ka:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 kk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ko:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 lt:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 lv:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ms:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 mt:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ne:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 nl:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 'no':
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 pa-pk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 pa:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 pl:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ps:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 pt:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ro:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ru:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 si:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sl:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 so:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sq:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sr:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sv:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 sw:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ta:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 th:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 tk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 tr:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 uk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 ur:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 uz:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 vi:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 yi:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 zh-hk:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 zh-tw:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -1,7 +1,11 @@
 ---
 zh:
   topical_events:
+    announcements:
     archived:
+    consultations:
+    documents:
     featured:
     headings:
       travel_advice:
+    publications:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -99,14 +99,17 @@ RSpec.feature "Topical Event pages" do
 
       within("#publications") do
         related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all publications", href: "/search/all?topical_events%5B%5D=something-very-topical")
       end
 
       within("#consultations") do
         related_consultations.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all consultations", href: "/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations&topical_events%5B%5D=something-very-topical")
       end
 
       within("#announcements") do
         related_announcements.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all announcements", href: "/search/news-and-communications?topical_events%5B%5D=something-very-topical")
       end
     end
 

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -1,11 +1,13 @@
 require "integration_spec_helper"
 
 RSpec.feature "Topical Event pages" do
+  include SearchApiHelpers
   let(:content_item) { fetch_fixture("topical_event") }
   let(:base_path) { content_item["base_path"] }
 
   before do
     stub_content_store_has_item(base_path, content_item)
+    stub_search(body: { results: [] })
   end
 
   it "sets the page title" do
@@ -63,6 +65,58 @@ RSpec.feature "Topical Event pages" do
     it "includes travel advice for Afghanistan" do
       visit base_path
       expect(page).to have_link(titleize_base_path(afghanistan_travel_advice_base_path), href: afghanistan_travel_advice_base_path)
+    end
+  end
+
+  context "documents list" do
+    let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
+    let(:related_consultations) { { "A consultation on Topicals" => "/foo/consultation_one", "Another consultation" => "/foo/consultation_two" } }
+    let(:related_announcements) { { "An announcement on Topicals" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
+
+    def search_api_response(titles_and_links_hash)
+      results_array = titles_and_links_hash.to_a.map do |title, link|
+        {
+          'link': link,
+          'title': title,
+          'public_timestamp': "2016-10-07T22:18:32Z",
+          'display_type': "some_display_type",
+        }
+      end
+      { 'results': results_array }
+    end
+
+    it "displays links to all related documents" do
+      stub_search(body: search_api_response(related_announcements))
+      stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
+      stub_search(body: search_api_response(related_consultations), params: { "filter_format" => "consultation" })
+
+      visit base_path
+
+      expect(page).to have_text("Documents")
+      expect(page).to have_text("Publications")
+      expect(page).to have_text("Consultations")
+      expect(page).to have_text("Announcements")
+
+      within("#publications") do
+        related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
+      end
+
+      within("#consultations") do
+        related_consultations.each { |title, link| expect(page).to have_link(title, href: link) }
+      end
+
+      within("#announcements") do
+        related_announcements.each { |title, link| expect(page).to have_link(title, href: link) }
+      end
+    end
+
+    it "doesn't display any document headers when there are no related documents" do
+      visit base_path
+
+      expect(page).not_to have_text("Publications")
+      expect(page).not_to have_text("Announcements")
+      expect(page).not_to have_text("Consultations")
+      expect(page).not_to have_text("Documents")
     end
   end
 

--- a/spec/helpers/topical_events_helper_spec.rb
+++ b/spec/helpers/topical_events_helper_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe TopicalEventsHelper do
+  it "correctly constructs search urls for different document types" do
+    expected_publication_url = "/search/all?topical_events%5B%5D=something-very-topical"
+    expected_consultation_url = "/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations&topical_events%5B%5D=something-very-topical"
+    expected_announcement_url = "/search/news-and-communications?topical_events%5B%5D=something-very-topical"
+
+    expected_results = {
+      publication: expected_publication_url,
+      consultation: expected_consultation_url,
+      announcement: expected_announcement_url,
+    }
+
+    expected_results.each do |document_type, expected_url|
+      expect(search_url(document_type, "something-very-topical")).to eq(expected_url)
+    end
+  end
+end

--- a/spec/services/topical_events_documents_spec.rb
+++ b/spec/services/topical_events_documents_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe TopicalEventsDocuments do
+  include SearchApiHelpers
+
+  describe "#fetch_related_documents_with_format" do
+    before do
+      @slug = "/some/slug"
+      @documents_service = TopicalEventsDocuments.new(@slug)
+    end
+
+    it "makes the correct call to search api" do
+      search_format = { some_format: "news_article" }
+      expected_search_params = search_format.merge(filter_topical_events: [@slug])
+
+      expect(Services.search_api)
+        .to receive(:search)
+        .with(hash_including(expected_search_params))
+        .and_return({ "results" => [] })
+
+      @documents_service.fetch_related_documents_with_format(search_format)
+    end
+
+    it "returns correctly formatted information about related documents" do
+      search_api_response = {
+        'results': [
+          {
+            'link': "/foo/policy_paper",
+            'title': "Policy on Topicals",
+            'public_timestamp': "2016-10-07T22:18:32Z",
+            'display_type': "news_article",
+          },
+          {
+            'link': "/foo/news_story",
+            'title': "PM attends summit on topical events",
+            'public_timestamp': "2018-10-07T22:18:32Z",
+            'content_store_document_type': "news_article",
+          },
+        ],
+      }
+
+      stub_search(body: search_api_response)
+
+      expect(@documents_service.fetch_related_documents_with_format({ filter_format: "news_article" })).to eq [
+        {
+          link: {
+            text: "Policy on Topicals",
+            path: "/foo/policy_paper",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2016-10-07T22:18:32Z"),
+            document_type: "News article",
+          },
+        },
+        {
+          link: {
+            text: "PM attends summit on topical events",
+            path: "/foo/news_story",
+          },
+          metadata: {
+            public_updated_at: Time.zone.parse("2018-10-07T22:18:32Z"),
+            document_type: "News article",
+          },
+        },
+      ]
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/huPXst3c)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR is part of work to move rendering of Topical Events from Whitehall to Collections. It adds the ability to render the lists of related documents under a topical event, under the categories of 'publications', 'consultations' and 'announcements'. The logic for retrieving these is copied from Whitehall, with the rendering implementation simplified.

This screenshot shows these sections as rendered by collections:

<img width="908" alt="Screenshot 2022-06-15 at 14 34 25" src="https://user-images.githubusercontent.com/25515510/173841002-edf23df5-d60e-4a83-8df3-5f16126ea5b9.png">

If you want to spin the service up locally via `govuk-docker-up app-live`, this is a good example of a topical event with lots of related documents that you can compare with the live site:

http://collections.dev.gov.uk/government/topical-events/budget-2021

vs 

http://gov.uk/government/topical-events/budget-2021

This also adds translations for topical event documents, with these defaulted to blank for all locales except English, as we do not currently support translations for topical events.