### PR TITLE
Add GA4 Tracking to accordions on the `/cost-of-living` page

### DIFF
--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -23,6 +23,13 @@
         "track-options": {
           "dimension114": list_index + 1
         },
+        ga4: {
+          event_name: 'select_content',
+          type: 'accordion',
+          text: list[:heading],
+          index: list_index + 1,
+          index_total: content.body[:accordion_content].map.size,
+        }
       },
     }
   end
@@ -71,6 +78,17 @@
           <%= render "govuk_publishing_components/components/accordion", {
             track_show_all_clicks: true,
             track_sections: true,
+            data_attributes: {
+              module: "ga4-event-tracker",
+            },
+            data_attributes_show_all: {
+              "ga4": {
+                event_name: "select_content",
+                type: "accordion",
+                index: 0,
+                index_total: content.body[:accordion_content].map.size
+              }.to_json,
+            },
             items: accordion_contents,
           } %>
         </div>


### PR DESCRIPTION
## What 

Add GA4 tracking to accordions on the [`/cost-of-living`](https://www.gov.uk/cost-of-living) page.

## Why

It is missing!

[Trello](https://trello.com/c/GPnbGxXJ/364-add-tracking-accordions-cost-of-living-hub)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
