### PR TITLE
Fix gem-track-click position

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -51,24 +51,26 @@
   border_top: border_top,
   font_size: "m"
 } if heading %>
-<div data-module="toggle-attribute">
-  <%
-    show_all_attributes = {
-      event_name: "select_content",
-      type: "accordion",
-      index: 0,
-      index_total: number_of_accordion_sections,
-    }
-  %>
-  <%= render 'govuk_publishing_components/components/accordion', {
-    heading_level: 3,
-    data_attributes: {
-      module: "gem-track-click ga4-event-tracker",
-    },
-    data_attributes_show_all: {
-      "ga4": show_all_attributes.to_json
-    },
-    items: accordion_contents,
-    margin_bottom: 3
-  } %>
+<div data-module="gem-track-click">
+  <div data-module="toggle-attribute">
+    <%
+      show_all_attributes = {
+        event_name: "select_content",
+        type: "accordion",
+        index: 0,
+        index_total: number_of_accordion_sections,
+      }
+    %>
+    <%= render 'govuk_publishing_components/components/accordion', {
+      heading_level: 3,
+      data_attributes: {
+        module: "ga4-event-tracker",
+      },
+      data_attributes_show_all: {
+        "ga4": show_all_attributes.to_json
+      },
+      items: accordion_contents,
+      margin_bottom: 3
+    } %>
+  </div>
 </div>


### PR DESCRIPTION
Hi @andysellick 

Would you be able to approve this? Thanks :+1:

It looks like for `gem-track-click` to work, the DOM has to be in this order, otherwise the accordion tracking is inverted. Without this it was sending `accordionClosed` to UA when an accordion was opened, and sending `accordionOpened` when an accordion was closed. I'm guessing the ordering of the click listeners firing plays a part here.

I've checked it locally with Omnibug and it's sending the correct state to UA now. This structure is also how `gem-track-click` was implemented previously before it was accidentally removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
