### PR TITLE
Remove "contents" from curated lists stubs and a redundant test

### DIFF
--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -39,10 +39,6 @@ module TopicHelper
         groups: [
           {
             name: "Oil rigs",
-            contents: [
-              "/what-is-oil",
-              "/apply-for-an-oil-licence",
-            ],
             content_ids: %w[
               what-is-oil-content-id
               apply-for-an-oil-licence-content-id
@@ -50,9 +46,6 @@ module TopicHelper
           },
           {
             name: "Piping",
-            contents: [
-              "/well-application-form",
-            ],
             content_ids: %w[
               well-application-form-content-id
             ],

--- a/spec/features/subtopic_page_spec.rb
+++ b/spec/features/subtopic_page_spec.rb
@@ -48,10 +48,6 @@ RSpec.feature "Subtopic pages" do
           groups: [
             {
               name: "Oil rigs",
-              contents: [
-                "/oil-rig-staffing",
-                "/oil-rig-safety-requirements",
-              ],
               content_ids: %w[
                 oil-rig-staffing-content-id
                 oil-rig-safety-requirements-content-id
@@ -59,9 +55,6 @@ RSpec.feature "Subtopic pages" do
             },
             {
               name: "Piping",
-              contents: [
-                "/undersea-piping-restrictions",
-              ],
               content_ids: %w[
                 undersea-piping-restrictions-content-id
               ],
@@ -238,18 +231,12 @@ RSpec.feature "Subtopic pages" do
           groups: [
             {
               name: "Oil rigs",
-              contents: [
-                "/oil-rig-safety-requirements",
-              ],
               content_ids: %w[
                 oil-rig-safety-requirements-content-id
               ],
             },
             {
               name: "Piping",
-              contents: [
-                "/undersea-piping-restrictions",
-              ],
               content_ids: %w[
                 undersea-piping-restrictions-content-id
               ],

--- a/spec/models/list_set_spec.rb
+++ b/spec/models/list_set_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe ListSet do
       [
         {
           "name" => "Paying HMRC",
-          "contents" => [
-            "/pay-paye-tax",
-            "/pay-psa",
-            "/pay-paye-penalty",
-          ],
           "content_ids" => %w[
             pay-paye-tax-content-id
             pay-psa-content-id
@@ -18,11 +13,6 @@ RSpec.describe ListSet do
         },
         {
           "name" => "Annual PAYE and payroll tasks",
-          "contents" => [
-            "/payroll-annual-reporting",
-            "/get-paye-forms-p45-p60",
-            "/employee-tax-codes",
-          ],
           "content_ids" => %w[
             payroll-annual-reporting-content-id
             get-paye-forms-p45-p60-content-id
@@ -61,7 +51,7 @@ RSpec.describe ListSet do
     end
 
     it "skips items no longer tagged to this subtopic" do
-      group_data[0]["contents"] << "/pay-bear-tax"
+      group_data[0]["content_ids"] << "/pay-bear-tax-content-id"
 
       groups = list_set.to_a
       expect(groups[0].contents.size).to eq(3)
@@ -71,16 +61,12 @@ RSpec.describe ListSet do
     it "omits groups with no active items in them" do
       group_data << {
         "name" => "Group with untagged items",
-        "contents" => [
-          "/pay-bear-tax",
-        ],
         "content_ids" => %w[
           pay-bear-tax-content-id
         ],
       }
       group_data << {
         "name" => "Empty group",
-        "contents" => [],
         "content_ids" => [],
       }
 
@@ -222,40 +208,6 @@ RSpec.describe ListSet do
       results = list_set.first.contents
       expect(results.length).to eq(1)
       expect(results.first.title).to eq("Baz")
-    end
-  end
-
-  describe "for a curated subtopic, when document's slug changed" do
-    let(:group_data) do
-      [
-        {
-          "name" => "Paying HMRC",
-          "contents" => [
-            "/pay-paye-tax-old-base-path",
-          ],
-          "content_ids" => %w[
-            pay-paye-tax-content-id
-          ],
-        },
-      ]
-    end
-
-    before do
-      search_api_has_documents_for_subtopic(
-        "paye-content-id",
-        %w[
-          pay-paye-tax
-        ],
-        page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
-      )
-    end
-
-    let(:list_set) { described_class.new("specialist_sector", "paye-content-id", group_data) }
-
-    it "provides the title and new base_path for group items" do
-      groups = list_set.to_a
-
-      expect(groups.first.contents.first.base_path).to eq("/pay-paye-tax")
     end
   end
 end


### PR DESCRIPTION
We migrated to use "content_ids" instead of "contents"

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
