### PR TITLE
Update references in workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,12 +26,12 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yaml@main
     with:
       gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
-      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
-      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
   trigger-deploy:
     name: Trigger deploy to ${{ github.event.inputs.environment }}
     needs: build-and-publish-image

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,6 +42,6 @@ jobs:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
-      WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
-      WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
-      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,7 @@
 name: Deploy
 
+run-name: Deploy ${{ inputs.gitRef }} to ${{ inputs.environment }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/set-automatic-deploys-enabled.yaml
+++ b/.github/workflows/set-automatic-deploys-enabled.yaml
@@ -1,20 +1,20 @@
-name: Set automatic_deploys_enabled (optionally image_tag too)
+name: Set automatic deploys
+
+run-name: Set automatic deploys to ${{ inputs.setAutomaticDeploys }} in ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
     inputs:
-      resetImageTag:
-        description: 'Reset image tag to main'
+      setAutomaticDeploys:
+        description: 'Set automatic deploys'
         required: false
-        default: false
-        type: boolean
-      automaticDeploysEnabled:
-        description: 'Activate automatic deploys'
-        required: false
-        default: true
-        type: boolean
+        type: choice
+        options:
+        - enabled
+        - disabled
+        default: 'enabled'
       environment:
-        description: 'Environment to deploy to'
+        description: 'Environment'
         required: true
         type: choice
         options:
@@ -24,14 +24,13 @@ on:
         default: 'integration'
 
 jobs:
-  set_automatic_deploys_enabled:
-    name: Set automatic_deploys_enabled to ${{ github.event.inputs.environment }}
-    uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys-enabled.yaml@main
+  set-automatic-deploys:
+    name: Set automatic deploys
+    uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys.yaml@main
     with:
-      resetImageTag: ${{ github.event.inputs.resetImageTag == 'true' }}
-      automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploysEnabled == 'true' }}
+      automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploys == 'enabled' }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
-      WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
-      WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
-      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_URL }}
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This PR updates the GitHub workflows to reference the updates to the reusable workflows in govuk-infrastructure for the deploy and set-automatic-deploys.

This PR also improves the workflows by giving them a description run-name and updates the references to the secrets they use.
