### PR TITLE
Update GTM analytics tracking attributes

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -30,12 +30,12 @@
         track_label: section["title"],
         track_dimension: number_of_accordion_sections,
         track_dimension_index: 26,
-        gtm_event_name: "select_content",
-        gtm_attributes: {
+        ga4: {
+          event_name: 'select_content',
           type: 'accordion',
           text: section["title"],
           index: index + 1,
-          'index-total': number_of_accordion_sections,
+          index_total: number_of_accordion_sections,
           section: 'n/a',
           action: 'n/a',
         }
@@ -57,9 +57,10 @@
   <div data-module="toggle-attribute">
     <%
       show_all_attributes = {
+        event_name: "select_content",
         type: "accordion",
         index: 0,
-        "index-total": number_of_accordion_sections,
+        index_total: number_of_accordion_sections,
         section: "n/a"
       }
     %>
@@ -69,8 +70,7 @@
         module: "govuk-accordion"
       },
       data_attributes_show_all: {
-        "gtm-event-name": "select_content",
-        "gtm-attributes": show_all_attributes.to_json
+        "ga4": show_all_attributes.to_json
       },
       items: accordion_contents,
       margin_bottom: 3


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Updates the data attributes used on accordion on the `/coronavirus` page for GTM analytics. Note that this change depends upon [this change in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/2864) being present in the currently installed gem version, but this can be safely merged ahead of that as it doesn't affect live and we're still just testing it anyway.

## Why
We updated the schema for how click tracking like this works, which meant that the tracking would no longer work.

## Visual changes
None.

Trello card: https://trello.com/c/obytEbqo/153-update-existing-code-with-schema-changes
