### PR TITLE
Update tracking on accordions

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -53,22 +53,9 @@
 } if heading %>
 <div data-module="gem-track-click">
   <div data-module="toggle-attribute">
-    <%
-      show_all_attributes = {
-        event_name: "select_content",
-        type: "accordion",
-        index: 0,
-        index_total: number_of_accordion_sections,
-      }
-    %>
     <%= render 'govuk_publishing_components/components/accordion', {
       heading_level: 3,
-      data_attributes: {
-        module: "ga4-event-tracker",
-      },
-      data_attributes_show_all: {
-        "ga4": show_all_attributes.to_json
-      },
+      ga4_tracking: true,
       items: accordion_contents,
       margin_bottom: 3
     } %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -86,22 +86,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="browse__section">
-
         <div data-module="toggle-attribute">
           <%= render "govuk_publishing_components/components/accordion", {
             track_show_all_clicks: true,
             track_sections: true,
-            data_attributes: {
-              module: "ga4-event-tracker",
-            },
-            data_attributes_show_all: {
-              "ga4": {
-                event_name: "select_content",
-                type: "accordion",
-                index: 0,
-                index_total: content.body[:accordion_content].map.size
-              }.to_json,
-            },
+            ga4_tracking: true,
             items: accordion_contents,
           } %>
         </div>

--- a/app/views/world_wide_taxons/accordion.html.erb
+++ b/app/views/world_wide_taxons/accordion.html.erb
@@ -48,21 +48,8 @@
             }
           %>
         <% end %>
-        <%
-          show_all_attributes = {
-            event_name: "select_content",
-            type: "accordion",
-            index: 0,
-            index_total: number_of_accordion_sections
-          }
-        %>
         <%= render 'govuk_publishing_components/components/accordion', {
-          data_attributes: {
-            module: "ga4-event-tracker",
-          },
-          data_attributes_show_all: {
-            "ga4": show_all_attributes.to_json
-          },
+          ga4_tracking: true,
           items: items
         } %>
       </div>


### PR DESCRIPTION
**DO NOT MERGE this change unless it also includes a [new version of the components gem](https://github.com/alphagov/govuk_publishing_components/pull/3091) with the mentioned change below**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

- ahead of a change to how tracking and accordion tracking works, update accordions to have the simpler `ga4_tracking:true` option instead of passing multiple data attributes

Pages that this occurs on:

- https://www.gov.uk/coronavirus
- https://www.gov.uk/cost-of-living
- https://www.gov.uk/world/afghanistan

## Why
We've been changing how tracking works a little, specifically in https://github.com/alphagov/govuk_publishing_components/pull/3082 and this PR updates to take account of that change.

## Visual changes
None.

Trello card: https://trello.com/c/LIhvDkyC/279-simplify-adding-ga4-tracking-to-accordions
