### PR TITLE
Use request path for World Location News

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -3,7 +3,7 @@ class WorldLocationNewsController < ApplicationController
   enable_request_formats show: :atom
 
   def show
-    path = world_location_news_path(params[:name])
+    path = request.path.gsub(".atom", "")
     @world_location_news = WorldLocationNews.find!(path)
 
     respond_to do |format|


### PR DESCRIPTION
We are currently using a path that doesn't contain the locale when requesting World Location News from the content store.

This means we can't currently show anything other than English content.

Changing to `request.path` means we will include the locale when retrieving the content.

This is consistent with the usage on organisation pages.

[Trello card](https://trello.com/c/APn84yVb/223-spike-into-whats-involved-in-rendering-non-english-world-location-news-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
