### PR TITLE
Only show topical event featured documents section when present

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -55,7 +55,7 @@
   </div>
 
   <div class="govuk-grid-column-full">
-    <% if @topical_event.ordered_featured_documents %>
+    <% if @topical_event.ordered_featured_documents&.any? %>
       <section id="featured">
         <%= render "govuk_publishing_components/components/heading", {
           text: I18n.t("topical_events.headings.featured"),


### PR DESCRIPTION
We are currently showing the featured documents section of topical event pages when there are no topical events present, as the `ordered_featured_documents` method returns an empty array.

Fixing this to check to see if there are any items in the array.

Example of this issue:
![Screenshot showing a topical event page with no featured documents.  There is a heading titled Featured but no documents are listed under it.](https://user-images.githubusercontent.com/6329861/180193772-68d562cd-1fb4-4244-8dc2-ea6f870287f9.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
