### PR TITLE
Add featured documents to world location news page

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -17,4 +17,20 @@ class WorldLocationNews
   def description
     @content_item.content_item_data["description"]
   end
+
+  def ordered_featured_documents
+    @content_item.content_item_data.dig("details", "ordered_featured_documents")&.map do |document|
+      {
+        href: document["href"],
+        image_src: document.dig("image", "url"),
+        image_alt: document.dig("image", "alt_text"),
+        heading_text: document["title"],
+        description: ActionView::Base.full_sanitizer.sanitize(document["summary"]).truncate(160, separator: " "),
+        context: {
+          date: document["public_updated_at"]&.to_date,
+          text: document["document_type"],
+        },
+      }
+    end
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -10,4 +10,28 @@
       title: @world_location_news.title,
     } %>
   </div>
+
+  <div class="govuk-grid-column-full">
+    <% if @world_location_news.ordered_featured_documents&.any? %>
+      <section id="featured">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: I18n.t("world_location_news.headings.featured"),
+          padding: true,
+          font_size: "l",
+          border_top: 2,
+          margin_bottom: 4,
+        } %>
+
+        <% @world_location_news.ordered_featured_documents.in_groups_of(3, false) do |row| %>
+          <div class="govuk-grid-row">
+            <% row.each do |document| %>
+              <div class="govuk-grid-column-one-third">
+                <%= render "govuk_publishing_components/components/image_card", document %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </section>
+    <% end %>
+  </div>
 </div>

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -17,4 +17,34 @@ RSpec.feature "World Location News pages" do
     visit base_path
     expect(page).to have_selector("meta[name='description'][content='Find out about the relations between the UK and Mock Country']", visible: :hidden)
   end
+
+  context "when there are featured documents" do
+    it "includes the featured documents header" do
+      visit base_path
+      expect(page).to have_text(I18n.t("world_location_news.headings.featured"))
+    end
+
+    it "includes links to the featured documents" do
+      visit base_path
+      expect(page).to have_link("A document related to this location", href: "https://www.gov.uk/somewhere")
+    end
+  end
+
+  context "when there are no featured documents" do
+    before do
+      stub_content_store_has_item(base_path, content_item_without_detail(content_item, "ordered_featured_documents"))
+    end
+
+    it "does not include the featured documents header" do
+      visit base_path
+      expect(page).to_not have_text(I18n.t("world_location_news.headings.featured"))
+    end
+  end
+
+private
+
+  def content_item_without_detail(content_item, key_to_remove)
+    content_item["details"] = content_item["details"].except(key_to_remove)
+    content_item
+  end
 end

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -1,5 +1,31 @@
 {
   "base_path": "/world/mock-country/news",
   "title": "UK and Mock Country",
-  "description": "Find out about the relations between the UK and Mock Country"
+  "description": "Find out about the relations between the UK and Mock Country",
+  "details": {
+    "ordered_featured_documents": [
+      {
+        "href": "https://www.gov.uk/somewhere",
+        "image": {
+          "url": "https://www.gov.uk/someimage.png",
+          "alt_text": "Alt text for the image"
+        },
+        "title": "A document related to this location",
+        "summary": "Very interesting document content. However this goes over the 160 character limit so when displayed this should be truncated in order to display the content neatly on the page.",
+        "document_type": "News",
+        "public_updated_at": "2022-07-28T15:45:46.000+01:00"
+      },
+      {
+        "href": "https://www.gov.uk/somewhere-without-an-update-date",
+        "image": {
+          "url": "https://www.gov.uk/someimage2.png",
+          "alt_text": "Alt text for the second image"
+        },
+        "title": "A document related to this location with no updated date",
+        "summary": "Very interesting document content.",
+        "document_type": "Blog",
+        "public_updated_at": null
+      }
+    ]
+  }
 }

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -11,4 +11,36 @@ RSpec.describe WorldLocationNews do
   it "should have a description" do
     expect(world_location_news.description).to eq("Find out about the relations between the UK and Mock Country")
   end
+
+  it "should map the ordered featured documents with truncated description where this exceeds 160 chars" do
+    expect(world_location_news.ordered_featured_documents.first).to eq(
+      {
+        href: "https://www.gov.uk/somewhere",
+        image_src: "https://www.gov.uk/someimage.png",
+        image_alt: "Alt text for the image",
+        heading_text: "A document related to this location",
+        description: "Very interesting document content. However this goes over the 160 character limit so when displayed this should be truncated in order to display the content...",
+        context: {
+          date: Date.parse("2022-07-28"),
+          text: "News",
+        },
+      },
+    )
+  end
+
+  it "should map the ordered featured documents with offsite links that have no date" do
+    expect(world_location_news.ordered_featured_documents.second).to eq(
+      {
+        href: "https://www.gov.uk/somewhere-without-an-update-date",
+        image_src: "https://www.gov.uk/someimage2.png",
+        image_alt: "Alt text for the second image",
+        heading_text: "A document related to this location with no updated date",
+        description: "Very interesting document content.",
+        context: {
+          date: nil,
+          text: "Blog",
+        },
+      },
+    )
+  end
 end


### PR DESCRIPTION
This page is currently rendered by Whitehall. This is part of the work to bring the rendering into Collections.

## Screenshots
| Collections  | Whitehall  |
|---|---|
| ![Screenshot showing a world location news page rendered by Collections.  It has a heading 1 labelled "France and the UK" and a heading 2 labelled "Featured".  Under this, there are 3 image cards showing featured documents.](https://user-images.githubusercontent.com/6329861/183848327-f5626951-6f8f-4435-9244-85f02f5f9933.png)  |  ![Screenshot showing a world location news page rendered by Whitehall.  It has a heading 1 labelled "France and the UK" and a heading 2 labelled "Featured".  Under this, there are 3 image cards showing featured documents in exactly the same way as in Collections.  There is additional page furniture (translation links and featured links) that are not yet present in the Collections rendered page.](https://user-images.githubusercontent.com/6329861/183848566-2d9f79c6-4eae-4acf-8eb2-ccc34b536a4d.png) |

[Trello card](https://trello.com/c/WNZ1IZAe)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
