### PR TITLE
Use canonical name when connecting to search-api.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     ffi (1.15.5)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    gds-api-adapters (83.0.0)
+    gds-api-adapters (84.0.0)
       addressable
       link_header
       null_logger

--- a/spec/features/person_spec.rb
+++ b/spec/features/person_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Person page" do
   end
 
   def stub_person_page_search_query(slug)
-    stub_request(:get, "https://search.test.gov.uk/search.json")
+    stub_request(:get, "https://search-api.test.gov.uk/search.json")
       .with(query: {
         count: 10,
         fields: %w[content_store_document_type link public_timestamp title],

--- a/spec/features/world_wide_taxon_browsing_spec.rb
+++ b/spec/features/world_wide_taxon_browsing_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature "Worldwide taxon browsing" do
 private
 
   def stub_search_api_tagged_content_request(content_id, search_result = [])
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=1000&fields%5B%5D=content_store_document_type&fields%5B%5D=description&fields%5B%5D=link&fields%5B%5D=title&filter_taxons%5B%5D=#{content_id}&order=title&start=0")
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=1000&fields%5B%5D=content_store_document_type&fields%5B%5D=description&fields%5B%5D=link&fields%5B%5D=title&filter_taxons%5B%5D=#{content_id}&order=title&start=0")
       .to_return(body: { results: search_result }.to_json)
   end
 

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -45,7 +45,7 @@ module OrganisationHelpers
 
   def build_search_api_query_url(params = {})
     query = Rack::Utils.build_nested_query default_params.merge(params)
-    "#{Plek.new.find('search')}/search.json?#{query}"
+    "#{Plek.new.find('search-api')}/search.json?#{query}"
   end
 
   def stub_empty_search_api_requests(organisation_slug)
@@ -60,12 +60,12 @@ module OrganisationHelpers
   end
 
   def stub_search_api_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
   end
 
   def stub_search_api_latest_content_with_acronym(organisation_slug)
-    stub_request(:get, Plek.new.find("search") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
   end
 


### PR DESCRIPTION
See alphagov/gds-api-adapters#1170 for context.

Depends on alphagov/publishing-e2e-tests#512.