### PR TITLE
Add world location news atom feed and email signup link

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,8 +1,22 @@
 class WorldLocationNewsController < ApplicationController
   around_action :switch_locale
+  enable_request_formats show: :atom
 
   def show
-    @world_location_news = WorldLocationNews.find!(request.path)
-    setup_content_item_and_navigation_helpers(@world_location_news)
+    path = world_location_news_path(params[:name])
+    @world_location_news = WorldLocationNews.find!(path)
+
+    respond_to do |format|
+      format.html do
+        setup_content_item_and_navigation_helpers(@world_location_news)
+      end
+
+      format.atom do
+        results = FeedContent.new(filter_world_locations: params[:name]).results(10)
+        items = results.map { |result| FeedEntryPresenter.new(result) }
+
+        render "feeds/feed", locals: { items: items, root_url: Plek.new.website_root + path, title: "#{@world_location_news.title} - Activity on GOV.UK" }
+      end
+    end
   end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -69,6 +69,10 @@
         <% else %>
           <p class="govuk-body"><%= I18n.t("world_location_news.no_updates") %></p>
         <% end %>
+
+        <%= render "govuk_publishing_components/components/subscription_links", {
+          feed_link_box_value: Plek.new.website_root + world_location_news_path(@world_location_news.slug, format: "atom")
+        } %>
       </section>
     </div>
   </div>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -71,6 +71,7 @@
         <% end %>
 
         <%= render "govuk_publishing_components/components/subscription_links", {
+          email_signup_link: "/email/subscriptions/new?topic_id=#{@world_location_news.slug}",
           feed_link_box_value: Plek.new.website_root + world_location_news_path(@world_location_news.slug, format: "atom")
         } %>
       </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,10 @@ Rails.application.routes.draw do
     get "/:slug", to: "step_nav#show"
   end
 
+  get "/world/:name/news(.:locale).atom",
+      to: "world_location_news#show",
+      as: :world_location_news_feed
+
   get "/world/:name/news(.:locale)",
       to: "world_location_news#show",
       as: :world_location_news

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -182,6 +182,31 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when requesting the atom feed" do
+    let(:related_documents) { { "An announcement on World Locations" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
+
+    before do
+      stub_search(body: search_api_response(related_documents))
+    end
+
+    it "sets the page title" do
+      visit "#{base_path}.atom"
+      expect(page).to have_title("#{content_item['title']} - Activity on GOV.UK")
+    end
+
+    it "should include the correct entries" do
+      visit "#{base_path}.atom"
+
+      entries = Hash.from_xml(page.html).dig("feed", "entry")
+
+      expect(entries.first).to include("title" => "some_display_type: An announcement on World Locations")
+      expect(entries.first["link"]).to include("href" => "http://www.test.gov.uk/foo/announcement_one")
+
+      expect(entries.second).to include("title" => "some_display_type: Another announcement")
+      expect(entries.second["link"]).to include("href" => "http://www.test.gov.uk/foo/announcement_two")
+    end
+  end
+
 private
 
   def content_item_without_detail(content_item, key_to_remove)

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -20,6 +20,11 @@ RSpec.feature "World Location News pages" do
     expect(page).to have_selector("meta[name='description'][content='Find out about the relations between the UK and Mock Country']", visible: :hidden)
   end
 
+  it "includes a link to the atom feed" do
+    visit base_path
+    expect(page).to have_field("Copy and paste this URL into your feed reader", with: "http://www.test.gov.uk/world/mock-country/news.atom")
+  end
+
   context "when there are featured documents" do
     it "includes the featured documents header" do
       visit base_path

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -25,6 +25,11 @@ RSpec.feature "World Location News pages" do
     expect(page).to have_field("Copy and paste this URL into your feed reader", with: "http://www.test.gov.uk/world/mock-country/news.atom")
   end
 
+  it "includes a link to signup for emails" do
+    visit base_path
+    expect(page).to have_link("Get emails", href: "/email/subscriptions/new?topic_id=mock-country")
+  end
+
   context "when there are featured documents" do
     it "includes the featured documents header" do
       visit base_path


### PR DESCRIPTION
This adds the following for World Location News, which are currently rendered by Whitehall:
- the rendering of the atom feed
- a link to the atom feed (using the same component as topical events, to make this consistent)
- a link to signup for email alerts

## Screenshots
### Whitehall rendered links
![Screenshot showing the latest document section, with two buttons: Get emails and Subscribe to feed.](https://user-images.githubusercontent.com/6329861/184854864-a65bf582-5ce0-4097-a79d-7f93a6e8d7dc.png)

### Collections rendered link
Before clicking the "Subscribe to feed" link:
![Screenshot showing the latest document section, with two buttons: Get emails and Subscribe to feed.](https://user-images.githubusercontent.com/6329861/184854916-c4ba4c38-8cd5-4962-a392-f4847ef06882.png)

After clicking the "Subscribe to feed" link:
![Screenshot showing the latest document section, with two buttons: Get emails and Subscribe to feed.  The subscribe to feed button is highlighted in yellow and a section has appeared underneath, containing an explanation of the feed and a link to the feed.](https://user-images.githubusercontent.com/6329861/184854952-12efc7db-c205-432c-9d77-28374cea0338.png)

### Whitehall rendered atom feed
![Screenshot showing part of an atom feed rendered by Whitehall.  It is identical to collections, except the update times are only accurate to the day, not the exact time.](https://user-images.githubusercontent.com/6329861/184855077-27ea9249-6c2b-49cd-b4a4-1f296b02124e.png)

### Collections rendered atom feed
![Screenshot showing part of an atom feed rendered by Collections.  It is identical to Whitehall, except the update times are accurate.](https://user-images.githubusercontent.com/6329861/184855098-d05205ac-ef90-4442-801e-dedde3a07e6c.png)

[Trello card](https://trello.com/c/3IV2aDkp)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
