### PR TITLE
Department acronym showing as Oim not OIM

### DIFF
--- a/app/presenters/organisations/document_presenter.rb
+++ b/app/presenters/organisations/document_presenter.rb
@@ -47,7 +47,7 @@ module Organisations
       document_type = I18n.t(document_translation, default: cleaned_document_type.titleize.gsub("_", " "))
 
       # Handle document types with acronyms
-      document_acronyms = %w[Foi Dfid Aaib Cma Esi Hmrc Html Maib Raib Utaac]
+      document_acronyms = %w[Foi Dfid Aaib Cma Esi Hmrc Html Maib Raib Utaac Oim]
       document_acronyms.each do |acronym|
         document_type.gsub!(acronym, acronym.upcase)
       end


### PR DESCRIPTION
## What 

Add `Oim` to the list of `document_acronyms`.

## Why

The Office for the Internal Market acronym showing as `Oim` not `OIM` as desired in the `Latest from the Office for the Internal Market` section on https://www.gov.uk/government/organisations/office-for-the-internal-market.

## Screenshots

| Before | After |
| --- | ---|
| <img width="1046" alt="Screenshot 2022-10-17 at 16 47 22" src="https://user-images.githubusercontent.com/44037625/196224994-bdbc7d24-c715-4a61-87ee-880f19ac363f.png"> | <img width="1046" alt="Screenshot 2022-10-17 at 16 47 45" src="https://user-images.githubusercontent.com/44037625/196225041-cff9fdf8-f188-41db-9a24-f1d4fde0af0a.png"> |

[Trello](https://trello.com/c/qdGD2UXl/246-fix-oim-rendering)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
