### PR TITLE
Fix person_spec test

### DIFF
--- a/spec/features/person_spec.rb
+++ b/spec/features/person_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Person page" do
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person").merge(
       "title" => name,
       "base_path" => base_path,
+      "lang" => "en",
     )
 
     stub_content_store_has_item(base_path, content_item)


### PR DESCRIPTION
## What

Add lang to the content_item stub in person_spec.

## Why

This was causing an error where this attribute was expected in application.html.erb to be passed into the meta tags component. It was absent,  so therefore it was causing a undefined method error.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
