### PR TITLE
Add Research Panel banner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,4 +1,6 @@
 class BrowseController < ApplicationController
+  include ResearchPanelBannerHelper
+
   slimmer_template "gem_layout_full_width"
 
   def index
@@ -10,6 +12,7 @@ class BrowseController < ApplicationController
   end
 
   def show
+    @sign_up_url = signup_url_for(request.path)
     page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
     setup_content_item_and_navigation_helpers(page)
 

--- a/app/controllers/second_level_browse_page_controller.rb
+++ b/app/controllers/second_level_browse_page_controller.rb
@@ -1,5 +1,8 @@
 class SecondLevelBrowsePageController < ApplicationController
+  include ResearchPanelBannerHelper
+
   def show
+    @sign_up_url = signup_url_for(request.path)
     setup_content_item_and_navigation_helpers(page)
     @dimension26 = count_link_sections(page)
     @dimension27 = count_total_links(page)

--- a/app/helpers/research_panel_banner_helper.rb
+++ b/app/helpers/research_panel_banner_helper.rb
@@ -1,0 +1,16 @@
+module ResearchPanelBannerHelper
+  SIGNUP_URL = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=GOV.UK&utm_source=govukhp&utm_medium=gov.uk&t=GDS&id=456".freeze
+  RECRUITMENT_PAGES = {
+    "/bank-holidays" => SIGNUP_URL,
+    "/browse/benefits" => SIGNUP_URL,
+    "/browse/births-deaths-marriages/register-offices" => SIGNUP_URL,
+    "/browse/disabilities" => SIGNUP_URL,
+    "/browse/disabilities/work" => SIGNUP_URL,
+    "/browse/driving/driving-licences" => SIGNUP_URL,
+  }.freeze
+
+  def signup_url_for(path)
+    key = RECRUITMENT_PAGES.keys.find { |topic| path.eql?(topic) }
+    RECRUITMENT_PAGES[key]
+  end
+end

--- a/app/helpers/research_panel_banner_helper.rb
+++ b/app/helpers/research_panel_banner_helper.rb
@@ -1,7 +1,6 @@
 module ResearchPanelBannerHelper
   SIGNUP_URL = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=GOV.UK&utm_source=govukhp&utm_medium=gov.uk&t=GDS&id=456".freeze
   RECRUITMENT_PAGES = {
-    "/bank-holidays" => SIGNUP_URL,
     "/browse/benefits" => SIGNUP_URL,
     "/browse/births-deaths-marriages/register-offices" => SIGNUP_URL,
     "/browse/disabilities" => SIGNUP_URL,
@@ -12,5 +11,9 @@ module ResearchPanelBannerHelper
   def signup_url_for(path)
     key = RECRUITMENT_PAGES.keys.find { |topic| path.eql?(topic) }
     RECRUITMENT_PAGES[key]
+  end
+
+  def recruitment_pages
+    RECRUITMENT_PAGES.keys
   end
 end

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -18,13 +18,24 @@
   } %>
 <% end %>
 
-<%= render "shared/browse_header", { margin_bottom: 9 } do %>
+<%= render "shared/browse_header", @sign_up_url ? { margin_bottom: 6 } : { margin_bottom: 9 } do %>
   <h1 class="browse__heading govuk-heading-xl">
     <%= page.title %>
   </h1>
   <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-2">
     <%= page.description %>
   </p>
+<% end %>
+
+<% if @sign_up_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help make GOV.UK better",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: @sign_up_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <%= render "shared/browse_cards_container" do %>

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -32,6 +32,17 @@
   </p>
 <% end %>
 
+<% if @sign_up_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help make GOV.UK better",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: @sign_up_url,
+      new_tab: true,
+    } %>
+  </div>
+<% end %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">

--- a/spec/features/research_panel_banner_spec.rb
+++ b/spec/features/research_panel_banner_spec.rb
@@ -1,0 +1,31 @@
+require "integration_spec_helper"
+
+RSpec.feature "Research panel banner" do
+  include SearchApiHelpers
+  include ResearchPanelBannerHelper
+
+  scenario "browse page is where we want to display research panel banner" do
+    recruitment_pages.each do |base_path|
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      schema["base_path"] = base_path
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], [base_path], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector(".gem-c-intervention")
+    end
+  end
+
+  scenario "browse page is not where we want to display the research panel banner" do
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to_not have_selector(".gem-c-intervention")
+  end
+end

--- a/spec/helpers/research_panel_banner_helper_spec.rb
+++ b/spec/helpers/research_panel_banner_helper_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe ResearchPanelBannerHelper do
+  include ResearchPanelBannerHelper
+
+  describe "#sign_up_url_for" do
+    let(:sign_up_url) { ResearchPanelBannerHelper::SIGNUP_URL }
+
+    it "returns SIGN_UP_URL for benefits, births-deaths-marriages/register-office, disabilities, disabilities/work, driving/driving-licences" do
+      ["/browse/benefits",
+       "/browse/births-deaths-marriages/register-offices",
+       "/browse/disabilities",
+       "/browse/disabilities/work",
+       "/browse/driving/driving-licences"].each do |browse_path|
+        expect(signup_url_for(browse_path)).to eq(sign_up_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

A selection of pages under /browse will show an intervention banner for recruiting users onto a research panel for user research.

These will be:

- /browse/benefits
- /browse/births-deaths-marriages/register-offices
- /browse/disabilities
- /browse/disabilities/work
- /browse/driving/driving-licences

See also related change in [Frontend for /bank-holidays page](url)

[Trello](https://trello.com/c/881ZGZm5/1497-banner-request-for-govuk-panel-m)

## Screenshots

### Before

#### Desktop

![www gov uk_browse_benefits(iPad Air)](https://user-images.githubusercontent.com/424772/203289943-94328adc-4c9f-4310-91e4-3728470e46aa.png)

#### Mobile

![www gov uk_browse(iPhone SE)](https://user-images.githubusercontent.com/424772/203826795-6a071d14-a081-4f81-b2ea-08906d1676f8.png)

### After

#### Desktop

![localhost_3070_browse_benefits(iPad Air)](https://user-images.githubusercontent.com/424772/203826422-fefe4379-9cbc-4d35-acd4-e29ca4efb6f1.png)

#### Mobile

![localhost_3070_browse_benefits(iPhone SE)](https://user-images.githubusercontent.com/424772/203826456-dc85e25b-c0dd-4f55-a3e2-043246fad0db.png)
