### PR TITLE
Fix errors in topical event tests

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -129,7 +129,7 @@ class TopicalEvent
 
   def emphasised_organisations
     @content_item.content_item_data.dig("details", "emphasised_organisations")&.map do |organisation_content_id|
-      @content_item.content_item_data.dig("links", "organisations").select { |organisation| organisation["content_id"] == organisation_content_id }
+      @content_item.content_item_data.dig("links", "organisations")&.select { |organisation| organisation["content_id"] == organisation_content_id }
     end
   end
 end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -120,7 +120,7 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% if @topical_event.travel_advice.any? %>
-      <section id="travel-advice"
+      <section id="travel-advice">
       <%= render "govuk_publishing_components/components/heading", {
         text: t("topical_events.headings.travel_advice"),
         font_size: "l",


### PR DESCRIPTION
We only noticed these problems after changing the usage of `better_errors` in https://github.com/alphagov/collections/pull/2852 as the test previous passed based on matching against the rendered error message.  The errors were introduced into the `main` branch after the `better_errors` PR was branch off `main`, so they weren't spotted in the pre-merge checks.

There are two corrections:

- Use safe navigation operator for emphasised organisations: a content item may not contain any links to organisations for a topical event, so we get a nil object which we cannot map. By adding the safe navigation operator, we overcome this.
- Add a missing `>` to a HTML tag.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
