### PR TITLE
Allow World Location News to be rendered

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,0 +1,8 @@
+class WorldLocationNewsController < ApplicationController
+  around_action :switch_locale
+
+  def show
+    @world_location_news = WorldLocationNews.find!(request.path)
+    setup_content_item_and_navigation_helpers(@world_location_news)
+  end
+end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -9,4 +9,12 @@ class WorldLocationNews
     content_item = ContentItem.find!(base_path)
     new(content_item)
   end
+
+  def title
+    @content_item.content_item_data["title"]
+  end
+
+  def description
+    @content_item.content_item_data["description"]
+  end
 end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -1,0 +1,12 @@
+class WorldLocationNews
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -1,0 +1,2 @@
+<div class="govuk-grid-row">
+</div>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -1,2 +1,13 @@
+<% content_for :title, @world_location_news.title %>
+
+<% content_for :meta_tags do %>
+  <%= tag("meta", name: "description", content: @world_location_news.description) if @world_location_news.description %>
+<% end %>
+
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      title: @world_location_news.title,
+    } %>
+  </div>
 </div>

--- a/config/locales/ar/world_location_news.yml
+++ b/config/locales/ar/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ar:
+  world_location_news:
+    headings:
+      announcements: إعلاناتنا
+      documents: المستندات
+      featured:
+      mission: مهمتنا
+      news: أخبار المواقع العالمية
+      organisations: المنظمات
+      publications: منشوراتنا
+      search: البحث حسب البلد أو الإقليم
+      statistics: إحصائياتنا

--- a/config/locales/az/world_location_news.yml
+++ b/config/locales/az/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+az:
+  world_location_news:
+    headings:
+      announcements: Elanlarımız
+      documents: Sənədlər
+      featured:
+      mission: Missiyamız
+      news: Dünya üzrə xəbərlər
+      organisations: Təşkilatlar
+      publications: Nəşrlərimiz
+      search: Ölkəyə və ya əraziyə əsasən axtarın
+      statistics: Statistikamız

--- a/config/locales/be/world_location_news.yml
+++ b/config/locales/be/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+be:
+  world_location_news:
+    headings:
+      announcements: Нашы аб'явы
+      documents: Дакументы
+      featured:
+      mission: Наша місія
+      news: Навіны пра месцазнаходжанне ў свеце
+      organisations: Арганізацыі
+      publications: Нашы публікацыі
+      search: Пошук па краіне або тэрыторыі
+      statistics: Наша статыстыка

--- a/config/locales/bg/world_location_news.yml
+++ b/config/locales/bg/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+bg:
+  world_location_news:
+    headings:
+      announcements: Нашите съобщения
+      documents: Документи
+      featured:
+      mission: Нашата мисия
+      news: Новини за местоположенията в света
+      organisations: Организации
+      publications: Нашите публикации
+      search: Търсене по страна или територия
+      statistics: Нашата статистика

--- a/config/locales/bn/world_location_news.yml
+++ b/config/locales/bn/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+bn:
+  world_location_news:
+    headings:
+      announcements: আমাদের ঘোষণাসমূহ
+      documents: নথিপত্র
+      featured:
+      mission: আমাদের মিশন
+      news: বিশ্বের অবস্থানসমূহের সংবাদ
+      organisations: প্রতিষ্ঠানসমূহ
+      publications: আমাদের প্রকাশনাসমূহ
+      search: দেশ বা অঞ্চল হিসেবে অনুসন্ধান করুন
+      statistics: আমাদের পরিসংখ্যান

--- a/config/locales/cs/world_location_news.yml
+++ b/config/locales/cs/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+cs:
+  world_location_news:
+    headings:
+      announcements: Naše oznámení
+      documents: Dokumenty
+      featured:
+      mission: Naše poslání
+      news: Zprávy o poloze ve světě
+      organisations: Organizace
+      publications: Naše publikace
+      search: Vyhledávání podle země nebo území
+      statistics: Naše statistika

--- a/config/locales/cy/world_location_news.yml
+++ b/config/locales/cy/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+cy:
+  world_location_news:
+    headings:
+      announcements: Ein cyhoeddiadau
+      documents: Dogfennau
+      featured:
+      mission: Ein cenhadaeth
+      news: Newyddion am leoliadau byd-eang
+      organisations: Sefydliadau
+      publications: Ein cyhoeddiadau
+      search: Chwilio yn ôl gwlad neu diriogaeth
+      statistics: Ein hystadegau

--- a/config/locales/da/world_location_news.yml
+++ b/config/locales/da/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+da:
+  world_location_news:
+    headings:
+      announcements: Vores meddelelser
+      documents: Dokumenter
+      featured:
+      mission: Vores mission
+      news: Verdens placering nyheder
+      organisations: Organisationer
+      publications: Vores publikationer
+      search: Søg efter land eller område
+      statistics: Vores statistikker

--- a/config/locales/de/world_location_news.yml
+++ b/config/locales/de/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+de:
+  world_location_news:
+    headings:
+      announcements: Unsere Ankündigungen
+      documents: Dokumente
+      featured:
+      mission: Unsere Aufgabe
+      news: Weltweite Standortnachrichten
+      organisations: Organisationen
+      publications: Unsere Veröffentlichungen
+      search: Nach Land oder Gebiet suchen
+      statistics: Unsere Statistiken

--- a/config/locales/dr/world_location_news.yml
+++ b/config/locales/dr/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+dr:
+  world_location_news:
+    headings:
+      announcements: اطلاعیه هایی ما
+      documents: اسناد
+      featured:
+      mission: ماموریت ما
+      news: اخبار موقعیت های جهان
+      organisations: سازمان ها
+      publications: انتشارات ما
+      search: جستجو به اساس کشور یا قلمرو
+      statistics: آمار ما

--- a/config/locales/el/world_location_news.yml
+++ b/config/locales/el/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+el:
+  world_location_news:
+    headings:
+      announcements: Οι ανακοινώσεις μας
+      documents: Έγγραφα
+      featured:
+      mission: Η αποστολή μας
+      news: Ειδήσεις παγκόσμιας τοποθεσίας
+      organisations: Οργανισμοί
+      publications: Οι δημοσιεύσεις μας
+      search: Αναζήτηση ανά χώρα ή περιοχή
+      statistics: Τα στατιστικά μας

--- a/config/locales/en/world_location_news.yml
+++ b/config/locales/en/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+en:
+  world_location_news:
+    headings:
+      announcements: Our announcements
+      documents: Documents
+      featured: Featured
+      mission: Our mission
+      news: World location news
+      organisations: Organisations
+      publications: Our publications
+      search: Search by country or territory
+      statistics: Our statistics

--- a/config/locales/es-419/world_location_news.yml
+++ b/config/locales/es-419/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+es-419:
+  world_location_news:
+    headings:
+      announcements: Nuestros comunicados
+      documents: Documentos
+      featured:
+      mission: Nuestra misión
+      news: Noticias sobre ubicaciones del mundo
+      organisations: Organizaciones
+      publications: Nuestras publicaciones
+      search: Búsqueda por país o territorio
+      statistics: Nuestras estadísticas

--- a/config/locales/es/world_location_news.yml
+++ b/config/locales/es/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+es:
+  world_location_news:
+    headings:
+      announcements: Nuestros anuncios
+      documents: Documentos
+      featured:
+      mission: Nuestra Misión
+      news: Noticias de situación mundial
+      organisations: Organizaciones
+      publications: Publicaciones
+      search: Búsqueda por país o territorio
+      statistics: Nuestras estadísticas

--- a/config/locales/et/world_location_news.yml
+++ b/config/locales/et/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+et:
+  world_location_news:
+    headings:
+      announcements: Meie teadaanded
+      documents: Dokumendid
+      featured:
+      mission: Meie missioon
+      news: Maailma asukoha uudised
+      organisations: Organisatsioonid
+      publications: Meie publikatsioonid
+      search: Otsige riigi või territooriumi järgi
+      statistics: Meie statistika

--- a/config/locales/fa/world_location_news.yml
+++ b/config/locales/fa/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+fa:
+  world_location_news:
+    headings:
+      announcements: اطلاعیه‌های ما
+      documents: اسناد
+      featured:
+      mission: مأموریت ما
+      news: اخبار مکان‌های جهانی
+      organisations: سازمان‌ها
+      publications: موارد منتشر شده ما
+      search: جستجو بر اساس کشور یا قلمرو
+      statistics: آمار ما

--- a/config/locales/fi/world_location_news.yml
+++ b/config/locales/fi/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+fi:
+  world_location_news:
+    headings:
+      announcements: Ilmoituksemme
+      documents: Asiakirjat
+      featured:
+      mission: Tehtävämme
+      news: Maailman sijaintiuutisia
+      organisations: Organisaatiot
+      publications: Julkaisumme
+      search: Hae maan tai alueen mukaan
+      statistics: Tilastomme

--- a/config/locales/fr/world_location_news.yml
+++ b/config/locales/fr/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+fr:
+  world_location_news:
+    headings:
+      announcements: Nos annonces
+      documents: Documents
+      featured:
+      mission: Notre mission
+      news: Nouvelles des emplacements dans le monde
+      organisations: Organisations
+      publications: Nos publications
+      search: Recherche par pays ou territoire
+      statistics: Nos statistiques

--- a/config/locales/gd/world_location_news.yml
+++ b/config/locales/gd/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+gd:
+  world_location_news:
+    headings:
+      announcements: Ár liostaí
+      documents: Doiciméid
+      featured:
+      mission: Ár misean
+      news: Nuacht domhanda
+      organisations: Eagraíochtaí
+      publications: Ár bhfoilseacháin
+      search: Cuardaigh de réir tíre nó réigiúin
+      statistics: Ár staitisticí

--- a/config/locales/gu/world_location_news.yml
+++ b/config/locales/gu/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+gu:
+  world_location_news:
+    headings:
+      announcements: અમારી જાહેરાતો
+      documents: દસ્તાવેજો
+      featured:
+      mission: અમારું મિશન
+      news: વર્લ્ડ લોકેશન ન્યૂઝ
+      organisations: સંસ્થાઓ
+      publications: અમારા પ્રકાશનો
+      search: દેશ અથવા ટેરિટરીથી શોધો
+      statistics: અમારા આંકડા

--- a/config/locales/he/world_location_news.yml
+++ b/config/locales/he/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+he:
+  world_location_news:
+    headings:
+      announcements: ההודעות שלנו
+      documents: מסמכים
+      featured:
+      mission: החזון שלנו
+      news: חדשות מיקום בעולם
+      organisations: ארגונים
+      publications: הפרסומים שלנו
+      search: חפש לפי מדינה או שטח
+      statistics: סטטיסטיקה שלנו

--- a/config/locales/hi/world_location_news.yml
+++ b/config/locales/hi/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+hi:
+  world_location_news:
+    headings:
+      announcements: हमारी घोषणाएं
+      documents: दस्तावेज़
+      featured:
+      mission: हमारा लक्ष्य
+      news: विश्व स्थानों की खबरें
+      organisations: संस्थाएं
+      publications: हमारे प्रकाशन
+      search: देश या क्षेत्र से खोजें
+      statistics: हमारे आंकड़े

--- a/config/locales/hr/world_location_news.yml
+++ b/config/locales/hr/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+hr:
+  world_location_news:
+    headings:
+      announcements: Naše obavijesti
+      documents: Dokumenti
+      featured:
+      mission: Naša misija
+      news: Vijesti o svjetskoj lokaciji
+      organisations: Organizacije
+      publications: Naša izdanja
+      search: Pretražujte prema zemlji ili teritoriju
+      statistics: Naša statistika

--- a/config/locales/hu/world_location_news.yml
+++ b/config/locales/hu/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+hu:
+  world_location_news:
+    headings:
+      announcements: Híreink
+      documents: Dokumentumok
+      featured:
+      mission: Küldetésünk
+      news: Hírek a világ különböző helyszíneiről
+      organisations: Szervezetek
+      publications: Kiadványaink
+      search: Keresés ország vagy terület szerint
+      statistics: Statisztikáink

--- a/config/locales/hy/world_location_news.yml
+++ b/config/locales/hy/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+hy:
+  world_location_news:
+    headings:
+      announcements: Մեր հայտարարությունները
+      documents: Փաստաթղթեր
+      featured:
+      mission: Մեր առաքելությունը
+      news: Նորություններ աշխարհից
+      organisations: Կազմակերպություններ
+      publications: Մեր հրապարակումները
+      search: Որոնել ըստ երկրի կամ տարածաշրջանի
+      statistics: Մեր վիճակագրությունը

--- a/config/locales/id/world_location_news.yml
+++ b/config/locales/id/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+id:
+  world_location_news:
+    headings:
+      announcements: Pengumuman kami
+      documents: Dokumen
+      featured:
+      mission: Misi kami
+      news: Berita lokasi dunia
+      organisations: Organisasi
+      publications: Publikasi kami
+      search: Cari menurut negara atau teritori
+      statistics: Statistik kami

--- a/config/locales/is/world_location_news.yml
+++ b/config/locales/is/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+is:
+  world_location_news:
+    headings:
+      announcements: Okkar tilkynningar
+      documents: Skjöl
+      featured:
+      mission: Okkar takmark
+      news: Fréttir af stöðum í heiminum
+      organisations: Samtök
+      publications: Okkar útgáfur
+      search: Leita eftir landi eða landsvæði
+      statistics: Okkar tölfræði

--- a/config/locales/it/world_location_news.yml
+++ b/config/locales/it/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+it:
+  world_location_news:
+    headings:
+      announcements: I nostri annunci
+      documents: Documenti
+      featured:
+      mission: La nostra missione
+      news: Notizie dai luoghi del mondo
+      organisations: Organizzazioni
+      publications: Le nostre pubblicazioni
+      search: Cerca per stato o territorio
+      statistics: Le nostre statistiche

--- a/config/locales/ja/world_location_news.yml
+++ b/config/locales/ja/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ja:
+  world_location_news:
+    headings:
+      announcements: お知らせ
+      documents: ドキュメント
+      featured:
+      mission: 使命
+      news: 世界各地からのニュース
+      organisations: 組織
+      publications: 出版物
+      search: 国または地域で検索
+      statistics: 統計

--- a/config/locales/ka/world_location_news.yml
+++ b/config/locales/ka/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ka:
+  world_location_news:
+    headings:
+      announcements: ჩვენი განცხადებები
+      documents: დოკუმენტები
+      featured:
+      mission: ჩვენი მისია
+      news: მსოფლიოს ლოკაციების სიახლეები
+      organisations: ორგანიზაციები
+      publications: ჩვენი პუბლიკაციები
+      search: მოძებნეთ ქვეყნის ან ტერიტორიის მიხედვით
+      statistics: ჩვენი სტატისტიკა

--- a/config/locales/kk/world_location_news.yml
+++ b/config/locales/kk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+kk:
+  world_location_news:
+    headings:
+      announcements: Біздің хабарландыруларымыз
+      documents: Құжаттар
+      featured:
+      mission: Біздің миссиямыз
+      news: Әлемдегі орын бойынша жаңалықтар
+      organisations: Ұйымдар
+      publications: Біздің жарияланымдар
+      search: Елі немесе территориясы бойынша іздеу
+      statistics: Біздің статистика

--- a/config/locales/ko/world_location_news.yml
+++ b/config/locales/ko/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ko:
+  world_location_news:
+    headings:
+      announcements: 공지사항
+      documents: 자료
+      featured:
+      mission: 대사관 안내
+      news: 월드 로케이션 뉴스
+      organisations: 조직 안내
+      publications: 출판물
+      search: 국가 또는 영토로 검색하기
+      statistics: 통계

--- a/config/locales/lt/world_location_news.yml
+++ b/config/locales/lt/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+lt:
+  world_location_news:
+    headings:
+      announcements: Mūsų skelbimai
+      documents: Dokumentai
+      featured:
+      mission: Mūsų misija
+      news: Pasaulio vietos naujienos
+      organisations: Organizacijos
+      publications: Mūsų publikacijos
+      search: Ieškoti pagal šalį ar teritoriją
+      statistics: Mūsų statistika

--- a/config/locales/lv/world_location_news.yml
+++ b/config/locales/lv/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+lv:
+  world_location_news:
+    headings:
+      announcements: Paziņojumi
+      documents: Dokumenti
+      featured:
+      mission: Misija
+      news: Pasaules ziņas
+      organisations: Organizācijas
+      publications: Publikācijas
+      search: Meklēt pēc valsts vai teritorijas
+      statistics: Statistikas dati

--- a/config/locales/ms/world_location_news.yml
+++ b/config/locales/ms/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ms:
+  world_location_news:
+    headings:
+      announcements: Pengumuman kami
+      documents: Dokumen
+      featured:
+      mission: Misi kami
+      news: Berita lokasi dunia
+      organisations: Organisasi
+      publications: Terbitan kami
+      search: Cari mengikut negara atau wilayah
+      statistics: Statistik kami

--- a/config/locales/mt/world_location_news.yml
+++ b/config/locales/mt/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+mt:
+  world_location_news:
+    headings:
+      announcements: L-avviżi tagħna
+      documents: Dokumenti
+      featured:
+      mission: Il-missjoni tagħna
+      news: Aħbarijiet dwar postijiet fid-dinja
+      organisations: Organizzazzjonijiet
+      publications: Pubblikazzjonijiet tagħna
+      search: Fittex permezz tal-pajjiż jew territorju
+      statistics: L-istatistiċi tagħna

--- a/config/locales/ne/world_location_news.yml
+++ b/config/locales/ne/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ne:
+  world_location_news:
+    headings:
+      announcements: हाम्रा घोषणाहरु
+      documents: कागजातहरु
+      featured:
+      mission: हाम्रो मिशन
+      news: विश्व स्थान समाचार
+      organisations: सङ्गठनहरू
+      publications: हाम्रा प्रकाशनहरु
+      search: देश वा क्षेत्रको नामले खोज
+      statistics: हाम्रो तथ्याङ्क

--- a/config/locales/nl/world_location_news.yml
+++ b/config/locales/nl/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+nl:
+  world_location_news:
+    headings:
+      announcements: Onze aankondigingen
+      documents: Documenten
+      featured:
+      mission: Onze missie
+      news: Wereld locatie nieuws
+      organisations: Organisaties
+      publications: Onze publicaties
+      search: Zoeken op land of gebied
+      statistics: Onze statistieken

--- a/config/locales/no/world_location_news.yml
+++ b/config/locales/no/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+'no':
+  world_location_news:
+    headings:
+      announcements: Våre kunngjøringer
+      documents: Dokumenter
+      featured:
+      mission: Vårt oppdrag
+      news: Nyheter fra ulike verdenshjørner
+      organisations: Organisasjoner
+      publications: Våre publikasjoner
+      search: Søk etter land eller territorium
+      statistics: Vår statistikk

--- a/config/locales/pa-pk/world_location_news.yml
+++ b/config/locales/pa-pk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+pa-pk:
+  world_location_news:
+    headings:
+      announcements: ساڈے اعلانات
+      documents: دستاویزات تک پہنچ دی حکمت عملی
+      featured:
+      mission: ساڈا فرض
+      news: ساری دُنیا دیاں خبراں
+      organisations: ادارے
+      publications: ساڈے شمارے
+      search: مُلک یا علاقے توں لبھو
+      statistics: ساڈے اعدادو شمار

--- a/config/locales/pa/world_location_news.yml
+++ b/config/locales/pa/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+pa:
+  world_location_news:
+    headings:
+      announcements: ਸਾਡੀਆਂ ਘੋਸ਼ਣਾਵਾਂ
+      documents: ਦਸਤਾਵੇਜ਼
+      featured:
+      mission: ਸਾਡਾ ਮਿਸ਼ਨ
+      news: ਵਿਸ਼ਵ ਸਥਾਨ ਦੀ ਖਬਰ
+      organisations: ਸੰਗਠਨ
+      publications: ਸਾਡੇ ਪ੍ਰਕਾਸ਼ਨ
+      search: ਦੇਸ਼ ਜਾਂ ਖੇਤਰ ਦੁਆਰਾ ਖੋਜ ਕਰੋ
+      statistics: ਸਾਡੇ ਅੰਕੜੇ

--- a/config/locales/pl/world_location_news.yml
+++ b/config/locales/pl/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+pl:
+  world_location_news:
+    headings:
+      announcements: Nasze ogłoszenia
+      documents: Dokumenty
+      featured:
+      mission: Nasza misja
+      news: Wiadomości ze świata
+      organisations: Organizacje
+      publications: Nasze publikacje
+      search: Wyszukiwanie według kraju lub terytorium
+      statistics: Nasze statystyki

--- a/config/locales/ps/world_location_news.yml
+++ b/config/locales/ps/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ps:
+  world_location_news:
+    headings:
+      announcements: زموږ اعلانونه
+      documents: اسناد
+      featured:
+      mission: زموږ ماموریت
+      news: د نړۍ موقعیت خبرونه
+      organisations: سازمانونه
+      publications: زموږ خپرونې
+      search: د هیواد یا سیمې له مخې لټون
+      statistics: زموږ احصایه

--- a/config/locales/pt/world_location_news.yml
+++ b/config/locales/pt/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+pt:
+  world_location_news:
+    headings:
+      announcements: Os nossos anúncios
+      documents: Documentos
+      featured:
+      mission: A nossa missão
+      news: Notícias de localização mundial
+      organisations: Organizações
+      publications: As nossas publicações
+      search: Pesquisa por país ou território
+      statistics: As nossas estatísticas

--- a/config/locales/ro/world_location_news.yml
+++ b/config/locales/ro/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ro:
+  world_location_news:
+    headings:
+      announcements: Anunțurile noastre
+      documents: Documente
+      featured:
+      mission: Misiunea noastră
+      news: Știri privind locația pe glob
+      organisations: Organizații
+      publications: Publicațiile noastre
+      search: Căutați după țară sau teritoriu
+      statistics: Statisticile noastre

--- a/config/locales/ru/world_location_news.yml
+++ b/config/locales/ru/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ru:
+  world_location_news:
+    headings:
+      announcements: Наши объявления
+      documents: Документы
+      featured:
+      mission: Наша цель
+      news: Новости из мест нахождения в мире
+      organisations: Организации
+      publications: Наши публикации
+      search: Поиск по стране или территории
+      statistics: Наша статистика

--- a/config/locales/si/world_location_news.yml
+++ b/config/locales/si/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+si:
+  world_location_news:
+    headings:
+      announcements: අපේ නිවේදන
+      documents: ලේඛන
+      featured:
+      mission: අපේ මෙහෙවර
+      news: ලෝක ස්ථානීය පුවෘත්ති
+      organisations: සංවිධාන
+      publications: අපේ ප්රකාශන
+      search: රට හෝ භූමිය අනුව සොයන්න
+      statistics: අපේ සංඛ්යාලේඛන

--- a/config/locales/sk/world_location_news.yml
+++ b/config/locales/sk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sk:
+  world_location_news:
+    headings:
+      announcements: Naše oznámenia
+      documents: Dokumenty
+      featured:
+      mission: Naše poslanie
+      news: Naša misia
+      organisations: Organizácie
+      publications: Naše publikácie
+      search: Vyhľadávanie podľa krajiny alebo územia
+      statistics: Naše štatistiky

--- a/config/locales/sl/world_location_news.yml
+++ b/config/locales/sl/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sl:
+  world_location_news:
+    headings:
+      announcements: Naši razglasi
+      documents: Dokumenti
+      featured:
+      mission: Naša misija
+      news: Novice z lokacij po svetu
+      organisations: Organizacije
+      publications: Naše publikacije
+      search: Išči po državah ali ozemljih
+      statistics: Naša statistika

--- a/config/locales/so/world_location_news.yml
+++ b/config/locales/so/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+so:
+  world_location_news:
+    headings:
+      announcements: Ku dhawaaqisahayaga
+      documents: Dukumentiyada
+      featured:
+      mission: Hadafkayaga
+      news: Wararka Goobta Dunida
+      organisations: Ururada
+      publications: Daabacadahayaga
+      search: Ku raadi dalka ama dhulka
+      statistics: Xog ururinahayaga

--- a/config/locales/sq/world_location_news.yml
+++ b/config/locales/sq/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sq:
+  world_location_news:
+    headings:
+      announcements: Njoftimet tona
+      documents: Dokumentet
+      featured:
+      mission: Misioni ynë
+      news: Lajmet për vendndodhjen botërore
+      organisations: Organizatat
+      publications: Publikimet tona
+      search: Kërkoni sipas vendit ose territorit
+      statistics: Statistikat tona

--- a/config/locales/sr/world_location_news.yml
+++ b/config/locales/sr/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sr:
+  world_location_news:
+    headings:
+      announcements: Naša saopštenja
+      documents: Dokumenti
+      featured:
+      mission: Naša misija
+      news: Vesti sa globalnih lokacija
+      organisations: Organizacije
+      publications: Naše publikacije
+      search: Pretraga po zemlji ili teritoriji
+      statistics: Naša statistika

--- a/config/locales/sv/world_location_news.yml
+++ b/config/locales/sv/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sv:
+  world_location_news:
+    headings:
+      announcements: Våra tillkännagivanden
+      documents: Dokument
+      featured:
+      mission: Vårt uppdrag
+      news: Nyheter om platser i världen
+      organisations: Organisationer
+      publications: Våra publikationer
+      search: Sök efter land eller område
+      statistics: Vår statistik

--- a/config/locales/sw/world_location_news.yml
+++ b/config/locales/sw/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+sw:
+  world_location_news:
+    headings:
+      announcements: Matangazo yetu
+      documents: Hati
+      featured:
+      mission: Dhamira yetu
+      news: Habari za kimataifa
+      organisations: Mashirika
+      publications: Machapisho yetu
+      search: Tafuta kulingana na nchi au eneo
+      statistics: Takwimu zetu

--- a/config/locales/ta/world_location_news.yml
+++ b/config/locales/ta/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ta:
+  world_location_news:
+    headings:
+      announcements: எங்கள் அறிவிப்புகள்
+      documents: ஆவணங்கள்
+      featured:
+      mission: எங்கள் செயல் இலக்கு
+      news: உலக இருப்பிடச் செய்தி
+      organisations: நிறுவனங்கள்
+      publications: எங்கள் வெளியீடுகள்
+      search: நாடு அல்லது பிரதேசம் வாரியாகத் தேடு
+      statistics: எங்கள் புள்ளியியல்

--- a/config/locales/th/world_location_news.yml
+++ b/config/locales/th/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+th:
+  world_location_news:
+    headings:
+      announcements: ประกาศของเรา
+      documents: เอกสาร
+      featured:
+      mission: ภารกิจของเรา
+      news: ข่าวสถานที่ทั่วโลก
+      organisations: องค์กร
+      publications: สิ่งพิมพ์ของเรา
+      search: ค้นหาด้วยประเทศหรือดินแดน
+      statistics: สถิติของเรา

--- a/config/locales/tk/world_location_news.yml
+++ b/config/locales/tk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+tk:
+  world_location_news:
+    headings:
+      announcements: Biziň bildirişlerimiz
+      documents: Resminamalar
+      featured:
+      mission: Biziň maksadymyz
+      news: Dünýä ýeri habarlary
+      organisations: Guramalar
+      publications: Biziň neşirlerimiz
+      search: Döwlet ýa-da territoriýa boýunça gözlemek
+      statistics: Biziň statistikamyz

--- a/config/locales/tr/world_location_news.yml
+++ b/config/locales/tr/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+tr:
+  world_location_news:
+    headings:
+      announcements: Duyurularımız
+      documents: Belgeler
+      featured:
+      mission: Misyonumuz
+      news: Dünya yeri haberleri
+      organisations: Kuruluşlar
+      publications: Yayınlarımız
+      search: Ülkeye veya bölgeye göre arama yapın
+      statistics: İstatistiklerimiz

--- a/config/locales/uk/world_location_news.yml
+++ b/config/locales/uk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+uk:
+  world_location_news:
+    headings:
+      announcements: Наші оголошення
+      documents: Документи
+      featured:
+      mission: Наша місія
+      news: Новини світових локацій
+      organisations: Організації
+      publications: Наші публікації
+      search: Пошук за країною чи територією
+      statistics: Наша статистика

--- a/config/locales/ur/world_location_news.yml
+++ b/config/locales/ur/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+ur:
+  world_location_news:
+    headings:
+      announcements: ہمارے اعلانات
+      documents: دستاویزات
+      featured:
+      mission: ہمارا مشن
+      news: عالمی مقام کی خبریں
+      organisations: تنظیمیں
+      publications: ہماری پبلیکیشنز
+      search: ملک یا خطے کے لحاظ سے تلاش کریں
+      statistics: ہمارے شماریات

--- a/config/locales/uz/world_location_news.yml
+++ b/config/locales/uz/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+uz:
+  world_location_news:
+    headings:
+      announcements: Бизнинг эълонлар
+      documents: Ҳужжатлар
+      featured:
+      mission: Бизнинг вазифалар
+      news: Жаҳон янгиликлари
+      organisations: Ташкилотлар
+      publications: Бизнинг нашрлар
+      search: Мамлакат ёки минтақа бўйича излаш
+      statistics: Бизнинг статистика

--- a/config/locales/vi/world_location_news.yml
+++ b/config/locales/vi/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+vi:
+  world_location_news:
+    headings:
+      announcements: Thông báo của chúng tôi
+      documents: Tài liệu
+      featured:
+      mission: Sứ mệnh của chúng tôi
+      news: Tin tức về vị trí trên thế giới
+      organisations: Tổ chức
+      publications: Các ấn phẩm của chúng tôi
+      search: Tìm kiếm theo quốc gia hoặc lãnh thổ
+      statistics: Thống kê của chúng tôi

--- a/config/locales/yi/world_location_news.yml
+++ b/config/locales/yi/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+yi:
+  world_location_news:
+    headings:
+      announcements:
+      documents: דאָקומענטן
+      featured:
+      mission:
+      news:
+      organisations:
+      publications:
+      search:
+      statistics:

--- a/config/locales/zh-hk/world_location_news.yml
+++ b/config/locales/zh-hk/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+zh-hk:
+  world_location_news:
+    headings:
+      announcements: 我們的公告
+      documents: 文件
+      featured:
+      mission: 我們的使命
+      news: 世界各地新聞
+      organisations: 組織
+      publications: 我們的出版物
+      search: 按國家或地區搜尋
+      statistics: 我們的統計資料

--- a/config/locales/zh-tw/world_location_news.yml
+++ b/config/locales/zh-tw/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+zh-tw:
+  world_location_news:
+    headings:
+      announcements: 我們的公告
+      documents: 文檔
+      featured:
+      mission: 我們的任務
+      news: 世界地點消息
+      organisations: 組織
+      publications: 我們的出版
+      search: 按國家或地區搜索
+      statistics: 我們的數據統計

--- a/config/locales/zh/world_location_news.yml
+++ b/config/locales/zh/world_location_news.yml
@@ -1,0 +1,13 @@
+---
+zh:
+  world_location_news:
+    headings:
+      announcements: 我们的公告
+      documents: 文件
+      featured:
+      mission: 我们的使命
+      news: 世界地点新闻
+      organisations: 组织机构
+      publications: 我们的出版物
+      search: 按国家或地区搜索
+      statistics: 我们的统计数据

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,10 @@ Rails.application.routes.draw do
     get "/:slug", to: "step_nav#show"
   end
 
+  get "/world/:name/news(.:locale)",
+      to: "world_location_news#show",
+      as: :world_location_news
+
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
 
   # We get requests for URLs like

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -256,13 +256,6 @@ RSpec.feature "Topical Event pages" do
 
 private
 
-  def fetch_fixture(filename)
-    json = File.read(
-      Rails.root.join("spec", "fixtures", "content_store", "#{filename}.json"),
-    )
-    JSON.parse(json)
-  end
-
   def content_item_without_detail(content_item, key_to_remove)
     content_item["details"] = content_item["details"].except(key_to_remove)
     content_item

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -8,5 +8,13 @@ RSpec.feature "World Location News pages" do
     stub_content_store_has_item(base_path, content_item)
   end
 
-  
+  it "sets the page title" do
+    visit base_path
+    expect(page).to have_title("UK and Mock Country - GOV.UK")
+  end
+
+  it "sets the page meta description" do
+    visit base_path
+    expect(page).to have_selector("meta[name='description'][content='Find out about the relations between the UK and Mock Country']", visible: :hidden)
+  end
 end

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -1,0 +1,12 @@
+require "integration_spec_helper"
+
+RSpec.feature "World Location News pages" do
+  let(:content_item) { fetch_fixture("world_location_news") }
+  let(:base_path) { content_item["base_path"] }
+
+  before do
+    stub_content_store_has_item(base_path, content_item)
+  end
+
+  
+end

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -1,3 +1,5 @@
 {
   "base_path": "/world/mock-country/news",
+  "title": "UK and Mock Country",
+  "description": "Find out about the relations between the UK and Mock Country"
 }

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -1,0 +1,3 @@
+{
+  "base_path": "/world/mock-country/news",
+}

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -152,13 +152,4 @@ RSpec.describe TopicalEvent do
       },
     ])
   end
-
-private
-
-  def fetch_fixture(filename)
-    json = File.read(
-      Rails.root.join("spec", "fixtures", "content_store", "#{filename}.json"),
-    )
-    JSON.parse(json)
-  end
 end

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -3,4 +3,12 @@ RSpec.describe WorldLocationNews do
   let(:content_item) { ContentItem.new(api_data) }
   let(:base_path) { content_item.base_path }
   let(:world_location_news) { described_class.new(content_item) }
+
+  it "should have a title" do
+    expect(world_location_news.title).to eq("UK and Mock Country")
+  end
+
+  it "should have a description" do
+    expect(world_location_news.description).to eq("Find out about the relations between the UK and Mock Country")
+  end
 end

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe WorldLocationNews do
+  let(:api_data) { fetch_fixture("world_location_news") }
+  let(:content_item) { ContentItem.new(api_data) }
+  let(:base_path) { content_item.base_path }
+  let(:world_location_news) { described_class.new(content_item) }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,3 +51,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
+
+def fetch_fixture(filename)
+  json = File.read(
+    Rails.root.join("spec", "fixtures", "content_store", "#{filename}.json"),
+  )
+  JSON.parse(json)
+end


### PR DESCRIPTION
This allows Collections to render World Location News pages.

It currently only includes the page's title and meta description tag.  Other parts of the page will be added in later PRs.

We have also ported the translations for headings over from Whitehall.  There were a few missing translations, which will need to be translated next time we procure translations.

Router currently points all World Location News pages to Whitehall, so this is safe to merge and deploy, despite the page not being fully completed yet.

[Trello card](https://trello.com/c/yciVdaIe)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
