### PR TITLE
Cost of living page header should match topics page header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,7 +37,6 @@ $govuk-include-default-font-face: false;
 @import "components/*";
 
 @import "views/browse";
-@import "views/cost_of_living";
 @import "views/topics";
 @import "views/topical_events";
 @import "views/taxons";

--- a/app/assets/stylesheets/views/_cost_of_living.scss
+++ b/app/assets/stylesheets/views/_cost_of_living.scss
@@ -1,3 +1,0 @@
-.cost-of-living-hub__header {
-  border-top: solid govuk-spacing(2) govuk-colour("blue");
-}

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -29,54 +29,42 @@
   end
 %>
 
-<header class="cost-of-living-hub__header">
-  <%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
-    <%= render 'govuk_publishing_components/components/breadcrumbs', {
-      breadcrumbs: breadcrumbs,
-      collapse_on_mobile: true,
-      inverse: true
-    } %>
+<%= render "shared/browse_breadcrumbs", {
+  breadcrumbs: breadcrumbs,
+  collapse_on_mobile: true,
+  inverse: true
+} %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: content.header[:heading],
-          inverse: true,
-          margin_top: 4,
-          margin_bottom: 6,
-        } %>
-      </div>
-    </div>
+<%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/lead_paragraph", {
-          text: content.header[:lede],
-          inverse: true,
-          margin_bottom: 2,
-        } %>
-      </div>
-    </div>
+  <%= render "govuk_publishing_components/components/title", {
+    title: content.header[:heading],
+    inverse: true,
+    margin_top: 6,
+    margin_bottom: 6,
+  } %>
 
-    <div class="govuk-grid-row covid__action-link-wrapper">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render 'govuk_publishing_components/components/action_link', {
-          white_arrow: true,
-          href: content.header[:href],
-          text: content.header[:link_text],
-          mobile_subtext: true,
-          light_text: true,
-          data: {
-            module: "gem-track-click",
-            track_category: "pageElementInteraction",
-            track_action: "Header",
-            track_label: content.header[:href],
-          }
-        } %>
-      </div>
-    </div>
-  <% end %>
-</header>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: content.header[:lede],
+    inverse: true,
+    margin_bottom: 5,
+  } %>
+
+  <%= render 'govuk_publishing_components/components/action_link', {
+    white_arrow: true,
+    href: content.header[:href],
+    text: content.header[:link_text],
+    mobile_subtext: true,
+    light_text: true,
+    data: {
+      module: "gem-track-click",
+      track_category: "pageElementInteraction",
+      track_action: "Header",
+      track_label: content.header[:href],
+    }
+  } %>
+
+<% end %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -3,7 +3,6 @@
 } %>
 
 <% content_for :title, content.page_title %>
-<% content_for :is_full_width_header, true %>
 
 <%
   accordion_contents = content.body[:accordion_content].map.with_index do |list, list_index|
@@ -29,11 +28,11 @@
   end
 %>
 
-<%= render "shared/browse_breadcrumbs", {
-  breadcrumbs: breadcrumbs,
-  collapse_on_mobile: true,
-  inverse: true
-} %>
+<% content_for :breadcrumbs do %>
+  <%= render "shared/browse_breadcrumbs", {
+    column_two_thirds: true
+  } %>
+<% end %>
 
 <%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
 

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -36,22 +36,15 @@
 
 <%= render "shared/browse_header", {
     two_thirds: true,
-    margin_bottom: 7,
-    padding_top: 0
+    margin_bottom: 7
   } do %>
 
-  <%= render "govuk_publishing_components/components/title", {
-    title: content.header[:heading],
-    inverse: true,
-    margin_top: 6,
-    margin_bottom: 6,
-  } %>
-
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: content.header[:lede],
-    inverse: true,
-    margin_bottom: 5,
-  } %>
+  <h1 class="browse__heading govuk-heading-xl">
+    <%= content.header[:heading] %>
+  </h1>
+  <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-6">
+    <%= content.header[:lede] %>
+  </p>
 
   <%= render 'govuk_publishing_components/components/action_link', {
     white_arrow: true,

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -34,7 +34,11 @@
   } %>
 <% end %>
 
-<%= render "shared/browse_header", { margin_bottom: 7, padding_top: 0 } do %>
+<%= render "shared/browse_header", {
+    two_thirds: true,
+    margin_bottom: 7,
+    padding_top: 0
+  } do %>
 
   <%= render "govuk_publishing_components/components/title", {
     title: content.header[:heading],


### PR DESCRIPTION
## What

The page header for the Cost of Living hub should match the page header for topics pages, both structurally and visually. Specific areas to change are:

* The blue bar should be the width of the content, not the full width of the page
* Matching the vertical margins and padding on header elements
* Removing redundant rows and columns

## Why
For visual consistency with the header on mainstream topics pages.

## Before
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/2166204/186927313-82cdc0ab-1eb2-4a69-a693-d592ed96dc8e.png">

## After
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/2166204/186927439-4f269a02-3589-4b07-9728-28182013c438.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
