### PR TITLE
Remove handler for JSON requests for browse

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,5 +1,4 @@
 class BrowseController < ApplicationController
-  enable_request_formats show: [:json]
   slimmer_template "gem_layout_full_width"
 
   def index

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,6 +1,4 @@
 class SecondLevelBrowsePageController < ApplicationController
-  enable_request_formats show: [:json]
-
   def show
     setup_content_item_and_navigation_helpers(page)
     @dimension26 = count_link_sections(page)


### PR DESCRIPTION
We removed these endpoints a while ago but didn't remove the handlers.

Crawlers have not been receiving the correct response as they trigger a 5xx instead of a 406 and continue to make their requests.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
