### PR TITLE
Remove unnecessary space from Arabic locale file

### DIFF
--- a/config/locales/ar/browse.yml
+++ b/config/locales/ar/browse.yml
@@ -2,5 +2,5 @@
 ar:
   browse:
     all_categories: جميع الفئات
-    description: 
-    title: 
+    description:
+    title:


### PR DESCRIPTION
This space does not need to be here, which results in their removal each time Rails Translation Manager is run.

Removing so this no longer happens.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
