### PR TITLE
Add metatags to the Cost of living landing page

### DIFF
--- a/app/controllers/cost_of_living_landing_page_controller.rb
+++ b/app/controllers/cost_of_living_landing_page_controller.rb
@@ -19,7 +19,7 @@ private
   end
 
   def content
-    @content ||= YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).symbolize_keys
+    @content ||= YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).deep_symbolize_keys
   end
 
   def breadcrumbs

--- a/app/views/cost_of_living_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/cost_of_living_landing_page/components/shared/_meta_tags.html.erb
@@ -1,0 +1,11 @@
+<% content_for :meta_tags do %>
+  <% page_url = File.join(request.base_url, request.path) %>
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="GOV.UK">
+  <meta property="og:url" content="<%= page_url %>">
+  <meta property="og:title" content="<%= metadata[:title] %>">
+  <meta property="og:description" content="<%= metadata[:description] %>">
+  <meta name="description" content="<%= metadata[:description] %>">
+
+  <link rel="canonical" href="<%= page_url %>">
+<% end %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -1,1 +1,5 @@
+<%= render partial: "cost_of_living_landing_page/components/shared/meta_tags", locals: {
+  metadata: content[:metadata]
+} %>
+
 <% content_for :title, content[:page_title] %>

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -1,2 +1,8 @@
 ---
 page_title: Help for households
+metadata:
+  title: Cost of living support
+  description: >-
+    Find out what support is available to help with the cost of living. This
+    includes income and disability benefits, bills and allowances, childcare,
+    housing and transport.

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Cost of Living hub page" do
       when_i_visit_the_cost_of_living_landing_page
       then_i_can_see_the_title
       then_i_can_see_the_breadcrumbs
+      and_there_are_metatags
     end
 
     def when_i_visit_the_cost_of_living_landing_page
@@ -22,6 +23,17 @@ RSpec.feature "Cost of Living hub page" do
 
     def then_i_can_see_the_breadcrumbs
       expect(page).to have_css(".govuk-breadcrumbs__link", text: "Home")
+    end
+
+    def and_there_are_metatags
+      expect(page).to have_selector(
+        "meta[property='og:title'][content='Cost of living support']",
+        visible: false,
+      )
+      expect(page).to have_selector(
+        "meta[name='description'][content='Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport.']",
+        visible: false,
+      )
     end
   end
 end


### PR DESCRIPTION

<kbd><img width="876" alt="Screenshot 2022-08-17 at 17 02 44" src="https://user-images.githubusercontent.com/38078064/185194178-bef976de-be0b-418b-b8ef-c88e74ef0bf5.png"><kbd>


https://trello.com/c/8MwgpHdu/1220-add-metadata-to-hub-page-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
