### PR TITLE
Update the Plek service name for Search API

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "PLEK_SERVICE_CONTENT_STORE_URI": {
       "value": "https://www.gov.uk/api"
     },
-    "PLEK_SERVICE_SEARCH_URI": {
+    "PLEK_SERVICE_SEARCH_API_URI": {
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_PROXY_STATIC_ENABLED=true \
   PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
   PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-https://assets.publishing.service.gov.uk} \
-  PLEK_SERVICE_SEARCH_URI=${PLEK_SERVICE_SEARCH_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_SEARCH_API_URI=${PLEK_SERVICE_SEARCH_API_URI-https://www.gov.uk/api} \
   bundle exec rails s -p 3070
 else
   echo "ERROR: other startup modes are not supported"


### PR DESCRIPTION
A [change] was name to gds-api-adapters to use the canonical name for search-api, rather than "search".

Plek uses the service name in it's [environment variables] to find the service. When the name of the service changed, Plek was unable to find service and errored with:

```
GdsApi::SocketErrorException - Failed to open TCP connection to search-api.www.gov.uk:443 (getaddrinfo: nodename nor servname provided, or not known)
```

[change]: https://github.com/alphagov/gds-api-adapters/pull/1170
[environment variables]: https://github.com/alphagov/plek#environment-variables

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
