### PR TITLE
Remove old GA4 attribute

### DIFF
--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -29,14 +29,7 @@
         track_action: "accordionClosed",
         track_label: section["title"],
         track_dimension: number_of_accordion_sections,
-        track_dimension_index: 26,
-        ga4: {
-          event_name: 'select_content',
-          type: 'accordion',
-          text: section["title"],
-          index: index,
-          index_total: number_of_accordion_sections,
-        }
+        track_dimension_index: 26
       }
     }
 

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -22,13 +22,6 @@
         "track-count": "accordionSection",
         "track-options": {
           "dimension114": list_index + 1
-        },
-        ga4: {
-          event_name: 'select_content',
-          type: 'accordion',
-          text: list[:heading],
-          index: list_index + 1,
-          index_total: content.body[:accordion_content].map.size,
         }
       },
     }

--- a/app/views/world_wide_taxons/accordion.html.erb
+++ b/app/views/world_wide_taxons/accordion.html.erb
@@ -27,14 +27,7 @@
             items << {
               data_attributes: {
                 "track-count": "accordionSection",
-                id: "section-panel-#{id}-#{index + 1}",
-                ga4: {
-                  event_name: 'select_content',
-                  type: 'accordion',
-                  text: taxon.title,
-                  index: index + 1,
-                  index_total: number_of_accordion_sections,
-                }
+                id: "section-panel-#{id}-#{index + 1}"
               },
               heading: {
                 text: taxon.title,


### PR DESCRIPTION
Hi @andysellick, would you be able to approve this? Thanks :+1:

We do not need this attribute now as we are using `ga4_tracking: true`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
