### PR TITLE
Add analytics that power page views custom dimensions to Cost of living hub

### DIFF
--- a/app/controllers/cost_of_living_landing_page_controller.rb
+++ b/app/controllers/cost_of_living_landing_page_controller.rb
@@ -5,7 +5,7 @@ class CostOfLivingLandingPageController < ApplicationController
     if Rails.application.config.unreleased_features
       render "show", locals: {
         breadcrumbs: breadcrumbs,
-        content: content_item,
+        content: presenter,
       }
     else
       render status: :not_found, plain: "Page not found"
@@ -20,6 +20,10 @@ private
 
   def content_item
     @content_item ||= YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).deep_symbolize_keys
+  end
+
+  def presenter
+    @presenter ||= CostOfLivingLandingPagePresenter.new(content_item)
   end
 
   def breadcrumbs

--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -1,0 +1,16 @@
+class CostOfLivingLandingPagePresenter
+  COMPONENTS = %i[
+    page_title
+    metadata
+    header
+    body
+  ].freeze
+
+  def initialize(content_item)
+    COMPONENTS.each do |component|
+      define_singleton_method component do
+        content_item[component]
+      end
+    end
+  end
+end

--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -13,4 +13,24 @@ class CostOfLivingLandingPagePresenter
       end
     end
   end
+
+  def link_clicked_track_data(track_action:, href:)
+    return {} unless internal_link?(href)
+
+    {
+      track_category: "contentsClicked",
+      track_action: track_action,
+      track_label: slug_for_href(href),
+    }
+  end
+
+private
+
+  def internal_link?(link)
+    link.starts_with?("https://www.gov.uk/")
+  end
+
+  def slug_for_href(href)
+    href.gsub("https://www.gov.uk/", "")
+  end
 end

--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -15,12 +15,13 @@ class CostOfLivingLandingPagePresenter
   end
 
   def link_clicked_track_data(track_action:, href:)
-    return {} unless internal_link?(href)
+    return { track_count: "contentLink" } unless internal_link?(href)
 
     {
       track_category: "contentsClicked",
       track_action: track_action,
       track_label: slug_for_href(href),
+      track_count: "contentLink",
     }
   end
 

--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -15,17 +15,14 @@
           <ul role="list" class="govuk-list browse__list">
              <% content_item[:links].each_with_index do |link_item, index| %>
               <li class="govuk-list browse__list-item">
-               <% track_data = {
-                   track_category: "contentsClicked",
-                   track_action: accordion_heading,
-                   track_label: link_item[:href].gsub("https://www.gov.uk/", ""),
-                  } if link_item[:href].starts_with?("https://www.gov.uk/")
-               %>
                <%= link_to(
                  link_item[:link_text],
                  link_item[:href],
                  class: "govuk-link",
-                 data: track_data,
+                 data: presenter.link_clicked_track_data(
+                  track_action: accordion_heading,
+                  href: link_item[:href]
+                 ),
                ) %>
              </li>
               <% end %>
@@ -37,17 +34,14 @@
       <li class="browse__list-item govuk-!-padding-bottom-1">
         <%= render "govuk_publishing_components/components/inset_text" do %>
           <p><%= content_item[:inset_text] %></p>
-          <% track_data = {
-              track_category: "contentsClicked",
-              track_action: accordion_heading,
-              track_label: content_item[:href].gsub("https://www.gov.uk/", ""),
-             } if content_item[:href].starts_with?("https://www.gov.uk/")
-          %>
           <%= link_to(
             content_item[:link_text],
             content_item[:href],
             class: "govuk-link",
-            data: track_data,
+            data: presenter.link_clicked_track_data(
+              track_action: accordion_heading,
+              href: content_item[:href]
+             ),
           ) %>
         <% end %>
       </li>

--- a/app/views/cost_of_living_landing_page/components/shared/_meta_tags.html.erb
+++ b/app/views/cost_of_living_landing_page/components/shared/_meta_tags.html.erb
@@ -6,6 +6,12 @@
   <meta property="og:title" content="<%= metadata[:title] %>">
   <meta property="og:description" content="<%= metadata[:description] %>">
   <meta name="description" content="<%= metadata[:description] %>">
+  <%= render "govuk_publishing_components/components/meta_tags", {
+    content_item: {
+      navigation_page_type: "Cost of living hub",
+      navigation_list_type: "curated",
+    }
+  } %>
 
   <link rel="canonical" href="<%= page_url %>">
 <% end %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -13,6 +13,7 @@
       },
       content: {
         html: render(partial: "links", locals: {
+          presenter: content,
           accordion_heading: list[:heading],
           list: list[:content],
           list_index: list_index,

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -1,12 +1,12 @@
 <%= render partial: "cost_of_living_landing_page/components/shared/meta_tags", locals: {
-  metadata: content[:metadata]
+  metadata: content.metadata
 } %>
 
-<% content_for :title, content[:page_title] %>
+<% content_for :title, content.page_title %>
 <% content_for :is_full_width_header, true %>
 
 <%
-  accordion_contents = content[:body][:accordion_content].map.with_index do |list, list_index|
+  accordion_contents = content.body[:accordion_content].map.with_index do |list, list_index|
     {
       heading: {
         text: list[:heading],
@@ -39,7 +39,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/title", {
-          title: content[:header][:heading],
+          title: content.header[:heading],
           inverse: true,
           margin_top: 4,
           margin_bottom: 6,
@@ -50,7 +50,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/lead_paragraph", {
-          text: content[:header][:lede],
+          text: content.header[:lede],
           inverse: true,
           margin_bottom: 2,
         } %>
@@ -61,15 +61,15 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render 'govuk_publishing_components/components/action_link', {
           white_arrow: true,
-          href: content[:header][:href],
-          text: content[:header][:link_text],
+          href: content.header[:href],
+          text: content.header[:link_text],
           mobile_subtext: true,
           light_text: true,
           data: {
             module: "gem-track-click",
             track_category: "pageElementInteraction",
             track_action: "Header",
-            track_label: content[:header][:href],
+            track_label: content.header[:href],
           }
         } %>
       </div>
@@ -82,7 +82,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="browse__section">
        <%= render "govuk_publishing_components/components/heading", {
-          text: content[:body][:heading],
+          text: content.body[:heading],
           margin_bottom: 6,
           font_size: "l"
         } %>

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
       and_there_is_link_tracking
+      and_there_is_accordion_section_tracking
     end
 
     def when_i_visit_the_cost_of_living_landing_page
@@ -48,6 +49,12 @@ RSpec.feature "Cost of Living hub page" do
       expect(link["data-track-action"]).to eq("Support with your income")
       expect(link["data-track-label"]).to eq("check-benefits-financial-support")
       expect(link["data-track-count"]).to eq("contentLink")
+    end
+
+    def and_there_is_accordion_section_tracking
+      accordion_section = page.first(".govuk-accordion__section-heading")
+
+      expect(accordion_section["data-track-count"]).to eq("accordionSection")
     end
   end
 end

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -40,6 +40,8 @@ RSpec.feature "Cost of Living hub page" do
         "meta[name='description'][content='Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport.']",
         visible: false,
       )
+      expect(page).to have_selector("meta[name='govuk:navigation-page-type'][content='Cost of living hub']", visible: false)
+      expect(page).to have_selector("meta[name='govuk:navigation-list-type'][content='curated']", visible: false)
     end
 
     def and_there_is_link_tracking

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_title
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
+      and_there_is_link_clicked_tracking
     end
 
     def when_i_visit_the_cost_of_living_landing_page
@@ -38,6 +39,14 @@ RSpec.feature "Cost of Living hub page" do
         "meta[name='description'][content='Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and transport.']",
         visible: false,
       )
+    end
+
+    def and_there_is_link_clicked_tracking
+      link = page.find("a", text: "Find out what benefits and financial support you may be able to get")
+
+      expect(link["data-track-category"]).to eq("contentsClicked")
+      expect(link["data-track-action"]).to eq("Support with your income")
+      expect(link["data-track-label"]).to eq("check-benefits-financial-support")
     end
   end
 end

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_title
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
-      and_there_is_link_clicked_tracking
+      and_there_is_link_tracking
     end
 
     def when_i_visit_the_cost_of_living_landing_page
@@ -41,12 +41,13 @@ RSpec.feature "Cost of Living hub page" do
       )
     end
 
-    def and_there_is_link_clicked_tracking
+    def and_there_is_link_tracking
       link = page.find("a", text: "Find out what benefits and financial support you may be able to get")
 
       expect(link["data-track-category"]).to eq("contentsClicked")
       expect(link["data-track-action"]).to eq("Support with your income")
       expect(link["data-track-label"]).to eq("check-benefits-financial-support")
+      expect(link["data-track-count"]).to eq("contentLink")
     end
   end
 end

--- a/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
+++ b/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
@@ -42,14 +42,15 @@ RSpec.describe CostOfLivingLandingPagePresenter do
                track_category: "contentsClicked",
                track_action: "Support with your income",
                track_label: "check-benefits-financial-support",
+               track_count: "contentLink",
              })
     end
 
-    it "returns no tracking attributes for an external link" do
+    it "returns number of links tracking attribute for an external link" do
       expect(presenter.link_clicked_track_data(
                track_action: track_action,
                href: "https://www.moneyhelper.org.uk/",
-             )).to eq({})
+             )).to eq({ track_count: "contentLink" })
     end
   end
 end

--- a/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
+++ b/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe CostOfLivingLandingPagePresenter do
+  it "provides getter methods for all component keys defined in the YAML" do
+    # To keep the yaml and presenter in sync. If it fails update COMPONENTS in the presenter
+    cost_of_living_hardcoded_content = YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).deep_symbolize_keys
+    presenter = described_class.new(cost_of_living_hardcoded_content)
+
+    expect(described_class::COMPONENTS).to match(cost_of_living_hardcoded_content.keys)
+    cost_of_living_hardcoded_content.each_key do |key|
+      expect(presenter).to respond_to(key)
+    end
+  end
+end

--- a/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
+++ b/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
@@ -1,4 +1,25 @@
 RSpec.describe CostOfLivingLandingPagePresenter do
+  let(:content_item) do
+    { body:
+      { heading: "Available support",
+        accordion_content: [
+          { heading: "Support with your income",
+            content: [
+              { subheading: nil,
+                links: [
+                  { link_text: "Find out what benefits and financial support you may be able to get", href: "https://www.gov.uk/check-benefits-financial-support" },
+                  { link_text: "Check if you’re getting the minimum wage", href: "https://www.gov.uk/am-i-getting-minimum-wage" },
+                ] },
+              { inset_text: "The Money Helper service provides free, confidential and impartial help tailored to individual needs.", link_text: "Use the Money Helper service", href: "https://www.moneyhelper.org.uk/" },
+              { subheading: "Check if you’re eligible for Universal Credit", links: [{ link_text: "Universal Credit in England, Scotland and Wales", href: "https://www.gov.uk/universal-credit/" }, { link_text: "Universal Credit in Northern Ireland", href: "https://www.nidirect.gov.uk/campaigns/universal-credit" }] },
+            ] },
+        ] } }
+  end
+
+  let(:presenter) do
+    described_class.new(content_item)
+  end
+
   it "provides getter methods for all component keys defined in the YAML" do
     # To keep the yaml and presenter in sync. If it fails update COMPONENTS in the presenter
     cost_of_living_hardcoded_content = YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).deep_symbolize_keys
@@ -7,6 +28,28 @@ RSpec.describe CostOfLivingLandingPagePresenter do
     expect(described_class::COMPONENTS).to match(cost_of_living_hardcoded_content.keys)
     cost_of_living_hardcoded_content.each_key do |key|
       expect(presenter).to respond_to(key)
+    end
+  end
+
+  describe "#link_clicked_track_data" do
+    let(:track_action) { "Support with your income" }
+
+    it "returns correct tracking attributes for an internal link" do
+      expect(presenter.link_clicked_track_data(
+               track_action: track_action,
+               href: "https://www.gov.uk/check-benefits-financial-support",
+             )).to eq({
+               track_category: "contentsClicked",
+               track_action: "Support with your income",
+               track_label: "check-benefits-financial-support",
+             })
+    end
+
+    it "returns no tracking attributes for an external link" do
+      expect(presenter.link_clicked_track_data(
+               track_action: track_action,
+               href: "https://www.moneyhelper.org.uk/",
+             )).to eq({})
     end
   end
 end


### PR DESCRIPTION
# Context

Additional meta tags that power the custom dimensions we normally see with events or page views aren't firing on the CoL page due to the content being hardcoded rather than coming from content store.

[Trello](https://trello.com/c/0pjp3DgK/1288-add-meta-tags-that-power-custom-dimensions-m)

Custom dimensions are populated via [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/465040b/app/assets/javascripts/govuk_publishing_components/analytics/custom-dimensions.js) gem.

## Depends on

-  https://github.com/alphagov/govuk_publishing_components/pull/2921

# What

This adds missing tracking attributes which populate the following custom dimensions:

- 26 - number of sections 
- 27 - number of links 
- 31 - navigation-list-type - "curated”
- 32 - navigation-page-type - “Cost of living hub”



It also includes a refactor to add a presenter so we can avoid having so much logic in the view and to be able to add unit test.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
