### PR TITLE
Render right to left languages properly on world location news translations

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -42,7 +42,7 @@ class WorldLocationNews
         description: ActionView::Base.full_sanitizer.sanitize(document["summary"]).truncate(160, separator: " "),
         context: {
           date: document["public_updated_at"]&.to_date,
-          text: I18n.t("shared.schema_name.#{document['document_type']&.parameterize(separator: '_')}", count: 1, default: document["document_type"]),
+          text: document["document_type"],
         },
       }
     end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -4,7 +4,7 @@
   <%= tag("meta", name: "description", content: @world_location_news.description) if @world_location_news.description %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" <%= dir_attribute %> <%= lang_attribute %>>
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       title: @world_location_news.title,
@@ -13,7 +13,7 @@
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>">
     <% if @world_location_news.ordered_translations.count > 1 %>
       <%= render "govuk_publishing_components/components/translation_nav", {
         translations: @world_location_news.ordered_translations,
@@ -28,7 +28,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full"  <%= dir_attribute %> <%= lang_attribute %>>
     <% if @world_location_news.ordered_featured_documents&.any? %>
       <section id="featured">
         <%= render "govuk_publishing_components/components/heading", {
@@ -81,7 +81,7 @@
 <% end %>
 
 <% if @world_location_news.mission_statement.present? %>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row"  <%= dir_attribute %> <%= lang_attribute %>>
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("world_location_news.headings.mission"),


### PR DESCRIPTION
[Trello](https://trello.com/c/RxH1E3eG/275-set-up-world-location-pages-to-deal-with-right-to-left-languages)

In order to switch rendering of translated world location news pages to collections, we need to ensure that we are rendering their text right-to-left. This PR fixes this.

| Currently rendered version (Whitehall) | Version rendered by collections after this PR |
|-----|-----|
|<img width="490" alt="Screenshot 2022-09-20 at 16 33 34" src="https://user-images.githubusercontent.com/25515510/191301772-e214cb41-bb14-4e90-ab4a-58fbe534d73c.png">|<img width="490" alt="Screenshot 2022-09-20 at 16 33 19" src="https://user-images.githubusercontent.com/25515510/191301862-571a6aeb-e4d7-4a43-a9a6-3e848951a5fd.png">|

Note here that we are missing some sections in the collections-rendered version of this content, vs the currently rendered version. This is because the currently rendered versions have links to documents that we are not porting over to collections, as we do not have non-English content in search.

Some examples of some RTL non-English world location news that can be used as comparisons if you spin collections up locally:

[https://www.gov.uk/world/iran/news.fa](https://www.gov.uk/world/iran/news.fa)
[https://www.gov.uk/world/israel/news.he](https://www.gov.uk/world/israel/news.he)
[https://www.gov.uk/world/pakistan/news.ur](https://www.gov.uk/world/pakistan/news.ur)
[https://www.gov.uk/world/algeria/news.ar](https://www.gov.uk/world/algeria/news.ar)
[https://www.gov.uk/world/egypt/news.ar](https://www.gov.uk/world/egypt/news.ar) (Prior to the second commit in this PR, this page was erroring - see commit for details)

**Request for frontend help**
I've chucked the lang attributes into all existing divs where we need it. However, should I create one wrapper div and only specify the RTL code once?

**Fix in this PR for some non-English news pages**

I have implemented a fix in the second commit which was causing the following page not to render: http://collections.dev.gov.uk/world/egypt/news.ar (and also any page where a translated document type contains no latin-script characters, so e.g. http://collections.dev.gov.uk/world/china/news.zg)

The alternative would be to do something on the lines of `&.downcase.gsub(/\s+/, '_')}", default: document['document_type']),` but really the only reason why this would work for translated document types was that it would be falling back to the default every time since the content item contains the translated document type (which is not a key in the locales file) so it is simpler to just use the document type from the content item. 

I note we have the same code for organisations, which will also cause issues when trying to render document types with entirely non [a-zA-Z] and [0-9] characters, so I think the same fix should go in there, whatever we decide to do here.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
