### PR TITLE
Some styling tweaks for topical events

### DIFF
--- a/app/assets/stylesheets/views/_topical_events.scss
+++ b/app/assets/stylesheets/views/_topical_events.scss
@@ -91,4 +91,10 @@
     }
     /* stylelint-enable */
   }
+
+  .topical-events__section-break,
+  .topical-events__social-media-links,
+  .topical-events__image {
+    @include govuk-responsive-margin(8, "bottom");
+  }
 }

--- a/app/assets/stylesheets/views/_topical_events.scss
+++ b/app/assets/stylesheets/views/_topical_events.scss
@@ -94,7 +94,8 @@
 
   .topical-events__section-break,
   .topical-events__social-media-links,
-  .topical-events__image {
+  .topical-events__image,
+  .topical-event__body-wrapper {
     @include govuk-responsive-margin(8, "bottom");
   }
 }

--- a/app/assets/stylesheets/views/_topical_events.scss
+++ b/app/assets/stylesheets/views/_topical_events.scss
@@ -8,6 +8,8 @@
 
   .organisations-list {
     list-style: none;
+    padding: 0;
+
     /* stylelint-disable */
     .organisations-list__item {
       float: left;

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -72,7 +72,7 @@ class TopicalEvent
         image_src: document.dig("image", "url"),
         image_alt: document.dig("image", "alt_text"),
         heading_text: document["title"],
-        description: document["summary"],
+        description: document["summary"].truncate(160, separator: " "),
       }
     end
   end

--- a/app/views/topical_events/_document_list_from_search_api.html.erb
+++ b/app/views/topical_events/_document_list_from_search_api.html.erb
@@ -7,6 +7,7 @@
     padding: true,
     font_size: 27,
     margin_bottom: 3,
+    heading_level: 3
   } %>
 <% end %>
 

--- a/app/views/topical_events/_document_list_from_search_api.html.erb
+++ b/app/views/topical_events/_document_list_from_search_api.html.erb
@@ -1,7 +1,7 @@
 <% heading ||= nil %>
 
 <% if heading %>
-  <section id="<%= heading.downcase.parameterize %>" class="document-block">
+  <section id="<%= heading.downcase.parameterize %>" class="govuk-!-margin-bottom-7">
   <%= render "govuk_publishing_components/components/heading", {
     text: heading,
     padding: true,
@@ -13,7 +13,6 @@
 
   <%= render "govuk_publishing_components/components/document_list", {
     items: documents,
-    margin_bottom: 6,
   } %>
 
   <p class="govuk-body">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -32,16 +32,18 @@
       </div>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/govspeak", {
-      } do %>
-        <%= @topical_event.body&.html_safe %>
-    <% end %>
+    <div class="topical-event__body-wrapper">
+      <%= render "govuk_publishing_components/components/govspeak", {
+        } do %>
+          <%= @topical_event.body&.html_safe %>
+      <% end %>
 
-    <% if @topical_event.about_page_link_text %>
-      <p class="govuk-body">
-        <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, html_options: { class: "govuk-link" }) %>
-      </p>
-    <% end %>
+      <% if @topical_event.about_page_link_text %>
+        <p class="govuk-body">
+          <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, html_options: { class: "govuk-link" }) %>
+        </p>
+      <% end %>
+    </div>
 
     <% if @topical_event.social_media_links %>
       <section id="social-media-links" class="topical-events__section-break">

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -17,10 +17,6 @@
       margin_bottom: 8,
     } %>
 
-    <% if @topical_event.image_url %>
-      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
-    <% end %>
-
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <% if @topical_event.organisations %>
@@ -29,6 +25,10 @@
           "Organisations": sanitize(array_of_links_to_organisations(@topical_event.organisations).to_sentence)
         }
       } %>
+    <% end %>
+
+    <% if @topical_event.image_url %>
+      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
     <% end %>
 
     <%= render "govuk_publishing_components/components/govspeak", {

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -40,7 +40,7 @@
 
       <% if @topical_event.about_page_link_text %>
         <p class="govuk-body">
-          <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, html_options: { class: "govuk-link" }) %>
+          <%= link_to(@topical_event.about_page_link_text, @topical_event.about_page_url, class: "govuk-link" ) %>
         </p>
       <% end %>
     </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -50,7 +50,7 @@
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-full govuk-!-margin-bottom-7">
+  <div class="govuk-grid-column-full">
     <% if @topical_event.ordered_featured_documents %>
       <section id="featured" class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/heading", {
@@ -72,7 +72,9 @@
         <% end %>
       </section>
     <% end %>
+  </div>
 
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
     <section id="latest">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.latest"),
@@ -95,7 +97,7 @@
     </section>
   </div>
 
-  <section id="documents" class="govuk-grid-column-full">
+  <section id="documents" class="govuk-grid-column-two-thirds">
     <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.detailed_guidance.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.documents"),

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -14,10 +14,9 @@
 
     <%= render "govuk_publishing_components/components/lead_paragraph", {
       text: @topical_event.description,
-      margin_bottom: 8,
     } %>
 
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-8">
 
     <% if @topical_event.organisations %>
       <%= render "govuk_publishing_components/components/metadata", {

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -43,31 +43,35 @@
     <% end %>
 
     <% if @topical_event.social_media_links %>
+      <section id="social-media-links" class="govuk-!-margin-bottom-7">
       <%= render "govuk_publishing_components/components/share_links", {
         links: @topical_event.social_media_links,
       } %>
+      </section>
     <% end %>
   </div>
 
   <div class="govuk-grid-column-full govuk-!-margin-bottom-7">
     <% if @topical_event.ordered_featured_documents %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.headings.featured"),
-        padding: true,
-        font_size: "l",
-        border_top: 2,
-        margin_bottom: 4,
-      } %>
+      <section id="featured" class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: I18n.t("topical_events.headings.featured"),
+          padding: true,
+          font_size: "l",
+          border_top: 2,
+          margin_bottom: 4,
+        } %>
 
-      <% @topical_event.ordered_featured_documents.in_groups_of(3, false) do |row| %>
-        <div class="govuk-grid-row">
-          <% row.each do |document| %>
-            <div class="govuk-grid-column-one-third">
-              <%= render "govuk_publishing_components/components/image_card", document %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+        <% @topical_event.ordered_featured_documents.in_groups_of(3, false) do |row| %>
+          <div class="govuk-grid-row">
+            <% row.each do |document| %>
+              <div class="govuk-grid-column-one-third">
+                <%= render "govuk_publishing_components/components/image_card", document %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </section>
     <% end %>
 
     <section id="latest">
@@ -92,7 +96,7 @@
     </section>
   </div>
 
-  <div class="govuk-grid-column-full">
+  <section id="documents" class="govuk-grid-column-full">
     <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.detailed_guidance.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.documents"),
@@ -107,10 +111,11 @@
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
     <%= render(partial: 'document_list_from_search_api', locals: { documents: @topical_event.detailed_guidance, heading: I18n.t("topical_events.headings.detailed_guides"), link_to: search_url(:detailed_guidance, @topical_event.slug) }) if @topical_event.detailed_guidance.any? %>
-  </div>
+  </section>
 
   <div class="govuk-grid-column-two-thirds">
     <% if @topical_event.travel_advice.any? %>
+      <section id="travel-advice"
       <%= render "govuk_publishing_components/components/heading", {
         text: t("topical_events.headings.travel_advice"),
         font_size: "l",
@@ -128,6 +133,7 @@
           }
         end
       } %>
+      </section>
     <% end %>
   </div>
 

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -16,7 +16,7 @@
       text: @topical_event.description,
     } %>
 
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-8">
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible topical-events__section-break">
 
     <% if @topical_event.organisations %>
       <%= render "govuk_publishing_components/components/metadata", {
@@ -27,7 +27,9 @@
     <% end %>
 
     <% if @topical_event.image_url %>
+      <div class="topical-events__image">
       <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
+      </div>
     <% end %>
 
     <%= render "govuk_publishing_components/components/govspeak", {
@@ -42,7 +44,7 @@
     <% end %>
 
     <% if @topical_event.social_media_links %>
-      <section id="social-media-links" class="govuk-!-margin-bottom-7">
+      <section id="social-media-links" class="topical-events__section-break">
       <%= render "govuk_publishing_components/components/share_links", {
         links: @topical_event.social_media_links,
       } %>
@@ -52,7 +54,7 @@
 
   <div class="govuk-grid-column-full">
     <% if @topical_event.ordered_featured_documents %>
-      <section id="featured" class="govuk-!-margin-bottom-6">
+      <section id="featured">
         <%= render "govuk_publishing_components/components/heading", {
           text: I18n.t("topical_events.headings.featured"),
           padding: true,
@@ -74,7 +76,7 @@
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+  <div class="govuk-grid-column-two-thirds topical-events__section-break">
     <section id="latest">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.latest"),

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -12,4 +12,4 @@ en:
       publications: Publications
       travel_advice: Travel Advice
     no_updates: There are no updates yet.
-    organisations: Who's involved
+    organisations: Who’s involved

--- a/spec/fixtures/content_store/topical_event.json
+++ b/spec/fixtures/content_store/topical_event.json
@@ -45,7 +45,7 @@
           "alt_text": "Alt text for the image"
         },
         "title": "A document related to this event",
-        "summary": "Very interesting document content."
+        "summary": "Very interesting document content. However this goes over the 160 character limit so when displayed this should be truncated in order to display the content neatly on the page."
       }
     ],
     "social_media_links": [

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -66,14 +66,14 @@ RSpec.describe TopicalEvent do
     ])
   end
 
-  it "should map the social media links" do
+  it "should map the ordered featured documents with truncated description where this exceeds 160 chars" do
     expect(topical_event.ordered_featured_documents).to eq([
       {
         href: "https://www.gov.uk/somewhere",
         image_src: "https://www.gov.uk/someimage.png",
         image_alt: "Alt text for the image",
         heading_text: "A document related to this event",
-        description: "Very interesting document content.",
+        description: "Very interesting document content. However this goes over the 160 character limit so when displayed this should be truncated in order to display the content...",
       },
     ])
   end


### PR DESCRIPTION
This PR gathers a number of styling tweaks to the topical events page in collections, either to: a) make the layout more logical, or b) make it more consistent with the Whitehall rendering, following review.

Fixes in this PR:
* Headings for different document types are h2s rather than h3s to make more sense with the format of the page
* Styling of 'latest' heading is the same as that of the 'Documents' heading, since they occupy the same place in the layout hierarchy of the page.
* Adds padding at appropriate points on the page
* Corrects ordering of layout of elements to be consistent with Whitehall
* Long summaries on featured documents are truncated to be consistent with Whitehall.

To see a rendered page:

`govuk-docker-up app-live`
Visit http://collections.dev.gov.uk/government/topical-events/nepal-earthquake-april-2015 and compare to the live site.
This topical event has most of the elements possible to standard topical events.

Slugs of some other topical events (for a locally spun up version of collections pointing to the live site:
* [budget-2021](http://collections.dev.gov.uk/government/topical-events/budget-2021)
* [afghanistan-uk-government-response](http://collections.dev.gov.uk/government/topical-events/afghanistan-uk-government-response) - this has a custom 'travel advice' section not seen on other topical events.
* [first-world-war-centenary](http://collections.dev.gov.uk/government/topical-events/first-world-war-centenary) - this has a custom external organisations set of logos at the bottom not seen on other topical events

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️