### PR TITLE
Small Dockerfile fixes for Replatforming.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,10 @@
 .git
 .gitignore
 CONTRIBUTING.md
-docs
 Jenkinsfile
 README.md
+docs
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,9 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
 FROM $builder_image AS builder
 
-RUN mkdir /app
-
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
-
 RUN bundle install
 
 COPY . /app


### PR DESCRIPTION
Remove an unnecessary `mkdir /app` from the Dockerfile, since this will be incompatible with an upcoming version of govuk-ruby-base.

Also remove some unneeded paths from the image.