### PR TITLE
Move 'Follow Us' out of 'What We Do' Row for No. 10 Org Page

### DIFF
--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -8,7 +8,7 @@
         lang: t_fallback('organisations.corporate_information')
       } %>
     <% end %>
-  <% if @show.corporate_information[:corporate_information_links][:items].any? %>
+  <% if @show.corporate_information[:corporate_information_links][:items].any? && !@organisation.is_no_10? %>
     <div class="<%= "organisation__section-border-top" if @organisation.is_promotional_org? %>">
       <%= render "components/topic-list", @show.corporate_information[:corporate_information_links] %>
     </div>
@@ -25,9 +25,25 @@
     <%= render "components/topic-list", @show.corporate_information[:job_links] %>
   <% end %>
 
-  <% if @organisation.secondary_corporate_information %>
+  <% if @organisation.secondary_corporate_information && !@organisation.is_no_10? %>
     <p class="organisation__secondary-corporate-information brand--<%= @organisation.brand %>">
       <%= @organisation.secondary_corporate_information.html_safe %>
     </p>
+  <% end %>
+
+  <% if @organisation.is_no_10? && @what_we_do.has_share_links? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t('organisations.follow_us'),
+        margin_bottom: 3,
+        heading_level: 3,
+        font_size: 19,
+        padding: true,
+        border_top: 5,
+        brand: @organisation.brand,        
+        lang: t_fallback('organisations.follow_us')
+      } %>
+      <div lang="en">
+        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links %>
+      </div>
   <% end %>
 </div>

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -27,7 +27,7 @@
       <% end %>
     </div>
 
-    <% if @what_we_do.has_share_links? %>
+    <% if @what_we_do.has_share_links? && !@organisation.is_no_10? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/heading", {
           text: t('organisations.follow_us'),


### PR DESCRIPTION
## What

Move 'Follow Us' column out of the same row as 'What We Do' for No. 10 Organisation page. Move 'Follow Us' to same row as 'Contact No. 10' in place of 'About Us'.

## Why

As part of the new design for No. 10 pages, there are some changes in layout. This is the most trivial to do with the least changes needing to be made to content of the page, so therefore it has been done first.

## Visual Differences

### Before

![Screenshot 2022-12-16 at 11 06 34](https://user-images.githubusercontent.com/3727504/208085442-4ccb8a63-1f95-4860-9401-e4bb9997294d.png)


![Screenshot 2022-12-16 at 11 06 39](https://user-images.githubusercontent.com/3727504/208085437-a2b58d59-3799-4fb7-976b-8afcdfda5236.png)

### After

![Screenshot 2022-12-16 at 14 14 02](https://user-images.githubusercontent.com/3727504/208117486-2654a736-313b-45c3-b36d-c1dc3fa5a85c.png)

![Screenshot 2022-12-16 at 14 14 06](https://user-images.githubusercontent.com/3727504/208117482-87069072-77de-402c-a0a0-310bf73c365e.png)

