### PR TITLE
Minor Fixes for Cost of Living Hub

### DIFF
--- a/app/assets/stylesheets/views/_colhub.scss
+++ b/app/assets/stylesheets/views/_colhub.scss
@@ -1,9 +1,5 @@
 .colhub__announcement {
   background-color: govuk-colour("light-grey");
-  padding: govuk-spacing(3) 0;
-  margin-bottom: govuk-spacing(4);
-  @include govuk-media-query($from: desktop) {
-    padding: govuk-spacing(6) 0;
-    margin-bottom: govuk-spacing(7);
-  }
+  padding: govuk-spacing(5) 0;
+  margin-bottom: govuk-spacing(7);
 }

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -83,7 +83,7 @@
               <%= link_to(
                 item[:link_text],
                 item[:href],
-                class: "govuk-link",
+                class: "govuk-footer__link",
                 data: content.link_clicked_track_data(
                  track_action: item[:link_text],
                  href: item[:href]


### PR DESCRIPTION
## What

A couple of maintenance fixes.

- Use footer link styles in the announcement
- Use responsive spacing mixins

## Why

These fixes that would have been done if the announcement had not needed to be released as soon as possible.

- The footer link style ensures that the contrast levels meet AAA accessibility standards. The blue styled links were only AA level of contrast. [This is in response to the comment that Hanna left on the original PR](https://github.com/alphagov/collections/pull/2972/files#r980108641).
- There are already responsive spacing mixins within govuk-frontend, so I've replaced the media queries with those mixins instead. [This is in response to the comment that Hanna left on the original PR](https://github.com/alphagov/collections/pull/2972/files#r980106671).

[Relevant Trello Card](https://trello.com/c/MlXyrLwz/1355-remove-fix-inline-changes-for-cost-of-living-hub-page-s)

## Visual Changes

### Before

![Screenshot 2022-10-07 at 16 01 44](https://user-images.githubusercontent.com/3727504/194585160-45cd5bcc-22a9-453c-b32d-ca566db322b1.png)


### After

![Screenshot 2022-10-07 at 16 02 04](https://user-images.githubusercontent.com/3727504/194585079-9ce4e227-cfa1-42d8-a416-f4b863127808.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
