### PR TITLE
Enable tracking for share links

### DIFF
--- a/app/presenters/organisations/what_we_do_presenter.rb
+++ b/app/presenters/organisations/what_we_do_presenter.rb
@@ -25,6 +25,7 @@ module Organisations
 
       {
         stacked: true,
+        track_as_follow: true,
         brand: org.brand,
         links: links,
       }

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -64,6 +64,7 @@
     <% if @topical_event.social_media_links %>
       <section id="social-media-links" class="topical-events__section-break">
       <%= render "govuk_publishing_components/components/share_links", {
+        track_as_follow: true,
         links: @topical_event.social_media_links,
       } %>
       </section>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable tracking of share links on organisation pages ([example org page](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport)) and topical event pages (according to [this docs page](https://docs.publishing.service.gov.uk/document-types/topical_event.html) these have been retired, but adding the tracking anyway in case they are reused at some point).

- uses the track_as_follow option to enable the GA4 link click tracker to track link clicks on links to social media sites from the share links component
- added to the what we do section of org pages
- and to topical event pages

## Why

Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/Bf4OkoBJ/384-add-tracking-follow-us
