### PR TITLE
Fix browse accordion tracking

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -66,9 +66,6 @@
     %>
     <%= render 'govuk_publishing_components/components/accordion', {
       heading_level: 3,
-      data_attributes: {
-        module: "govuk-accordion"
-      },
       data_attributes_show_all: {
         "ga4": show_all_attributes.to_json
       },

--- a/app/views/second_level_browse_page/new_show_curated.html.erb
+++ b/app/views/second_level_browse_page/new_show_curated.html.erb
@@ -85,17 +85,17 @@
       <% end %>
 
       <div data-module="toggle-attribute">
+        <%
+          custom_dimensions = {
+            dimension114: 0,
+          }
+        %>
         <%= render "govuk_publishing_components/components/accordion", {
           track_show_all_clicks: true,
           track_sections: true,
           heading_level: 2,
-          data_attributes: {
-            show_all_attributes: {
-              "track-options": {
-                dimension114: 0,
-              }
-            },
-            module: "govuk-accordion",
+          data_attributes_show_all: {
+            "track-options": custom_dimensions.to_json,
           },
           items: accordion_contents,
           margin_bottom: 4,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix accordion 'show all sections' link tracking on https://www.gov.uk/browse/benefits/manage-your-benefit

The options being passed to the component were incorrectly formatted. I'll write up a better guide for reference after this, but here's the basics.

- the show all sections link is created by JS in the `govuk-frontend` code, so we can't append attributes directly to it
- instead we pass `data_attributes_show_all` to the component, which is read by our JS as data attributes to be appended to the show all link once created
- the format of `data_attributes_show_all` must be:

```ruby
<%
value1 = {
  something: 1
}

value2 = {
  something: 2
}
%>

# in the call to the component

data_attributes_show_all: {
  "attribute-name": value1.to_json,
  "another-attribute": value2.to_json,
}
```

This will produce attributes on the show all link that looks like the following.

```
data-attribute-name="{"something":1}" data-another-attribute="{"something":2}"
```

Also remove passing of the components own JS module identifier to the accordion, as it doesn't need to be - it's explicitly added [in the accordion template](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_accordion.html.erb#L25).

## Why
Incorrectly formatted option was resulting in a data attribute of `[Object object]` being incorrectly appended to the link, which was then unable to be interpreted as JSON as expected by the accordion component JavaScript.

## Visual changes
None.
