### PR TITLE
Show guidance and regulation rather than detailed guides on topical events

### DIFF
--- a/app/helpers/document_list_helper.rb
+++ b/app/helpers/document_list_helper.rb
@@ -13,7 +13,7 @@ private
   def base_path(content_type)
     { announcement: "/search/news-and-communications?",
       consultation: "/search/policy-papers-and-consultations?",
-      detailed_guidance: "/search/all?",
+      guidance_and_regulation: "/search/all?",
       latest: "/search/all?",
       publication: "/search/all?",
       statistic: "/search/research-and-statistics?" }[content_type]
@@ -26,7 +26,7 @@ private
         content_store_document_type: %w[open_consultations closed_consultations],
         topical_events: [slug],
       }
-    when :detailed_guidance
+    when :guidance_and_regulation
       {
         content_purpose_supergroup: "guidance_and_regulation",
         topical_events: [slug],

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -111,8 +111,8 @@ class TopicalEvent
     @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_store_document_type: announcement_document_types })
   end
 
-  def detailed_guidance
-    @detailed_guidance ||= @documents_service.fetch_related_documents_with_format({ filter_format: "detailed_guidance" })
+  def guidance_and_regulation
+    @guidance_and_regulation ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_supergroup: "guidance_and_regulation" })
   end
 
   def organisations

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -97,18 +97,7 @@ class TopicalEvent
   end
 
   def announcements
-    announcement_document_types = %w[
-      press_release
-      news_article
-      news_story
-      fatality_notice
-      speech
-      written_statement
-      oral_statement
-      authored_article
-      government_response
-    ]
-    @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_store_document_type: announcement_document_types })
+    @announcements ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_supergroup: "news_and_communications", reject_content_purpose_subgroup: %w[decisions updates_and_alerts] })
   end
 
   def guidance_and_regulation

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -102,7 +102,7 @@
   </div>
 
   <section id="documents" class="govuk-grid-column-two-thirds">
-    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.detailed_guidance.any? %>
+    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.guidance_and_regulation.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.documents"),
         padding: true,
@@ -115,7 +115,7 @@
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.headings.publications"), link_to: search_url(:topical_event, :publication, @topical_event.slug) }) if @topical_event.publications.any? %>
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:topical_event, :consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:topical_event, :announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
-    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.detailed_guidance, heading: I18n.t("topical_events.headings.detailed_guides"), link_to: search_url(:topical_event, :detailed_guidance, @topical_event.slug) }) if @topical_event.detailed_guidance.any? %>
+    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.guidance_and_regulation, heading: I18n.t("topical_events.headings.guidance_and_regulation"), link_to: search_url(:topical_event, :guidance_and_regulation, @topical_event.slug) }) if @topical_event.guidance_and_regulation.any? %>
   </section>
 
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -5,9 +5,9 @@ ar:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -5,9 +5,9 @@ az:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -5,9 +5,9 @@ be:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -5,9 +5,9 @@ bg:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -5,9 +5,9 @@ bn:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -5,9 +5,9 @@ cs:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -5,9 +5,9 @@ cy:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -5,9 +5,9 @@ da:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -5,9 +5,9 @@ de:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -5,9 +5,9 @@ dr:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -5,9 +5,9 @@ el:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -5,9 +5,9 @@ en:
     headings:
       announcements: Announcements
       consultations: Consultations
-      detailed_guides: Detailed Guides
       documents: Documents
       featured: Featured
+      guidance_and_regulation: Guidance and regulation
       latest: Latest
       publications: Publications
       travel_advice: Travel Advice

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -10,6 +10,6 @@ en:
       guidance_and_regulation: Guidance and regulation
       latest: Latest
       publications: Publications
-      travel_advice: Travel Advice
+      travel_advice: Travel advice
     no_updates: There are no updates yet.
     organisations: Who’s involved

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -5,9 +5,9 @@ es-419:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -5,9 +5,9 @@ es:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -5,9 +5,9 @@ et:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -5,9 +5,9 @@ fa:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -5,9 +5,9 @@ fi:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -5,9 +5,9 @@ fr:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -5,9 +5,9 @@ gd:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -5,9 +5,9 @@ gu:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -5,9 +5,9 @@ he:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -5,9 +5,9 @@ hi:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -5,9 +5,9 @@ hr:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -5,9 +5,9 @@ hu:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -5,9 +5,9 @@ hy:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -5,9 +5,9 @@ id:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -5,9 +5,9 @@ is:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -5,9 +5,9 @@ it:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -5,9 +5,9 @@ ja:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -5,9 +5,9 @@ ka:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -5,9 +5,9 @@ kk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -5,9 +5,9 @@ ko:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -5,9 +5,9 @@ lt:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -5,9 +5,9 @@ lv:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -5,9 +5,9 @@ ms:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -5,9 +5,9 @@ mt:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -5,9 +5,9 @@ ne:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -5,9 +5,9 @@ nl:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -5,9 +5,9 @@
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -5,9 +5,9 @@ pa-pk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -5,9 +5,9 @@ pa:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -5,9 +5,9 @@ pl:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -5,9 +5,9 @@ ps:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -5,9 +5,9 @@ pt:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -5,9 +5,9 @@ ro:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -5,9 +5,9 @@ ru:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -5,9 +5,9 @@ si:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -5,9 +5,9 @@ sk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -5,9 +5,9 @@ sl:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -5,9 +5,9 @@ so:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -5,9 +5,9 @@ sq:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -5,9 +5,9 @@ sr:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -5,9 +5,9 @@ sv:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -5,9 +5,9 @@ sw:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -5,9 +5,9 @@ ta:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -5,9 +5,9 @@ th:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -5,9 +5,9 @@ tk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -5,9 +5,9 @@ tr:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -5,9 +5,9 @@ uk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -5,9 +5,9 @@ ur:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -5,9 +5,9 @@ uz:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -5,9 +5,9 @@ vi:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -5,9 +5,9 @@ yi:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -5,9 +5,9 @@ zh-hk:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -5,9 +5,9 @@ zh-tw:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -5,9 +5,9 @@ zh:
     headings:
       announcements:
       consultations:
-      detailed_guides:
       documents:
       featured:
+      guidance_and_regulation:
       latest:
       publications:
       travel_advice:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Topical Event pages" do
     let(:related_guidance_and_regulation) { { "Some guidance" => "/foo/detailed_guidance_one", "Another bit of guidance" => "/foo/detailed_guidance_two" } }
 
     it "displays links to all related documents" do
-      stub_search(body: search_api_response(related_announcements))
+      stub_search(body: search_api_response(related_announcements), params: { "filter_content_purpose_supergroup" => "news_and_communications" })
       stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
       stub_search(body: search_api_response(related_consultations), params: { "filter_format" => "consultation" })
       stub_search(body: search_api_response(related_guidance_and_regulation), params: { "filter_content_purpose_supergroup" => "guidance_and_regulation" })

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -77,13 +77,13 @@ RSpec.feature "Topical Event pages" do
     let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
     let(:related_consultations) { { "A consultation on Topicals" => "/foo/consultation_one", "Another consultation" => "/foo/consultation_two" } }
     let(:related_announcements) { { "An announcement on Topicals" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
-    let(:related_guidance) { { "Some guidance" => "/foo/detailed_guidance_one", "Another bit of guidance" => "/foo/detailed_guidance_two" } }
+    let(:related_guidance_and_regulation) { { "Some guidance" => "/foo/detailed_guidance_one", "Another bit of guidance" => "/foo/detailed_guidance_two" } }
 
     it "displays links to all related documents" do
       stub_search(body: search_api_response(related_announcements))
       stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
       stub_search(body: search_api_response(related_consultations), params: { "filter_format" => "consultation" })
-      stub_search(body: search_api_response(related_guidance), params: { "filter_format" => "detailed_guidance" })
+      stub_search(body: search_api_response(related_guidance_and_regulation), params: { "filter_content_purpose_supergroup" => "guidance_and_regulation" })
 
       visit base_path
 
@@ -91,7 +91,7 @@ RSpec.feature "Topical Event pages" do
       expect(page).to have_text("Publications")
       expect(page).to have_text("Consultations")
       expect(page).to have_text("Announcements")
-      expect(page).to have_text("Detailed Guides")
+      expect(page).to have_text("Guidance and regulation")
 
       within("#publications") do
         related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
@@ -108,9 +108,9 @@ RSpec.feature "Topical Event pages" do
         expect(page).to have_link("See all announcements", href: "/search/news-and-communications?topical_events%5B%5D=something-very-topical")
       end
 
-      within("#detailed-guides") do
-        related_guidance.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all detailed guides", href: "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical")
+      within("#guidance-and-regulation") do
+        related_guidance_and_regulation.each { |title, link| expect(page).to have_link(title, href: link) }
+        expect(page).to have_link("See all guidance and regulation", href: "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical")
       end
     end
 

--- a/spec/helpers/document_list_helper_spec.rb
+++ b/spec/helpers/document_list_helper_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe DocumentListHelper do
       expected_consultation_url = "/search/policy-papers-and-consultations?content_store_document_type%5B%5D=open_consultations&content_store_document_type%5B%5D=closed_consultations&topical_events%5B%5D=something-very-topical"
       expected_announcement_url = "/search/news-and-communications?topical_events%5B%5D=something-very-topical"
       expected_latest_url = "/search/all?order=updated-newest&topical_events%5B%5D=something-very-topical"
-      expected_detailed_guidance_url = "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical"
+      expected_guidance_and_regulation_url = "/search/all?content_purpose_supergroup=guidance_and_regulation&topical_events%5B%5D=something-very-topical"
 
       expected_results = {
         publication: expected_publication_url,
         consultation: expected_consultation_url,
         announcement: expected_announcement_url,
         latest: expected_latest_url,
-        detailed_guidance: expected_detailed_guidance_url,
+        guidance_and_regulation: expected_guidance_and_regulation_url,
       }
 
       expected_results.each do |document_type, expected_url|

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -87,11 +87,9 @@ RSpec.describe TopicalEvent do
     end
 
     it "should make correct call to search api for announcements" do
-      announcement_formats = %w[press_release news_article news_story fatality_notice speech written_statement oral_statement authored_article government_response]
-
       expect(Services.search_api)
         .to receive(:search)
-        .with(default_params.merge({ filter_content_store_document_type: announcement_formats }))
+        .with(default_params.merge({ filter_content_purpose_supergroup: "news_and_communications", reject_content_purpose_subgroup: %w[decisions updates_and_alerts] }))
         .and_return({ "results" => [] })
 
       topical_event.announcements

--- a/spec/models/topical_event_spec.rb
+++ b/spec/models/topical_event_spec.rb
@@ -118,10 +118,10 @@ RSpec.describe TopicalEvent do
     it "should make the correct call to search api for detailed guidance" do
       expect(Services.search_api)
         .to receive(:search)
-              .with(default_params.merge({ filter_format: "detailed_guidance" }))
+              .with(default_params.merge({ filter_content_purpose_supergroup: "guidance_and_regulation" }))
               .and_return({ "results" => [] })
 
-      topical_event.detailed_guidance
+      topical_event.guidance_and_regulation
     end
 
     it "should make the correct call to search api for latest" do


### PR DESCRIPTION
We have switched to using the content_purpose_supergroup of guidance_and_regulation rather than the filter_format of detailed_guidance for topical events. This aligns more with other content types in collections, e.g. organisations, which prefer content_purpose_supergroups instead of specific document types. This also means that the link to search is now more relevant, as it links to all guidance and regulation for the topical event, rather than just to detailed guides.

This also updates the announcements section to use the existing content purpose supergroup for this type - no changes expected to content on page.

| Rendering of section currently | Rendering of section as per this PR |
| --------- | ----------- |
| <img width="708" alt="Screenshot 2022-08-15 at 16 26 43" src="https://user-images.githubusercontent.com/25515510/184665288-f1aa0656-7b18-4aed-8f32-329be3ddb38f.png"> | <img width="726" alt="Screenshot 2022-08-15 at 16 24 45" src="https://user-images.githubusercontent.com/25515510/184665327-6d4a2c96-f847-4c84-910b-5f4f9ef8a661.png">|

[Trello](https://trello.com/c/SkGhAxxl/181-update-topical-events-finder-link-to-just-show-detailed-gudiance)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
