### PR TITLE
Add world location news translations

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -46,4 +46,15 @@ class WorldLocationNews
   def mission_statement
     @content_item.content_item_data.dig("details", "mission_statement")
   end
+
+  def translations
+    @translations ||= @content_item.content_item_data.dig("links", "available_translations")&.map do |translation|
+      {
+        locale: translation["locale"],
+        base_path: translation["base_path"],
+        text: I18n.t("shared.language_name", locale: translation["locale"]),
+        active: I18n.locale.to_s == translation["locale"],
+      }
+    end
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -13,6 +13,13 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
+    <% if @world_location_news.translations.count > 1 %>
+      <%= render "govuk_publishing_components/components/translation_nav", {
+        translations: @world_location_news.translations,
+        no_margin_top: true,
+      } %>
+    <% end %>
+
     <%= render "components/topic-list", {
         items: @world_location_news.ordered_featured_links,
     } %>

--- a/config/locales/fr/shared.yml
+++ b/config/locales/fr/shared.yml
@@ -7,6 +7,6 @@ fr:
       title: Parcourir GOV.UK
     get_emails: Obtenir des courriels pour ce sujet
     language_direction: ltr
-    language_name: français
+    language_name: Français
     topics:
       title: "%{title}: informations détaillées"

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -73,6 +73,34 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when there are translations" do
+    it "includes a link to the other languages only" do
+      visit base_path
+
+      expect(page).to have_link("Cymraeg", href: "/world/somewhere.cy")
+
+      expect(page).to have_text("English")
+      expect(page).not_to have_link("English", href: "/world/somewhere")
+    end
+  end
+
+  context "when there are no translations" do
+    before do
+      content_item["links"]["available_translations"] = [
+        {
+          "locale": "en",
+          "base_path": "/world/somewhere",
+        },
+      ]
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "includes does not include the translation navigation" do
+      visit base_path
+      expect(page).not_to have_text("English")
+    end
+  end
+
 private
 
   def content_item_without_detail(content_item, key_to_remove)

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -38,5 +38,17 @@
         "title": "A second link to somewhere"
       }
     ]
+  },
+  "links": {
+    "available_translations": [
+      {
+        "locale": "en",
+        "base_path": "/world/somewhere"
+      },
+      {
+        "locale": "cy",
+        "base_path": "/world/somewhere.cy"
+      }
+    ]
   }
 }

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -62,4 +62,23 @@ RSpec.describe WorldLocationNews do
       ],
     )
   end
+
+  it "should map the translations" do
+    expect(world_location_news.translations).to eq(
+      [
+        {
+          locale: "en",
+          base_path: "/world/somewhere",
+          text: "English",
+          active: true,
+        },
+        {
+          locale: "cy",
+          base_path: "/world/somewhere.cy",
+          text: "Cymraeg",
+          active: false,
+        },
+      ],
+    )
+  end
 end


### PR DESCRIPTION
This page is currently rendered by Whitehall. This is part of the work to bring the rendering into Collections.

## Screenshots
| Collections  | Whitehall  |
|---|---|
| ![Screenshot showing a world location news page rendered by Collections.  In the top right, there is a translation navigation bar.  The text English is present (and is not a link) alongside a link labelled Français.](https://user-images.githubusercontent.com/6329861/183939961-03b85a08-9f8e-480e-953a-ea050d3e5d92.png) | ![Screenshot showing a world location news page rendered by Whitehall.  In the top right, there is a translation navigation bar.  The text English is present (and is not a link) alongside a link labelled Français.](https://user-images.githubusercontent.com/6329861/183940196-020ec93c-3033-438a-a3f8-c862d0ae600c.png) |

This also correctly deals with right-to-left languages, e.g. Arabic (note the title is not translated as there is currently an issue with the presentation from Whitehall, this will be dealt with separately):

| Collections  | Whitehall  |
|---|---|
| ![Screenshot of the top section of a world location news page rendered by Collections.  There are two languages listed: the Arabic word for Arabic and English.  The Arabic text is right-to-left and is marked up correctly.](https://user-images.githubusercontent.com/6329861/183941869-c72c59e5-fb53-48fa-bb46-d6e1a8f4ab82.png) | ![Screenshot of the top section of a world location news page rendered by Whitehall.  There are two languages listed: the Arabic word for Arabic and English.  The Arabic text is right-to-left and is marked up correctly.](https://user-images.githubusercontent.com/6329861/183941996-6689b60d-a264-4609-900d-ce68931da946.png) |

[Trello card](https://trello.com/c/t64h51QN)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
