### PR TITLE
Remove excess padding from nested lists in accordions

### DIFF
--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -1,7 +1,7 @@
 <ul role="list" class="govuk-list browse__list" data-module="gem-track-click">
   <% list.each_with_index do |content_item, index| %>
     <% if content_item[:links] %>
-      <li class="govuk-list browse__list-item govuk-!-padding-bottom-1">
+      <li class="govuk-list govuk-!-padding-bottom-1">
          <% if content_item[:subheading] %>
            <%= render "govuk_publishing_components/components/heading", {
             text: content_item[:subheading],


### PR DESCRIPTION
## What

Removal of class on the top of level of nested lists within accordions on the Cost of Living hub.

## Why

Was resulting in overly large gaps between the lists within the accordions. This small fix makes the spacing smaller while still maintaining good spacing between each list.

## Visual Differences

### Before

![Screenshot 2022-10-07 at 12 19 20](https://user-images.githubusercontent.com/3727504/194541632-ce0ae328-49d7-4b04-ad8e-eb69ddc64682.png)


### After

![Screenshot 2022-10-07 at 12 20 18](https://user-images.githubusercontent.com/3727504/194541612-b3d96a4d-f6bc-47ec-839f-e6ed6c4906e5.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
