### PR TITLE
Reintroduce gem-track-click on accordion

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -63,7 +63,7 @@
   <%= render 'govuk_publishing_components/components/accordion', {
     heading_level: 3,
     data_attributes: {
-      module: "ga4-event-tracker",
+      module: "gem-track-click ga4-event-tracker",
     },
     data_attributes_show_all: {
       "ga4": show_all_attributes.to_json


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Hi @andysellick 

Would you be able to approve this? Thanks :+1:

`gem-track-click` was accidentally removed from the coronavirus landing page accordion. Therefore the dual tracking with UA and GTM hasn't been active on the accordion since August 19th, as the UA tracking was removed by mistake. See here https://github.com/alphagov/collections/pull/2892#discussion_r948794097 and you can see `gem-track-click` was on the accordion[ on August 18th](https://web.archive.org/web/20220818050946/https://gov.uk/coronavirus) - there was a `<div data-module="gem-track-click gtm-click-tracking">` wrapping the whole accordion.

Therefore this branch reintroduces `gem-track-click`.