### PR TITLE
Updating base image to use a new image with Ruby on Minideb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,29 @@
-# TODO: make this default to govuk-ruby once it's being pushed somewhere public
-# (unless we decide to use Bitnami instead)
-ARG base_image=ruby:2.7.6-slim-buster
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
-FROM $base_image AS builder
-# This image is only intended to be able to run this app in a production RAILS_ENV
-ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
+FROM $builder_image AS builder
 
 RUN mkdir /app
+
 WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version /app/
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install --jobs 4 --retry=2
+
+COPY Gemfile* .ruby-version /app/
+
+RUN bundle install
+
 COPY . /app
 
-RUN GOVUK_APP_DOMAIN=www.gov.uk \
-    GOVUK_WEBSITE_ROOT=http://www.gov.uk \
-    bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -fr /app/log
+
 
 FROM $base_image
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=collections
-# TODO: include nodejs in the base image (govuk-ruby).
-# TODO: apt-get upgrade in the base image
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs
+
+ENV GOVUK_APP_NAME=collections
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app
+
+USER app
 WORKDIR /app
+
 CMD bundle exec puma


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)

Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
