### PR TITLE
Add featured links to world location news page

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -18,6 +18,15 @@ class WorldLocationNews
     @content_item.content_item_data["description"]
   end
 
+  def ordered_featured_links
+    @content_item.content_item_data.dig("details", "ordered_featured_links")&.map do |link|
+      {
+        path: link["href"],
+        text: link["title"],
+      }
+    end
+  end
+
   def ordered_featured_documents
     @content_item.content_item_data.dig("details", "ordered_featured_documents")&.map do |document|
       {

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -8,9 +8,18 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       title: @world_location_news.title,
+      margin_top: 0,
     } %>
   </div>
 
+  <div class="govuk-grid-column-one-third">
+    <%= render "components/topic-list", {
+        items: @world_location_news.ordered_featured_links,
+    } %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <% if @world_location_news.ordered_featured_documents&.any? %>
       <section id="featured">

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -65,6 +65,14 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when there are featured links" do
+    it "includes the featured links" do
+      visit base_path
+      expect(page).to have_link("A link to somewhere", href: "https://www.gov.uk/somewhere")
+      expect(page).to have_link("A second link to somewhere", href: "https://www.gov.uk/somewhere2")
+    end
+  end
+
 private
 
   def content_item_without_detail(content_item, key_to_remove)

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -27,6 +27,16 @@
         "document_type": "Blog",
         "public_updated_at": null
       }
+    ],
+    "ordered_featured_links": [
+      {
+        "href": "https://www.gov.uk/somewhere",
+        "title": "A link to somewhere"
+      },
+      {
+        "href": "https://www.gov.uk/somewhere2",
+        "title": "A second link to somewhere"
+      }
     ]
   }
 }

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -47,4 +47,19 @@ RSpec.describe WorldLocationNews do
   it "should return the mission statement" do
     expect(world_location_news.mission_statement).to eq("Our mission is to test world location news.")
   end
+
+  it "should map the ordered featured links" do
+    expect(world_location_news.ordered_featured_links).to eq(
+      [
+        {
+          path: "https://www.gov.uk/somewhere",
+          text: "A link to somewhere",
+        },
+        {
+          path: "https://www.gov.uk/somewhere2",
+          text: "A second link to somewhere",
+        },
+      ],
+    )
+  end
 end


### PR DESCRIPTION
This page is currently rendered by Whitehall. This is part of the work to bring the rendering into Collections.

There are two differences:
- We are now using the `topic-list` component, which will make this view consistent with organisation pages.  This varies slightly from the Whitehall rendered version of the page.
- There are currently 6 featured links in the screenshot below.  This is because the code in Whitehall to publish these links does not currently limit the number of items.  This will be corrected in https://github.com/alphagov/whitehall/pull/6724.

## Screenshots
| Collections  | Whitehall  |
|---|---|
| ![Screenshot showing a world location news page rendered by Collections.  It has 6 links in the top right hand corner, which link to featured content.](https://user-images.githubusercontent.com/6329861/183898362-1471b200-fe4a-454f-96e3-70f0a19e2b84.png)  |  ![Screenshot showing a world location news page rendered by Collections.  It has 5 links in the top right hand corner, which link to featured content.](https://user-images.githubusercontent.com/6329861/183898532-c8c301b9-aec6-4328-81bd-1ad58256c229.png) |

[Trello card](https://trello.com/c/i577upcN)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
