### PR TITLE
Add mission statement to world location news page

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -33,4 +33,8 @@ class WorldLocationNews
       }
     end
   end
+
+  def mission_statement
+    @content_item.content_item_data.dig("details", "mission_statement")
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -35,3 +35,21 @@
     <% end %>
   </div>
 </div>
+
+<% if @world_location_news.mission_statement.present? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("world_location_news.headings.mission"),
+        padding: true,
+        font_size: "l",
+        border_top: 2,
+        margin_bottom: 2,
+      } %>
+
+      <p class="govuk-body">
+        <%= @world_location_news.mission_statement %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -41,6 +41,30 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when there is a mission statement" do
+    it "includes the mission statement header" do
+      visit base_path
+      expect(page).to have_text(I18n.t("world_location_news.headings.mission"))
+    end
+
+    it "includes the mission statement" do
+      visit base_path
+      expect(page).to have_text("Our mission is to test world location news.")
+    end
+  end
+
+  context "when the mission statement is empty" do
+    before do
+      content_item["details"]["mission_statement"] = ""
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "does not include the mission statement header" do
+      visit base_path
+      expect(page).to_not have_text(I18n.t("world_location_news.headings.mission"))
+    end
+  end
+
 private
 
   def content_item_without_detail(content_item, key_to_remove)

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -3,6 +3,7 @@
   "title": "UK and Mock Country",
   "description": "Find out about the relations between the UK and Mock Country",
   "details": {
+    "mission_statement": "Our mission is to test world location news.",
     "ordered_featured_documents": [
       {
         "href": "https://www.gov.uk/somewhere",

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -43,4 +43,8 @@ RSpec.describe WorldLocationNews do
       },
     )
   end
+
+  it "should return the mission statement" do
+    expect(world_location_news.mission_statement).to eq("Our mission is to test world location news.")
+  end
 end


### PR DESCRIPTION
This page is currently rendered by Whitehall. This is part of the work to bring the rendering into Collections.

## Screenshots
| Collections | Whitehall |
|---|---|
| ![Screenshot of mission statement rendered by Collections.  There is a heading 2 titled 'Our mission' then a paragraph of text.](https://user-images.githubusercontent.com/6329861/184106865-45dc949f-31cd-4807-8f53-380154973d95.png) | ![Screenshot of mission statement rendered by Whitehall.  There is a heading 2 titled 'Our mission' then a paragraph of text.](https://user-images.githubusercontent.com/6329861/184106878-598531f0-01bb-4b13-a530-31197226fe17.png) |

[Trello card](https://trello.com/c/wvMip7tS/176-add-mission-statement-to-world-location-news-page-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
