### PR TITLE
Use New No Emergency Banner Template

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -5,6 +5,8 @@ class TopicalEventsController < ApplicationController
     path = topical_event_path(params[:name])
     @topical_event = TopicalEvent.find!(path)
 
+    slimmer_template "gem_layout_no_emergency_banner" if @topical_event.slug == "her-majesty-queen-elizabeth-ii"
+
     respond_to do |format|
       format.html do
         setup_content_item_and_navigation_helpers(@topical_event)


### PR DESCRIPTION
For the Queen topical page, it was requested that the emergency be removed as it creates a circular journey and pushes content down. After https://github.com/alphagov/static/pull/2876 is merged and deployed, this can be merged and will result in no emergency banner on the Queen topical page.

## Before

![Screenshot 2022-09-12 at 15 43 28](https://user-images.githubusercontent.com/3727504/189683909-11b2292e-d4bc-4087-9a2f-59704b576616.png)

## After

![Screenshot 2022-09-12 at 15 33 19](https://user-images.githubusercontent.com/3727504/189683957-e9939aee-98ec-457a-9891-dae8e505afbb.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
