### PR TITLE
Fix Plek URL for Static in development

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {
-      "value": "assets.digital.cabinet-office.gov.uk"
+      "value": "https://assets.publishing.service.gov.uk"
     },
     "RAILS_SERVE_STATIC_ASSETS": {
       "value": "yes"

--- a/startup.sh
+++ b/startup.sh
@@ -7,7 +7,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   GOVUK_PROXY_STATIC_ENABLED=true \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
-  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk} \
   PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3070
 else


### PR DESCRIPTION
This updates the URLs to use the asset domain and use HTTPS. This is required for the Static proxy to correctly forward request.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
