### PR TITLE
Add additional sections for International Delegation pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,3 +44,4 @@ $govuk-include-default-font-face: false;
 @import "views/organisation";
 @import "views/covid";
 @import "views/colhub";
+@import "views/world_location_news";

--- a/app/assets/stylesheets/views/_world_location_news.scss
+++ b/app/assets/stylesheets/views/_world_location_news.scss
@@ -1,0 +1,5 @@
+.world-location-news-show {
+  .world_location_news__address {
+    font-style: normal;
+  }
+}

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -86,4 +86,8 @@ class WorldLocationNews
   def organisations
     @content_item.content_item_data.dig("links", "organisations")
   end
+
+  def worldwide_organisations
+    @content_item.content_item_data.dig("links", "worldwide_organisations")
+  end
 end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -82,4 +82,8 @@ class WorldLocationNews
   def type
     @content_item.content_item_data.dig("details", "world_location_news_type")
   end
+
+  def organisations
+    @content_item.content_item_data.dig("links", "organisations")
+  end
 end

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -90,4 +90,8 @@ class WorldLocationNews
   def worldwide_organisations
     @content_item.content_item_data.dig("links", "worldwide_organisations")
   end
+
+  def contacts
+    @content_item.content_item_data.dig("links", "ordered_contacts")
+  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -186,7 +186,7 @@
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third">
-          <% contact.dig("details", "post_addresses").each do |address| %>
+          <% contact.dig("details", "post_addresses")&.each do |address| %>
             <address class="govuk-body world_location_news__address">
               <%= Govspeak::HCardPresenter.new(address.symbolize_keys).render %>
             </address>
@@ -194,7 +194,7 @@
         </div>
 
         <div class="govuk-grid-column-two-thirds">
-          <% contact.dig("details", "email_addresses").each do |email_address| %>
+          <% contact.dig("details", "email_addresses")&.each do |email_address| %>
             <p class="govuk-body">
               Email
               <br>
@@ -202,7 +202,7 @@
             </p>
           <% end %>
 
-          <% contact.dig("details", "phone_numbers").each do |phone_number| %>
+          <% contact.dig("details", "phone_numbers")&.each do |phone_number| %>
             <p class="govuk-body">
               <%= phone_number["title"] %>
               <br>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -98,7 +98,7 @@
 
 <% if I18n.locale == :en && (@world_location_news.announcements.any? || @world_location_news.publications.any? || @world_location_news.statistics.any?) %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("world_location_news.headings.documents"),
         padding: true,
@@ -110,6 +110,40 @@
       <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.announcements, heading: I18n.t("world_location_news.headings.announcements"), link_to: search_url(:world_location_news, :announcement, @world_location_news.slug) }) if @world_location_news.announcements.any? %>
       <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.publications, heading: I18n.t("world_location_news.headings.publications"), link_to: search_url(:world_location_news, :publication, @world_location_news.slug) }) if @world_location_news.publications.any? %>
       <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @world_location_news.statistics, heading: I18n.t("world_location_news.headings.statistics"), link_to: search_url(:world_location_news, :statistic, @world_location_news.slug) }) if @world_location_news.statistics.any? %>
+    </div>
+  </div>
+<% end %>
+
+<% if @world_location_news.organisations&.any? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
+      <section id="organisations">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: I18n.t("world_location_news.headings.organisations"),
+          padding: true,
+          font_size: 27,
+          margin_bottom: 3,
+          heading_level: 2,
+          border_top: 2,
+        } %>
+
+        <% @world_location_news.organisations.flatten.in_groups_of(3, false) do |row| %>
+          <div class="govuk-grid-row">
+            <% row.each do |organisation|%>
+              <div class="govuk-grid-column-one-third govuk-!-padding-bottom-7">
+                <%= render "govuk_publishing_components/components/organisation_logo", {
+                  organisation: {
+                    name: organisation["title"],
+                    url: organisation["base_path"],
+                    crest: organisation.dig("details", "logo", "crest"),
+                    brand: organisation.dig("details", "brand"),
+                  }
+                } %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </section>
     </div>
   </div>
 <% end %>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -147,3 +147,27 @@
     </div>
   </div>
 <% end %>
+
+<% if @world_location_news.worldwide_organisations&.any? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
+      <% @world_location_news.worldwide_organisations.each do |organisation| %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: organisation["title"],
+          padding: true,
+          border_top: 1,
+          margin_bottom: 3,
+          heading_level: 3,
+        } %>
+
+        <p class="govuk-body">
+          <%= organisation["description"] %>
+        </p>
+
+        <p class="govuk-body">
+          <%= link_to(I18n.t("world_location_news.find_out_more"), organisation["base_path"]) %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, @world_location_news.title %>
+<% page_class "world-location-news-show" %>
 
 <% content_for :meta_tags do %>
   <%= tag("meta", name: "description", content: @world_location_news.description) if @world_location_news.description %>
@@ -168,6 +169,48 @@
           <%= link_to(I18n.t("world_location_news.find_out_more"), organisation["base_path"]) %>
         </p>
       <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% @world_location_news.contacts&.each do |contact| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: contact.dig("details", "title"),
+        padding: true,
+        border_top: 1,
+        margin_bottom: 3,
+        heading_level: 3,
+      } %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <% contact.dig("details", "post_addresses").each do |address| %>
+            <address class="govuk-body world_location_news__address">
+              <%= Govspeak::HCardPresenter.new(address.symbolize_keys).render %>
+            </address>
+          <% end %>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+          <% contact.dig("details", "email_addresses").each do |email_address| %>
+            <p class="govuk-body">
+              Email
+              <br>
+              <%= link_to(email_address["email"], "mailto:#{email_address['email']}", class: "govuk-link") %>
+            </p>
+          <% end %>
+
+          <% contact.dig("details", "phone_numbers").each do |phone_number| %>
+            <p class="govuk-body">
+              <%= phone_number["title"] %>
+              <br>
+              <span dir="ltr"><%= phone_number["number"] %></span>
+            </p>
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/config/locales/ar/world_location_news.yml
+++ b/config/locales/ar/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ar:
   world_location_news:
+    find_out_more: اطلع على الملف الكامل وجميع تفاصيل الاتصال
     headings:
       announcements: إعلاناتنا
       documents: المستندات

--- a/config/locales/az/world_location_news.yml
+++ b/config/locales/az/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 az:
   world_location_news:
+    find_out_more: Tam profil və əlaqə məlumatlarımıza baxın
     headings:
       announcements: Elanlarımız
       documents: Sənədlər

--- a/config/locales/be/world_location_news.yml
+++ b/config/locales/be/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 be:
   world_location_news:
+    find_out_more: Паглядзець усю інфармацыю і кантактныя дадзеныя
     headings:
       announcements: Нашы аб'явы
       documents: Дакументы

--- a/config/locales/bg/world_location_news.yml
+++ b/config/locales/bg/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 bg:
   world_location_news:
+    find_out_more: Вижте пълния профил и всички данни за контакт
     headings:
       announcements: Нашите съобщения
       documents: Документи

--- a/config/locales/bn/world_location_news.yml
+++ b/config/locales/bn/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 bn:
   world_location_news:
+    find_out_more: সম্পূর্ণ প্রোফাইল ও সকল কন্টাক্টের বিস্তারিত তথ্য দেখুন
     headings:
       announcements: আমাদের ঘোষণাসমূহ
       documents: নথিপত্র

--- a/config/locales/cs/world_location_news.yml
+++ b/config/locales/cs/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 cs:
   world_location_news:
+    find_out_more: Zobrazit celý profil a všechny kontaktní údaje
     headings:
       announcements: Naše oznámení
       documents: Dokumenty

--- a/config/locales/cy/world_location_news.yml
+++ b/config/locales/cy/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 cy:
   world_location_news:
+    find_out_more: Gweler y proffil llawn a'r holl fanylion cyswllt
     headings:
       announcements: Ein cyhoeddiadau
       documents: Dogfennau

--- a/config/locales/da/world_location_news.yml
+++ b/config/locales/da/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 da:
   world_location_news:
+    find_out_more: Se hele profilen og alle kontaktoplysninger
     headings:
       announcements: Vores meddelelser
       documents: Dokumenter

--- a/config/locales/de/world_location_news.yml
+++ b/config/locales/de/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 de:
   world_location_news:
+    find_out_more: Vollständiges Profil und alle Kontaktdaten anzeigen
     headings:
       announcements: Unsere Ankündigungen
       documents: Dokumente

--- a/config/locales/dr/world_location_news.yml
+++ b/config/locales/dr/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 dr:
   world_location_news:
+    find_out_more: تمام پروفایل و جزیٔیات تماس با ما را مشاهده نماید
     headings:
       announcements: اطلاعیه هایی ما
       documents: اسناد

--- a/config/locales/el/world_location_news.yml
+++ b/config/locales/el/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 el:
   world_location_news:
+    find_out_more: Δείτε το πλήρες προφίλ και όλα τα στοιχεία επικοινωνίας
     headings:
       announcements: Οι ανακοινώσεις μας
       documents: Έγγραφα

--- a/config/locales/en/world_location_news.yml
+++ b/config/locales/en/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 en:
   world_location_news:
+    find_out_more: See full profile and all contact details
     headings:
       announcements: Our announcements
       documents: Documents

--- a/config/locales/es-419/world_location_news.yml
+++ b/config/locales/es-419/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 es-419:
   world_location_news:
+    find_out_more: Ver el perfil completo y todos los datos de contacto
     headings:
       announcements: Nuestros comunicados
       documents: Documentos

--- a/config/locales/es/world_location_news.yml
+++ b/config/locales/es/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 es:
   world_location_news:
+    find_out_more: Vea el perfil completo y los detalles de contacto
     headings:
       announcements: Nuestros anuncios
       documents: Documentos

--- a/config/locales/et/world_location_news.yml
+++ b/config/locales/et/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 et:
   world_location_news:
+    find_out_more: Vaata kogu profiili ja kõiki kontaktandmeid
     headings:
       announcements: Meie teadaanded
       documents: Dokumendid

--- a/config/locales/fa/world_location_news.yml
+++ b/config/locales/fa/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 fa:
   world_location_news:
+    find_out_more: مشاهده پروفایل کامل و تمام جزئیات تماس
     headings:
       announcements: اطلاعیه‌های ما
       documents: اسناد

--- a/config/locales/fi/world_location_news.yml
+++ b/config/locales/fi/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 fi:
   world_location_news:
+    find_out_more: Katso koko profiili ja kaikki yhteystiedot
     headings:
       announcements: Ilmoituksemme
       documents: Asiakirjat

--- a/config/locales/fr/world_location_news.yml
+++ b/config/locales/fr/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 fr:
   world_location_news:
+    find_out_more: Afficher le profil complet et toutes les coordonnées
     headings:
       announcements: Nos annonces
       documents: Documents

--- a/config/locales/gd/world_location_news.yml
+++ b/config/locales/gd/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 gd:
   world_location_news:
+    find_out_more: Féach ar phróifíl iomlán agus faisnéis teagmhála
     headings:
       announcements: Ár liostaí
       documents: Doiciméid

--- a/config/locales/gu/world_location_news.yml
+++ b/config/locales/gu/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 gu:
   world_location_news:
+    find_out_more: સંપૂર્ણ પ્રોફાઇલ અને તમામ સંપર્ક વિગતો જુઓ
     headings:
       announcements: અમારી જાહેરાતો
       documents: દસ્તાવેજો

--- a/config/locales/he/world_location_news.yml
+++ b/config/locales/he/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 he:
   world_location_news:
+    find_out_more: ראה/י פרופיל מלא ופרטי התקשרות
     headings:
       announcements: ההודעות שלנו
       documents: מסמכים

--- a/config/locales/hi/world_location_news.yml
+++ b/config/locales/hi/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 hi:
   world_location_news:
+    find_out_more: पूरी रूप रेखा और समस्त संपर्क विवरण देखें
     headings:
       announcements: हमारी घोषणाएं
       documents: दस्तावेज़

--- a/config/locales/hr/world_location_news.yml
+++ b/config/locales/hr/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 hr:
   world_location_news:
+    find_out_more: Pogledajte cijeli profil i sve podatke za kontakt
     headings:
       announcements: Naše obavijesti
       documents: Dokumenti

--- a/config/locales/hu/world_location_news.yml
+++ b/config/locales/hu/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 hu:
   world_location_news:
+    find_out_more: A teljes profil és elérhetőség megtekintése
     headings:
       announcements: Híreink
       documents: Dokumentumok

--- a/config/locales/hy/world_location_news.yml
+++ b/config/locales/hy/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 hy:
   world_location_news:
+    find_out_more: Դիտել ամբողջական պրոֆիլը և կոնտակտային բոլոր տվյալները
     headings:
       announcements: Մեր հայտարարությունները
       documents: Փաստաթղթեր

--- a/config/locales/id/world_location_news.yml
+++ b/config/locales/id/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 id:
   world_location_news:
+    find_out_more: Lihat profil lengkap dan semua detail kontak
     headings:
       announcements: Pengumuman kami
       documents: Dokumen

--- a/config/locales/is/world_location_news.yml
+++ b/config/locales/is/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 is:
   world_location_news:
+    find_out_more: Sjá allan prófílinn og allar upplýsingar til að hafa samband
     headings:
       announcements: Okkar tilkynningar
       documents: Skjöl

--- a/config/locales/it/world_location_news.yml
+++ b/config/locales/it/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 it:
   world_location_news:
+    find_out_more: Vedi il profilo completo e tutti i dettagli di contatto
     headings:
       announcements: I nostri annunci
       documents: Documenti

--- a/config/locales/ja/world_location_news.yml
+++ b/config/locales/ja/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ja:
   world_location_news:
+    find_out_more: プロフィール全体とすべての連絡先の詳細を見る
     headings:
       announcements: お知らせ
       documents: ドキュメント

--- a/config/locales/ka/world_location_news.yml
+++ b/config/locales/ka/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ka:
   world_location_news:
+    find_out_more: იხილეთ სრული პროფილი და ყველა საკონტაქტო ინფორმაცია
     headings:
       announcements: ჩვენი განცხადებები
       documents: დოკუმენტები

--- a/config/locales/kk/world_location_news.yml
+++ b/config/locales/kk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 kk:
   world_location_news:
+    find_out_more: Толық профильді және барлық байланыс мәліметтерін қараңыз
     headings:
       announcements: Біздің хабарландыруларымыз
       documents: Құжаттар

--- a/config/locales/ko/world_location_news.yml
+++ b/config/locales/ko/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ko:
   world_location_news:
+    find_out_more: 프로필과 연락처 보기
     headings:
       announcements: 공지사항
       documents: 자료

--- a/config/locales/lt/world_location_news.yml
+++ b/config/locales/lt/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 lt:
   world_location_news:
+    find_out_more: Visa informacija apie mus ir  kontaktai
     headings:
       announcements: Mūsų skelbimai
       documents: Dokumentai

--- a/config/locales/lv/world_location_news.yml
+++ b/config/locales/lv/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 lv:
   world_location_news:
+    find_out_more: Skatīt pilnu profilu un kontaktinformāciju
     headings:
       announcements: Paziņojumi
       documents: Dokumenti

--- a/config/locales/ms/world_location_news.yml
+++ b/config/locales/ms/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ms:
   world_location_news:
+    find_out_more: Lihat profil lengkap dan semua butiran hubungan
     headings:
       announcements: Pengumuman kami
       documents: Dokumen

--- a/config/locales/mt/world_location_news.yml
+++ b/config/locales/mt/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 mt:
   world_location_news:
+    find_out_more: Ara l-profil kollu u d-dettalji tal-kuntatt
     headings:
       announcements: L-avviżi tagħna
       documents: Dokumenti

--- a/config/locales/ne/world_location_news.yml
+++ b/config/locales/ne/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ne:
   world_location_news:
+    find_out_more: पूर्ण प्रोफाइल र सबै सम्पर्क विवरण हेर्नुहोस्
     headings:
       announcements: हाम्रा घोषणाहरु
       documents: कागजातहरु

--- a/config/locales/nl/world_location_news.yml
+++ b/config/locales/nl/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 nl:
   world_location_news:
+    find_out_more: Bekijk het volledige profiel en alle contactgegevens
     headings:
       announcements: Onze aankondigingen
       documents: Documenten

--- a/config/locales/no/world_location_news.yml
+++ b/config/locales/no/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 'no':
   world_location_news:
+    find_out_more: Se hele profilen og alle kontaktdetaljer
     headings:
       announcements: Våre kunngjøringer
       documents: Dokumenter

--- a/config/locales/pa-pk/world_location_news.yml
+++ b/config/locales/pa-pk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 pa-pk:
   world_location_news:
+    find_out_more: ساری تصویر تے رابطہ دی تفصیلات ویکھو
     headings:
       announcements: ساڈے اعلانات
       documents: دستاویزات تک پہنچ دی حکمت عملی

--- a/config/locales/pa/world_location_news.yml
+++ b/config/locales/pa/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 pa:
   world_location_news:
+    find_out_more: ਪੂਰਾ ਪ੍ਰੋਫਾਈਲ ਅਤੇ ਸਾਰੇ ਸੰਪਰਕ ਵੇਰਵੇ ਵੇਖੋ
     headings:
       announcements: ਸਾਡੀਆਂ ਘੋਸ਼ਣਾਵਾਂ
       documents: ਦਸਤਾਵੇਜ਼

--- a/config/locales/pl/world_location_news.yml
+++ b/config/locales/pl/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 pl:
   world_location_news:
+    find_out_more: Zobacz pełen profil i wszystkie dane kontaktowe
     headings:
       announcements: Nasze ogłoszenia
       documents: Dokumenty

--- a/config/locales/ps/world_location_news.yml
+++ b/config/locales/ps/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ps:
   world_location_news:
+    find_out_more: بشپړ پروفایل او د اړیکې ټول توضیحات وګورئ
     headings:
       announcements: زموږ اعلانونه
       documents: اسناد

--- a/config/locales/pt/world_location_news.yml
+++ b/config/locales/pt/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 pt:
   world_location_news:
+    find_out_more: Ver o perfil completo e todas as informações de contacto
     headings:
       announcements: Os nossos anúncios
       documents: Documentos

--- a/config/locales/ro/world_location_news.yml
+++ b/config/locales/ro/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ro:
   world_location_news:
+    find_out_more: Vedeți profilul complet și toate detaliile de contact
     headings:
       announcements: Anunțurile noastre
       documents: Documente

--- a/config/locales/ru/world_location_news.yml
+++ b/config/locales/ru/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ru:
   world_location_news:
+    find_out_more: Общая информация и контакты
     headings:
       announcements: Наши объявления
       documents: Документы

--- a/config/locales/si/world_location_news.yml
+++ b/config/locales/si/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 si:
   world_location_news:
+    find_out_more: සම්පූර්ණ පැතිකඩ සහ සියලු සබඳතා විස්තර බලන්න
     headings:
       announcements: අපේ නිවේදන
       documents: ලේඛන

--- a/config/locales/sk/world_location_news.yml
+++ b/config/locales/sk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sk:
   world_location_news:
+    find_out_more: Pozrite si celý profil a všetky kontaktné údaje
     headings:
       announcements: Naše oznámenia
       documents: Dokumenty

--- a/config/locales/sl/world_location_news.yml
+++ b/config/locales/sl/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sl:
   world_location_news:
+    find_out_more: Oglejte si celoten profil in vse kontaktne podatke
     headings:
       announcements: Naši razglasi
       documents: Dokumenti

--- a/config/locales/so/world_location_news.yml
+++ b/config/locales/so/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 so:
   world_location_news:
+    find_out_more: Eeg borofaayl dhamaystiran iyo dhamaan faahfaahinta meesha lagala xidhiidhayo
     headings:
       announcements: Ku dhawaaqisahayaga
       documents: Dukumentiyada

--- a/config/locales/sq/world_location_news.yml
+++ b/config/locales/sq/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sq:
   world_location_news:
+    find_out_more: Shikoni profilin e plotë dhe të gjitha detajet e kontaktit
     headings:
       announcements: Njoftimet tona
       documents: Dokumentet

--- a/config/locales/sr/world_location_news.yml
+++ b/config/locales/sr/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sr:
   world_location_news:
+    find_out_more: Pogledajte pun profil i sve kontakt detalje
     headings:
       announcements: Naša saopštenja
       documents: Dokumenti

--- a/config/locales/sv/world_location_news.yml
+++ b/config/locales/sv/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sv:
   world_location_news:
+    find_out_more: Se hela profilen och alla kontaktuppgifter
     headings:
       announcements: Våra tillkännagivanden
       documents: Dokument

--- a/config/locales/sw/world_location_news.yml
+++ b/config/locales/sw/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 sw:
   world_location_news:
+    find_out_more: Angalia wasifu wote na anwani zote za mawasiliano
     headings:
       announcements: Matangazo yetu
       documents: Hati

--- a/config/locales/ta/world_location_news.yml
+++ b/config/locales/ta/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ta:
   world_location_news:
+    find_out_more: முழு சுயவிபரத்தையும் அனைத்து தொடர்பு விபரங்களையும் காண்க
     headings:
       announcements: எங்கள் அறிவிப்புகள்
       documents: ஆவணங்கள்

--- a/config/locales/th/world_location_news.yml
+++ b/config/locales/th/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 th:
   world_location_news:
+    find_out_more: ดูรายแฟ้มประวัติฉบับเต็มและรายละเอียดการติดต่อทั้งหมด
     headings:
       announcements: ประกาศของเรา
       documents: เอกสาร

--- a/config/locales/tk/world_location_news.yml
+++ b/config/locales/tk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 tk:
   world_location_news:
+    find_out_more: Doly maglumatlarymyzy we ähli habarlaşmak üçin maglumatlarymyzy okaň
     headings:
       announcements: Biziň bildirişlerimiz
       documents: Resminamalar

--- a/config/locales/tr/world_location_news.yml
+++ b/config/locales/tr/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 tr:
   world_location_news:
+    find_out_more: Tüm profil ve tüm irtibat bilgilerine bakın
     headings:
       announcements: Duyurularımız
       documents: Belgeler

--- a/config/locales/uk/world_location_news.yml
+++ b/config/locales/uk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 uk:
   world_location_news:
+    find_out_more: Дивіться повний профіль та всі контактні дані
     headings:
       announcements: Наші оголошення
       documents: Документи

--- a/config/locales/ur/world_location_news.yml
+++ b/config/locales/ur/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 ur:
   world_location_news:
+    find_out_more: پوری پروفائل اور رابطے کی تمام تفصیلات دیکھیں
     headings:
       announcements: ہمارے اعلانات
       documents: دستاویزات

--- a/config/locales/uz/world_location_news.yml
+++ b/config/locales/uz/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 uz:
   world_location_news:
+    find_out_more: Тўлиқ профиль ва боғланиш учун маълумотларни кўринг
     headings:
       announcements: Бизнинг эълонлар
       documents: Ҳужжатлар

--- a/config/locales/vi/world_location_news.yml
+++ b/config/locales/vi/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 vi:
   world_location_news:
+    find_out_more: Xem hồ sơ đầy đủ và tất cả các chi tiết liên hệ
     headings:
       announcements: Thông báo của chúng tôi
       documents: Tài liệu

--- a/config/locales/yi/world_location_news.yml
+++ b/config/locales/yi/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 yi:
   world_location_news:
+    find_out_more:
     headings:
       announcements:
       documents: דאָקומענטן

--- a/config/locales/zh-hk/world_location_news.yml
+++ b/config/locales/zh-hk/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 zh-hk:
   world_location_news:
+    find_out_more: 查閱全部資訊和聯絡資料
     headings:
       announcements: 我們的公告
       documents: 文件

--- a/config/locales/zh-tw/world_location_news.yml
+++ b/config/locales/zh-tw/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 zh-tw:
   world_location_news:
+    find_out_more: 查看完整資料和所有聯繫細節
     headings:
       announcements: 我們的公告
       documents: 文檔

--- a/config/locales/zh/world_location_news.yml
+++ b/config/locales/zh/world_location_news.yml
@@ -1,6 +1,7 @@
 ---
 zh:
   world_location_news:
+    find_out_more: 查看完整简介和全部联系方式
     headings:
       announcements: 我们的公告
       documents: 文件

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -217,6 +217,38 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when there are no worldwide organisations" do
+    before do
+      stub_content_store_has_item(base_path, content_item_without_link(content_item, "worldwide_organisations"))
+    end
+
+    it "does not include the section" do
+      visit base_path
+
+      expect(page).to_not have_text("See full profile and all contact details")
+    end
+  end
+
+  context "when there are worldwide organisations" do
+    it "includes the title" do
+      visit base_path
+
+      expect(page).to have_text("UK delegation to nowhere")
+    end
+
+    it "includes the description" do
+      visit base_path
+
+      expect(page).to have_text("Information about our delegation")
+    end
+
+    it "includes a link to the worldwide organisation" do
+      visit base_path
+
+      expect(page).to have_link("See full profile and all contact details", href: "/world/nowhere")
+    end
+  end
+
   context "when requesting the atom feed" do
     let(:related_documents) { { "An announcement on World Locations" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
 

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -197,6 +197,26 @@ RSpec.feature "World Location News pages" do
     end
   end
 
+  context "when there are no organisations" do
+    before do
+      stub_content_store_has_item(base_path, content_item_without_link(content_item, "organisations"))
+    end
+
+    it "does not include a link to the organisations" do
+      visit base_path
+
+      expect(page).to_not have_text("Organisations")
+    end
+  end
+
+  context "when there are organisations" do
+    it "includes logos for the organisations" do
+      visit base_path
+
+      expect(page).to have_css(".gem-c-organisation-logo", count: 2)
+    end
+  end
+
   context "when requesting the atom feed" do
     let(:related_documents) { { "An announcement on World Locations" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
 
@@ -226,6 +246,11 @@ private
 
   def content_item_without_detail(content_item, key_to_remove)
     content_item["details"] = content_item["details"].except(key_to_remove)
+    content_item
+  end
+
+  def content_item_without_link(content_item, key_to_remove)
+    content_item["links"] = content_item["links"].except(key_to_remove)
     content_item
   end
 end

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -74,6 +74,14 @@
           "brand": "department-2"
        }
       }
+    ],
+    "worldwide_organisations": [
+      {
+        "content_id": "world-org-1",
+        "title": "UK delegation to nowhere",
+        "base_path": "/world/nowhere",
+        "description": "Information about our delegation"
+      }
     ]
   }
 }

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -50,6 +50,30 @@
         "locale": "en",
         "base_path": "/world/somewhere"
       }
+    ],
+    "organisations": [
+      {
+        "content_id": "org-1",
+        "title": "Department 1",
+        "base_path": "government/organisations/department-1",
+        "details": {
+          "logo": {
+            "crest": "single-identity"
+          },
+          "brand": "department-1"
+        }
+      },
+      {
+        "content_id": "org-2",
+        "title": "Department 2",
+        "base_path": "government/organisations/department-2",
+        "details": {
+          "logo": {
+            "crest": "single-identity"
+          },
+          "brand": "department-2"
+       }
+      }
     ]
   }
 }

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -121,4 +121,31 @@ RSpec.describe WorldLocationNews do
   it "should include the type" do
     expect(world_location_news.type).to eq("world_location")
   end
+
+  it "should map the organisations" do
+    expect(world_location_news.organisations).to eq([
+      {
+        content_id: "org-1",
+        base_path: "government/organisations/department-1",
+        title: "Department 1",
+        details: {
+          logo: {
+            crest: "single-identity",
+          },
+          brand: "department-1",
+        },
+      }.deep_stringify_keys,
+      {
+        content_id: "org-2",
+        base_path: "government/organisations/department-2",
+        title: "Department 2",
+        details: {
+          logo: {
+            crest: "single-identity",
+          },
+          brand: "department-2",
+        },
+      }.deep_stringify_keys,
+    ])
+  end
 end

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -148,4 +148,15 @@ RSpec.describe WorldLocationNews do
       }.deep_stringify_keys,
     ])
   end
+
+  it "should map the worldwide organisations" do
+    expect(world_location_news.worldwide_organisations).to eq([
+      {
+        content_id: "world-org-1",
+        base_path: "/world/nowhere",
+        title: "UK delegation to nowhere",
+        description: "Information about our delegation",
+      }.deep_stringify_keys,
+    ])
+  end
 end


### PR DESCRIPTION
International Delegation pages are a subtype of World Location News.

They include a number of additional sections, which are added into the page in this PR.

The style of some elements has changed slightly, as we move away from Whitehall's own rendering of components to properly using GOV.UK Publishing Components.

Additionally, Whitehall renders the incorrect crest for organisations that do not use the coat of arms, incorrectly uses the FCDO colour scheme for all organisations and links to FCDO on all organisation logos.  This is fixed in the Collections rendered version.

## Screenshots
| Collections  | Whitehall  |
|---|---|
| ![Screenshot showing an international delegation page rendered by Collections.  The logo crest for the Ministry of Defence is now correctly showing the MoD crest, rather than the coat of arms. ](https://user-images.githubusercontent.com/6329861/200557022-378b9cb6-95b3-45bd-b990-ea299c374bd0.png) | ![Screenshot showing the same international delegation page rendered by Whitehall.](https://user-images.githubusercontent.com/6329861/200552290-23f08a3f-9454-42d9-b6cf-52aa3d1f2183.png) |

This PR is dependent on https://github.com/alphagov/publishing-api/pull/2187 being merged and the Worldwide Organisation pages republished.

[Trello card](https://trello.com/c/SHpTX3sI/364-get-collections-to-render-additional-information-for-international-delegation-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
