### PR TITLE
Rename GA4 analytics attribute - state to action

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -37,7 +37,7 @@
           index: index + 1,
           'index-total': number_of_accordion_sections,
           section: 'n/a',
-          state: 'n/a',
+          action: 'n/a',
         }
       }
     }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Rename a GA4 attribute on the accordions on `/coronavirus`.

- part of a change across the site
- applies only to the new GA4 code, not live in production

## Visual changes
None.

Trello card: https://trello.com/c/BRyCFCVf/334-uistate-should-be-uiaction