### PR TITLE
Remove restriction to hide Cost of living from staging and production

### DIFF
--- a/app/controllers/cost_of_living_landing_page_controller.rb
+++ b/app/controllers/cost_of_living_landing_page_controller.rb
@@ -2,14 +2,10 @@ class CostOfLivingLandingPageController < ApplicationController
   slimmer_template "gem_layout_full_width"
 
   def show
-    if Rails.application.config.unreleased_features
-      render "show", locals: {
-        breadcrumbs: breadcrumbs,
-        content: presenter,
-      }
-    else
-      render status: :not_found, plain: "Page not found"
-    end
+    render "show", locals: {
+      breadcrumbs: breadcrumbs,
+      content: presenter,
+    }
   end
 
 private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,10 +59,6 @@ Rails.application.configure do
   # Allow requests for all domains e.g. <app>.dev.gov.uk
   config.hosts.clear
 
-  # Configuration to stop Cost of Living landing page showing in production before
-  # campaign goes live
-  config.unreleased_features = true
-
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,13 +81,6 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
-  # Configuration to stop features showing in production before
-  # things go live. For example, Cost of living page.
-  # Relies on env var being set in Puppet.
-  # For Cost of living, it has this set to true: https://github.com/alphagov/govuk-puppet/pull/11781
-  # for integration.
-  config.unreleased_features = ENV["UNRELEASED_FEATURES"].present?
-
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,10 +52,6 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
-  # Configuration to stop Cost of Living landing page showing in production before
-  # campaign goes live
-  config.unreleased_features = false
-
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/spec/controllers/cost_of_living_landing_page_controller_spec.rb
+++ b/spec/controllers/cost_of_living_landing_page_controller_spec.rb
@@ -11,18 +11,8 @@ RSpec.describe CostOfLivingLandingPageController do
     end
 
     it "has a success response" do
-      allow(Rails.configuration).to receive(:unreleased_features).and_return(true)
-
       get :show
       expect(response).to have_http_status(:success)
-    end
-
-    context "feature flag is set to false" do
-      it "returns a not found/404 status" do
-        allow(Rails.configuration).to receive(:unreleased_features).and_return(false)
-
-        expect(get(:show)).to have_http_status(:not_found)
-      end
     end
   end
 end

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -6,10 +6,6 @@ RSpec.feature "Cost of Living hub page" do
   end
 
   describe "the landing page" do
-    before do
-      allow(Rails.configuration).to receive(:unreleased_features).and_return(true)
-    end
-
     scenario "renders" do
       when_i_visit_the_cost_of_living_landing_page
       then_i_can_see_the_title


### PR DESCRIPTION
When we are ready to make the page live to the public, we need to remove this.

[Trello](https://trello.com/c/EREQ5Vtj/1240-go-live-remove-access-restriction-to-hub-page-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
