### PR TITLE
Remove 'ga4_tracking: true' from step by step nav

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id, ga4_tracking: true)
+    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id)
   end
 
   def self.find!(base_path)


### PR DESCRIPTION
We have noticed a bug so we'll remove the tracking for now.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
