### PR TITLE
Add rendering of Topical Event atom feeds

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -1,6 +1,21 @@
 class TopicalEventsController < ApplicationController
+  enable_request_formats show: :atom
+
   def show
-    @topical_event = TopicalEvent.find!(request.path)
-    setup_content_item_and_navigation_helpers(@topical_event)
+    path = topical_event_path(params[:name])
+    @topical_event = TopicalEvent.find!(path)
+
+    respond_to do |format|
+      format.html do
+        setup_content_item_and_navigation_helpers(@topical_event)
+      end
+
+      format.atom do
+        results = FeedContent.new(filter_topical_events: params[:name]).results(10)
+        items = results.map { |result| FeedEntryPresenter.new(result) }
+
+        render "feeds/feed", locals: { items: items, root_url: Plek.new.website_root + path, title: "#{@topical_event.title} - Activity on GOV.UK" }
+      end
+    end
   end
 end

--- a/app/services/feed_content.rb
+++ b/app/services/feed_content.rb
@@ -5,16 +5,16 @@ class FeedContent
     @search_query = search_query
   end
 
-  def results
-    search_response["results"]
+  def results(count = 20)
+    search_response(count)["results"]
   end
 
 private
 
-  def search_response
+  def search_response(count)
     params = search_query.merge(
       start: 0,
-      count: 20,
+      count: count,
       fields: SearchApiFields::FEED_SEARCH_FIELDS,
       reject_content_purpose_supergroup: "other",
       order: "-public_timestamp",

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -41,7 +41,7 @@
   <div class="govuk-grid-column-full govuk-!-margin-bottom-7">
     <% if @topical_event.ordered_featured_documents %>
       <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.featured"),
+        text: I18n.t("topical_events.headings.featured"),
         padding: true,
         font_size: "l",
         border_top: 2,
@@ -60,7 +60,7 @@
     <% end %>
 
     <%= render "govuk_publishing_components/components/heading", {
-      text: I18n.t("topical_events.latest"),
+      text: I18n.t("topical_events.headings.latest"),
       padding: true,
       font_size: 27,
       border_top: 2,
@@ -75,7 +75,7 @@
   <div class="govuk-grid-column-full">
     <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? %>
       <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.documents"),
+        text: I18n.t("topical_events.headings.documents"),
         padding: true,
         font_size: "l",
         border_top: 2,
@@ -83,9 +83,9 @@
       } %>
     <% end %>
 
-    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.publications"), link_to: search_url(:publication, @topical_event.slug) }) if @topical_event.publications.any? %>
-    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.consultations"), link_to: search_url(:consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
-    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.announcements"), link_to: search_url(:announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.headings.publications"), link_to: search_url(:publication, @topical_event.slug) }) if @topical_event.publications.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -38,7 +38,7 @@
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full govuk-!-margin-bottom-7">
     <% if @topical_event.ordered_featured_documents %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.featured"),
@@ -59,6 +59,20 @@
       <% end %>
     <% end %>
 
+    <%= render "govuk_publishing_components/components/heading", {
+      text: I18n.t("topical_events.latest"),
+      padding: true,
+      font_size: 27,
+      border_top: 2,
+      margin_bottom: 3,
+    } %>
+
+    <%= render "govuk_publishing_components/components/subscription_links", {
+      feed_link_box_value: Plek.new.website_root + topical_event_path(@topical_event.slug, format: "atom")
+    } %>
+  </div>
+
+  <div class="govuk-grid-column-full">
     <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.documents"),

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -8,4 +8,5 @@ ar:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ar:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 az:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -8,4 +8,5 @@ az:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 be:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -8,4 +8,5 @@ be:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -8,4 +8,5 @@ bg:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 bg:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -8,4 +8,5 @@ bn:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 bn:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -8,4 +8,5 @@ cs:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 cs:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 cy:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -8,4 +8,5 @@ cy:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 da:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -8,4 +8,5 @@ da:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -8,4 +8,5 @@ de:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 de:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -8,4 +8,5 @@ dr:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 dr:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 el:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -8,4 +8,5 @@ el:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 en:
   topical_events:
-    announcements: "Announcements"
     archived: "(Archived)"
-    consultations: "Consultations"
-    documents: "Documents"
-    featured: "Featured"
     headings:
-      travel_advice: "Travel Advice"
-    latest: "Latest"
-    publications: "Publications"
+      announcements: Announcements
+      consultations: Consultations
+      documents: Documents
+      featured: Featured
+      latest: Latest
+      publications: Publications
+      travel_advice: Travel Advice

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -8,4 +8,5 @@ en:
     featured: "Featured"
     headings:
       travel_advice: "Travel Advice"
+    latest: "Latest"
     publications: "Publications"

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 es-419:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -8,4 +8,5 @@ es-419:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -8,4 +8,5 @@ es:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 es:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 et:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -8,4 +8,5 @@ et:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -8,4 +8,5 @@ fa:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 fa:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -8,4 +8,5 @@ fi:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 fi:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 fr:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -8,4 +8,5 @@ fr:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 gd:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -8,4 +8,5 @@ gd:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -8,4 +8,5 @@ gu:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 gu:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 he:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -8,4 +8,5 @@ he:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 hi:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -8,4 +8,5 @@ hi:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 hr:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -8,4 +8,5 @@ hr:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -8,4 +8,5 @@ hu:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 hu:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 hy:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -8,4 +8,5 @@ hy:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -8,4 +8,5 @@ id:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 id:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -8,4 +8,5 @@ is:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 is:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -8,4 +8,5 @@ it:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 it:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ja:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -8,4 +8,5 @@ ja:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ka:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -8,4 +8,5 @@ ka:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -8,4 +8,5 @@ kk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 kk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ko:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -8,4 +8,5 @@ ko:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -8,4 +8,5 @@ lt:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 lt:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 lv:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -8,4 +8,5 @@ lv:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ms:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -8,4 +8,5 @@ ms:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 mt:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -8,4 +8,5 @@ mt:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ne:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -8,4 +8,5 @@ ne:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -8,4 +8,5 @@ nl:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 nl:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 'no':
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -8,4 +8,5 @@
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -8,4 +8,5 @@ pa-pk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 pa-pk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -8,4 +8,5 @@ pa:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 pa:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 pl:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -8,4 +8,5 @@ pl:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ps:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -8,4 +8,5 @@ ps:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 pt:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -8,4 +8,5 @@ pt:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ro:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -8,4 +8,5 @@ ro:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -8,4 +8,5 @@ ru:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ru:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -8,4 +8,5 @@ si:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 si:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -8,4 +8,5 @@ sk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sl:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -8,4 +8,5 @@ sl:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -8,4 +8,5 @@ so:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 so:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sq:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -8,4 +8,5 @@ sq:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -8,4 +8,5 @@ sr:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sr:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sv:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -8,4 +8,5 @@ sv:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 sw:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -8,4 +8,5 @@ sw:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -8,4 +8,5 @@ ta:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ta:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 th:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -8,4 +8,5 @@ th:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 tk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -8,4 +8,5 @@ tk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -8,4 +8,5 @@ tr:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 tr:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 uk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -8,4 +8,5 @@ uk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 ur:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -8,4 +8,5 @@ ur:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -8,4 +8,5 @@ uz:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 uz:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -8,4 +8,5 @@ vi:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 vi:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 yi:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -8,4 +8,5 @@ yi:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 zh-hk:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -8,4 +8,5 @@ zh-hk:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 zh-tw:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -8,4 +8,5 @@ zh-tw:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -1,12 +1,12 @@
 ---
 zh:
   topical_events:
-    announcements:
     archived:
-    consultations:
-    documents:
-    featured:
     headings:
+      announcements:
+      consultations:
+      documents:
+      featured:
+      latest:
+      publications:
       travel_advice:
-    latest:
-    publications:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -8,4 +8,5 @@ zh:
     featured:
     headings:
       travel_advice:
+    latest:
     publications:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,10 @@ Rails.application.routes.draw do
   get "/government/people/:name(.:locale)", to: "people#show"
   get "/government/ministers(.:locale)", to: "ministers#index"
   get "/government/ministers/:name(.:locale)", to: "roles#show"
-  get "/government/topical-events/:name", to: "topical_events#show"
+
+  get "/government/topical-events/:name",
+      to: "topical_events#show",
+      as: :topical_event
 
   scope :api, defaults: { format: :json } do
     get "/organisations",

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature "Topical Event pages" do
   context "when there are featured documents" do
     it "includes the featured documents header" do
       visit base_path
-      expect(page).to have_text(I18n.t("topical_events.featured"))
+      expect(page).to have_text(I18n.t("topical_events.headings.featured"))
     end
 
     it "includes links to the featured documents" do
@@ -155,7 +155,7 @@ RSpec.feature "Topical Event pages" do
 
     it "does not include the featured documents header" do
       visit base_path
-      expect(page).to_not have_text(I18n.t("topical_events.featured"))
+      expect(page).to_not have_text(I18n.t("topical_events.headings.featured"))
     end
   end
 


### PR DESCRIPTION
This adds the rendering of atom feeds for Topical Events, plus includes a link from the Topical Event page to subscribe to the feed.

Example signup link:
![Screenshot showing the signup link for a topical event.  The button reads 'Subscribe to feed' and once clicked shows a text box with the URL to copy.](https://user-images.githubusercontent.com/6329861/176436012-9158e8f9-2b93-4efd-a249-3a92f7d7a6e4.png)

[Example feed](https://gist.github.com/brucebolt/b91e348a928536dddd417829d2b4c0fd)

[Trello card](https://trello.com/c/Qw5HPt8T)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
