### PR TITLE
Change default cache time to 5 mins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,7 +95,7 @@ private
     render status: status_code, plain: "#{status_code} error"
   end
 
-  def set_expiry(duration = 30.minutes, public_cache: true)
+  def set_expiry(duration = 5.minutes, public_cache: true)
     unless Rails.env.development?
       expires_in(duration, public: public_cache)
     end

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BrowseController do
     it "set correct expiry headers" do
       get :index
 
-      expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+      expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.describe BrowseController do
 
       it "sets correct expiry headers" do
         get :show, params: { top_level_slug: "benefits" }
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
 
       it "responds to html by default" do

--- a/spec/controllers/second_level_browse_page_controller_spec.rb
+++ b/spec/controllers/second_level_browse_page_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SecondLevelBrowsePageController do
 
       it "set correct expiry headers" do
         get :show, params: params
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
 
       it "responds to html by default" do

--- a/spec/controllers/services_and_information_controller_spec.rb
+++ b/spec/controllers/services_and_information_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ServicesAndInformationController do
 
       get :index, params: { organisation_id: "hm-revenue-customs" }
 
-      expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+      expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
     end
   end
 

--- a/spec/controllers/subtopics_controller_spec.rb
+++ b/spec/controllers/subtopics_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SubtopicsController do
       it "sets expiry headers for 30 minutes" do
         get :show, params: { topic_slug: "oil-and-gas", subtopic_slug: "wells" }
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
     end
 

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TopicsController do
       it "sets expiry headers for 30 minutes" do
         get :show, params: { topic_slug: "oil-and-gas" }
 
-        expect(response.headers["Cache-Control"]).to eq("max-age=1800, public")
+        expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       end
     end
 


### PR DESCRIPTION
This is a very quick fix to reduce the global caching time of this application from 30 mins to 5 mins. This is a temporary fix to remedy RFC 144 not being implemented fully in Collections: https://github.com/alphagov/collections/pull/2659

The need for a temporary fix is because we are doing a reshuffle today, and want to avoid people manually clearing cache entries.

There shouldn't be any need for pages in this application to be caching pages for longer than 5 mins.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
