### PR TITLE
Replace markup with components

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -46,10 +46,6 @@ $browse-header-background-colour: #263135;
   margin-bottom: govuk-spacing(6);
 }
 
-.browse__description {
-  margin-bottom: govuk-spacing(2);
-}
-
 .browse__section {
   margin-bottom: govuk-spacing(9);
 

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -18,9 +18,11 @@
   <h1 class="browse__heading govuk-heading-xl">
     <%= t("browse.title") %>
   </h1>
-  <p class="browse__description gem-c-lead-paragraph gem-c-lead-paragraph--inverse">
-    <%= t("browse.description") %>
-  </p>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: t("browse.description"),
+    margin_bottom: 2,
+    inverse: true
+  } %>
 <% end %>
 
 <%= render "shared/browse_cards_container" do %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -22,9 +22,11 @@
   <h1 class="browse__heading govuk-heading-xl">
     <%= page.title %>
   </h1>
-  <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-2">
-    <%= page.description %>
-  </p>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: page.description,
+    margin_bottom: 2,
+    inverse: true
+  } %>
 <% end %>
 
 <% if @sign_up_url %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -41,10 +41,11 @@
   <h1 class="browse__heading govuk-heading-xl">
     <%= content.header[:heading] %>
   </h1>
-  <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-6">
-    <%= content.header[:lede] %>
-  </p>
-
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: content.header[:lede],
+    margin_bottom: 6,
+    inverse: true
+  } %>
 <% end %>
 
 <div class="colhub__announcement" data-module="gem-track-click">

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -26,10 +26,11 @@
     margin_bottom: 6,
     text: page.title,
   } %>
-
-  <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-2">
-    <%= page.description %>
-  </p>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: page.description,
+    margin_bottom: 2,
+    inverse: true
+  } %>
 <% end %>
 
 <% if @sign_up_url %>

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -26,10 +26,11 @@
     margin_bottom: 6,
     text: page.title,
   } %>
-
-  <p class="gem-c-lead-paragraph gem-c-lead-paragraph--inverse govuk-!-margin-bottom-2">
-    <%= page.description %>
-  </p>
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: page.description,
+    margin_bottom: 2,
+    inverse: true
+  } %>
 <% end %>
 
 <div class="govuk-width-container">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace copies of `govuk_publishing_components` components with actual components on the [browse pages](https://www.gov.uk/browse) and [cost of living page](https://www.gov.uk/cost-of-living).

- markup from component had been copied into template and restyled, breaking component isolation rule
- same effect can be achieved by using options within the component to control margin and appearance
- no visual changes

## Why
Using the components directly allows ease of future updates, improves developer confidence when making a change to a component, and reduces unnecessary code in applications.

## Visual changes
None.
