### PR TITLE
Fix the announcement of unordered lists in Safari+Voiceover

### DIFF
--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -1,4 +1,4 @@
-<ul class="govuk-list browse__list" data-module="gem-track-click">
+<ul role="list" class="govuk-list browse__list" data-module="gem-track-click">
   <% list.each_with_index do |content_item, index| %>
     <% if content_item[:links] %>
       <li class="govuk-list browse__list-item govuk-!-padding-bottom-1">
@@ -12,7 +12,7 @@
           } %>
          <% end %>
          <% if content_item[:links] %>
-          <ul class="govuk-list browse__list">
+          <ul role="list" class="govuk-list browse__list">
              <% content_item[:links].each_with_index do |link_item, index| %>
               <li class="govuk-list browse__list-item">
                <% track_data = {


### PR DESCRIPTION
## What
Unordered lists aren't announced by Voiceover in Safari when the bullet styling is removed. This is a known issue, for example see here: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html

Adding `role=“list”` to the UL element forces Voiceover to make the correct announcement in Safari.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
