### PR TITLE
Add important info suffix to links within CoL accordions

### DIFF
--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -24,6 +24,7 @@
                   href: link_item[:href]
                  ),
                ) %>
+               <% if link_item[:important_info] %>- <%= link_item[:important_info] %><% end %>
              </li>
               <% end %>
             <% end %>

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -123,6 +123,7 @@ body:
         href: /winter-fuel-payment
       - link_text: Find out about the Warm Home Discount Scheme
         href: /the-warm-home-discount-scheme
+        important_info: opens 14 November 2022
       - link_text: Apply for the Cold Weather Payment
         href: /cold-weather-payment
       - link_text: Find out if you can get cheaper phone and broadband on the Ofcom website

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
       and_there_is_the_announcements_section
+      and_there_is_an_important_info_suffix_on_some_link
       and_there_is_link_tracking
       and_there_is_accordion_section_tracking
     end
@@ -43,6 +44,10 @@ RSpec.feature "Cost of Living hub page" do
 
     def and_there_is_the_announcements_section
       expect(page).to have_text("Announcements")
+    end
+
+    def and_there_is_an_important_info_suffix_on_some_link
+      expect(page).to have_text("opens 14 November 2022")
     end
 
     def and_there_is_link_tracking


### PR DESCRIPTION
Some links need to have additional, contextual information around the link. For now a suffix is the best way to achieve this for the example given.

[Trello](https://trello.com/c/SyPImuUb/1377-col-inline-link-announcement-approach-update-m)

## Visual changes

### Before

![Screenshot 2022-10-19 at 16 43 41](https://user-images.githubusercontent.com/424772/196740465-4180d386-0831-4b34-9e70-92bdc48a6771.png)

### After

<img width="1312" alt="Screenshot 2022-10-20 at 11 08 34" src="https://user-images.githubusercontent.com/424772/196920871-d6b161c0-f352-469e-b7f3-b15c8687148f.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
