### PR TITLE
Add action link stylesheet

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/govuk_frontend_support";
 // @import "govuk_publishing_components/component_support";
 @import "govuk_publishing_components/components/accordion";
+@import "govuk_publishing_components/components/action-link";
 @import "govuk_publishing_components/components/back-link";
 @import "govuk_publishing_components/components/big-number";
 @import "govuk_publishing_components/components/breadcrumbs";


### PR DESCRIPTION
## What

Includes the action link component's stylesheet to the main collections stylesheet.

## Why

Currently, the action link stylesheet is included in Static's stylesheet - but the component is only used in collections. Rather than loading the CSS for everyone, we should only includes it only in collections' stylesheet.

Adding this to collections means it can then be removed from Static.

## Visual differences

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
