### PR TITLE
Add development

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,22 @@
+class DevelopmentController < ApplicationController
+  layout false
+
+  def index
+    @schema_names = %w[
+      coronavirus_landing_page
+      finder
+      mainstream_browse_page
+      ministerial_role
+      organisation
+      person
+      services_and_information
+      step_by_step_nav
+      taxon
+      topic
+      topical_event
+      world_location_news
+    ]
+
+    @paths = YAML.load_file(Rails.root.join("config/govuk_examples.yml"))
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>collections development page</title>
+  <meta name="robots" content="noindex, nofollow">
+  <%= stylesheet_link_tag "application", integrity: false %>
+</head>
+<body>
+<div id="wrapper">
+  <main class="govspeak">
+    <%= render "govuk_publishing_components/components/title", title: "collections" %>
+    <% html = capture do %>
+      <p>Here is a list of the content types that collections renders and an example page.</p>
+      <table>
+        <% @paths.each do |name, path| %>
+          <tr>
+            <td>
+              <%= name %>
+            </td>
+            <td>
+              <%= link_to path, path %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    <% end %>
+    <%= render 'govuk_publishing_components/components/govspeak', content: html %>
+  </main>
+</div>
+</body>
+</html>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -1,0 +1,13 @@
+---
+coronavirus_landing_page: /coronavirus
+finder: /government/organisations
+mainstream_browse_page: /browse/driving
+ministerial_role: /government/ministers/secretary-of-state-for-education
+organisation: /government/organisations/companies-house
+person: /government/people/matthew-hancock
+services_and_information: /government/organisations/hm-revenue-customs/services-information
+step_by_step_nav: /get-tax-free-childcare
+taxon: /transport/driving-and-motorcycle-tests
+topic: /topic/personal-tax/self-assessment
+topical_event: /government/topical-events/autumn-statement-2022
+world_location_news: /world/ukraine/news

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,10 @@ Rails.application.routes.draw do
 
   get "/cost-of-living", to: "cost_of_living_landing_page#show", as: :cost_of_living_landing_page
 
+  unless Rails.env.production?
+    get "/development", to: "development#index"
+  end
+
   get "/browse.json" => redirect("/api/content/browse")
 
   resources :browse, only: %i[index show], param: :top_level_slug do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add an info page listing examples of pages the app renders.

## What

Add a page for dev mode to show a list of example pages this app renders.

## Why

We have a page like this for `government-frontend`. As we consolidate our rendering apps and they render more and more content types, it's hard to track/remember.

[Trello card](https://trello.com/c/RysOWfk4/68-add-an-index-page-to-frontend-apps-like-in-government-frontend)

## Screenshots?

![localhost_3070_development(iPad Air)](https://user-images.githubusercontent.com/424772/205980088-3ec15178-7bc0-4fa8-957b-47cd56f4818e.png)

