### PR TITLE
Set cache expiry to the value for the content item

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,10 +95,9 @@ private
     render status: status_code, plain: "#{status_code} error"
   end
 
-  def set_expiry(duration = 5.minutes, public_cache: true)
-    duration = @content_item.max_age if @content_item
-    unless Rails.env.development?
-      expires_in(duration, public: public_cache)
+  def set_expiry
+    if !Rails.env.development? && @content_item
+      expires_in(@content_item.max_age, public: @content_item.public_cache)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -96,6 +96,7 @@ private
   end
 
   def set_expiry(duration = 5.minutes, public_cache: true)
+    duration = @content_item.max_age if @content_item
     unless Rails.env.development?
       expires_in(duration, public: public_cache)
     end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,8 +1,4 @@
 class OrganisationsController < ApplicationController
-  skip_before_action :set_expiry
-  before_action do
-    set_expiry content_item.max_age, public_cache: content_item.public_cache
-  end
   around_action :switch_locale, only: %i[show court]
 
   def index

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe BrowseController do
         links: {
           top_level_browse_pages: top_level_browse_pages,
         },
+        max_age: 300,
       )
     end
 

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OrganisationsController do
     it "set correct expiry headers" do
       get :show, params: { organisation_name: "ministry-of-magic" }
 
-      expect(response.headers["Cache-Control"]).to eq("max-age=900, public")
+      expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
     end
   end
 end


### PR DESCRIPTION
We had the expiry hard coded to 5 minutes to match what we have set as the default at all the other layers. What we want is to have it overridable at the content item level rather than hard coded.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
