### PR TITLE
Add additional tracking for Cost of living hub

### DIFF
--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -1,5 +1,3 @@
-<% track_action ||= "contentLink" %>
-
 <ul class="govuk-list browse__list" data-module="gem-track-click">
   <% list.each_with_index do |content_item, index| %>
     <% if content_item[:links] %>
@@ -17,21 +15,17 @@
           <ul class="govuk-list browse__list">
              <% content_item[:links].each_with_index do |link_item, index| %>
               <li class="govuk-list browse__list-item">
+               <% track_data = {
+                   track_category: "contentsClicked",
+                   track_action: accordion_heading,
+                   track_label: link_item[:href].gsub("https://www.gov.uk/", ""),
+                  } if link_item[:href].starts_with?("https://www.gov.uk/")
+               %>
                <%= link_to(
                  link_item[:link_text],
                  link_item[:href],
                  class: "govuk-link",
-                 data: {
-                   # track_category: "browseClicked",
-                   track_count: "contentLink",
-                   track_action: track_action,
-                   # track_label: list_item.base_path,
-                   # track_options: {
-                   #   dimension28: list.count.to_s,
-                   #   dimension29: list_item.title,
-                   #   dimension114: "#{list_index + 1}.#{index + 1}",
-                   # },
-                 },
+                 data: track_data,
                ) %>
              </li>
               <% end %>

--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -37,10 +37,17 @@
       <li class="browse__list-item govuk-!-padding-bottom-1">
         <%= render "govuk_publishing_components/components/inset_text" do %>
           <p><%= content_item[:inset_text] %></p>
+          <% track_data = {
+              track_category: "contentsClicked",
+              track_action: accordion_heading,
+              track_label: content_item[:href].gsub("https://www.gov.uk/", ""),
+             } if content_item[:href].starts_with?("https://www.gov.uk/")
+          %>
           <%= link_to(
             content_item[:link_text],
             content_item[:href],
             class: "govuk-link",
+            data: track_data,
           ) %>
         <% end %>
       </li>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -87,7 +87,8 @@
         } %>
         <div data-module="toggle-attribute">
           <%= render "govuk_publishing_components/components/accordion", {
-            items: accordion_contents
+            track_show_all_clicks: true,
+            items: accordion_contents,
           } %>
         </div>
       </div>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -88,6 +88,7 @@
         <div data-module="toggle-attribute">
           <%= render "govuk_publishing_components/components/accordion", {
             track_show_all_clicks: true,
+            track_sections: true,
             items: accordion_contents,
           } %>
         </div>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -13,6 +13,7 @@
       },
       content: {
         html: render(partial: "links", locals: {
+          accordion_heading: list[:heading],
           list: list[:content],
           list_index: list_index,
         }),


### PR DESCRIPTION
Adds in additional tracking required from [Performance analyst docs](https://docs.google.com/presentation/d/1ERC0U2vI76t2Nm4Y4gLJWNoHgPl6iy2YvVr4stmduJA/edit#slide=id.g14486b99c14_0_23).
[Trello](https://trello.com/c/BrDDL2pi/1244-update-hub-page-with-additional-analytics-m)

Tracking for "Check what support..." is already in place: https://github.com/alphagov/collections/blob/main/app/views/cost_of_living_landing_page/show.html.erb#L67-L72

Tested EventListeners locally.

_Note:_ This could benefit from a presenter so we can move some logic. Given the frontend devs are still working on the views we may want to delay this refactor.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
