### PR TITLE
Use blue bar from gem instead of pseudoelement

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -22,18 +22,6 @@ $browse-header-background-colour: #263135;
   // Setting the overflow to auto is required to prevent the breadcrumb
   // component's margin from collapsing.
   overflow: auto;
-
-  // We want to show a constrained width blue bar _within_ the grey header.
-  // But the full width layout template doesn't include the blue bar - so we
-  // need to add a blue bar manually to this template.
-  &:before {
-    background-color: $govuk-brand-colour;
-    content: "";
-    display: block;
-    margin: auto;
-    max-width: 960px;
-    height: govuk-spacing(2);
-  }
 }
 
 // The header spacings are a work in progress.

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,6 +7,7 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
+    <div class="gem-c-layout-for-public__blue-bar"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
## What

Remove the blue bar pseudo element on browse pages (and Cost of Living hub). Add the blue bar element from the govuk_publishing_components gem instead.

## Why

On gov.uk, other apps/pages that have the blue bar beneath the navbar use the gem_layout template. On that template, the blue bar is part of the template partial itself and individual apps are not responsible for rendering it. However the full width header background of Browse pages means that we have to use a gem_layout_full_width template. This template does not have the blue bar and so the Browse page partials render this blue bar themselves. 

I thought that perhaps the blue bar could be added to the full width gem layout as an option but this resulted in a gap between the blue bar and where the background colour for the banner starts.

![Screenshot 2022-10-06 at 12 58 55](https://user-images.githubusercontent.com/3727504/194337098-a9875736-c81e-4f02-97fe-234942c6316f.png)

So the best solution I could see was to use the styling of the blue bar from the gem itself. This at least will ensure consistency between apps going forward and fixes the issue that was occurring on tablet screen sizes (see below).

## Visual Differences

### Before

![Screenshot 2022-10-06 at 15 16 11](https://user-images.githubusercontent.com/3727504/194336786-42bc1c19-ac45-42d9-822c-ff707d0ed403.png)

### After

![Screenshot 2022-10-06 at 15 16 50](https://user-images.githubusercontent.com/3727504/194336839-15a5cb4a-362d-4cd6-b1e7-30eaa44b3b88.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
