### PR TITLE
Build the Cost of living hub frontend

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,6 +39,7 @@ $govuk-include-default-font-face: false;
 @import "components/*";
 
 @import "views/browse";
+@import "views/cost_of_living";
 @import "views/topics";
 @import "views/topical_events";
 @import "views/taxons";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/document-list";
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
+@import "govuk_publishing_components/components/inset-text";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";

--- a/app/assets/stylesheets/views/_cost_of_living.scss
+++ b/app/assets/stylesheets/views/_cost_of_living.scss
@@ -1,0 +1,3 @@
+.cost-of-living-hub__header {
+  border-top: solid govuk-spacing(2) govuk-colour("blue");
+}

--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -1,0 +1,55 @@
+<% track_action ||= "contentLink" %>
+
+<ul class="govuk-list browse__list" data-module="gem-track-click">
+  <% list.each_with_index do |content_item, index| %>
+    <% if content_item[:links] %>
+      <li class="govuk-list browse__list-item govuk-!-padding-bottom-1">
+         <% if content_item[:subheading] %>
+           <%= render "govuk_publishing_components/components/heading", {
+            text: content_item[:subheading],
+            heading_level: 3,
+            font_size: "s",
+            padding: index > 0 ? true : false,
+            margin_bottom: index === 0 ? 3 : 0,
+          } %>
+         <% end %>
+         <% if content_item[:links] %>
+          <ul class="govuk-list browse__list">
+             <% content_item[:links].each_with_index do |link_item, index| %>
+              <li class="govuk-list browse__list-item">
+               <%= link_to(
+                 link_item[:link_text],
+                 link_item[:href],
+                 class: "govuk-link",
+                 data: {
+                   # track_category: "browseClicked",
+                   track_count: "contentLink",
+                   track_action: track_action,
+                   # track_label: list_item.base_path,
+                   # track_options: {
+                   #   dimension28: list.count.to_s,
+                   #   dimension29: list_item.title,
+                   #   dimension114: "#{list_index + 1}.#{index + 1}",
+                   # },
+                 },
+               ) %>
+             </li>
+              <% end %>
+            <% end %>
+          </ul>
+      </li>
+    <%# The below can all go when we get the actual data %>
+    <% elsif content_item[:inset_text] %>
+      <li class="browse__list-item govuk-!-padding-bottom-1">
+        <%= render "govuk_publishing_components/components/inset_text" do %>
+          <p><%= content_item[:inset_text] %></p>
+          <%= link_to(
+            content_item[:link_text],
+            content_item[:href],
+            class: "govuk-link",
+          ) %>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -3,3 +3,53 @@
 } %>
 
 <% content_for :title, content[:page_title] %>
+<% content_for :is_full_width_header, true %>
+
+<header class="cost-of-living-hub__header">
+  <%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      breadcrumbs: breadcrumbs,
+      collapse_on_mobile: true,
+      inverse: true
+    } %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/title", {
+          title: content[:header][:heading],
+          inverse: true,
+          margin_top: 4,
+          margin_bottom: 6,
+        } %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/lead_paragraph", {
+          text: content[:header][:lede],
+          inverse: true,
+          margin_bottom: 2,
+        } %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row covid__action-link-wrapper">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render 'govuk_publishing_components/components/action_link', {
+          white_arrow: true,
+          href: content[:header][:href],
+          text: content[:header][:link_text],
+          mobile_subtext: true,
+          light_text: true,
+          data: {
+            module: "gem-track-click",
+            track_category: "pageElementInteraction",
+            track_action: "Header",
+            track_label: content[:header][:href],
+          }
+        } %>
+      </div>
+    </div>
+  <% end %>
+</header>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -5,6 +5,28 @@
 <% content_for :title, content[:page_title] %>
 <% content_for :is_full_width_header, true %>
 
+<%
+  accordion_contents = content[:body][:accordion_content].map.with_index do |list, list_index|
+    {
+      heading: {
+        text: list[:heading],
+      },
+      content: {
+        html: render(partial: "links", locals: {
+          list: list[:content],
+          list_index: list_index,
+        }),
+      },
+      data_attributes: {
+        "track-count": "accordionSection",
+        "track-options": {
+          "dimension114": list_index + 1
+        },
+      },
+    }
+  end
+%>
+
 <header class="cost-of-living-hub__header">
   <%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
     <%= render 'govuk_publishing_components/components/breadcrumbs', {
@@ -53,3 +75,22 @@
     </div>
   <% end %>
 </header>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="browse__section">
+       <%= render "govuk_publishing_components/components/heading", {
+          text: content[:body][:heading],
+          margin_bottom: 6,
+          font_size: "l"
+        } %>
+        <div data-module="toggle-attribute">
+          <%= render "govuk_publishing_components/components/accordion", {
+            items: accordion_contents
+          } %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_browse_header.html.erb
+++ b/app/views/shared/_browse_header.html.erb
@@ -1,9 +1,12 @@
 <%
    two_thirds ||= false
    margin_bottom ||= 0
+   padding_top ||= false
 
    header_wrapper_classes = %w(browse__header-wrapper)
    header_wrapper_classes << "govuk-!-margin-bottom-#{margin_bottom}" if !margin_bottom.zero?
+
+   header_wrapper_classes << "govuk-!-padding-top-#{padding_top}" if padding_top.is_a? Numeric
 
    column_classes = %w()
    column_classes << (two_thirds ? "govuk-grid-column-two-thirds" : "govuk-grid-column-full")

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -1,8 +1,203 @@
 ---
-page_title: Help for households
+page_title: Cost of living support
 metadata:
   title: Cost of living support
   description: >-
     Find out what support is available to help with the cost of living. This
     includes income and disability benefits, bills and allowances, childcare,
     housing and transport.
+header:
+  heading: Cost of living support
+  lede: Support is available to help with the cost of living
+  link_text: Check what support you could be eligible for
+  href: https://www.google.co.uk
+body:
+  heading: Available support
+  accordion_content:
+  - heading: Support with your income
+    content:
+      - subheading:
+        links:
+        - link_text: Find out what benefits and financial support you may be able to get
+          href: https://www.gov.uk/check-benefits-financial-support
+        - link_text: Check if you’re getting the minimum wage
+          href: https://www.gov.uk/am-i-getting-minimum-wage
+        - link_text: Claim Marriage Allowance
+          href: https://www.gov.uk/marriage-allowance
+        - link_text: Extra money available for carers
+          href: https://www.gov.uk/carers-allowance
+        - link_text: Get help with savings if you’re on a low income (Help to Save)
+          href: https://www.gov.uk/get-help-savings-low-income
+        - link_text: Claim tax relief on work-related expenses
+          href: https://www.gov.uk/tax-relief-for-employees
+      - inset_text: The Money Helper service provides free, confidential and impartial help tailored to individual needs.
+        link_text: Use the Money Helper service
+        href: https://www.moneyhelper.org.uk/
+      - subheading: Check if you’re eligible for Universal Credit
+        links:
+        - link_text: Universal Credit in England, Scotland and Wales
+          href: https://www.gov.uk/universal-credit/
+        - link_text: Universal Credit in Northern Ireland
+          href: https://www.nidirect.gov.uk/campaigns/universal-credit
+      - subheading: Pension Credit if you’re on a low income
+        links:
+          - link_text: Pension Credit in England, Scotland and Wales
+            href: https://www.gov.uk/pension-credit
+          - link_text: Pension Credit in Northern Ireland
+            href: https://www.nidirect.gov.uk/articles/understanding-pension-credit
+      - subheading: Jobseeker's Allowance (JSA) if you're unemployed
+        links:
+        - link_text: JSA in England, Scotland and Wales
+          href: https://www.gov.uk/jobseekers-allowance
+        - link_text: JSA in Northern Ireland
+          href: https://www.nidirect.gov.uk/articles/jobseekers-allowance
+  - heading: Support if you’re disabled
+    content:
+      - subheading: Check if you’re eligible for Universal Credit
+        links:
+        - link_text: Universal Credit if you’re disabled in England, Scotland and Wales
+          href: https://www.gov.uk/health-conditions-disability-universal-credit
+        - link_text: Universal Credit in Northern Ireland
+          href: https://www.nidirect.gov.uk/campaigns/universal-credit
+      - subheading: Check if you’re eligible for Employment and Support Allowance (ESA)
+        links:
+        - link_text: ‘New style’ ESA in England, Scotland and Wales
+          href: https://www.gov.uk/employment-support-allowance
+        - link_text: ‘New style’ ESA in Northern Ireland
+          href: https://www.nidirect.gov.uk/articles/employment-and-support-allowance
+      - subheading: Check if you’re eligible for Personal Independence Payment (PIP)
+        links:
+        - link_text: PIP in England, Scotland and Wales
+          href: https://www.gov.uk/pip
+        - link_text: PIP in Northern Ireland
+          href: https://www.nidirect.gov.uk/articles/personal-independence-payment-pip
+      - subheading: Support to get or stay in work
+        links:
+        - link_text: Access to Work in England
+          href: https://www.gov.uk/access-to-work
+        - link_text: Access to Work in Northern Ireland
+          href: https://www.nidirect.gov.uk/articles/employment-support-information
+      - subheading: Check if you’re eligible for Adult Disability Payment in Scotland
+        links:
+        - link_text: Adult Disability Payment in Scotland
+          href: https://www.mygov.scot/adult-disability-payment
+      - subheading: Support if your child is disabled
+        links:
+        - link_text: Disability Living Allowance (DLA) for children in England, Wales and Northern Ireland
+          href: https://www.gov.uk/disability-living-allowance-children
+        - link_text: Child Disability Payment in Scotland
+          href: https://www.mygov.scot/child-disability-payment
+  - heading: Help with your bills
+    content:
+    - subheading: UK wide
+      links:
+      - link_text: Cost of Living Payment
+        href: https://www.gov.uk/guidance/cost-of-living-payment
+      - link_text: Energy Bills Support Scheme
+        href: https://www.gov.uk/government/news/energy-bills-support-scheme-explainer
+      - link_text: Disability Cost of Living Payment
+        href: https://www.gov.uk/guidance/cost-of-living-payment
+      - link_text: Winter Fuel Payment and Pensioner Cost of Living Payment
+        href: https://www.gov.uk/winter-fuel-payment
+      - link_text: Cold Weather Payment
+        href: https://www.gov.uk/cold-weather-payment
+      - link_text: Check with your energy supplier to see if you can get the Warm Home Discount
+        href: https://www.ofgem.gov.uk/information-consumers/energy-advice-households/finding-your-energy-supplier-or-network-operator
+      - link_text: Contact your local council to check if you’re eligible for the Household Support Fund
+        href: https://www.gov.uk/find-local-council
+      - link_text: Cheaper phone and broadband
+        href: https://www.ofcom.org.uk/phones-telecoms-and-internet/advice-for-consumers/costs-and-billing/social-tariffs
+      - link_text: Help paying your Water Bill
+        href: https://www.ccwater.org.uk/households/help-with-my-bills/
+    - subheading: Help with your Council Tax or rates
+      links:
+      - link_text: Council Tax rebate in England, Scotland and Wales
+        href: https://www.gov.uk/guidance/council-tax-rebate-factsheet
+      - link_text: Rate Relief in Northern Ireland
+        href: https://www.nidirect.gov.uk/rates-help
+    - subheading: Help with health costs
+      links:
+      - link_text: NHS Low Income Scheme in England and Wales
+        href: https://www.nhs.uk/nhs-services/help-with-health-costs/nhs-low-income-scheme-lis/
+      - link_text: Help with Health Costs in Scotland
+        href: https://www.nhsinform.scot/care-support-and-rights/health-rights/access/help-with-health-costs
+    - subheading: Budgeting loans in you’re claiming benefits
+      links:
+      - link_text: Budgeting loans in England, Scotland and Wales
+        href: https://www.gov.uk/budgeting-help-benefits
+      - link_text: Social Fund Budgeting Loan in Northern Ireland
+        href: https://www.nidirect.gov.uk/articles/social-fund-budgeting-loan
+  - heading: Childcare costs
+    content:
+    - subheading: UK Wide
+      links:
+      - link_text: Check what help you could get with childcare costs
+        href: https://www.gov.uk/childcare-calculator
+      - link_text: Claim Child Benefit
+        href: https://www.gov.uk/child-benefit
+      - link_text: Claim back childcare costs if you get Universal Credit
+        href: https://www.gov.uk/guidance/universal-credit-childcare-costs
+    - subheading: Check if your child can get free school meals
+      links:
+        - link_text: Free school meals in England
+          href: https://www.gov.uk/apply-free-school-meals
+        - link_text: Free school meals in Northern Ireland
+          href: https://www.nidirect.gov.uk/articles/nutrition-and-school-lunches
+        - link_text: Free school meals in Scotland
+          href: https://www.mygov.scot/school-meals
+        - link_text: Free school meals in Wales
+          href: https://gov.wales/find-out-about-free-school-meals
+    - subheading: Get help with school transport costs
+      links:
+      - link_text: Help with school transport costs in England and Wales
+        href: https://www.gov.uk/help-home-school-transport
+      - link_text: Help with school transport costs in Scotland
+        href: https://www.mygov.scot/free-school-transport
+      - link_text: Help with school transport costs in Northern Ireland
+        href: https://www.eani.org.uk/help-available/home-to-school-transport
+    - subheading: Support if your child is disabled
+      links:
+      - link_text: Disability Living Allowance (DLA) for children in England, Wales and Northern Ireland
+        href: https://www.gov.uk/disability-living-allowance-children
+      - link_text: Child Disability Payment in Scotland
+        href: https://www.mygov.scot/child-disability-payment
+    - subheading: Get help with food and milk for your child
+      links:
+      - link_text: Claim Healthy Start vouchers
+        href: https://www.healthystart.nhs.uk/how-to-apply/
+      - link_text: Best Start Foods in Scotland
+        href: https://www.mygov.scot/best-start-grant-best-start-foods
+    - subheading: Get help with maternity costs
+      links:
+      - link_text: Get help with maternity costs in England, Wales and Northern Ireland
+        href: https://www.gov.uk/sure-start-maternity-grant
+      - link_text: Get help with maternity costs (Scotland)
+        href: https://www.mygov.scot/best-start-grant-best-start-foods
+  - heading: Housing support
+    content:
+    - subheading: UK wide
+      links:
+      - link_text: Get help with housing costs if you get Universal Credit
+        href: https://www.gov.uk/housing-and-universal-credit
+      - link_text: Get help with interest payments on mortgages or loans
+        href: https://www.gov.uk/support-for-mortgage-interest
+      - link_text: Contact your council for help with housing costs and Council Tax
+        href: https://www.gov.uk/find-local-council
+    - subheading: Check if you’re eligible for Housing Benefit
+      links:
+      - link_text: Housing Benefit in England, Scotland and Wales
+        href: https://www.gov.uk/housing-benefit
+      - link_text: Housing Benefit in Northern Ireland
+        href: https://www.nihe.gov.uk/Housing-Help/Housing-Benefit/Making-a-claim-for-Housing-Benefit
+    - heading: Transport costs
+      content:
+      - subheading: UK wide
+        links:
+        - link_text: Save a third on rail journeys
+          href: https://www.railcard.co.uk/
+        - link_text: 50% off travel if you’re on Universal Credit
+          href: https://www.nationalrail.co.uk/times_fares/jobcentre-plus-card.aspx
+        - link_text: Apply for an older person’s bus pass
+          href: https://www.gov.uk/apply-for-elderly-person-bus-pass
+        - link_text: Apply for an disabled person’s bus pass
+          href: https://www.gov.uk/apply-for-disabled-bus-pass

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -10,7 +10,7 @@ header:
   heading: Cost of living support
   lede: Support is available to help with the cost of living
   link_text: Check what support you could be eligible for
-  href: https://www.google.co.uk
+  href: /
 body:
   heading: Available support
   accordion_content:

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Cost of Living hub page" do
     end
 
     def then_i_can_see_the_title
-      expect(page).to have_title("Help for households")
+      expect(page).to have_title("Cost of living support")
     end
 
     def then_i_can_see_the_breadcrumbs


### PR DESCRIPTION
This PR adds the frontend for the Cost of Living hub. It is based on the already existing Browse pages (including some of the classes used for those pages) and uses the accordion component. As there is no content in the content store for the pages, this page content is stored in a YML file.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Relevant Trello Cards
- [Building Header for Cost of Living page ](https://trello.com/c/tZXyaXV6/1203-create-header-of-cost-of-living-hub-m)
- [Building Body for Cost of Living page](https://trello.com/c/Ny93RuWT/1206-create-body-of-cost-of-living-hub-m)