### PR TITLE
Change layout of topical event summary section

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -12,16 +12,13 @@
       context: (I18n.t("topical_events.archived") if @topical_event.archived?)
     } %>
 
-    <%= render "govuk_publishing_components/components/lead_paragraph", {
-      text: @topical_event.description,
-      margin_bottom: 8,
-    } %>
+    <div class="govuk-!-margin-bottom-8">
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: @topical_event.description,
+      } %>
 
-    <% if @topical_event.image_url %>
-      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
-    <% end %>
-
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    </div>
 
     <% if @topical_event.organisations %>
       <%= render "govuk_publishing_components/components/metadata", {
@@ -29,6 +26,10 @@
           "Organisations": sanitize(array_of_links_to_organisations(@topical_event.organisations).to_sentence)
         }
       } %>
+    <% end %>
+
+    <% if @topical_event.image_url %>
+      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
     <% end %>
 
     <%= render "govuk_publishing_components/components/govspeak", {


### PR DESCRIPTION
This changes the layout of the topical event summary section to match the Whitehall version of the page by:

- moving the organisation names to be above the image
- moving the horizontal section break to appear below the lead paragraph
- add the correct margin under the section break

Screenshot examples:

|Before these changes|After these changes|Whitehall rendered version|
|---|---|---|
|![Screenshot showing a topical event page with the content in the following order: title, lead paragraph, image, horizontal rule line, organisations and summary text.](https://user-images.githubusercontent.com/6329861/178455529-42bf7f29-882e-4ae4-a7fe-c77b290819bd.png)|![Screenshot showing a topical event page with the content in the following order: title, lead paragraph, horizontal rule, organisations, image and summary text.](https://user-images.githubusercontent.com/6329861/178455682-22a7ce3f-1bbd-4ff3-873a-4825c6770c66.png)|![Screenshot showing a topical event page with the content in the following order: title, lead paragraph, horizontal rule, organisations, image and summary text.](https://user-images.githubusercontent.com/6329861/178456001-31b022d4-38e8-4346-ac9d-2b654a6aa8c2.png)|

[Trello card](https://trello.com/c/gBGGw6T3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
