### PR TITLE
Enable Static proxy for Heroku deployments

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     },
+    "GOVUK_PROXY_STATIC_URL": {
+      "value": "https://www.gov.uk"
+    },
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://www.gov.uk/api"
     },


### PR DESCRIPTION
This sets the GOVUK_PROXY_STATIC_URL env var to enable the proxy to Static in production. This is so the application continues, when Static changes to use relative URLs for assets. See https://github.com/alphagov/govuk_app_config/pull/261 and https://github.com/alphagov/govuk-puppet/pull/11801