### PR TITLE
Remove hardcoded list of document types

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -97,17 +97,7 @@ class TopicalEvent
   end
 
   def announcements
-    announcement_document_types = %w[
-      press_release
-      news_article
-      news_story
-      fatality_notice
-      speech
-      written_statement
-      oral_statement
-      authored_article
-      government_response
-    ]
+    announcement_document_types = GovukDocumentTypes.supergroup_document_types("announcements")
     @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_store_document_type: announcement_document_types })
   end
 

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe TopicalEvent do
     end
 
     it "should make correct call to search api for announcements" do
-      announcement_formats = %w[press_release news_article news_story fatality_notice speech written_statement oral_statement authored_article government_response]
+      announcement_formats = GovukDocumentTypes.supergroup_document_types("announcements")
 
       expect(Services.search_api)
         .to receive(:search)


### PR DESCRIPTION
We had previously hardcoded a list of document types to retrieve when getting announcements to display on topical event pages.

These can be replaced with the [data in the `govuk_document_types` gem](https://github.com/alphagov/govuk_document_types/blob/61305fb8e6db45a251a0527fc379f07ce68a0144/data/supertypes.yml#L54-L64).

This means the list won't get out of date if (for example) new content types are added or removed from the group.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
