### PR TITLE
Remove Publications from Topical Events pages

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -127,8 +127,7 @@
         margin_bottom: 3,
       } %>
     <% end %>
-
-    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.publications, heading: I18n.t("topical_events.headings.publications"), link_to: search_url(:topical_event, :publication, @topical_event.slug) }) if @topical_event.publications.any? %>
+    
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:topical_event, :consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:topical_event, :announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.guidance_and_regulation, heading: I18n.t("topical_events.headings.guidance_and_regulation"), link_to: search_url(:topical_event, :guidance_and_regulation, @topical_event.slug) }) if @topical_event.guidance_and_regulation.any? %>

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -74,29 +74,38 @@ RSpec.feature "Topical Event pages" do
   end
 
   context "documents list" do
-    let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
     let(:related_consultations) { { "A consultation on Topicals" => "/foo/consultation_one", "Another consultation" => "/foo/consultation_two" } }
     let(:related_announcements) { { "An announcement on Topicals" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
     let(:related_guidance_and_regulation) { { "Some guidance" => "/foo/detailed_guidance_one", "Another bit of guidance" => "/foo/detailed_guidance_two" } }
 
+    context "related publications" do
+      let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
+
+      it "displays related publications" do
+        stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
+
+        visit base_path
+
+        expect(page).to have_text("Publications")
+
+        within("#publications") do
+          related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
+          expect(page).to have_link("See all publications", href: "/search/all?topical_events%5B%5D=something-very-topical")
+        end
+      end
+    end
+
     it "displays links to all related documents" do
       stub_search(body: search_api_response(related_announcements), params: { "filter_content_purpose_supergroup" => "news_and_communications" })
-      stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
       stub_search(body: search_api_response(related_consultations), params: { "filter_format" => "consultation" })
       stub_search(body: search_api_response(related_guidance_and_regulation), params: { "filter_content_purpose_supergroup" => "guidance_and_regulation" })
 
       visit base_path
 
       expect(page).to have_text("Documents")
-      expect(page).to have_text("Publications")
       expect(page).to have_text("Consultations")
       expect(page).to have_text("Announcements")
       expect(page).to have_text("Guidance and regulation")
-
-      within("#publications") do
-        related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all publications", href: "/search/all?topical_events%5B%5D=something-very-topical")
-      end
 
       within("#consultations") do
         related_consultations.each { |title, link| expect(page).to have_link(title, href: link) }

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Topical Event pages" do
     context "related publications" do
       let(:related_publications) { { "Policy on Topicals" => "/foo/policy_paper", "PM attends summit on topical events" => "/foo/news_story" } }
 
-      it "displays related publications" do
+      xit "displays related publications" do
         stub_search(body: search_api_response(related_publications), params: { "filter_format" => "publication" })
 
         visit base_path


### PR DESCRIPTION
The publications list on the Topical Event page for Her Majesty Queen Elizabeth II
 duplicates other lists. Removing for all Topical Event pages for now as we will replace with a new pattern based on Organisation pages that are powered by Supergroups.

https://trello.com/c/5Z31B1bw/1337-remove-publications-section-of-topical-event-page

## Screenshots

### Before

![www gov uk_government_topical-events_her-majesty-queen-elizabeth-ii](https://user-images.githubusercontent.com/424772/189679311-0f358942-bca6-4c4d-9589-21d4154d23c8.png)

### After

![localhost_3070_government_topical-events_her-majesty-queen-elizabeth-ii (1)](https://user-images.githubusercontent.com/424772/189679344-af609da5-1d93-4091-93ad-034610e22dd3.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
