### PR TITLE
Add document sections to world location news page

### DIFF
--- a/app/helpers/document_list_helper.rb
+++ b/app/helpers/document_list_helper.rb
@@ -15,7 +15,8 @@ private
       consultation: "/search/policy-papers-and-consultations?",
       detailed_guidance: "/search/all?",
       latest: "/search/all?",
-      publication: "/search/all?" }[content_type]
+      publication: "/search/all?",
+      statistic: "/search/research-and-statistics?" }[content_type]
   end
 
   def topical_event_query_params(content_type, slug)
@@ -47,6 +48,16 @@ private
     when :latest
       {
         order: "updated-newest",
+        world_locations: [slug],
+      }
+    when :publication
+      {
+        content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency],
+        order: "updated-newest",
+        world_locations: [slug],
+      }
+    else
+      {
         world_locations: [slug],
       }
     end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -66,4 +66,16 @@ class WorldLocationNews
   def latest
     @latest ||= @documents_service.fetch_related_documents_with_format
   end
+
+  def announcements
+    @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_supergroup: "news_and_communications" })
+  end
+
+  def publications
+    @publications ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency] })
+  end
+
+  def statistics
+    @statistics ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_subgroup: "statistics" })
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -91,3 +91,21 @@
     </div>
   </div>
 <% end %>
+
+<% if I18n.locale == :en && (@world_location_news.announcements.any? || @world_location_news.publications.any? || @world_location_news.statistics.any?) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: I18n.t("world_location_news.headings.documents"),
+        padding: true,
+        font_size: "l",
+        border_top: 2,
+        margin_bottom: 3,
+      } %>
+
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.announcements, heading: I18n.t("world_location_news.headings.announcements"), link_to: search_url(:world_location_news, :announcement, @world_location_news.slug) }) if @world_location_news.announcements.any? %>
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.publications, heading: I18n.t("world_location_news.headings.publications"), link_to: search_url(:world_location_news, :publication, @world_location_news.slug) }) if @world_location_news.publications.any? %>
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.statistics, heading: I18n.t("world_location_news.headings.statistics"), link_to: search_url(:world_location_news, :statistic, @world_location_news.slug) }) if @world_location_news.statistics.any? %>
+    </div>
+  </div>
+<% end %>

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -81,4 +81,40 @@ RSpec.describe WorldLocationNews do
       ],
     )
   end
+
+  context "document lists" do
+    let(:default_params) do
+      { filter_world_locations: [base_path.sub(%r{/world/}, "").sub(%r{/news}, "")],
+        count: 3,
+        order: "-public_timestamp",
+        fields: SearchApiFields::WORLD_LOCATION_NEWS_SEARCH_FIELDS }
+    end
+
+    it "should make correct call to search api for announcements" do
+      expect(Services.search_api)
+        .to receive(:search)
+        .with(default_params.merge({ filter_content_purpose_supergroup: "news_and_communications" }))
+        .and_return({ "results" => [] })
+
+      world_location_news.announcements
+    end
+
+    it "should make correct call to search api for publications" do
+      expect(Services.search_api)
+          .to receive(:search)
+          .with(default_params.merge({ filter_content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency] }))
+          .and_return({ "results" => [] })
+
+      world_location_news.publications
+    end
+
+    it "should make correct call to search api for statistics" do
+      expect(Services.search_api)
+          .to receive(:search)
+          .with(default_params.merge({ filter_content_purpose_subgroup: "statistics" }))
+          .and_return({ "results" => [] })
+
+      world_location_news.statistics
+    end
+  end
 end


### PR DESCRIPTION
This page is currently rendered by Whitehall. This is part of the work to bring the rendering into Collections.

We have tried to reuse as much code as possible from topical events in rendering this section.

The horizontal line between each section has been updated to match the style of Topical Event pages.  This differs from the rendering in Whitehall.

The number of documents in each section has been updated to match Topical Event pages, meaning we can re-use code without having inconsistencies between the content types.

## Screenshots
| Collections | Whitehall |
|---|---|
| ![Screenshot of part of the world location news page for Cyprus rendered by Collections.  There is a header labelled Documents.  Under this there are three sections: announcements, publications and statistics.  They all contain a maximum of 3 documents.  There is no horizontal line between each document type.](https://user-images.githubusercontent.com/6329861/184651970-8b59b8f8-184e-4ebe-b418-32bff1e8a4f9.png) | ![Screenshot of part of the world location news page for Cyprus rendered by Whitehall.  There is a header labelled Documents.  Under this there are three sections: announcements, publications and statistics.  They all contain a maximum of 2 documents.  There is a horizontal line between each document type.](https://user-images.githubusercontent.com/6329861/184614249-31a43322-7b28-4bcd-baa3-20052b0fb76d.png) |

[Trello card](https://trello.com/c/O7wicoig)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
