### PR TITLE
Add GA4 tracking to world taxon accordion, C-19 landing page and the 2nd level browse page

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -6,7 +6,7 @@
   accordion_contents = []
   number_of_accordion_sections = accordions.length
 %>
-<% accordions.each_with_index do | section, index | %>
+<% accordions.each.with_index(1) do | section, index | %>
   <% content = capture do %>
     <%# this element captures an override from the accordion that the last item has margin 0 %>
     <div class="covid__accordion-inner">
@@ -34,10 +34,8 @@
           event_name: 'select_content',
           type: 'accordion',
           text: section["title"],
-          index: index + 1,
+          index: index,
           index_total: number_of_accordion_sections,
-          section: 'n/a',
-          action: 'n/a',
         }
       }
     }
@@ -53,24 +51,24 @@
   border_top: border_top,
   font_size: "m"
 } if heading %>
-<div data-module="gem-track-click gtm-click-tracking">
-  <div data-module="toggle-attribute">
-    <%
-      show_all_attributes = {
-        event_name: "select_content",
-        type: "accordion",
-        index: 0,
-        index_total: number_of_accordion_sections,
-        section: "n/a"
-      }
-    %>
-    <%= render 'govuk_publishing_components/components/accordion', {
-      heading_level: 3,
-      data_attributes_show_all: {
-        "ga4": show_all_attributes.to_json
-      },
-      items: accordion_contents,
-      margin_bottom: 3
-    } %>
-  </div>
+<div data-module="toggle-attribute">
+  <%
+    show_all_attributes = {
+      event_name: "select_content",
+      type: "accordion",
+      index: 0,
+      index_total: number_of_accordion_sections,
+    }
+  %>
+  <%= render 'govuk_publishing_components/components/accordion', {
+    heading_level: 3,
+    data_attributes: {
+      module: "ga4-event-tracker",
+    },
+    data_attributes_show_all: {
+      "ga4": show_all_attributes.to_json
+    },
+    items: accordion_contents,
+    margin_bottom: 3
+  } %>
 </div>

--- a/app/views/second_level_browse_page/_show_curated_accordion.html.erb
+++ b/app/views/second_level_browse_page/_show_curated_accordion.html.erb
@@ -2,7 +2,7 @@
   custom_dimensions = {
     dimension114: (page.lists.count + 1).to_s,
   }
-  accordion_contents = page.lists.map.with_index do |list, list_index|
+  accordion_contents = page.lists.map.with_index(1) do |list, list_index|
     {
       heading: {
         text: list[:title],
@@ -16,8 +16,15 @@
       data_attributes: {
         "track-count": "accordionSection",
         "track-options": {
-          "dimension114": list_index + 1 
+          "dimension114": list_index,
         },
+        ga4: {
+          event_name: "select_content",
+          type: "accordion",
+          text: list[:title],
+          index: list_index,
+          index_total: page.lists.count + 1,
+        }
       },
     }
   end
@@ -46,6 +53,13 @@
       data_attributes: {
         "track-count": "accordionSection",
         "track-options": custom_dimensions.to_json,
+        ga4: {
+          event_name: "select_content",
+          type: "accordion",
+          text: t("second_level_browse.more_on_this_topic"),
+          index: accordion_contents.length,
+          index_total: page.lists.count + 1,
+        }
       },
     }
   %>
@@ -58,12 +72,24 @@
         dimension114: "0",
       }
     %>
+    <%
+      show_all_attributes = {
+        event_name: "select_content",
+        type: "accordion",
+        index: 0,
+        index_total: accordion_contents.count + 1,
+      }
+    %>
     <%= render "govuk_publishing_components/components/accordion", {
       track_show_all_clicks: true,
       track_sections: true,
       heading_level: 2,
+      data_attributes: {
+        module: "ga4-event-tracker",
+      },
       data_attributes_show_all: {
         "track-options": custom_dimensions.to_json,
+        "ga4": show_all_attributes.to_json
       },
       items: accordion_contents,
       margin_bottom: 6,

--- a/app/views/world_wide_taxons/accordion.html.erb
+++ b/app/views/world_wide_taxons/accordion.html.erb
@@ -11,7 +11,10 @@
   <div class="govuk-grid-row child-topic-contents">
     <div class="govuk-grid-column-two-thirds">
       <div class="topic-content">
-        <% items = [] %>
+        <%
+          items = []
+          number_of_accordion_sections = presented_taxon.accordion_content.length
+        %>
         <% presented_taxon.accordion_content.each_with_index do |taxon, index| %>
           <% contents = capture do %>
             <%= render 'components/taxon-list', {
@@ -25,6 +28,13 @@
               data_attributes: {
                 "track-count": "accordionSection",
                 id: "section-panel-#{id}-#{index + 1}",
+                ga4: {
+                  event_name: 'select_content',
+                  type: 'accordion',
+                  text: taxon.title,
+                  index: index + 1,
+                  index_total: number_of_accordion_sections,
+                }
               },
               heading: {
                 text: taxon.title,
@@ -38,7 +48,23 @@
             }
           %>
         <% end %>
-        <%= render 'govuk_publishing_components/components/accordion', items: items %>
+        <%
+          show_all_attributes = {
+            event_name: "select_content",
+            type: "accordion",
+            index: 0,
+            index_total: number_of_accordion_sections
+          }
+        %>
+        <%= render 'govuk_publishing_components/components/accordion', {
+          data_attributes: {
+            module: "ga4-event-tracker",
+          },
+          data_attributes_show_all: {
+            "ga4": show_all_attributes.to_json
+          },
+          items: items
+        } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We are currently working to complete the implementation of GA4 tracking on all accordions, across all frontend apps.

This PR adds tracking to the accordions on the following pages:
- [x] [/app/views/world_wide_taxons/accordion.html.erb](https://github.com/alphagov/collections/blob/main/app/views/world_wide_taxons/accordion.html.erb)
- [x] [/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb](https://github.com/alphagov/collections/blob/main/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb)
- [x] [/app/views/second_level_browse_page/_show_curated_accordion.html.erb](https://github.com/alphagov/collections/blob/main/app/views/second_level_browse_page/_show_curated_accordion.html.erb)

Example URL(s):
- https://www.gov.uk/world/afghanistan

Co-authored-by: Graham Lewis <@gclssvglx>

[Trello](https://trello.com/c/0gjuZZxe/344-complete-the-implementation-of-ga4-accordions-on-all-frontend-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️