### PR TITLE
Allow all hosts for dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,9 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end


### PR DESCRIPTION
[A recent rails upgrade removed this](https://github.com/alphagov/collections/pull/2864/files#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47L65-L66) and it meant that collections wouldn't work in docker

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
