### PR TITLE
Fix failing person_spec test

### DIFF
--- a/spec/features/person_spec.rb
+++ b/spec/features/person_spec.rb
@@ -28,6 +28,9 @@ RSpec.feature "Person page" do
     content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "person").merge(
       "title" => name,
       "base_path" => base_path,
+      "links" => {
+        "primary_publishing_organisation": nil,
+      },
     )
 
     stub_content_store_has_item(base_path, content_item)


### PR DESCRIPTION
## What

Set the primary_publishing_organisation of the stub content_item in person_spec to nil.

## Why

[`GovukSchemas::RandomExample`](https://github.com/alphagov/collections/blob/c62053eb77caf20137c1b46dc3092cd2146fe9e1/spec/features/person_spec.rb#L28) can at times generate a schema with primary_publishing_organisation set to an empty array. This caused an error in [govuk_publishing_components metatag component](https://github.com/alphagov/govuk_publishing_components/blob/3a82a2d9cc43ead9ba247100f4e2a76ef31fc60c/lib/govuk_publishing_components/presenters/meta_tags.rb#L45) which would cause the page to fail to load and the tests to fail as a result. Noticed that when `primary_publishing_organisation` was either not set or set to an array with a hash then the test would not fail. So therefore setting it to be always nil for this test will mean that the page can load and this test can always take place.

## How

This error was discovered because of the output of `displays the person page` which included the following snippets

`expected to find text "Rufus Scrimgeour" in "NoMethodError at /government/people/rufus-scrimgeour ==================================================== undefined method '[]' for nil:NilClass `

`' Full backtrace -------------- - govuk_publishing_components (29.12.0) lib/govuk_publishing_components/presenters/meta_tags.rb:46:in 'add_core_tags' - govuk_publishing_components (29.12.0) lib/govuk_publishing_components/presenters/meta_tags.rb:21:in 'meta_tags'`

This directed me to the [following line in the govuk_publishing_components metatag component](https://github.com/alphagov/govuk_publishing_components/blob/3a82a2d9cc43ead9ba247100f4e2a76ef31fc60c/lib/govuk_publishing_components/presenters/meta_tags.rb#L45) where I noticed that the check was only checking to see if the variable `primary_publisher` was undefined/nil and not taking into account the case in which `primary_publisher` could have been set to an empty array. This meant that the line accessing a hash at the first element of `primary_publisher` could fail. I then output the randomly generated schema to the console to see if there could be random schemas that did have `primary_publisher` set to an empty array and this did turn out to be the case. The addition of a line in the test always setting primary_publisher to nil fixed the issue as it meant the code attempting to access the first key of the element of the array would never be run (and it does not need to run for this test). 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
