### PR TITLE
Include World Location News type on news page

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -78,4 +78,8 @@ class WorldLocationNews
   def statistics
     @statistics ||= @documents_service.fetch_related_documents_with_format({ filter_content_purpose_subgroup: "statistics" })
   end
+
+  def type
+    @content_item.content_item_data.dig("details", "world_location_news_type")
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -9,6 +9,7 @@
     <%= render "govuk_publishing_components/components/title", {
       title: @world_location_news.title,
       margin_top: 0,
+      context: I18n.t("world_location_news.types.#{@world_location_news.type}"),
     } %>
   </div>
 

--- a/config/locales/ar/world_location_news.yml
+++ b/config/locales/ar/world_location_news.yml
@@ -7,9 +7,11 @@ ar:
       featured:
       latest: الأحدث
       mission: مهمتنا
-      news: أخبار المواقع العالمية
       organisations: المنظمات
       publications: منشوراتنا
       search: البحث حسب البلد أو الإقليم
       statistics: إحصائياتنا
     no_updates: لا توجد تحديثات بعد.
+    types:
+      international_delegation: وفد دولي
+      world_location: أخبار المواقع العالمية

--- a/config/locales/az/world_location_news.yml
+++ b/config/locales/az/world_location_news.yml
@@ -7,9 +7,11 @@ az:
       featured:
       latest: Ən son
       mission: Missiyamız
-      news: Dünya üzrə xəbərlər
       organisations: Təşkilatlar
       publications: Nəşrlərimiz
       search: Ölkəyə və ya əraziyə əsasən axtarın
       statistics: Statistikamız
     no_updates: Hələ yenilənmələr yoxdur.
+    types:
+      international_delegation: Beynəlxalq səlahiyyətin ötürülməsi
+      world_location: Dünya üzrə xəbərlər

--- a/config/locales/be/world_location_news.yml
+++ b/config/locales/be/world_location_news.yml
@@ -7,9 +7,11 @@ be:
       featured:
       latest: Апошняе
       mission: Наша місія
-      news: Навіны пра месцазнаходжанне ў свеце
       organisations: Арганізацыі
       publications: Нашы публікацыі
       search: Пошук па краіне або тэрыторыі
       statistics: Наша статыстыка
     no_updates: Ніякіх абнаўленняў пакуль няма.
+    types:
+      international_delegation: Міжнародная дэлегацыя
+      world_location: Навіны пра месцазнаходжанне ў свеце

--- a/config/locales/bg/world_location_news.yml
+++ b/config/locales/bg/world_location_news.yml
@@ -7,9 +7,11 @@ bg:
       featured:
       latest: Последни
       mission: Нашата мисия
-      news: Новини за местоположенията в света
       organisations: Организации
       publications: Нашите публикации
       search: Търсене по страна или територия
       statistics: Нашата статистика
     no_updates: Все още няма актуализация.
+    types:
+      international_delegation: Международна делегация
+      world_location: Новини за местоположенията в света

--- a/config/locales/bn/world_location_news.yml
+++ b/config/locales/bn/world_location_news.yml
@@ -7,9 +7,11 @@ bn:
       featured:
       latest: সাম্প্রতিক
       mission: আমাদের মিশন
-      news: বিশ্বের অবস্থানসমূহের সংবাদ
       organisations: প্রতিষ্ঠানসমূহ
       publications: আমাদের প্রকাশনাসমূহ
       search: দেশ বা অঞ্চল হিসেবে অনুসন্ধান করুন
       statistics: আমাদের পরিসংখ্যান
     no_updates: এখনও কোনো আপডেট নেই।
+    types:
+      international_delegation: আন্তর্জাতিক প্রতিনিধি
+      world_location: বিশ্বের অবস্থানসমূহের সংবাদ

--- a/config/locales/cs/world_location_news.yml
+++ b/config/locales/cs/world_location_news.yml
@@ -7,9 +7,11 @@ cs:
       featured:
       latest: Nejnovější
       mission: Naše poslání
-      news: Zprávy o poloze ve světě
       organisations: Organizace
       publications: Naše publikace
       search: Vyhledávání podle země nebo území
       statistics: Naše statistika
     no_updates: Zatím nejsou k dispozici žádné aktualizace.
+    types:
+      international_delegation: Mezinárodní delegace
+      world_location: Zprávy o poloze ve světě

--- a/config/locales/cy/world_location_news.yml
+++ b/config/locales/cy/world_location_news.yml
@@ -7,9 +7,11 @@ cy:
       featured:
       latest: Y diweddaraf
       mission: Ein cenhadaeth
-      news: Newyddion am leoliadau byd-eang
       organisations: Sefydliadau
       publications: Ein cyhoeddiadau
       search: Chwilio yn ôl gwlad neu diriogaeth
       statistics: Ein hystadegau
     no_updates: Does dim diweddariadau eto.
+    types:
+      international_delegation: Dirprwyaeth ryngwladol
+      world_location: Newyddion am leoliadau byd-eang

--- a/config/locales/da/world_location_news.yml
+++ b/config/locales/da/world_location_news.yml
@@ -7,9 +7,11 @@ da:
       featured:
       latest: Senest
       mission: Vores mission
-      news: Verdens placering nyheder
       organisations: Organisationer
       publications: Vores publikationer
       search: Søg efter land eller område
       statistics: Vores statistikker
     no_updates: Der er ingen opdateringer endnu.
+    types:
+      international_delegation: Internationale delegation
+      world_location: Verdens placering nyheder

--- a/config/locales/de/world_location_news.yml
+++ b/config/locales/de/world_location_news.yml
@@ -7,9 +7,11 @@ de:
       featured:
       latest: Neueste
       mission: Unsere Aufgabe
-      news: Weltweite Standortnachrichten
       organisations: Organisationen
       publications: Unsere Veröffentlichungen
       search: Nach Land oder Gebiet suchen
       statistics: Unsere Statistiken
     no_updates: Es liegen noch keine Aktualisierungen vor.
+    types:
+      international_delegation: Internationale Delegation
+      world_location: Weltweite Standortnachrichten

--- a/config/locales/dr/world_location_news.yml
+++ b/config/locales/dr/world_location_news.yml
@@ -7,9 +7,11 @@ dr:
       featured:
       latest: جدیدترین ها
       mission: ماموریت ما
-      news: اخبار موقعیت های جهان
       organisations: سازمان ها
       publications: انتشارات ما
       search: جستجو به اساس کشور یا قلمرو
       statistics: آمار ما
     no_updates: کدام آپدیتی تا هنوز موجود نیست
+    types:
+      international_delegation: هیٔت بین المللی
+      world_location: اخبار موقعیت های جهان

--- a/config/locales/el/world_location_news.yml
+++ b/config/locales/el/world_location_news.yml
@@ -7,9 +7,11 @@ el:
       featured:
       latest: Πιο πρόσφατα
       mission: Η αποστολή μας
-      news: Ειδήσεις παγκόσμιας τοποθεσίας
       organisations: Οργανισμοί
       publications: Οι δημοσιεύσεις μας
       search: Αναζήτηση ανά χώρα ή περιοχή
       statistics: Τα στατιστικά μας
     no_updates: Δεν υπάρχουν ακόμα ενημερώσεις.
+    types:
+      international_delegation: Διεθνής αντιπροσωπεία
+      world_location: Ειδήσεις παγκόσμιας τοποθεσίας

--- a/config/locales/en/world_location_news.yml
+++ b/config/locales/en/world_location_news.yml
@@ -7,9 +7,11 @@ en:
       featured: Featured
       latest: Latest
       mission: Our mission
-      news: World location news
       organisations: Organisations
       publications: Our publications
       search: Search by country or territory
       statistics: Our statistics
     no_updates: There are no updates yet.
+    types:
+      international_delegation: International delegation
+      world_location: World location news

--- a/config/locales/es-419/world_location_news.yml
+++ b/config/locales/es-419/world_location_news.yml
@@ -7,9 +7,11 @@ es-419:
       featured:
       latest: Más reciente
       mission: Nuestra misión
-      news: Noticias sobre ubicaciones del mundo
       organisations: Organizaciones
       publications: Nuestras publicaciones
       search: Búsqueda por país o territorio
       statistics: Nuestras estadísticas
     no_updates: Aún no hay actualizaciones.
+    types:
+      international_delegation: Delegación internacional
+      world_location: Noticias sobre ubicaciones del mundo

--- a/config/locales/es/world_location_news.yml
+++ b/config/locales/es/world_location_news.yml
@@ -7,9 +7,11 @@ es:
       featured:
       latest: Actualizaciones más recientes
       mission: Nuestra Misión
-      news: Noticias de situación mundial
       organisations: Organizaciones
       publications: Publicaciones
       search: Búsqueda por país o territorio
       statistics: Nuestras estadísticas
     no_updates: No hay actualizaciones
+    types:
+      international_delegation: Delegación internacional
+      world_location: Noticias de situación mundial

--- a/config/locales/et/world_location_news.yml
+++ b/config/locales/et/world_location_news.yml
@@ -7,9 +7,11 @@ et:
       featured:
       latest: Viimased
       mission: Meie missioon
-      news: Maailma asukoha uudised
       organisations: Organisatsioonid
       publications: Meie publikatsioonid
       search: Otsige riigi või territooriumi järgi
       statistics: Meie statistika
     no_updates: Uuendusi pole veel.
+    types:
+      international_delegation: Rahvusvaheline delegatsioon
+      world_location: Maailma asukoha uudised

--- a/config/locales/fa/world_location_news.yml
+++ b/config/locales/fa/world_location_news.yml
@@ -7,9 +7,11 @@ fa:
       featured:
       latest: آخرین
       mission: مأموریت ما
-      news: اخبار مکان‌های جهانی
       organisations: سازمان‌ها
       publications: موارد منتشر شده ما
       search: جستجو بر اساس کشور یا قلمرو
       statistics: آمار ما
     no_updates: هنوز هیچ بروزرسانی وجود ندارد.
+    types:
+      international_delegation: هیأت بین‌المللی
+      world_location: اخبار مکان‌های جهانی

--- a/config/locales/fi/world_location_news.yml
+++ b/config/locales/fi/world_location_news.yml
@@ -7,9 +7,11 @@ fi:
       featured:
       latest: Uusin
       mission: Tehtävämme
-      news: Maailman sijaintiuutisia
       organisations: Organisaatiot
       publications: Julkaisumme
       search: Hae maan tai alueen mukaan
       statistics: Tilastomme
     no_updates: Ei vielä päivityksiä.
+    types:
+      international_delegation: Kansainvälinen valtuuskunta
+      world_location: Maailman sijaintiuutisia

--- a/config/locales/fr/world_location_news.yml
+++ b/config/locales/fr/world_location_news.yml
@@ -7,9 +7,11 @@ fr:
       featured:
       latest: Récent
       mission: Notre mission
-      news: Nouvelles des emplacements dans le monde
       organisations: Organisations
       publications: Nos publications
       search: Recherche par pays ou territoire
       statistics: Nos statistiques
     no_updates: Aucune mise à jour n'a encore été effectuée.
+    types:
+      international_delegation: Délégation internationale
+      world_location: Nouvelles des emplacements dans le monde

--- a/config/locales/gd/world_location_news.yml
+++ b/config/locales/gd/world_location_news.yml
@@ -7,9 +7,11 @@ gd:
       featured:
       latest: le déanaí
       mission: Ár misean
-      news: Nuacht domhanda
       organisations: Eagraíochtaí
       publications: Ár bhfoilseacháin
       search: Cuardaigh de réir tíre nó réigiúin
       statistics: Ár staitisticí
     no_updates: Gan nuashonrú fós.
+    types:
+      international_delegation: Toscaireacht idirnáisiúnta
+      world_location: Nuacht domhanda

--- a/config/locales/gu/world_location_news.yml
+++ b/config/locales/gu/world_location_news.yml
@@ -7,9 +7,11 @@ gu:
       featured:
       latest: નવીનતમ
       mission: અમારું મિશન
-      news: વર્લ્ડ લોકેશન ન્યૂઝ
       organisations: સંસ્થાઓ
       publications: અમારા પ્રકાશનો
       search: દેશ અથવા ટેરિટરીથી શોધો
       statistics: અમારા આંકડા
     no_updates: હજુ સુધી કોઈ અપડેટ્સ નથી.
+    types:
+      international_delegation: આંતરરાષ્ટ્રીય પ્રતિનિધિમંડળ
+      world_location: વર્લ્ડ લોકેશન ન્યૂઝ

--- a/config/locales/he/world_location_news.yml
+++ b/config/locales/he/world_location_news.yml
@@ -7,9 +7,11 @@ he:
       featured:
       latest: אחרון
       mission: החזון שלנו
-      news: חדשות מיקום בעולם
       organisations: ארגונים
       publications: הפרסומים שלנו
       search: חפש לפי מדינה או שטח
       statistics: סטטיסטיקה שלנו
     no_updates: אין עדכונים נוספים.
+    types:
+      international_delegation: משלחת בינלאומית
+      world_location: חדשות מיקום בעולם

--- a/config/locales/hi/world_location_news.yml
+++ b/config/locales/hi/world_location_news.yml
@@ -7,9 +7,11 @@ hi:
       featured:
       latest: नवीनतम
       mission: हमारा लक्ष्य
-      news: विश्व स्थानों की खबरें
       organisations: संस्थाएं
       publications: हमारे प्रकाशन
       search: देश या क्षेत्र से खोजें
       statistics: हमारे आंकड़े
     no_updates: अभी तक कोई नए समाचार नहीं हैं।
+    types:
+      international_delegation: अंतर्राष्ट्रीय प्रतिनिधिमंडल
+      world_location: विश्व स्थानों की खबरें

--- a/config/locales/hr/world_location_news.yml
+++ b/config/locales/hr/world_location_news.yml
@@ -7,9 +7,11 @@ hr:
       featured:
       latest: Najnoviji
       mission: Naša misija
-      news: Vijesti o svjetskoj lokaciji
       organisations: Organizacije
       publications: Naša izdanja
       search: Pretražujte prema zemlji ili teritoriju
       statistics: Naša statistika
     no_updates: Još nema ažuriranja.
+    types:
+      international_delegation: Međunarodna delegacija
+      world_location: Vijesti o svjetskoj lokaciji

--- a/config/locales/hu/world_location_news.yml
+++ b/config/locales/hu/world_location_news.yml
@@ -7,9 +7,11 @@ hu:
       featured:
       latest: Legfrissebb
       mission: Küldetésünk
-      news: Hírek a világ különböző helyszíneiről
       organisations: Szervezetek
       publications: Kiadványaink
       search: Keresés ország vagy terület szerint
       statistics: Statisztikáink
     no_updates: Még nincs frissebb változat.
+    types:
+      international_delegation: Nemzetközi delegáció
+      world_location: Hírek a világ különböző helyszíneiről

--- a/config/locales/hy/world_location_news.yml
+++ b/config/locales/hy/world_location_news.yml
@@ -7,9 +7,11 @@ hy:
       featured:
       latest: Թարմացումներ
       mission: Մեր առաքելությունը
-      news: Նորություններ աշխարհից
       organisations: Կազմակերպություններ
       publications: Մեր հրապարակումները
       search: Որոնել ըստ երկրի կամ տարածաշրջանի
       statistics: Մեր վիճակագրությունը
     no_updates: 'Դեռևս թարմացումներ չկան:'
+    types:
+      international_delegation: Միջազգային պատվիրակություն
+      world_location: Նորություններ աշխարհից

--- a/config/locales/id/world_location_news.yml
+++ b/config/locales/id/world_location_news.yml
@@ -7,9 +7,11 @@ id:
       featured:
       latest: Terbaru
       mission: Misi kami
-      news: Berita lokasi dunia
       organisations: Organisasi
       publications: Publikasi kami
       search: Cari menurut negara atau teritori
       statistics: Statistik kami
     no_updates: Belum ada pembaruan.
+    types:
+      international_delegation:
+      world_location: Berita lokasi dunia

--- a/config/locales/is/world_location_news.yml
+++ b/config/locales/is/world_location_news.yml
@@ -7,9 +7,11 @@ is:
       featured:
       latest: Nýjasta
       mission: Okkar takmark
-      news: Fréttir af stöðum í heiminum
       organisations: Samtök
       publications: Okkar útgáfur
       search: Leita eftir landi eða landsvæði
       statistics: Okkar tölfræði
     no_updates: Það eru engar uppfærslur.
+    types:
+      international_delegation: Alþjóðleg sendinefnd
+      world_location: Fréttir af stöðum í heiminum

--- a/config/locales/it/world_location_news.yml
+++ b/config/locales/it/world_location_news.yml
@@ -7,9 +7,11 @@ it:
       featured:
       latest: Ultimo
       mission: La nostra missione
-      news: Notizie dai luoghi del mondo
       organisations: Organizzazioni
       publications: Le nostre pubblicazioni
       search: Cerca per stato o territorio
       statistics: Le nostre statistiche
     no_updates: Non ci sono ancora aggiornamenti.
+    types:
+      international_delegation: Delegazione internazionale
+      world_location: Notizie dai luoghi del mondo

--- a/config/locales/ja/world_location_news.yml
+++ b/config/locales/ja/world_location_news.yml
@@ -7,9 +7,11 @@ ja:
       featured:
       latest: 最新
       mission: 使命
-      news: 世界各地からのニュース
       organisations: 組織
       publications: 出版物
       search: 国または地域で検索
       statistics: 統計
     no_updates: まだ更新はありません。
+    types:
+      international_delegation:
+      world_location: 世界各地からのニュース

--- a/config/locales/ka/world_location_news.yml
+++ b/config/locales/ka/world_location_news.yml
@@ -7,9 +7,11 @@ ka:
       featured:
       latest: ბოლო
       mission: ჩვენი მისია
-      news: მსოფლიოს ლოკაციების სიახლეები
       organisations: ორგანიზაციები
       publications: ჩვენი პუბლიკაციები
       search: მოძებნეთ ქვეყნის ან ტერიტორიის მიხედვით
       statistics: ჩვენი სტატისტიკა
     no_updates: სიახლეები ჯერ არ ყოფილა.
+    types:
+      international_delegation: საერთაშორისო დელეგაცია
+      world_location: მსოფლიოს ლოკაციების სიახლეები

--- a/config/locales/kk/world_location_news.yml
+++ b/config/locales/kk/world_location_news.yml
@@ -7,9 +7,11 @@ kk:
       featured:
       latest: Ең соңғы
       mission: Біздің миссиямыз
-      news: Әлемдегі орын бойынша жаңалықтар
       organisations: Ұйымдар
       publications: Біздің жарияланымдар
       search: Елі немесе территориясы бойынша іздеу
       statistics: Біздің статистика
     no_updates: Әлі жаңартулар жоқ.
+    types:
+      international_delegation: Халықаралық делегация
+      world_location: Әлемдегі орын бойынша жаңалықтар

--- a/config/locales/ko/world_location_news.yml
+++ b/config/locales/ko/world_location_news.yml
@@ -7,9 +7,11 @@ ko:
       featured:
       latest: 최신
       mission: 대사관 안내
-      news: 월드 로케이션 뉴스
       organisations: 조직 안내
       publications: 출판물
       search: 국가 또는 영토로 검색하기
       statistics: 통계
     no_updates: 관련 내용이 아직 없습니다.
+    types:
+      international_delegation:
+      world_location: 월드 로케이션 뉴스

--- a/config/locales/lt/world_location_news.yml
+++ b/config/locales/lt/world_location_news.yml
@@ -7,9 +7,11 @@ lt:
       featured:
       latest: Paskutinės
       mission: Mūsų misija
-      news: Pasaulio vietos naujienos
       organisations: Organizacijos
       publications: Mūsų publikacijos
       search: Ieškoti pagal šalį ar teritoriją
       statistics: Mūsų statistika
     no_updates: Atnaujinimų nėra.
+    types:
+      international_delegation: Tarptautinė delegacija
+      world_location: Pasaulio vietos naujienos

--- a/config/locales/lv/world_location_news.yml
+++ b/config/locales/lv/world_location_news.yml
@@ -7,9 +7,11 @@ lv:
       featured:
       latest: Jaunākais
       mission: Misija
-      news: Pasaules ziņas
       organisations: Organizācijas
       publications: Publikācijas
       search: Meklēt pēc valsts vai teritorijas
       statistics: Statistikas dati
     no_updates: Pagaidām jaunumu nav
+    types:
+      international_delegation: Starptautiskā delegācija
+      world_location: Pasaules ziņas

--- a/config/locales/ms/world_location_news.yml
+++ b/config/locales/ms/world_location_news.yml
@@ -7,9 +7,11 @@ ms:
       featured:
       latest: Terkini
       mission: Misi kami
-      news: Berita lokasi dunia
       organisations: Organisasi
       publications: Terbitan kami
       search: Cari mengikut negara atau wilayah
       statistics: Statistik kami
     no_updates: Belum ada kemas kini.
+    types:
+      international_delegation:
+      world_location: Berita lokasi dunia

--- a/config/locales/mt/world_location_news.yml
+++ b/config/locales/mt/world_location_news.yml
@@ -7,9 +7,11 @@ mt:
       featured:
       latest: L-iktar riċenti
       mission: Il-missjoni tagħna
-      news: Aħbarijiet dwar postijiet fid-dinja
       organisations: Organizzazzjonijiet
       publications: Pubblikazzjonijiet tagħna
       search: Fittex permezz tal-pajjiż jew territorju
       statistics: L-istatistiċi tagħna
     no_updates: Għad m'hemmx aġġornamenti.
+    types:
+      international_delegation: Delegazzjoni internazzjonali
+      world_location: Aħbarijiet dwar postijiet fid-dinja

--- a/config/locales/ne/world_location_news.yml
+++ b/config/locales/ne/world_location_news.yml
@@ -7,9 +7,11 @@ ne:
       featured:
       latest: पछिल्लो
       mission: हाम्रो मिशन
-      news: विश्व स्थान समाचार
       organisations: सङ्गठनहरू
       publications: हाम्रा प्रकाशनहरु
       search: देश वा क्षेत्रको नामले खोज
       statistics: हाम्रो तथ्याङ्क
     no_updates: अहिले सम्म कुनै अद्यावधिक छैन।
+    types:
+      international_delegation: अन्तर्राष्ट्रिय प्रतिनिधिमण्डल
+      world_location: विश्व स्थान समाचार

--- a/config/locales/nl/world_location_news.yml
+++ b/config/locales/nl/world_location_news.yml
@@ -7,9 +7,11 @@ nl:
       featured:
       latest: Laatste
       mission: Onze missie
-      news: Wereld locatie nieuws
       organisations: Organisaties
       publications: Onze publicaties
       search: Zoeken op land of gebied
       statistics: Onze statistieken
     no_updates: Er zijn nog geen updates.
+    types:
+      international_delegation: Internationale delegatie
+      world_location: Wereld locatie nieuws

--- a/config/locales/no/world_location_news.yml
+++ b/config/locales/no/world_location_news.yml
@@ -7,9 +7,11 @@
       featured:
       latest: Siste
       mission: Vårt oppdrag
-      news: Nyheter fra ulike verdenshjørner
       organisations: Organisasjoner
       publications: Våre publikasjoner
       search: Søk etter land eller territorium
       statistics: Vår statistikk
     no_updates: Det er ingen oppdateringer ennå.
+    types:
+      international_delegation: Internasjonal delegasjon
+      world_location: Nyheter fra ulike verdenshjørner

--- a/config/locales/pa-pk/world_location_news.yml
+++ b/config/locales/pa-pk/world_location_news.yml
@@ -7,9 +7,11 @@ pa-pk:
       featured:
       latest: تازہ ترین
       mission: ساڈا فرض
-      news: ساری دُنیا دیاں خبراں
       organisations: ادارے
       publications: ساڈے شمارے
       search: مُلک یا علاقے توں لبھو
       statistics: ساڈے اعدادو شمار
     no_updates: ہون تک کوئی تازہ ترین حال دا پتہ نئیں لگیا
+    types:
+      international_delegation: بین الاقوامی وفد
+      world_location: ساری دُنیا دیاں خبراں

--- a/config/locales/pa/world_location_news.yml
+++ b/config/locales/pa/world_location_news.yml
@@ -7,9 +7,11 @@ pa:
       featured:
       latest: ਨਵੀਨਤਮ
       mission: ਸਾਡਾ ਮਿਸ਼ਨ
-      news: ਵਿਸ਼ਵ ਸਥਾਨ ਦੀ ਖਬਰ
       organisations: ਸੰਗਠਨ
       publications: ਸਾਡੇ ਪ੍ਰਕਾਸ਼ਨ
       search: ਦੇਸ਼ ਜਾਂ ਖੇਤਰ ਦੁਆਰਾ ਖੋਜ ਕਰੋ
       statistics: ਸਾਡੇ ਅੰਕੜੇ
     no_updates: ਅਜੇ ਕੋਈ ਅਪਡੇਟ ਨਹੀਂ ਹਨ।
+    types:
+      international_delegation: ਅੰਤਰਰਾਸ਼ਟਰੀ ਵਫਦ
+      world_location: ਵਿਸ਼ਵ ਸਥਾਨ ਦੀ ਖਬਰ

--- a/config/locales/pl/world_location_news.yml
+++ b/config/locales/pl/world_location_news.yml
@@ -7,9 +7,11 @@ pl:
       featured:
       latest: Najnowsze
       mission: Nasza misja
-      news: Wiadomości ze świata
       organisations: Organizacje
       publications: Nasze publikacje
       search: Wyszukiwanie według kraju lub terytorium
       statistics: Nasze statystyki
     no_updates: Aktualizacje nie są jeszcze dostępne.
+    types:
+      international_delegation: Delegacja międzynarodowa
+      world_location: Wiadomości ze świata

--- a/config/locales/ps/world_location_news.yml
+++ b/config/locales/ps/world_location_news.yml
@@ -7,9 +7,11 @@ ps:
       featured:
       latest: وروستی
       mission: زموږ ماموریت
-      news: د نړۍ موقعیت خبرونه
       organisations: سازمانونه
       publications: زموږ خپرونې
       search: د هیواد یا سیمې له مخې لټون
       statistics: زموږ احصایه
     no_updates: تراوسه کوم تازه معلومات نشته.
+    types:
+      international_delegation: نړیوال پلاوی
+      world_location: د نړۍ موقعیت خبرونه

--- a/config/locales/pt/world_location_news.yml
+++ b/config/locales/pt/world_location_news.yml
@@ -7,9 +7,11 @@ pt:
       featured:
       latest: Mais recentes
       mission: A nossa missão
-      news: Notícias de localização mundial
       organisations: Organizações
       publications: As nossas publicações
       search: Pesquisa por país ou território
       statistics: As nossas estatísticas
     no_updates: Ainda não há atualizações.
+    types:
+      international_delegation: Delegação internacional
+      world_location: Notícias de localização mundial

--- a/config/locales/ro/world_location_news.yml
+++ b/config/locales/ro/world_location_news.yml
@@ -7,9 +7,11 @@ ro:
       featured:
       latest: Cele mai recente
       mission: Misiunea noastră
-      news: Știri privind locația pe glob
       organisations: Organizații
       publications: Publicațiile noastre
       search: Căutați după țară sau teritoriu
       statistics: Statisticile noastre
     no_updates: Nu există încă actualizări
+    types:
+      international_delegation: Delegare internațională
+      world_location: Știri privind locația pe glob

--- a/config/locales/ru/world_location_news.yml
+++ b/config/locales/ru/world_location_news.yml
@@ -7,9 +7,11 @@ ru:
       featured:
       latest: Последние новости
       mission: Наша цель
-      news: Новости из мест нахождения в мире
       organisations: Организации
       publications: Наши публикации
       search: Поиск по стране или территории
       statistics: Наша статистика
     no_updates: Обновлений нет.
+    types:
+      international_delegation: Международная делегация
+      world_location: Новости из мест нахождения в мире

--- a/config/locales/si/world_location_news.yml
+++ b/config/locales/si/world_location_news.yml
@@ -7,9 +7,11 @@ si:
       featured:
       latest: නවතම
       mission: අපේ මෙහෙවර
-      news: ලෝක ස්ථානීය පුවෘත්ති
       organisations: සංවිධාන
       publications: අපේ ප්රකාශන
       search: රට හෝ භූමිය අනුව සොයන්න
       statistics: අපේ සංඛ්යාලේඛන
     no_updates: තවම යාවත්කාලීන කිසිවක් නොමැත.
+    types:
+      international_delegation: ජාත්යන්තර නියෝජිත පිරිස
+      world_location: ලෝක ස්ථානීය පුවෘත්ති

--- a/config/locales/sk/world_location_news.yml
+++ b/config/locales/sk/world_location_news.yml
@@ -7,9 +7,11 @@ sk:
       featured:
       latest: Najnovšie
       mission: Naše poslanie
-      news: Naša misia
       organisations: Organizácie
       publications: Naše publikácie
       search: Vyhľadávanie podľa krajiny alebo územia
       statistics: Naše štatistiky
     no_updates: Zatiaľ nie sú k dispozícii žiadne aktualizácie.
+    types:
+      international_delegation: Medzinárodná delegácia
+      world_location: Naša misia

--- a/config/locales/sl/world_location_news.yml
+++ b/config/locales/sl/world_location_news.yml
@@ -7,9 +7,11 @@ sl:
       featured:
       latest: Najnovejše
       mission: Naša misija
-      news: Novice z lokacij po svetu
       organisations: Organizacije
       publications: Naše publikacije
       search: Išči po državah ali ozemljih
       statistics: Naša statistika
     no_updates: Posodobitve še niso na voljo.
+    types:
+      international_delegation: Mednarodna delegacija
+      world_location: Novice z lokacij po svetu

--- a/config/locales/so/world_location_news.yml
+++ b/config/locales/so/world_location_news.yml
@@ -7,9 +7,11 @@ so:
       featured:
       latest: Ugu dambeeyay
       mission: Hadafkayaga
-      news: Wararka Goobta Dunida
       organisations: Ururada
       publications: Daabacadahayaga
       search: Ku raadi dalka ama dhulka
       statistics: Xog ururinahayaga
     no_updates: Wali wax cusub ma jiraan.
+    types:
+      international_delegation: Wafti caalami ah
+      world_location: Wararka Goobta Dunida

--- a/config/locales/sq/world_location_news.yml
+++ b/config/locales/sq/world_location_news.yml
@@ -7,9 +7,11 @@ sq:
       featured:
       latest: Më të fundit
       mission: Misioni ynë
-      news: Lajmet për vendndodhjen botërore
       organisations: Organizatat
       publications: Publikimet tona
       search: Kërkoni sipas vendit ose territorit
       statistics: Statistikat tona
     no_updates: Ende nuk ka përditësime.
+    types:
+      international_delegation: Delegacion ndërkombëtar
+      world_location: Lajmet për vendndodhjen botërore

--- a/config/locales/sr/world_location_news.yml
+++ b/config/locales/sr/world_location_news.yml
@@ -7,9 +7,11 @@ sr:
       featured:
       latest: Najnovije
       mission: Naša misija
-      news: Vesti sa globalnih lokacija
       organisations: Organizacije
       publications: Naše publikacije
       search: Pretraga po zemlji ili teritoriji
       statistics: Naša statistika
     no_updates: Još nema novosti.
+    types:
+      international_delegation: Međunarodna delegacija
+      world_location: Vesti sa globalnih lokacija

--- a/config/locales/sv/world_location_news.yml
+++ b/config/locales/sv/world_location_news.yml
@@ -7,9 +7,11 @@ sv:
       featured:
       latest: Senaste
       mission: Vårt uppdrag
-      news: Nyheter om platser i världen
       organisations: Organisationer
       publications: Våra publikationer
       search: Sök efter land eller område
       statistics: Vår statistik
     no_updates: Det finns inga uppdateringar ännu.
+    types:
+      international_delegation: Internationell delegation
+      world_location: Nyheter om platser i världen

--- a/config/locales/sw/world_location_news.yml
+++ b/config/locales/sw/world_location_news.yml
@@ -7,9 +7,11 @@ sw:
       featured:
       latest: Habari mpya
       mission: Dhamira yetu
-      news: Habari za kimataifa
       organisations: Mashirika
       publications: Machapisho yetu
       search: Tafuta kulingana na nchi au eneo
       statistics: Takwimu zetu
     no_updates: Bado hakuna masasisho.
+    types:
+      international_delegation: Ujumbe wa kimataifa
+      world_location: Habari za kimataifa

--- a/config/locales/ta/world_location_news.yml
+++ b/config/locales/ta/world_location_news.yml
@@ -7,9 +7,11 @@ ta:
       featured:
       latest: சமீபத்தியது
       mission: எங்கள் செயல் இலக்கு
-      news: உலக இருப்பிடச் செய்தி
       organisations: நிறுவனங்கள்
       publications: எங்கள் வெளியீடுகள்
       search: நாடு அல்லது பிரதேசம் வாரியாகத் தேடு
       statistics: எங்கள் புள்ளியியல்
     no_updates: எந்த புதுப்பித்தல்களும் இல்லை.
+    types:
+      international_delegation: சர்வதேச தூதுக்குழு
+      world_location: உலக இருப்பிடச் செய்தி

--- a/config/locales/th/world_location_news.yml
+++ b/config/locales/th/world_location_news.yml
@@ -7,9 +7,11 @@ th:
       featured:
       latest: ล่าสุด
       mission: ภารกิจของเรา
-      news: ข่าวสถานที่ทั่วโลก
       organisations: องค์กร
       publications: สิ่งพิมพ์ของเรา
       search: ค้นหาด้วยประเทศหรือดินแดน
       statistics: สถิติของเรา
     no_updates: ยังไม่มีการปรับปรุง
+    types:
+      international_delegation:
+      world_location: ข่าวสถานที่ทั่วโลก

--- a/config/locales/tk/world_location_news.yml
+++ b/config/locales/tk/world_location_news.yml
@@ -7,9 +7,11 @@ tk:
       featured:
       latest: Iň täze
       mission: Biziň maksadymyz
-      news: Dünýä ýeri habarlary
       organisations: Guramalar
       publications: Biziň neşirlerimiz
       search: Döwlet ýa-da territoriýa boýunça gözlemek
       statistics: Biziň statistikamyz
     no_updates: Heniz täzelenmeler ýok.
+    types:
+      international_delegation: Halkara delegasiýa
+      world_location: Dünýä ýeri habarlary

--- a/config/locales/tr/world_location_news.yml
+++ b/config/locales/tr/world_location_news.yml
@@ -7,9 +7,11 @@ tr:
       featured:
       latest: En güncel
       mission: Misyonumuz
-      news: Dünya yeri haberleri
       organisations: Kuruluşlar
       publications: Yayınlarımız
       search: Ülkeye veya bölgeye göre arama yapın
       statistics: İstatistiklerimiz
     no_updates: Henüz hiç güncelleme yok.
+    types:
+      international_delegation: Uluslararası delegasyon
+      world_location: Dünya yeri haberleri

--- a/config/locales/uk/world_location_news.yml
+++ b/config/locales/uk/world_location_news.yml
@@ -7,9 +7,11 @@ uk:
       featured:
       latest: Останні
       mission: Наша місія
-      news: Новини світових локацій
       organisations: Організації
       publications: Наші публікації
       search: Пошук за країною чи територією
       statistics: Наша статистика
     no_updates: Оновлення поки немає.
+    types:
+      international_delegation: Міжнародна делегація
+      world_location: Новини світових локацій

--- a/config/locales/ur/world_location_news.yml
+++ b/config/locales/ur/world_location_news.yml
@@ -7,9 +7,11 @@ ur:
       featured:
       latest: تازہ ترین
       mission: ہمارا مشن
-      news: عالمی مقام کی خبریں
       organisations: تنظیمیں
       publications: ہماری پبلیکیشنز
       search: ملک یا خطے کے لحاظ سے تلاش کریں
       statistics: ہمارے شماریات
     no_updates: ابھی تک کوئی اپ ڈیٹس نہیں ہیں۔
+    types:
+      international_delegation: عالمی وفد
+      world_location: عالمی مقام کی خبریں

--- a/config/locales/uz/world_location_news.yml
+++ b/config/locales/uz/world_location_news.yml
@@ -7,9 +7,11 @@ uz:
       featured:
       latest: Энг сўнгги
       mission: Бизнинг вазифалар
-      news: Жаҳон янгиликлари
       organisations: Ташкилотлар
       publications: Бизнинг нашрлар
       search: Мамлакат ёки минтақа бўйича излаш
       statistics: Бизнинг статистика
     no_updates: Янгиланишлар мавжуд эмас.
+    types:
+      international_delegation: Халқаро делегация
+      world_location: Жаҳон янгиликлари

--- a/config/locales/vi/world_location_news.yml
+++ b/config/locales/vi/world_location_news.yml
@@ -7,9 +7,11 @@ vi:
       featured:
       latest: Mới nhất
       mission: Sứ mệnh của chúng tôi
-      news: Tin tức về vị trí trên thế giới
       organisations: Tổ chức
       publications: Các ấn phẩm của chúng tôi
       search: Tìm kiếm theo quốc gia hoặc lãnh thổ
       statistics: Thống kê của chúng tôi
     no_updates: Chưa có cập nhật.
+    types:
+      international_delegation:
+      world_location: Tin tức về vị trí trên thế giới

--- a/config/locales/yi/world_location_news.yml
+++ b/config/locales/yi/world_location_news.yml
@@ -7,9 +7,11 @@ yi:
       featured:
       latest:
       mission:
-      news:
       organisations:
       publications:
       search:
       statistics:
     no_updates:
+    types:
+      international_delegation:
+      world_location:

--- a/config/locales/zh-hk/world_location_news.yml
+++ b/config/locales/zh-hk/world_location_news.yml
@@ -7,9 +7,11 @@ zh-hk:
       featured:
       latest: 最新消息
       mission: 我們的使命
-      news: 世界各地新聞
       organisations: 組織
       publications: 我們的出版物
       search: 按國家或地區搜尋
       statistics: 我們的統計資料
     no_updates: 目前暫無更新。
+    types:
+      international_delegation: 國際代表
+      world_location: 世界各地新聞

--- a/config/locales/zh-tw/world_location_news.yml
+++ b/config/locales/zh-tw/world_location_news.yml
@@ -7,9 +7,11 @@ zh-tw:
       featured:
       latest: 最新
       mission: 我們的任務
-      news: 世界地點消息
       organisations: 組織
       publications: 我們的出版
       search: 按國家或地區搜索
       statistics: 我們的數據統計
     no_updates: 尚未更新
+    types:
+      international_delegation: 國際代表團
+      world_location: 世界地點消息

--- a/config/locales/zh/world_location_news.yml
+++ b/config/locales/zh/world_location_news.yml
@@ -7,9 +7,11 @@ zh:
       featured:
       latest: 最新
       mission: 我们的使命
-      news: 世界地点新闻
       organisations: 组织机构
       publications: 我们的出版物
       search: 按国家或地区搜索
       statistics: 我们的统计数据
     no_updates: 尚未更新。
+    types:
+      international_delegation:
+      world_location: 世界地点新闻

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -15,6 +15,11 @@ RSpec.feature "World Location News pages" do
     expect(page).to have_title("UK and Mock Country - GOV.UK")
   end
 
+  it "sets the document type" do
+    visit base_path
+    expect(page).to have_text("World location news")
+  end
+
   it "sets the page meta description" do
     visit base_path
     expect(page).to have_selector("meta[name='description'][content='Find out about the relations between the UK and Mock Country']", visible: :hidden)

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -37,7 +37,8 @@
         "href": "https://www.gov.uk/somewhere2",
         "title": "A second link to somewhere"
       }
-    ]
+    ],
+    "world_location_news_type": "world_location"
   },
   "links": {
     "available_translations": [

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -117,4 +117,8 @@ RSpec.describe WorldLocationNews do
       world_location_news.statistics
     end
   end
+
+  it "should include the type" do
+    expect(world_location_news.type).to eq("world_location")
+  end
 end


### PR DESCRIPTION
This adds a label above the page title to inform users whether this is a World Location or International Delegation.

## Screenshots
| Collections | Whitehall |
|---|---|
| ![Screenshot showing the header section of a World Location News page rendered by Collections.  There is a 'World location' label above the page title.](https://user-images.githubusercontent.com/6329861/185076442-24255c9a-c931-434f-8e9d-ddc785ea1004.png) | ![Screenshot showing the header section of a World Location News page rendered by Whitehall.  There is a 'World location' label above the page title.](https://user-images.githubusercontent.com/6329861/185075087-078b2d0c-4b29-4440-a36d-cb9ccd7acab4.png) |

[Trello card](https://trello.com/c/zxDhAkI3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
