### PR TITLE
Fix link for "Apply for a Council Tax reduction in England, Scotland …

### DIFF
--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -132,7 +132,7 @@ body:
     - subheading: Support with Council Tax
       links:
       - link_text: Apply for a Council Tax reduction in England, Scotland and Wales
-        href: /guidance/council-tax-rebate-factsheet
+        href: /apply-council-tax-reduction
       - link_text: Apply for Rate Relief in Northern Ireland
         href: https://www.nidirect.gov.uk/rates-help
     - subheading: Support with prescriptions and health costs


### PR DESCRIPTION
…and Wales"

This is pointing to the wrong resource.

[Trello](https://trello.com/c/OGbXZhIG/1390-placeholder-changing-link-under-support-with-your-bills-to-bring-user-to-correct-place-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
