### PR TITLE
Updating to new components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (30.4.1)
+    govuk_publishing_components (30.5.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -383,7 +383,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.2.5)
     rinku (2.0.6)
-    rouge (3.30.0)
+    rouge (4.0.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

Update to latest version of the components gem, to fix the underline problem on organisation logos - https://github.com/alphagov/govuk_publishing_components/pull/2949


Preview of the page is https://collections-pr-2947.herokuapp.com/government/topical-events/her-majesty-queen-elizabeth-ii