### PR TITLE
Add LevelTwoBrowse AB test for the templates

### DIFF
--- a/app/controllers/ab_tests/level_two_browse_ab_testable.rb
+++ b/app/controllers/ab_tests/level_two_browse_ab_testable.rb
@@ -1,0 +1,30 @@
+module AbTests::LevelTwoBrowseAbTestable
+  CUSTOM_DIMENSION = 47
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def level_two_browse_test
+    @level_two_browse_test ||= GovukAbTesting::AbTest.new(
+      "LevelTwoBrowse",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def level_two_browse_variant
+    level_two_browse_test.requested_variant(request.headers)
+  end
+
+  def set_level_two_browse_response_header
+    level_two_browse_variant.configure_response(response)
+  end
+
+  def level_two_browse_variant_b?
+    page_under_test? && level_two_browse_variant.variant?("B")
+  end
+
+  def page_under_test?
+    request.path =~ /browse\/[\w-]*\/[\w-]*/
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 class ApplicationController < ActionController::Base
+  include AbTests::LevelTwoBrowseAbTestable
   include Slimmer::Template
 
+  helper_method :level_two_browse_variant
+  helper_method :page_under_test?
   helper_method :content_item_h
 
   protect_from_forgery with: :exception
 
+  before_action :set_level_two_browse_response_header_if_level_two_page
   before_action :set_expiry
   before_action :restrict_request_formats
 
@@ -107,5 +111,9 @@ private
 
   def render_partial(partial_name, locals = {})
     render_to_string(partial_name, formats: [:html], layout: false, locals: locals)
+  end
+
+  def set_level_two_browse_response_header_if_level_two_page
+    set_level_two_browse_response_header if page_under_test?
   end
 end

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -12,16 +12,13 @@ private
 
   def show_html
     slimmer_template "gem_layout_full_width"
-    curated_partial = if level_two_browse_variant_b?
-                        "show_curated_accordion"
-                      else
-                        "show_curated_list"
-                      end
-    template = if page.lists.curated?
-                 :show_curated
-               else
-                 :show_a_to_z
-               end
+
+    if page.lists.curated?
+      template = :show_curated
+      curated_partial = level_two_browse_variant_b? ? "show_curated_accordion" : "show_curated_list"
+    else
+      template = :show_a_to_z
+    end
     render(template, locals: { page: page, curated_partial: curated_partial, meta_section: meta_section })
   end
 

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,7 +1,5 @@
 class SecondLevelBrowsePageController < ApplicationController
-  def new_browse_variant_b?
-    params["b"].present?
-  end
+  helper_method :level_two_browse_variant_b?
 
   def show
     setup_content_item_and_navigation_helpers(page)
@@ -14,7 +12,7 @@ private
 
   def show_html
     slimmer_template "gem_layout_full_width"
-    curated_partial = if new_browse_variant_b?
+    curated_partial = if level_two_browse_variant_b?
                         "show_curated_accordion"
                       else
                         "show_curated_list"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
   <%= stylesheet_link_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
+  <%= level_two_browse_variant.analytics_meta_tag.html_safe if page_under_test? %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
   <%= stylesheet_link_tag "print.css", :media => "print", integrity: false %>
 </head>

--- a/spec/controllers/second_level_browse_page_controller_spec.rb
+++ b/spec/controllers/second_level_browse_page_controller_spec.rb
@@ -39,6 +39,95 @@ RSpec.describe SecondLevelBrowsePageController do
       end
     end
 
+    context "AB test: Second level browse pages showing accordions or lists" do
+      render_views
+
+      let :params do
+        {
+          top_level_slug: "benefits",
+          second_level_slug: "entitlement",
+        }
+      end
+
+      subject { get :show, params: params }
+
+      before do
+        stub_content_store_has_item(
+          "/browse/benefits/entitlement",
+          content_id: "entitlement-content-id",
+          title: "Entitlement",
+          base_path: "/browse/benefits/entitlement",
+          links: {
+            top_level_browse_pages: top_level_browse_pages,
+            second_level_browse_pages: second_level_browse_pages,
+            active_top_level_browse_page: [{
+              content_id: "content-id-for-benefits",
+              title: "Benefits",
+              base_path: "/browse/benefits",
+            }],
+            related_topics: [{ title: "A linked topic", base_path: "/browse/linked-topic" }],
+          },
+          details: details,
+        )
+
+        search_api_has_documents_for_browse_page(
+          "entitlement-content-id",
+          %w[entitlement],
+          page_size: 1000,
+        )
+      end
+
+      describe "GET second_level_browse_page for uncurated topic" do
+        let(:details) { {} }
+
+        it "renders correct template and partials for variant B" do
+          with_variant LevelTwoBrowse: "B" do
+            expect(subject).to render_template(:show_a_to_z,
+                                               locals: { curated_partial: "show_curated_accordion" })
+          end
+        end
+
+        it "renders correct template and partials for variant A" do
+          with_variant LevelTwoBrowse: "A" do
+            expect(subject).to render_template(:show_a_to_z,
+                                               locals: { curated_partial: "show_curated_list" })
+          end
+        end
+
+        it "renders correct template and partials for variant Z" do
+          with_variant LevelTwoBrowse: "Z" do
+            expect(subject).to render_template(:show_a_to_z,
+                                               locals: { curated_partial: "show_curated_list" })
+          end
+        end
+      end
+
+      describe "GET second_level_browse_page for curated topic" do
+        let(:details) { { groups: [{ name: "something", contents: ["/something"] }] } }
+
+        it "renders correct template and partials for variant B" do
+          with_variant LevelTwoBrowse: "B" do
+            expect(subject).to render_template(:show_curated,
+                                               locals: { curated_partial: "show_curated_accordion" })
+          end
+        end
+
+        it "renders correct template and partials for variant A" do
+          with_variant LevelTwoBrowse: "A" do
+            expect(subject).to render_template(:show_curated,
+                                               locals: { curated_partial: "show_curated_list" })
+          end
+        end
+
+        it "renders correct template and partials for variant Z" do
+          with_variant LevelTwoBrowse: "Z" do
+            expect(subject).to render_template(:show_curated,
+                                               locals: { curated_partial: "show_curated_list" })
+          end
+        end
+      end
+    end
+
     it "404 if the section does not exist" do
       stub_content_store_does_not_have_item("/browse/crime-and-justice/frume")
       params = {

--- a/spec/controllers/second_level_browse_page_controller_spec.rb
+++ b/spec/controllers/second_level_browse_page_controller_spec.rb
@@ -83,21 +83,21 @@ RSpec.describe SecondLevelBrowsePageController do
         it "renders correct template and partials for variant B" do
           with_variant LevelTwoBrowse: "B" do
             expect(subject).to render_template(:show_a_to_z,
-                                               locals: { curated_partial: "show_curated_accordion" })
+                                               locals: { curated_partial: nil })
           end
         end
 
         it "renders correct template and partials for variant A" do
           with_variant LevelTwoBrowse: "A" do
             expect(subject).to render_template(:show_a_to_z,
-                                               locals: { curated_partial: "show_curated_list" })
+                                               locals: { curated_partial: nil })
           end
         end
 
         it "renders correct template and partials for variant Z" do
           with_variant LevelTwoBrowse: "Z" do
             expect(subject).to render_template(:show_a_to_z,
-                                               locals: { curated_partial: "show_curated_list" })
+                                               locals: { curated_partial: nil })
           end
         end
       end


### PR DESCRIPTION
B – accordion
A – new design (listings)
Z – new design (listings)

https://trello.com/c/seHiut4T/1142-prepare-and-switch-to-a-5050-b-c-test-once-the-new-level-2-template-is-built

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
