### PR TITLE
Fix wrong variable name in set-automatic-deploys GitHub workflow.

### DIFF
--- a/.github/workflows/set-automatic-deploys.yaml
+++ b/.github/workflows/set-automatic-deploys.yaml
@@ -28,7 +28,7 @@ jobs:
     name: Set automatic deploys
     uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys.yaml@main
     with:
-      automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploys == 'enabled' }}
+      automaticDeploysEnabled: ${{ github.event.inputs.setAutomaticDeploys == 'enabled' }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_ARGO_EVENTS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
This fixes a bug where the `Set automatic deploys` workflow would always disable automatic deploys even with the input `setAutomaticDeploys=enable`.

Tested: [ran from branch](https://github.com/alphagov/collections/actions/runs/3471035053/jobs/5799996274), observed that the webhook is now called with `AUTOMATIC_DEPLOYS_ENABLED: true` when `setAutomaticDeploys=enable`
