### PR TITLE
Render image on Topical Event page

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -18,6 +18,14 @@ class TopicalEvent
     @content_item.content_item_data["description"]
   end
 
+  def image_url
+    @content_item.content_item_data.dig("details", "image", "url")
+  end
+
+  def image_alt_text
+    @content_item.content_item_data.dig("details", "image", "alt_text")
+  end
+
   def body
     @content_item.content_item_data.dig("details", "body")
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -16,6 +16,10 @@
       margin_bottom: 8,
     } %>
 
+    <% if @topical_event.image_url %>
+      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
+    <% end %>
+
     <%= render "govuk_publishing_components/components/govspeak", {
       } do %>
         <%= @topical_event.body&.html_safe %>

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -23,6 +23,11 @@ RSpec.feature "Topical Event pages" do
     expect(page).to have_selector("meta[name='description'][content='#{content_item['description']}']", visible: :hidden)
   end
 
+  it "includes the image and alt text" do
+    visit base_path
+    expect(page).to have_css("img[src='https://www.gov.uk/some-image.png'][alt='Text describing the image']")
+  end
+
   it "sets the body text" do
     visit base_path
     expect(page).to have_text(content_item.dig("details", "body"))

--- a/spec/fixtures/content_store/topical_event.json
+++ b/spec/fixtures/content_store/topical_event.json
@@ -5,6 +5,10 @@
   "details": {
     "about_page_link_text": "Read more about this event",
     "body": "This is a very important topical event.",
+    "image": {
+      "url": "https://www.gov.uk/some-image.png",
+      "alt_text": "Text describing the image"
+    },
     "end_date": "2016-04-28T00:00:00+00:00",
     "ordered_featured_documents": [
       {

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe TopicalEvent do
     expect(topical_event.description).to eq("This event is happening soon")
   end
 
+  it "should return the image URL and alt text" do
+    expect(topical_event.image_url).to eq("https://www.gov.uk/some-image.png")
+    expect(topical_event.image_alt_text).to eq("Text describing the image")
+  end
+
   it "show have body text" do
     expect(topical_event.body).to eq("This is a very important topical event.")
   end


### PR DESCRIPTION
This adds the topical event image (known in some places in Whitehall as a logo) to the topical event page.

## Example rendered by Collections
![Screenshot of a topical event page rendered by Collections, showing the image situated between the topical event's summary and body sections](https://user-images.githubusercontent.com/6329861/173370233-b7655aed-c30a-42e1-a8a4-fa6909e01616.png)


[Trello card](https://trello.com/c/uNbOV24p)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
