### PR TITLE
Add redirect from root path to browse

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   # content-store (by collections-publisher) - whenever the routes below
   # change, also change the routes claimed by collections-publisher.
 
+  get "/", to: redirect(path: :browse)
+
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }


### PR DESCRIPTION
Sometimes users and devs are confused when they go to the root path on preview apps and see an error. Previously there was just no route set there. Setting this to redirect to Browse as a minor fix, given that Collections primarily renders topics, seems sensible.

A good iteration would be to add something akin to the [development page in government-frontend](https://github.com/alphagov/government-frontend/blob/main/app/views/development/index.html.erb)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
