### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,11 @@ $covid-grey: #272828;
 $covid-yellow: #fff500;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 // gem components
 @import "govuk_publishing_components/govuk_frontend_support";
 // @import "govuk_publishing_components/component_support";


### PR DESCRIPTION
## What

Prevent the font from being included in `collections`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `collections`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `collections`.

Before (the font paths contains `collections`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181218530-53798852-d35b-4fab-9d5d-e9f51a37caae.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181218560-7847de69-d045-4bfc-8701-3251da9a33d0.png">

---

## Search page examples to sanity check:

- https://collections-pr-2883.herokuapp.com/government/organisations