### PR TITLE
Move Text of Cost of Living Hub Announcements to .yml

### DIFF
--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -2,6 +2,7 @@ class CostOfLivingLandingPagePresenter
   COMPONENTS = %i[
     page_title
     metadata
+    announcements
     header
     body
   ].freeze

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -73,18 +73,17 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {
-            text: "Announcements",
+            text: content.announcements[:heading],
             padding: true
           } %>
-
-          <p class="govuk-body">There will be an automatic limit on how much you will be charged for each unit of gas or electricity from 1 October.
-            <a class="govuk-link" href="/government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022">Find out how the Energy Price Guarantee limits your energy prices.</a>
-          </p>
-
-          <p class="govuk-body">
-            You may get calls, emails or messages that pretend to be from a government service or energy bill support scheme. If you get a message asking for your personal details (for example, bank details or passwords) this could be a scam.
-            <a class="govuk-link" href="/report-suspicious-emails-websites-phishing">Report anything you think is suspicious</a>.
-          </p>
+          <% content.announcements[:body].each do | body | %>
+            <p class="govuk-body">
+              <%= body[:content] %>
+              <a class="govuk-link" href="<%= body[:href] %>">
+                <%= body[:link_text] %>
+              </a>
+            </p>
+          <% end %>
       </div>
     </div>
   </div>

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -6,6 +6,15 @@ metadata:
     Find out what support is available to help with the cost of living. This
     includes income and disability benefits, bills and allowances, childcare,
     housing and travel.
+announcements:
+  heading: Announcements
+  body:
+  - content: There will be an automatic limit on how much you will be charged for each unit of gas or electricity from 1 October.
+    link_text: Find out how the Energy Price Guarantee limits your energy prices.
+    href: /government/publications/energy-bills-support/energy-bills-support-factsheet-8-september-2022
+  - content: You may get calls, emails or messages that pretend to be from a government service or energy bill support scheme. If you get a message asking for your personal details (for example, bank details or passwords) this could be a scam.
+    link_text: Report anything you think is suspicious.
+    href: /report-suspicious-emails-websites-phishing
 header:
   heading: Cost of living support
   lede: Find out what support is available to help with the cost of living. This includes income and disability benefits, bills and allowances, childcare, housing and travel.


### PR DESCRIPTION
In an effort to release the announcement as soon possible, the content was hardcoded in the template instead of being added to the content_item.yml. This PR moves the text to content_item.yml.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
