### PR TITLE
Afghanistan travel advice

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -22,6 +22,10 @@ class TopicalEvent
     @content_item.content_item_data.dig("details", "body")
   end
 
+  def slug
+    @content_item.content_item_data["base_path"].sub(%r{/government/topical-events/}, "")
+  end
+
   def end_date
     Date.parse(@content_item.content_item_data.dig("details", "end_date")) if @content_item.content_item_data.dig("details", "end_date")
   end
@@ -62,5 +66,12 @@ class TopicalEvent
         description: document["summary"],
       }
     end
+  end
+
+  def travel_advice
+    return [] if slug != "afghanistan-uk-government-response"
+
+    advice = ContentItem.find!("/foreign-travel-advice/afghanistan").to_hash
+    [advice.slice("base_path", "title")]
   end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -55,4 +55,26 @@
       <% end %>
     <% end %>
   </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @topical_event.travel_advice.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("topical_events.headings.travel_advice"),
+        font_size: "l",
+        margin_bottom: 4,
+        padding: true,
+        border_top: 2,
+      } %>
+      <%= render "govuk_publishing_components/components/document_list", {
+        items: @topical_event.travel_advice.map do |travel_advice|
+          {
+            link: {
+              text: travel_advice["title"],
+              path: travel_advice["base_path"]
+            }
+          }
+        end
+      } %>
+    <% end %>
+  </div>
 </div>

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -3,3 +3,5 @@ ar:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -3,3 +3,5 @@ az:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -3,3 +3,5 @@ be:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -3,3 +3,5 @@ bg:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -3,3 +3,5 @@ bn:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -3,3 +3,5 @@ cs:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -3,3 +3,5 @@ cy:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -3,3 +3,5 @@ da:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -3,3 +3,5 @@ de:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -3,3 +3,5 @@ dr:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -3,3 +3,5 @@ el:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -3,3 +3,5 @@ en:
   topical_events:
     archived: "(Archived)"
     featured: "Featured"
+    headings:
+      travel_advice: "Travel Advice"

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -3,3 +3,5 @@ es-419:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -3,3 +3,5 @@ es:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -3,3 +3,5 @@ et:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -3,3 +3,5 @@ fa:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -3,3 +3,5 @@ fi:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -3,3 +3,5 @@ fr:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -3,3 +3,5 @@ gd:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -3,3 +3,5 @@ gu:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -3,3 +3,5 @@ he:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -3,3 +3,5 @@ hi:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -3,3 +3,5 @@ hr:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -3,3 +3,5 @@ hu:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -3,3 +3,5 @@ hy:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -3,3 +3,5 @@ id:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -3,3 +3,5 @@ is:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -3,3 +3,5 @@ it:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -3,3 +3,5 @@ ja:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -3,3 +3,5 @@ ka:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -3,3 +3,5 @@ kk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -3,3 +3,5 @@ ko:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -3,3 +3,5 @@ lt:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -3,3 +3,5 @@ lv:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -3,3 +3,5 @@ ms:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -3,3 +3,5 @@ mt:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -3,3 +3,5 @@ ne:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -3,3 +3,5 @@ nl:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -3,3 +3,5 @@
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -3,3 +3,5 @@ pa-pk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -3,3 +3,5 @@ pa:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -3,3 +3,5 @@ pl:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -3,3 +3,5 @@ ps:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -3,3 +3,5 @@ pt:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -3,3 +3,5 @@ ro:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -3,3 +3,5 @@ ru:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -3,3 +3,5 @@ si:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -3,3 +3,5 @@ sk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -3,3 +3,5 @@ sl:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -3,3 +3,5 @@ so:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -3,3 +3,5 @@ sq:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -3,3 +3,5 @@ sr:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -3,3 +3,5 @@ sv:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -3,3 +3,5 @@ sw:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -3,3 +3,5 @@ ta:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -3,3 +3,5 @@ th:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -3,3 +3,5 @@ tk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -3,3 +3,5 @@ tr:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -3,3 +3,5 @@ uk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -3,3 +3,5 @@ ur:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -3,3 +3,5 @@ uz:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -3,3 +3,5 @@ vi:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -3,3 +3,5 @@ yi:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -3,3 +3,5 @@ zh-hk:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -3,3 +3,5 @@ zh-tw:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -3,3 +3,5 @@ zh:
   topical_events:
     archived:
     featured:
+    headings:
+      travel_advice:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -46,6 +46,21 @@ RSpec.feature "Topical Event pages" do
     end
   end
 
+  context "afghanistan response topical event" do
+    let(:base_path) { "/government/topical-events/afghanistan-uk-government-response" }
+    let(:afghanistan_travel_advice_base_path) { "/foreign-travel-advice/afghanistan" }
+
+    before do
+      stub_content_store_has_item(base_path)
+      stub_content_store_has_item(afghanistan_travel_advice_base_path)
+    end
+
+    it "includes travel advice for Afghanistan" do
+      visit base_path
+      expect(page).to have_link(titleize_base_path(afghanistan_travel_advice_base_path), href: afghanistan_travel_advice_base_path)
+    end
+  end
+
   it "includes a link to the about page" do
     visit base_path
     expect(page).to have_link(content_item.dig("details", "about_page_link_text"), href: "#{base_path}/about")


### PR DESCRIPTION
The uk response in Afghanistan is a unique Topical event. I think as some 2nd line work a case was added whereby that Topical event would have a link to the travel advice for Afghanistan (commit here https://github.com/alphagov/whitehall/commit/40fc29efa2f733c51c615592d7556c77e3a58fac). 

This ports that work over and adds tests. It's not ideal to have this hardcoded and there's work in the pipeline to allow travel advice to be tagged to topical events (trello - https://trello.com/c/hmcqxhAr/579-allow-travel-advice-to-be-tagged-to-topical-events).

Trello - https://trello.com/c/CO4br0wH/76-add-afghanistan-travel-advice-link-to-collections-rendered-topical-event

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️