### PR TITLE
Browse topics

### DIFF
--- a/app/controllers/ab_tests/new_browse_ab_testable.rb
+++ b/app/controllers/ab_tests/new_browse_ab_testable.rb
@@ -21,7 +21,7 @@ module AbTests::NewBrowseAbTestable
   end
 
   def new_browse_variant_b?
-    page_under_test? && new_browse_variant.variant?("B")
+    true
   end
 
   def page_under_test?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,7 @@ private
   end
 
   def breadcrumb_content
-    render_partial("_breadcrumbs")
+    render_partial("_breadcrumbs", locals = { request: request })
   end
 
   def render_partial(partial_name, locals = {})

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -73,6 +73,6 @@ private
 
   def level_two_topic_page
     path = "/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}"
-    Topic.find(path) if topic_browse_mapping(path).present?
+    Topic.find(path) if topic_as_browse_mapping(request).present?
   end
 end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,5 +1,6 @@
 class SecondLevelBrowsePageController < ApplicationController
   enable_request_formats show: [:json]
+  include TopicBrowseHelper
 
   def show
     setup_content_item_and_navigation_helpers(page)
@@ -43,9 +44,8 @@ private
   end
 
   def page
-    @page ||= MainstreamBrowsePage.find(
-      "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}",
-    )
+    @page ||=
+      level_two_topic_page.presence || second_level_browse_page
   end
 
   def count_link_sections(page)
@@ -63,5 +63,16 @@ private
     end
 
     link_count
+  end
+
+  def second_level_browse_page
+    MainstreamBrowsePage.find(
+      "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}",
+    )
+  end
+
+  def level_two_topic_page
+    path = "/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}"
+    Topic.find(path) if topic_browse_mapping(path).present?
   end
 end

--- a/app/helpers/topic_browse_helper.rb
+++ b/app/helpers/topic_browse_helper.rb
@@ -1,6 +1,14 @@
 module TopicBrowseHelper
   def topic_browse_mapping(path)
+    check_browse_paths(path) || check_topic_paths(path)
+  end
+
+  def check_browse_paths(path)
     mappings.find { |m| m["browse_path"] == path }
+  end
+
+  def check_topic_paths(path)
+    mappings.find { |m| m["topic_path"] == path }
   end
 
   def mappings

--- a/app/helpers/topic_browse_helper.rb
+++ b/app/helpers/topic_browse_helper.rb
@@ -1,14 +1,16 @@
 module TopicBrowseHelper
-  def topic_browse_mapping(path)
-    check_browse_paths(path) || check_topic_paths(path)
-  end
 
-  def check_browse_paths(path)
+  def browse_to_topic_mapping(path)
     mappings.find { |m| m["browse_path"] == path }
   end
 
-  def check_topic_paths(path)
-    mappings.find { |m| m["topic_path"] == path }
+  def topic_as_browse_mapping(request)
+    mapping = mappings.find { |m| m["topic_path"] == request.path }
+    return unless mapping
+
+    referer = URI(request.referer)
+    return if (request.path).include?(referer.path)
+    mapping
   end
 
   def mappings

--- a/app/helpers/topic_browse_helper.rb
+++ b/app/helpers/topic_browse_helper.rb
@@ -1,0 +1,9 @@
+module TopicBrowseHelper
+  def topic_browse_mapping(path)
+    mappings.find { |m| m["browse_path"] == path }
+  end
+
+  def mappings
+    @mappings ||= YAML.load_file(Rails.root.join("config/topic_browse.yml").to_s)["mappings"]
+  end
+end

--- a/app/lib/topic_browse_routing_constraint.rb
+++ b/app/lib/topic_browse_routing_constraint.rb
@@ -1,0 +1,8 @@
+class TopicBrowseRoutingConstraint
+  include TopicBrowseHelper
+
+  def matches?(request)
+    @path = request.path
+    topic_browse_mapping(@path).present?
+  end
+end

--- a/app/lib/topic_browse_routing_constraint.rb
+++ b/app/lib/topic_browse_routing_constraint.rb
@@ -2,7 +2,6 @@ class TopicBrowseRoutingConstraint
   include TopicBrowseHelper
 
   def matches?(request)
-    @path = request.path
-    topic_browse_mapping(@path).present?
+    topic_as_browse_mapping(request).present?
   end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,4 +1,5 @@
 class MainstreamBrowsePage
+  include TopicBrowseHelper
   attr_reader :content_item
 
   delegate(
@@ -30,6 +31,12 @@ class MainstreamBrowsePage
   end
 
   def second_level_browse_pages
+    return level_two_browse if level_two_specialist_topic.blank?
+
+    level_two_browse << level_two_specialist_topic
+  end
+
+  def level_two_browse
     links = linked_items("second_level_browse_pages")
 
     if second_level_pages_curated?
@@ -39,6 +46,13 @@ class MainstreamBrowsePage
     else
       links
     end
+  end
+
+  def level_two_specialist_topic
+    mapping = topic_browse_mapping(base_path)
+    return if mapping.blank?
+
+    Topic.find(mapping["topic_path"])
   end
 
   def second_level_pages_curated?

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -49,7 +49,7 @@ class MainstreamBrowsePage
   end
 
   def level_two_specialist_topic
-    mapping = topic_browse_mapping(base_path)
+    mapping = browse_to_topic_mapping(base_path)
     return if mapping.blank?
 
     Topic.find(mapping["topic_path"])

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -49,4 +49,27 @@ class Topic
   def slug
     base_path.sub(%r{\A/topic/}, "")
   end
+
+  def related_topics
+    []
+  end
+
+  # These attributes are required to support the Miller collumns. Once the NewBrowse AB test is complete,
+  # and we render only the new browse templates, these can be removed.
+
+  def second_level_browse_pages
+    children
+  end
+
+  def active_top_level_browse_page
+    parent
+  end
+
+  def second_level_pages_curated?
+    true
+  end
+
+  def top_level_browse_pages
+    []
+  end
 end

--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -2,8 +2,9 @@
 class Breadcrumbs
   include TopicBrowseHelper
 
-  def initialize(content_item)
+  def initialize(content_item, request)
     @content_item = content_item
+    @request = request
   end
 
   def breadcrumbs
@@ -18,7 +19,7 @@ class Breadcrumbs
 
 private
 
-  attr_reader :content_item
+  attr_reader :content_item, :request
 
   def all_parents
     parents = []
@@ -34,11 +35,11 @@ private
   end
 
   def topic_browse_breadcrumb
-    mapping = check_topic_paths(content_item["base_path"])
-    if mapping
-      page = MainstreamBrowsePage.find(mapping["browse_path"])
-      [{ "title" => page.title, "base_path" => page.base_path }]
-    end
+    mapping = topic_as_browse_mapping(request)
+    return if mapping.blank?
+    
+    page = MainstreamBrowsePage.find(mapping["browse_path"])
+    [{ "title" => page.title, "base_path" => page.base_path }]
   end
 
   def parent_selector

--- a/app/presenters/breadcrumbs.rb
+++ b/app/presenters/breadcrumbs.rb
@@ -1,11 +1,13 @@
 # Breadcrumbs for Mainstream browse and old topic pages
 class Breadcrumbs
+  include TopicBrowseHelper
+
   def initialize(content_item)
     @content_item = content_item
   end
 
   def breadcrumbs
-    ordered_parents = all_parents.map do |parent|
+    ordered_parents = parent_selector.map do |parent|
       { title: parent.fetch("title"), url: parent.fetch("base_path") }
     end
 
@@ -29,5 +31,17 @@ private
     end
 
     parents
+  end
+
+  def topic_browse_breadcrumb
+    mapping = check_topic_paths(content_item["base_path"])
+    if mapping
+      page = MainstreamBrowsePage.find(mapping["browse_path"])
+      [{ "title" => page.title, "base_path" => page.base_path }]
+    end
+  end
+
+  def parent_selector
+    topic_browse_breadcrumb.presence || all_parents
   end
 end

--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -1,7 +1,7 @@
 <% inverse ||= false %>
 
 <%= render 'govuk_publishing_components/components/breadcrumbs', {
-  breadcrumbs: Breadcrumbs.new(@content_item).breadcrumbs,
+  breadcrumbs: Breadcrumbs.new(@content_item, request).breadcrumbs,
   collapse_on_mobile: true,
   inverse: inverse
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
   end
 
   resources :topics, only: %i[index show], path: :topic, param: :topic_slug do
+    constraints TopicBrowseRoutingConstraint.new do
+      get ":subtopic_slug", on: :member, to: "second_level_browse_page#show"
+    end
     get ":subtopic_slug", on: :member, to: "subtopics#show"
   end
 

--- a/config/topic_browse.yml
+++ b/config/topic_browse.yml
@@ -2,5 +2,5 @@
   # browse_path: /browse/tax (level one browse)
   # topic_path: /topic/benefits-credits/tax-credits (level two specialist topic)
 mappings:
- - browse_path:
-   topic_path:
+ - browse_path: /browse/tax
+   topic_path: /topic/benefits-credits/tax-credits

--- a/config/topic_browse.yml
+++ b/config/topic_browse.yml
@@ -1,0 +1,6 @@
+  # examples:
+  # browse_path: /browse/tax (level one browse)
+  # topic_path: /topic/benefits-credits/tax-credits (level two specialist topic)
+mappings:
+ - browse_path:
+   topic_path:

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -90,6 +90,7 @@ RSpec.feature "Mainstream browsing" do
 
       expect(page.status_code).to eq(200)
       expect(page).to have_selector("h1", text: "Level two specialist topic")
+      expect(page).to have_selector("a.govuk-breadcrumbs__link", text: "Level one browse page")
     end
   end
 end

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -29,4 +29,67 @@ RSpec.feature "Mainstream browsing" do
       expect(page).to have_selector(".gem-c-breadcrumbs")
     end
   end
+
+  context "level two specialist topic content exists for a level one browse page" do
+    let(:level_one_browse_url) { "/browse/one" }
+    let(:level_two_topic_url) { "/topic/second/level" }
+    let(:test_yaml) do
+      { "mappings" =>
+        [
+          {
+            "browse_path" => level_one_browse_url,
+            "topic_path" => level_two_topic_url,
+          },
+        ] }
+    end
+
+    let(:level_two_browse_content_item) do
+      GovukSchemas::Example.find("mainstream_browse_page", example_name: "curated_level_2_page")
+       .merge(
+         "title" => "Level two browse page",
+       )
+    end
+
+    let(:browse_content_item) do
+      GovukSchemas::Example.find("mainstream_browse_page", example_name: "top_level_page")
+       .merge(
+         "base_path" => level_one_browse_url,
+         "title" => "Level one browse page",
+         "links" => { "second_level_browse_pages" => [level_two_browse_content_item] },
+       )
+    end
+
+    before do
+      allow(YAML).to receive(:load_file).and_return(test_yaml)
+      stub_content_store_has_item(browse_content_item["base_path"], browse_content_item)
+      topic_content_item = GovukSchemas::Example.find("topic", example_name: "curated_subtopic").merge(
+        "title" => "Level two specialist topic",
+        "base_path" => level_two_topic_url,
+        "content_id" => "1234",
+      )
+      stub_content_store_has_item(level_two_topic_url, topic_content_item)
+
+      search_api_has_documents_for_subtopic(
+        topic_content_item["content_id"],
+        %w[employee-tax-codes],
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      )
+    end
+
+    scenario "the level two topics are visible on the level one browse grid" do
+      visit browse_content_item["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_link("Level two browse page")
+      expect(page).to have_link("Level two specialist topic")
+    end
+
+    scenario "clicking the level two specialist topic link" do
+      visit browse_content_item["base_path"]
+      click_link("Level two specialist topic")
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector("h1", text: "Level two specialist topic")
+    end
+  end
 end

--- a/spec/helpers/topic_browse_helper_spec.rb
+++ b/spec/helpers/topic_browse_helper_spec.rb
@@ -18,5 +18,10 @@ RSpec.describe TopicBrowseHelper do
       expect(topic_browse_mapping("boo")).to be nil
       expect(topic_browse_mapping("foo")).to eq({ "browse_path" => "foo", "topic_path" => "bar" })
     end
+
+    it "returns the topic mapping for a given topic base path" do
+      expect(topic_browse_mapping("boo")).to be nil
+      expect(topic_browse_mapping("bar")).to eq({ "browse_path" => "foo", "topic_path" => "bar" })
+    end
   end
 end

--- a/spec/helpers/topic_browse_helper_spec.rb
+++ b/spec/helpers/topic_browse_helper_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe TopicBrowseHelper do
+  let(:test_yaml) do
+    { "mappings" =>
+      [
+        {
+          "browse_path" => "foo",
+          "topic_path" => "bar",
+        },
+      ] }
+  end
+
+  before do
+    allow(YAML).to receive(:load_file).and_return(test_yaml)
+  end
+
+  describe "#topic_browse_mapping" do
+    it "returns the topic mapping for a given browse base path" do
+      expect(topic_browse_mapping("boo")).to be nil
+      expect(topic_browse_mapping("foo")).to eq({ "browse_path" => "foo", "topic_path" => "bar" })
+    end
+  end
+end

--- a/spec/lib/topic_browse_routing_constraint_spec.rb
+++ b/spec/lib/topic_browse_routing_constraint_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe TopicBrowseRoutingConstraint do
+  let(:test_yaml) do
+    { "mappings" =>
+      [
+        {
+          "browse_path" => "/browse/foo",
+          "topic_path" => "/topic/bar",
+        },
+      ] }
+  end
+
+  let(:empty_config_yaml) do
+    { "mappings" => [] }
+  end
+
+  describe "#matches?" do
+    context "when a topic browse mapping exists" do
+      before do
+        allow(YAML).to receive(:load_file).and_return(test_yaml)
+      end
+
+      it "should return true if the path matches" do
+        request = double("request", path: "/topic/bar")
+        subject = described_class.new
+        expect(subject.matches?(request)).to be(true)
+      end
+
+      it "should return false if the path does not match" do
+        request = double("request", path: "/topic/nope")
+        subject = described_class.new
+        expect(subject.matches?(request)).to be(false)
+      end
+    end
+
+    context "when there are no browse topic mappings" do
+      before do
+        allow(YAML).to receive(:load_file).and_return(empty_config_yaml)
+      end
+
+      it "should return true if the path matches" do
+        request = double("request", path: "/topic/bar")
+        subject = described_class.new
+        expect(subject.matches?(request)).to be(false)
+      end
+
+      it "should return false if the path does not match" do
+        request = double("request", path: "/topic/nope")
+        subject = described_class.new
+        expect(subject.matches?(request)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -96,6 +96,47 @@ RSpec.describe MainstreamBrowsePage do
         ]
         expect(page.second_level_browse_pages.map(&:content_id)).to eq(expected)
       end
+
+      context "when there is a mapped level two specialist topic" do
+        let(:level_two_topic_url) { "/topic/second/level" }
+        let(:level_one_browse_url) { api_data["base_path"] }
+        let(:test_yaml) do
+          { "mappings" =>
+            [
+              {
+                "browse_path" => level_one_browse_url,
+                "topic_path" => level_two_topic_url,
+              },
+            ] }
+        end
+
+        let(:topic_api_data) do
+          GovukSchemas::RandomExample.for_schema(frontend_schema: "topic").merge(
+            "title" => "Level two specialist topic",
+            "base_path" => level_two_topic_url,
+            "content_id" => "1234",
+            "links" => {},
+          )
+        end
+
+        before do
+          allow(YAML).to receive(:load_file).and_return(test_yaml)
+          stub_content_store_has_item(level_two_topic_url, topic_api_data)
+          api_data["links"]["second_level_browse_pages"] = [
+            second_level_browse_page2,
+            second_level_browse_page1,
+          ]
+        end
+
+        it "adds second level specialist topics to the set of links" do
+          expected = [
+            second_level_browse_page2["content_id"],
+            second_level_browse_page1["content_id"],
+            topic_api_data["content_id"],
+          ]
+          expect(page.second_level_browse_pages.map(&:content_id)).to eq(expected)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Reimplementation of https://github.com/alphagov/collections/pull/2861 to include a configuration file for adding new specialist topic mappings.

## New behaviour

- Surface some well maintained level two specialist topics in mainstream browse.
- Display those topics in the browse style if the user has navigated from browse. If they've come via the level one specialist topic parent page, then display the page as normal. 

<img width="1268" alt="Screenshot 2022-07-21 at 12 19 39" src="https://user-images.githubusercontent.com/17908089/180201600-3360fd2d-fcb1-4f98-af09-3a715bcd2f3b.png">


## Conditional rendering of specialist topic page

### 1. Visitor coming from browse 
- https://collections-pr-2866.herokuapp.com/browse
- Click on Money and Tax
- Click on Tax credits
==> See page as browse with browse breadcrumb

<img width="762" alt="Screenshot 2022-07-21 at 12 17 46" src="https://user-images.githubusercontent.com/17908089/180201316-4f013fe8-aaac-4b0d-acaa-3336dd19355a.png">


### 2. Visitor coming from topic parent
- Visit https://collections-pr-2866.herokuapp.com/topic
- Click on Benefits
- Click on Tax credits
- Hard refresh (as your browser has cached the page from the above visit)
==> See page as topic with topic breadcrumb

<img width="990" alt="Screenshot 2022-07-21 at 12 18 00" src="https://user-images.githubusercontent.com/17908089/180201378-a94be414-3999-468d-9035-a1b89944401c.png">

https://trello.com/c/r7omPpSs/1133-spike-surfacing-specialist-topics-in-mainstream-browse

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
