### PR TITLE
Add ga4 tracking to step by step nav components

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id)
+    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id, ga4_tracking: true)
   end
 
   def self.find!(base_path)


### PR DESCRIPTION
This will enable tracking on the 'Step by step' nav components when the latest version of `govuk_publishing_components` is released.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
