### PR TITLE
Add email signup link to Topical Event

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -68,6 +68,7 @@
     } %>
 
     <%= render "govuk_publishing_components/components/subscription_links", {
+      email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}",
       feed_link_box_value: Plek.new.website_root + topical_event_path(@topical_event.slug, format: "atom")
     } %>
   </div>

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -35,6 +35,11 @@ RSpec.feature "Topical Event pages" do
     expect(page).to have_text(content_item.dig("details", "body"))
   end
 
+  it "includes a link to signup for emails" do
+    visit base_path
+    expect(page).to have_link("Get emails", href: "/email-signup?link=/government/topical-events/something-very-topical")
+  end
+
   context "when the event is current" do
     it "does not show the archived text" do
       Timecop.freeze("2016-04-18") do


### PR DESCRIPTION
Adds an email signup link to the Topical Event page rendered by Whitehall.

Screenshot of link:
![Screenshot showing a 'Get emails' button alongside the existing 'Subscribe to feed' button](https://user-images.githubusercontent.com/6329861/176700970-25e27bca-af53-4bdb-ba81-708bb5f39795.png)

The button is visually different from Whitehall as we are using the component with a copyable feed link, as per the [component guide](https://components.publishing.service.gov.uk/component-guide/subscription_links) when the copyable feed button is used.

This depends on code from https://github.com/alphagov/collections/pull/2839.

[Trello card](https://trello.com/c/tk9DUB5x)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
