### PR TITLE
Add tracking to the links in Cost of Living announcements section

### DIFF
--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -68,7 +68,7 @@
 
 <% end %>
 
-<div class="colhub__announcement">
+<div class="colhub__announcement" data-module="gem-track-click">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -80,7 +80,15 @@
           <% content.announcements[:body].each do |item| %>
             <p class="govuk-body">
               <%= item[:content] %>
-              <%= link_to item[:link_text], item[:link_text], class: "govuk-link" %>
+              <%= link_to(
+                item[:link_text],
+                item[:href],
+                class: "govuk-link",
+                data: content.link_clicked_track_data(
+                 track_action: item[:link_text],
+                 href: item[:href]
+                )
+              ) %>
             </p>
           <% end %>
       </div>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -76,12 +76,11 @@
             text: content.announcements[:heading],
             padding: true
           } %>
-          <% content.announcements[:body].each do | body | %>
+
+          <% content.announcements[:body].each do |item| %>
             <p class="govuk-body">
-              <%= body[:content] %>
-              <a class="govuk-link" href="<%= body[:href] %>">
-                <%= body[:link_text] %>
-              </a>
+              <%= item[:content] %>
+              <%= link_to item[:link_text], item[:link_text], class: "govuk-link" %>
             </p>
           <% end %>
       </div>

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_title
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
+      and_there_is_the_announcements_section
       and_there_is_link_tracking
       and_there_is_accordion_section_tracking
     end
@@ -38,6 +39,10 @@ RSpec.feature "Cost of Living hub page" do
       )
       expect(page).to have_selector("meta[name='govuk:navigation-page-type'][content='Cost of living hub']", visible: false)
       expect(page).to have_selector("meta[name='govuk:navigation-list-type'][content='curated']", visible: false)
+    end
+
+    def and_there_is_the_announcements_section
+      expect(page).to have_text("Announcements")
     end
 
     def and_there_is_link_tracking


### PR DESCRIPTION
## Changes
- Add tracking to the links in Cost of Living announcements section

Review

- [x] Reviewed in integration by a Performance analysts. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
