### PR TITLE
Use content_ids for curated lists

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,5 +14,6 @@ class Document
     :content_store_document_type,
     :organisations,
     :image_url,
+    :content_id,
   )
 end

--- a/app/models/list_set.rb
+++ b/app/models/list_set.rb
@@ -48,8 +48,8 @@ private
 
   def curated_list
     curated_data = @group_data.map do |group|
-      contents = group["contents"].map do |base_path|
-        content_tagged_to_tag.find { |content| content.base_path == base_path }
+      contents = group["content_ids"].map do |content_id|
+        content_tagged_to_tag.find { |content| content.content_id == content_id }
       end
 
       ListSet::List.new(group["name"], contents.compact) if contents.any?
@@ -63,7 +63,7 @@ private
       :start => 0,
       :count => SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
       filter_name => [@tag_content_id],
-      :fields => %w[title link format],
+      :fields => %w[title link format content_id],
     )
   end
 

--- a/app/models/search_api_search.rb
+++ b/app/models/search_api_search.rb
@@ -23,6 +23,7 @@ class SearchApiSearch
         content_store_document_type: result["content_store_document_type"],
         organisations:,
         image_url: result["image_url"],
+        content_id: result["content_id"],
       )
     end
   end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -43,11 +43,18 @@ module TopicHelper
               "/what-is-oil",
               "/apply-for-an-oil-licence",
             ],
+            content_ids: %w[
+              what-is-oil-content-id
+              apply-for-an-oil-licence-content-id
+            ],
           },
           {
             name: "Piping",
             contents: [
               "/well-application-form",
+            ],
+            content_ids: %w[
+              well-application-form-content-id
             ],
           },
         ],

--- a/spec/features/subtopic_page_spec.rb
+++ b/spec/features/subtopic_page_spec.rb
@@ -52,11 +52,18 @@ RSpec.feature "Subtopic pages" do
                 "/oil-rig-staffing",
                 "/oil-rig-safety-requirements",
               ],
+              content_ids: %w[
+                oil-rig-staffing-content-id
+                oil-rig-safety-requirements-content-id
+              ],
             },
             {
               name: "Piping",
               contents: [
                 "/undersea-piping-restrictions",
+              ],
+              content_ids: %w[
+                undersea-piping-restrictions-content-id
               ],
             },
           ],
@@ -176,7 +183,7 @@ RSpec.feature "Subtopic pages" do
       expect(titles).to eq(expected_titles)
     end
 
-    fit "paginates the results" do
+    it "paginates the results" do
       # Given there is latest content for a subtopic
       search_api_has_latest_documents_for_subtopic(
         "content-id-for-offshore",
@@ -234,11 +241,17 @@ RSpec.feature "Subtopic pages" do
               contents: [
                 "/oil-rig-safety-requirements",
               ],
+              content_ids: %w[
+                oil-rig-safety-requirements-content-id
+              ],
             },
             {
               name: "Piping",
               contents: [
                 "/undersea-piping-restrictions",
+              ],
+              content_ids: %w[
+                undersea-piping-restrictions-content-id
               ],
             },
           ],

--- a/spec/models/list_set_spec.rb
+++ b/spec/models/list_set_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe ListSet do
             "/pay-psa",
             "/pay-paye-penalty",
           ],
+          "content_ids" => %w[
+            pay-paye-tax-content-id
+            pay-psa-content-id
+            pay-paye-penalty-content-id
+          ],
         },
         {
           "name" => "Annual PAYE and payroll tasks",
@@ -17,6 +22,11 @@ RSpec.describe ListSet do
             "/payroll-annual-reporting",
             "/get-paye-forms-p45-p60",
             "/employee-tax-codes",
+          ],
+          "content_ids" => %w[
+            payroll-annual-reporting-content-id
+            get-paye-forms-p45-p60-content-id
+            employee-tax-codes-content-id
           ],
         },
       ]
@@ -64,10 +74,14 @@ RSpec.describe ListSet do
         "contents" => [
           "/pay-bear-tax",
         ],
+        "content_ids" => %w[
+          pay-bear-tax-content-id
+        ],
       }
       group_data << {
         "name" => "Empty group",
         "contents" => [],
+        "content_ids" => [],
       }
 
       expect(list_set.count).to eq(2)
@@ -208,6 +222,40 @@ RSpec.describe ListSet do
       results = list_set.first.contents
       expect(results.length).to eq(1)
       expect(results.first.title).to eq("Baz")
+    end
+  end
+
+  describe "for a curated subtopic, when document's slug changed" do
+    let(:group_data) do
+      [
+        {
+          "name" => "Paying HMRC",
+          "contents" => [
+            "/pay-paye-tax-old-base-path",
+          ],
+          "content_ids" => %w[
+            pay-paye-tax-content-id
+          ],
+        },
+      ]
+    end
+
+    before do
+      search_api_has_documents_for_subtopic(
+        "paye-content-id",
+        %w[
+          pay-paye-tax
+        ],
+        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+      )
+    end
+
+    let(:list_set) { described_class.new("specialist_sector", "paye-content-id", group_data) }
+
+    it "provides the title and new base_path for group items" do
+      groups = list_set.to_a
+
+      expect(groups.first.contents.first.base_path).to eq("/pay-paye-tax")
     end
   end
 end

--- a/spec/support/search_api_helpers.rb
+++ b/spec/support/search_api_helpers.rb
@@ -195,6 +195,7 @@ module SearchApiHelpers
       "document_type" => "edition",
       "content_store_document_type" => "guidance",
       "organisations" => [{ "title" => "Tagged Organisation Title" }],
+      "content_id" => "#{slug}-content-id",
     }
   end
 


### PR DESCRIPTION
## Context

When a content item is tagged to a curated Mainstream browse or Specialist topic and this content item’s slug changes, the link disappears from the topic page. This is because the curated lists/groups are based on base paths. The “contents” slugs/base paths don’t get updated as a part of dependency resolution in Publishing API.

## What
Use content_ids to present curated lists instead of base_paths, as they are less volatile.

## How to test it

### Example steps to replicate the issue

In Publisher:
1. Create a new edition of a document tagged to [a curated Mainstream browse page](https://www.integration.publishing.service.gov.uk/browse/childcare-parenting/childcare) (you can only edit slug of a draft edition)
2. Metatags -> change slug -> Save
3. Submit for 2i -> Skip review -> Publish 

In the Frontend: 
- the tag is removed from the Mainstream browse curated list
- content Item: still has the old slug in [“details”][“groups”]

In Collections Publisher:
- Content appears under Unused links
- The content (list item) appears in the List but link goes to https://content-tagger.integration.publishing.service.gov.uk/taggings/lookup

### What should happen
There should be no change in the rendering app and Collections Publisher i.e. the item should remain in the list.

## Depends on
- https://github.com/alphagov/publishing-api/pull/2201
- https://github.com/alphagov/collections-publisher/pull/1749
- https://github.com/alphagov/collections-publisher/pull/1772
- [x] All Mainstream browse pages and Specialist topics have been republished

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
