### PR TITLE
Add topical event latest documents section

### DIFF
--- a/app/helpers/topical_events_helper.rb
+++ b/app/helpers/topical_events_helper.rb
@@ -6,13 +6,19 @@ module TopicalEventsHelper
 private
 
   def base_path(content_type)
-    { publication: "/search/all?",
+    { latest: "/search/all?",
+      publication: "/search/all?",
       consultation: "/search/policy-papers-and-consultations?",
       announcement: "/search/news-and-communications?" }[content_type]
   end
 
   def query_params(content_type, slug)
     case content_type
+    when :latest
+      {
+        order: "updated-newest",
+        topical_events: [slug],
+      }
     when :publication
       {
         topical_events: [slug],

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -84,6 +84,10 @@ class TopicalEvent
     [advice.slice("base_path", "title")]
   end
 
+  def latest
+    @latest ||= @documents_service.fetch_related_documents_with_format
+  end
+
   def publications
     @publications ||= @documents_service.fetch_related_documents_with_format({ filter_format: "publication" })
   end

--- a/app/services/topical_events_documents.rb
+++ b/app/services/topical_events_documents.rb
@@ -5,7 +5,7 @@ class TopicalEventsDocuments
     @slug = slug
   end
 
-  def fetch_related_documents_with_format(filter_format)
+  def fetch_related_documents_with_format(filter_format = {})
     search_response = Services.search_api.search(default_search_options.merge(filter_format))
     format_results(search_response)
   end

--- a/app/views/topical_events/_document_list_from_search_api.html.erb
+++ b/app/views/topical_events/_document_list_from_search_api.html.erb
@@ -1,32 +1,41 @@
-<section id="<%= heading.downcase.parameterize %>" class="document-block">
+<% heading ||= nil %>
+
+<% if heading %>
+  <section id="<%= heading.downcase.parameterize %>" class="document-block">
   <%= render "govuk_publishing_components/components/heading", {
     text: heading,
     padding: true,
     font_size: 27,
     margin_bottom: 3,
   } %>
+<% end %>
 
-    <%= render "govuk_publishing_components/components/document_list", {
-      items: documents,
-      margin_bottom: 6,
-    } %>
+  <%= render "govuk_publishing_components/components/document_list", {
+    items: documents,
+    margin_bottom: 6,
+  } %>
 
   <p class="govuk-body">
+    <% see_all_link_text = heading ? "See all #{heading.downcase}" : "See all" %>
+
     <%=
       link_to(
-        "See all #{heading.downcase}",
+        see_all_link_text,
         link_to,
         class: "govuk-link",
         data: {
           track_category: 'navPolicyAreaLinkClicked',
-          track_action: "#{heading}",
+          track_action: see_all_link_text.parameterize.underscore,
           track_label: link_to,
           track_options: {
             dimension28: documents.size.to_s,
-            dimension29: "See all #{heading.downcase}"
+            dimension29: see_all_link_text,
           }
         }
       )
     %>
   </p>
-</section>
+
+<% if heading %>
+  </section>
+<% end %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -59,18 +59,26 @@
       <% end %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: I18n.t("topical_events.headings.latest"),
-      padding: true,
-      font_size: 27,
-      border_top: 2,
-      margin_bottom: 3,
-    } %>
+    <section id="latest">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("topical_events.headings.latest"),
+        padding: true,
+        font_size: 27,
+        border_top: 2,
+        margin_bottom: 3,
+      } %>
 
-    <%= render "govuk_publishing_components/components/subscription_links", {
-      email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}",
-      feed_link_box_value: Plek.new.website_root + topical_event_path(@topical_event.slug, format: "atom")
-    } %>
+      <% if @topical_event.latest.any? %>
+        <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.latest, link_to: search_url(:latest, @topical_event.slug) })  %>
+      <% else %>
+        <p class="govuk-body"><%= I18n.t("topical_events.no_updates") %></p>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/subscription_links", {
+        email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}",
+        feed_link_box_value: Plek.new.website_root + topical_event_path(@topical_event.slug, format: "atom")
+      } %>
+    </section>
   </div>
 
   <div class="govuk-grid-column-full">

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -10,3 +10,4 @@ ar:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -10,3 +10,4 @@ az:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -10,3 +10,4 @@ be:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -10,3 +10,4 @@ bg:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -10,3 +10,4 @@ bn:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -10,3 +10,4 @@ cs:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -10,3 +10,4 @@ cy:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -10,3 +10,4 @@ da:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -10,3 +10,4 @@ de:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -10,3 +10,4 @@ dr:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -10,3 +10,4 @@ el:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -10,3 +10,4 @@ en:
       latest: Latest
       publications: Publications
       travel_advice: Travel Advice
+    no_updates: There are no updates yet.

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -10,3 +10,4 @@ es-419:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -10,3 +10,4 @@ es:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -10,3 +10,4 @@ et:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -10,3 +10,4 @@ fa:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -10,3 +10,4 @@ fi:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -10,3 +10,4 @@ fr:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -10,3 +10,4 @@ gd:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -10,3 +10,4 @@ gu:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -10,3 +10,4 @@ he:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -10,3 +10,4 @@ hi:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -10,3 +10,4 @@ hr:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -10,3 +10,4 @@ hu:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -10,3 +10,4 @@ hy:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -10,3 +10,4 @@ id:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -10,3 +10,4 @@ is:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -10,3 +10,4 @@ it:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -10,3 +10,4 @@ ja:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -10,3 +10,4 @@ ka:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -10,3 +10,4 @@ kk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -10,3 +10,4 @@ ko:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -10,3 +10,4 @@ lt:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -10,3 +10,4 @@ lv:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -10,3 +10,4 @@ ms:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -10,3 +10,4 @@ mt:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -10,3 +10,4 @@ ne:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -10,3 +10,4 @@ nl:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -10,3 +10,4 @@
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -10,3 +10,4 @@ pa-pk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -10,3 +10,4 @@ pa:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -10,3 +10,4 @@ pl:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -10,3 +10,4 @@ ps:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -10,3 +10,4 @@ pt:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -10,3 +10,4 @@ ro:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -10,3 +10,4 @@ ru:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -10,3 +10,4 @@ si:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -10,3 +10,4 @@ sk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -10,3 +10,4 @@ sl:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -10,3 +10,4 @@ so:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -10,3 +10,4 @@ sq:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -10,3 +10,4 @@ sr:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -10,3 +10,4 @@ sv:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -10,3 +10,4 @@ sw:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -10,3 +10,4 @@ ta:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -10,3 +10,4 @@ th:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -10,3 +10,4 @@ tk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -10,3 +10,4 @@ tr:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -10,3 +10,4 @@ uk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -10,3 +10,4 @@ ur:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -10,3 +10,4 @@ uz:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -10,3 +10,4 @@ vi:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -10,3 +10,4 @@ yi:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -10,3 +10,4 @@ zh-hk:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -10,3 +10,4 @@ zh-tw:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -10,3 +10,4 @@ zh:
       latest:
       publications:
       travel_advice:
+    no_updates:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -116,6 +116,35 @@ RSpec.feature "Topical Event pages" do
     end
   end
 
+  context "latest documents" do
+    let(:latest_documents) { { "Some document" => "/foo/latest_one", "Another document" => "/foo/latest_two" } }
+
+    it "displays the latest documents" do
+      stub_search(body: search_api_response(latest_documents))
+
+      visit base_path
+
+      expect(page).to have_text("Latest")
+
+      within("#latest") do
+        latest_documents.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all", href: "/search/all?order=updated-newest&topical_events%5B%5D=something-very-topical")
+      end
+    end
+
+    it "displays a message when there are no documents yet" do
+      stub_search(body: search_api_response({}))
+
+      visit base_path
+
+      expect(page).to have_text("Latest")
+
+      within("#latest") do
+        expect(page).to have_text("There are no updates yet.")
+      end
+    end
+  end
+
   it "includes a link to the about page" do
     visit base_path
     expect(page).to have_link(content_item.dig("details", "about_page_link_text"), href: "#{base_path}/about")

--- a/spec/helpers/topical_events_helper_spec.rb
+++ b/spec/helpers/topical_events_helper_spec.rb
@@ -3,11 +3,13 @@ RSpec.describe TopicalEventsHelper do
     expected_publication_url = "/search/all?topical_events%5B%5D=something-very-topical"
     expected_consultation_url = "/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations&topical_events%5B%5D=something-very-topical"
     expected_announcement_url = "/search/news-and-communications?topical_events%5B%5D=something-very-topical"
+    expected_latest_url = "/search/all?order=updated-newest&topical_events%5B%5D=something-very-topical"
 
     expected_results = {
       publication: expected_publication_url,
       consultation: expected_consultation_url,
       announcement: expected_announcement_url,
+      latest: expected_latest_url,
     }
 
     expected_results.each do |document_type, expected_url|

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -114,6 +114,15 @@ RSpec.describe TopicalEvent do
 
       topical_event.publications
     end
+
+    it "should make the correct call to search api for latest" do
+      expect(Services.search_api)
+        .to receive(:search)
+              .with(default_params)
+              .and_return({ "results" => [] })
+
+      topical_event.latest
+    end
   end
 
 private


### PR DESCRIPTION
This adds a 'latest' documents section to the topical events page, which displays the latest documents (of any type) linked to the topical collection.

| Collections Rendering | Whitehall Rendering |
|--------|--------|
|<img width="810" alt="Screenshot 2022-07-05 at 15 19 28" src="https://user-images.githubusercontent.com/25515510/177365402-ec4c7916-0698-46d1-8c56-b79a301a8559.png"> | <img width="610" alt="Screenshot 2022-07-05 at 15 19 45" src="https://user-images.githubusercontent.com/25515510/177365356-f2023197-62af-4eb3-8f5e-73669cfd39dc.png"> |


[Trello card](https://trello.com/c/5BG65SGT/145-add-topical-event-latest-documents-to-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
