### PR TITLE
Add detailed guidance

### DIFF
--- a/app/helpers/topical_events_helper.rb
+++ b/app/helpers/topical_events_helper.rb
@@ -6,29 +6,31 @@ module TopicalEventsHelper
 private
 
   def base_path(content_type)
-    { latest: "/search/all?",
-      publication: "/search/all?",
+    { announcement: "/search/news-and-communications?",
       consultation: "/search/policy-papers-and-consultations?",
-      announcement: "/search/news-and-communications?" }[content_type]
+      detailed_guidance: "/search/all?",
+      latest: "/search/all?",
+      publication: "/search/all?" }[content_type]
   end
 
   def query_params(content_type, slug)
     case content_type
-    when :latest
-      {
-        order: "updated-newest",
-        topical_events: [slug],
-      }
-    when :publication
-      {
-        topical_events: [slug],
-      }
     when :consultation
       {
         content_store_document_type: %w[open_consultations closed_consultations],
         topical_events: [slug],
       }
-    when :announcement
+    when :detailed_guidance
+      {
+        content_purpose_supergroup: "guidance_and_regulation",
+        topical_events: [slug],
+      }
+    when :latest
+      {
+        order: "updated-newest",
+        topical_events: [slug],
+      }
+    else
       {
         topical_events: [slug],
       }

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -110,4 +110,8 @@ class TopicalEvent
     ]
     @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_store_document_type: announcement_document_types })
   end
+
+  def detailed_guidance
+    @detailed_guidance ||= @documents_service.fetch_related_documents_with_format({ filter_format: "detailed_guidance" })
+  end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -82,7 +82,7 @@
   </div>
 
   <div class="govuk-grid-column-full">
-    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? %>
+    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.detailed_guidance.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.documents"),
         padding: true,
@@ -95,6 +95,7 @@
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.headings.publications"), link_to: search_url(:publication, @topical_event.slug) }) if @topical_event.publications.any? %>
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
+    <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.detailed_guidance, heading: I18n.t("topical_events.headings.detailed_guides"), link_to: search_url(:detailed_guidance, @topical_event.slug) }) if @topical_event.detailed_guidance.any? %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -5,6 +5,7 @@ ar:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -5,6 +5,7 @@ az:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -5,6 +5,7 @@ be:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -5,6 +5,7 @@ bg:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -5,6 +5,7 @@ bn:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -5,6 +5,7 @@ cs:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -5,6 +5,7 @@ cy:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -5,6 +5,7 @@ da:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -5,6 +5,7 @@ de:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -5,6 +5,7 @@ dr:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -5,6 +5,7 @@ el:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -5,6 +5,7 @@ en:
     headings:
       announcements: Announcements
       consultations: Consultations
+      detailed_guides: Detailed Guides
       documents: Documents
       featured: Featured
       latest: Latest

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -5,6 +5,7 @@ es-419:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -5,6 +5,7 @@ es:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -5,6 +5,7 @@ et:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -5,6 +5,7 @@ fa:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -5,6 +5,7 @@ fi:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -5,6 +5,7 @@ fr:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -5,6 +5,7 @@ gd:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -5,6 +5,7 @@ gu:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -5,6 +5,7 @@ he:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -5,6 +5,7 @@ hi:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -5,6 +5,7 @@ hr:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -5,6 +5,7 @@ hu:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -5,6 +5,7 @@ hy:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -5,6 +5,7 @@ id:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -5,6 +5,7 @@ is:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -5,6 +5,7 @@ it:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -5,6 +5,7 @@ ja:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -5,6 +5,7 @@ ka:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -5,6 +5,7 @@ kk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -5,6 +5,7 @@ ko:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -5,6 +5,7 @@ lt:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -5,6 +5,7 @@ lv:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -5,6 +5,7 @@ ms:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -5,6 +5,7 @@ mt:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -5,6 +5,7 @@ ne:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -5,6 +5,7 @@ nl:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -5,6 +5,7 @@
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -5,6 +5,7 @@ pa-pk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -5,6 +5,7 @@ pa:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -5,6 +5,7 @@ pl:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -5,6 +5,7 @@ ps:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -5,6 +5,7 @@ pt:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -5,6 +5,7 @@ ro:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -5,6 +5,7 @@ ru:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -5,6 +5,7 @@ si:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -5,6 +5,7 @@ sk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -5,6 +5,7 @@ sl:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -5,6 +5,7 @@ so:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -5,6 +5,7 @@ sq:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -5,6 +5,7 @@ sr:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -5,6 +5,7 @@ sv:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -5,6 +5,7 @@ sw:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -5,6 +5,7 @@ ta:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -5,6 +5,7 @@ th:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -5,6 +5,7 @@ tk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -5,6 +5,7 @@ tr:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -5,6 +5,7 @@ uk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -5,6 +5,7 @@ ur:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -5,6 +5,7 @@ uz:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -5,6 +5,7 @@ vi:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -5,6 +5,7 @@ yi:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -5,6 +5,7 @@ zh-hk:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -5,6 +5,7 @@ zh-tw:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -5,6 +5,7 @@ zh:
     headings:
       announcements:
       consultations:
+      detailed_guides:
       documents:
       featured:
       latest:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -77,11 +77,13 @@ RSpec.feature "Topical Event pages" do
     let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
     let(:related_consultations) { { "A consultation on Topicals" => "/foo/consultation_one", "Another consultation" => "/foo/consultation_two" } }
     let(:related_announcements) { { "An announcement on Topicals" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
+    let(:related_guidance) { { "Some guidance" => "/foo/detailed_guidance_one", "Another bit of guidance" => "/foo/detailed_guidance_two" } }
 
     it "displays links to all related documents" do
       stub_search(body: search_api_response(related_announcements))
       stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
       stub_search(body: search_api_response(related_consultations), params: { "filter_format" => "consultation" })
+      stub_search(body: search_api_response(related_guidance), params: { "filter_format" => "detailed_guidance" })
 
       visit base_path
 
@@ -89,6 +91,7 @@ RSpec.feature "Topical Event pages" do
       expect(page).to have_text("Publications")
       expect(page).to have_text("Consultations")
       expect(page).to have_text("Announcements")
+      expect(page).to have_text("Detailed Guides")
 
       within("#publications") do
         related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
@@ -104,6 +107,11 @@ RSpec.feature "Topical Event pages" do
         related_announcements.each { |title, link| expect(page).to have_link(title, href: link) }
         expect(page).to have_link("See all announcements", href: "/search/news-and-communications?topical_events%5B%5D=something-very-topical")
       end
+
+      within("#detailed-guides") do
+        related_guidance.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all detailed guides", href: "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical")
+      end
     end
 
     it "doesn't display any document headers when there are no related documents" do
@@ -113,6 +121,7 @@ RSpec.feature "Topical Event pages" do
       expect(page).not_to have_text("Announcements")
       expect(page).not_to have_text("Consultations")
       expect(page).not_to have_text("Documents")
+      expect(page).not_to have_text("Detailed Guides")
     end
   end
 

--- a/spec/helpers/topical_events_helper_spec.rb
+++ b/spec/helpers/topical_events_helper_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe TopicalEventsHelper do
     expected_consultation_url = "/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations&topical_events%5B%5D=something-very-topical"
     expected_announcement_url = "/search/news-and-communications?topical_events%5B%5D=something-very-topical"
     expected_latest_url = "/search/all?order=updated-newest&topical_events%5B%5D=something-very-topical"
+    expected_detailed_guidance_url = "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical"
 
     expected_results = {
       publication: expected_publication_url,
       consultation: expected_consultation_url,
       announcement: expected_announcement_url,
       latest: expected_latest_url,
+      detailed_guidance: expected_detailed_guidance_url,
     }
 
     expected_results.each do |document_type, expected_url|

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -115,6 +115,15 @@ RSpec.describe TopicalEvent do
       topical_event.publications
     end
 
+    it "should make the correct call to search api for detailed guidance" do
+      expect(Services.search_api)
+        .to receive(:search)
+              .with(default_params.merge({ filter_format: "detailed_guidance" }))
+              .and_return({ "results" => [] })
+
+      topical_event.detailed_guidance
+    end
+
     it "should make the correct call to search api for latest" do
       expect(Services.search_api)
         .to receive(:search)


### PR DESCRIPTION
Add detailed guidance section to topical events.

There are some differences from the Whitehall rendering for this section. We have decided to render as a sub group under the `documents` header, rather than separately as Whitehall does. We do not think there is a good product reason to treat these as logically separate from other document types. We are also using the shared document lists component which makes the styling consistent with the other document types.

|Collections rendering | Whitehall rendering |
|-------------|-----------|
| <img width="606" alt="Screenshot 2022-07-01 at 15 59 46" src="https://user-images.githubusercontent.com/25515510/176919807-5874fe86-2b42-4788-869a-4b2f9c7134fe.png"> |<img width="610" alt="Screenshot 2022-07-01 at 16 00 16" src="https://user-images.githubusercontent.com/25515510/176919814-90be0eac-8f74-4fcc-92a3-8cf5a1f82a65.png"> |


The non-visual / less immediately obvious differences between the Whitehall rendered content and this are: 

* Detailed guides are retrieved from search api, rather than from the local Whitehall database
* The number of documents displayed has changed, from a maximum of 5 in Whitehall, to 3 here for consistency with other document types. However, we have added a 'see all' link, which was previously not given in the Whitehall rendering, meaning that there was no obvious way to see documents beyond the first 5 returned.
* The ordering has changed, and is now based on the 'public timestamp' from search api. There was some other ordering going on in Whitehall that I'm not sure it makes sense to replicate, timestamp seems like a sensible ordering.
* Whitehall was also doing some [eager loading](https://github.com/alphagov/whitehall/blob/f57384eb5f87c95038b68b7037032d9e0ee9a4b3/app/controllers/topical_events_controller.rb#L22) of the detailed guidance it displayed. I'm not sure whether we need to do anything equivalent here.

Note that the 'see all' link actually links to the 'guidance and regulations' topics. I'm not aware that regulations are a separate document type, but if we think that this will return some results we don't want, I'm not sure there is a way of doing this without creating a separate finder. But is at least better than the current Whitehall situation where you can't see anything beyond the 5 links presented to you 🤷 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
