### PR TITLE
Remove unnecessary compatibility flags

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,3 @@
-$govuk-compatibility-govuktemplate: false;
-$govuk-use-legacy-palette: false;
-
 $covid-grey: #272828;
 $covid-yellow: #fff500;
 $govuk-new-link-styles: true;


### PR DESCRIPTION
## What

Remove `$govuk-compatibility-govuktemplate` and `$govuk-use-legacy-palette` flags from the stylesheet.

## Why

`$govuk-compatibility-govuktemplate` is [false by default][1], so can be removed.

`$govuk-use-legacy-palette` is [false if no other backwards compatibility flags are set][2], so will default to false in this application - and can therefore be removed

## Visual changes

None.

[1]: https://github.com/alphagov/govuk-frontend/blob/4f51e6c086a10a375cb75568bebda77f230981d3/package/govuk/settings/_compatibility.scss#L27
[2]: https://github.com/alphagov/govuk-frontend/blob/4f51e6c086a10a375cb75568bebda77f230981d3/package/govuk/settings/_colours-palette.scss#L19-L27

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
