### PR TITLE
Only use `better_errors` in development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,11 @@ group :test do
   gem "webmock", require: false
 end
 
-group :development, :test do
+group :development do
   gem "better_errors"
+end
+
+group :development, :test do
   gem "binding_of_caller"
   gem "climate_control"
   gem "govuk_test"

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,6 @@
 class TaxonsController < ApplicationController
   rescue_from Taxon::InAlphaPhase, with: :error_404
+  rescue_from Taxon::NotATaxon, with: :error_404
   slimmer_template "gem_layout_full_width"
 
   def show

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -16,6 +16,8 @@ class Taxon
   class InAlphaPhase < StandardError
   end
 
+  class NotATaxon < StandardError; end
+
   def initialize(content_item)
     @content_item = content_item
   end
@@ -24,7 +26,7 @@ class Taxon
     content_item = ContentItem.find!(base_path)
 
     unless content_item.document_type == "taxon"
-      raise "Tried to render a taxon page for content item that is not a taxon"
+      raise NotATaxon
     end
 
     if content_item.phase == "alpha"

--- a/spec/features/world_location_taxon_spec.rb
+++ b/spec/features/world_location_taxon_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "World location taxon page" do
   end
 
   scenario "does not contain the feed selector if we are browsing a world location leaf page" do
-    world_usa = world_usa_taxon(base_path: base_path)
+    world_usa = world_usa_taxon(base_path: base_path, phase: "live")
     world_usa.delete("links")
 
     stub_content_store_has_item(base_path, world_usa)

--- a/spec/support/taxon_browsing_helper.rb
+++ b/spec/support/taxon_browsing_helper.rb
@@ -19,7 +19,7 @@ module TaxonBrowsingHelper
   end
 
   def then_there_should_be_an_error
-    expect(page.status_code).to eq(500)
+    expect(page.status_code).to eq(404)
   end
 
   def given_there_is_a_taxon_with_children


### PR DESCRIPTION
This application uses `better_errors` to produce pretty error messages when an error occurs.

This is great for development in a browser, but as the error is returned as a HTML response, we don't ever see the error when running feature tests (as Capybara thinks the page loaded ok). All we see is that the test expectation fails.

Example of a failing test before this change (you've no idea whether the failure is because the element isn't there or because there is an error in the code):
```
1) Topical Event pages afghanistan response topical event includes travel advice for Afghanistan
   Failure/Error: expect(page).to have_link(titleize_base_path(afghanistan_travel_advice_base_path), href: afghanistan_travel_advice_base_path)
     expected to find link "Foreign travel advice afghanistan" with href "/foreign-travel-advice/afghanistan" but there were no matches
   # ./spec/features/topical_event_spec.rb:72:in `block (3 levels) in <top (required)>'
```

Example of a failing test after this change (you can now see there's an error with the code):
```
 1) Topical Event pages afghanistan response topical event includes travel advice for Afghanistan
    Failure/Error:
      @content_item.content_item_data.dig("links", "organisations").map do |organisation|
        {
          content_id: organisation["content_id"],
          base_path: organisation["base_path"],
          title: organisation["title"],
          crest: organisation.dig("details", "logo", "crest"),
          brand: organisation.dig("details", "brand"),
        }
      end

    ActionView::Template::Error:
      undefined method `map' for nil:NilClass
    # ./app/models/topical_event.rb:111:in `organisations'
    # ./app/views/topical_events/show.html.erb:26:in `_app_views_topical_events_show_html_erb___4491315266640037643_67180'
    # ./spec/features/topical_event_spec.rb:71:in `block (3 levels) in <top (required)>'
    # ------------------
    # --- Caused by: ---
    # NoMethodError:
    #   undefined method `map' for nil:NilClass
    #   ./app/models/topical_event.rb:111:in `organisations'
```

By moving `better_errors` to only be included in the development environment, we will see actual errors when running tests locally.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
