### PR TITLE
Don't strip / from track label on CoL page

### DIFF
--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -20,7 +20,7 @@ class CostOfLivingLandingPagePresenter
     {
       track_category: "contentsClicked",
       track_action: track_action,
-      track_label: slug_for_href(href),
+      track_label: href,
       track_count: "contentLink",
     }
   end
@@ -29,9 +29,5 @@ private
 
   def internal_link?(link)
     link.starts_with?("/")
-  end
-
-  def slug_for_href(href)
-    href.gsub("/", "")
   end
 end

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Cost of Living hub page" do
 
       expect(link["data-track-category"]).to eq("contentsClicked")
       expect(link["data-track-action"]).to eq("Support with your income")
-      expect(link["data-track-label"]).to eq("check-benefits-financial-support")
+      expect(link["data-track-label"]).to eq("/check-benefits-financial-support")
       expect(link["data-track-count"]).to eq("contentLink")
     end
 

--- a/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
+++ b/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
@@ -32,16 +32,16 @@ RSpec.describe CostOfLivingLandingPagePresenter do
   end
 
   describe "#link_clicked_track_data" do
-    let(:track_action) { "Support with your income" }
+    let(:track_action) { "Support with your bills" }
 
     it "returns correct tracking attributes for an internal link" do
       expect(presenter.link_clicked_track_data(
                track_action: track_action,
-               href: "/check-benefits-financial-support",
+               href: "/guidance/universal-credit-childcare-costs",
              )).to eq({
                track_category: "contentsClicked",
-               track_action: "Support with your income",
-               track_label: "check-benefits-financial-support",
+               track_action: "Support with your bills",
+               track_label: "/guidance/universal-credit-childcare-costs",
                track_count: "contentLink",
              })
     end


### PR DESCRIPTION
Bug fix. This changes the example in the test to the one including "/" in the middle. We also want the value to include / at the beginning.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
