### PR TITLE
Correct order of translations on World Location news pages

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -52,15 +52,15 @@ class WorldLocationNews
     @content_item.content_item_data.dig("details", "mission_statement")
   end
 
-  def translations
-    @translations ||= @content_item.content_item_data.dig("links", "available_translations")&.map do |translation|
+  def ordered_translations
+    @ordered_translations ||= @content_item.content_item_data.dig("links", "available_translations")&.map { |translation|
       {
         locale: translation["locale"],
         base_path: translation["base_path"],
         text: I18n.t("shared.language_name", locale: translation["locale"]),
         active: I18n.locale.to_s == translation["locale"],
       }
-    end
+    }&.sort_by { |t| t[:locale] == I18n.default_locale.to_s ? "" : t[:locale] }
   end
 
   def latest

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -14,9 +14,9 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <% if @world_location_news.translations.count > 1 %>
+    <% if @world_location_news.ordered_translations.count > 1 %>
       <%= render "govuk_publishing_components/components/translation_nav", {
-        translations: @world_location_news.translations,
+        translations: @world_location_news.ordered_translations,
         no_margin_top: true,
       } %>
     <% end %>

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -43,12 +43,12 @@
   "links": {
     "available_translations": [
       {
-        "locale": "en",
-        "base_path": "/world/somewhere"
-      },
-      {
         "locale": "cy",
         "base_path": "/world/somewhere.cy"
+      },
+      {
+        "locale": "en",
+        "base_path": "/world/somewhere"
       }
     ]
   }

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe WorldLocationNews do
     )
   end
 
-  it "should map the translations" do
-    expect(world_location_news.translations).to eq(
+  it "should order the translations" do
+    expect(world_location_news.ordered_translations).to eq(
       [
         {
           locale: "en",


### PR DESCRIPTION

<img width="1000" alt="Screenshot 2022-08-31 at 13 04 31" src="https://user-images.githubusercontent.com/24547183/187674522-912d4db4-c695-4358-b059-b750ba460cd0.png">


Trello: https://trello.com/c/6mCz9HL2/225-world-location-news-rendering-in-collections-fix-order-of-translated-tabs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
