### PR TITLE
Changes to promotional items on No. 10 page

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -77,6 +77,7 @@ module Organisations
           brand: org.brand,
           heading_level: 3,
           large: @org.is_no_10?,
+          extra_details_no_indent: @org.is_no_10?,
         }
 
         if item["title"].present?

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -76,6 +76,7 @@ module Organisations
           end,
           brand: org.brand,
           heading_level: 3,
+          large: @org.is_no_10?,
         }
 
         if item["title"].present?

--- a/app/views/organisations/_promotional_features_no_10.html.erb
+++ b/app/views/organisations/_promotional_features_no_10.html.erb
@@ -1,0 +1,16 @@
+<% if @documents.has_promotional_features? %>
+<section class="organisation__margin-bottom organisation__section-wrap">
+  <% @documents.promotional_features.each do |feature| %>
+    <div class="">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: feature[:title],
+        heading_level: 2,
+        padding: true,
+        border_top: 5,
+        brand: @organisation.brand
+      } %>
+      <%= render "govuk_publishing_components/components/image_card", feature[:items].first %>
+    </div>
+  <% end %>
+</section>
+<% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -7,8 +7,11 @@
 <%= render partial: 'featured_news' %>
 <%= render partial: 'latest_documents' %>
 <%= render partial: 'what_we_do' %>
-<% if @organisation.is_promotional_org? %>
+<% if @organisation.is_promotional_org? && !@organisation.is_no_10? %>
   <%= render partial: 'promotional_features' %>
+<% end %>
+<% if @organisation.is_promotional_org? && @organisation.is_no_10? %>
+  <%= render partial: 'promotional_features_no_10' %>
 <% end %>
 <% unless @organisation.is_promotional_org? %>
   <% if @supergroups.has_groups? && !@organisation.is_promotional_org?  %>

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -123,14 +123,53 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
         ],
+        first_item: {
+          description: "Story 1-1",
+          href: "https://www.gov.uk/government/policies/1-1",
+          image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
+          image_alt: "Image 1-1",
+          extra_details: [
+            {
+              text: "Single departmental plans",
+              href: "https://www.gov.uk/government/collections/1-1",
+            },
+            {
+              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/1-1",
+            },
+          ],
+          brand: nil,
+          heading_level: 3,
+          large: false,
+        },
       },
       {
         title: "Two features",
         number_of_items: 2,
         parent_column_class: "column-2",
         child_column_class: "govuk-grid-column-one-half",
+        first_item: {
+          description: "Story 2-1",
+          href: "https://www.gov.uk/government/policies/2-1",
+          image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
+          image_alt: "Image 2-1",
+          extra_details: [
+            {
+              text: "Single departmental plans",
+              href: "https://www.gov.uk/government/collections/2-1",
+            },
+            {
+              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-1",
+            },
+          ],
+          brand: nil,
+          heading_level: 3,
+          large: false,
+        },
         items: [
           {
             description: "Story 2-1",
@@ -149,6 +188,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
           {
             description: "Story 2-2",
@@ -167,6 +207,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
         ],
       },
@@ -175,6 +216,25 @@ RSpec.describe Organisations::DocumentsPresenter do
         number_of_items: 3,
         parent_column_class: "column-3",
         child_column_class: "govuk-grid-column-one-third",
+        first_item: {
+          description: "Story 3-1<br/><br/>And a new line",
+          href: "https://www.gov.uk/government/policies/3-1",
+          image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
+          image_alt: "Image 3-1",
+          extra_details: [
+            {
+              text: "Single departmental plans",
+              href: "https://www.gov.uk/government/collections/3-1",
+            },
+            {
+              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-1",
+            },
+          ],
+          brand: nil,
+          heading_level: 3,
+          large: false,
+        },
         items: [
           {
             description: "Story 3-1<br/><br/>And a new line",
@@ -193,6 +253,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
           {
             description: "Story 3-2",
@@ -211,6 +272,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
           {
             description: "Story 3-3",
@@ -230,6 +292,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: false,
           },
         ],
       },

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -124,52 +124,15 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
           },
         ],
-        first_item: {
-          description: "Story 1-1",
-          href: "https://www.gov.uk/government/policies/1-1",
-          image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
-          image_alt: "Image 1-1",
-          extra_details: [
-            {
-              text: "Single departmental plans",
-              href: "https://www.gov.uk/government/collections/1-1",
-            },
-            {
-              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
-              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/1-1",
-            },
-          ],
-          brand: nil,
-          heading_level: 3,
-          large: false,
-        },
       },
       {
         title: "Two features",
         number_of_items: 2,
         parent_column_class: "column-2",
         child_column_class: "govuk-grid-column-one-half",
-        first_item: {
-          description: "Story 2-1",
-          href: "https://www.gov.uk/government/policies/2-1",
-          image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
-          image_alt: "Image 2-1",
-          extra_details: [
-            {
-              text: "Single departmental plans",
-              href: "https://www.gov.uk/government/collections/2-1",
-            },
-            {
-              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
-              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-1",
-            },
-          ],
-          brand: nil,
-          heading_level: 3,
-          large: false,
-        },
         items: [
           {
             description: "Story 2-1",
@@ -189,6 +152,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
           },
           {
             description: "Story 2-2",
@@ -208,6 +172,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
           },
         ],
       },
@@ -216,25 +181,6 @@ RSpec.describe Organisations::DocumentsPresenter do
         number_of_items: 3,
         parent_column_class: "column-3",
         child_column_class: "govuk-grid-column-one-third",
-        first_item: {
-          description: "Story 3-1<br/><br/>And a new line",
-          href: "https://www.gov.uk/government/policies/3-1",
-          image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
-          image_alt: "Image 3-1",
-          extra_details: [
-            {
-              text: "Single departmental plans",
-              href: "https://www.gov.uk/government/collections/3-1",
-            },
-            {
-              text: "Prime Minister's and Cabinet Office ministers' transparency publications",
-              href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-1",
-            },
-          ],
-          brand: nil,
-          heading_level: 3,
-          large: false,
-        },
         items: [
           {
             description: "Story 3-1<br/><br/>And a new line",
@@ -254,6 +200,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
           },
           {
             description: "Story 3-2",
@@ -273,6 +220,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
           },
           {
             description: "Story 3-3",
@@ -293,6 +241,163 @@ RSpec.describe Organisations::DocumentsPresenter do
             brand: nil,
             heading_level: 3,
             large: false,
+            extra_details_no_indent: false,
+          },
+        ],
+      },
+    ]
+
+    expect(documents_presenter.promotional_features).to eq(expected)
+  end
+
+  it "formats promotional features data correctly if organisation is No. 10" do
+    documents_presenter = presenter_from_organisation_hash(organisation_no_10)
+
+    stub_search_api_latest_content_requests("prime-ministers-office-10-downing-street")
+
+    expected = [
+      {
+        title: "One feature",
+        number_of_items: 1,
+        parent_column_class: "column-1",
+        child_column_class: nil,
+        items: [
+          {
+            description: "Story 1-1",
+            href: "https://www.gov.uk/government/policies/1-1",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
+            image_alt: "Image 1-1",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/1-1",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/1-1",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
+          },
+        ],
+      },
+      {
+        title: "Two features",
+        number_of_items: 2,
+        parent_column_class: "column-2",
+        child_column_class: "govuk-grid-column-one-half",
+        items: [
+          {
+            description: "Story 2-1",
+            href: "https://www.gov.uk/government/policies/2-1",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
+            image_alt: "Image 2-1",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/2-1",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-1",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
+          },
+          {
+            description: "Story 2-2",
+            href: "https://www.gov.uk/government/policies/2-2",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
+            image_alt: "Image 2-2",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/2-2",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-2",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
+          },
+        ],
+      },
+      {
+        title: "Three features",
+        number_of_items: 3,
+        parent_column_class: "column-3",
+        child_column_class: "govuk-grid-column-one-third",
+        items: [
+          {
+            description: "Story 3-1<br/><br/>And a new line",
+            href: "https://www.gov.uk/government/policies/3-1",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
+            image_alt: "Image 3-1",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/3-1",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-1",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
+          },
+          {
+            description: "Story 3-2",
+            href: "https://www.gov.uk/government/policies/3-3",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
+            image_alt: "Image 3-2",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/3-2",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-2",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
+          },
+          {
+            description: "Story 3-3",
+            href: "https://www.gov.uk/government/policies/3-3",
+            image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
+            image_alt: "Image 3-3",
+            heading_text: "An unexpected title",
+            extra_details: [
+              {
+                text: "Single departmental plans",
+                href: "https://www.gov.uk/government/collections/3-3",
+              },
+              {
+                text: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-3",
+              },
+            ],
+            brand: "prime-ministers-office-10-downing-street",
+            heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
           },
         ],
       },

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -376,6 +376,146 @@ module OrganisationHelpers
     }.with_indifferent_access
   end
 
+  def organisation_no_10
+    {
+      title: "Prime Minister's Office, 10 Downing Street",
+      base_path: "/government/organisations/prime-ministers-office-10-downing-street",
+      details: {
+        ordered_promotional_features: [
+          {
+            title: "One feature",
+            items: [
+              {
+                title: "",
+                href: "https://www.gov.uk/government/policies/1-1",
+                summary: "Story 1-1",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
+                  alt_text: "Image 1-1",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/1-1",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/1-1",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: "Two features",
+            items: [
+              {
+                title: "",
+                href: "https://www.gov.uk/government/policies/2-1",
+                summary: "Story 2-1",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
+                  alt_text: "Image 2-1",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/2-1",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-1",
+                  },
+                ],
+              },
+              {
+                title: "",
+                href: "https://www.gov.uk/government/policies/2-2",
+                summary: "Story 2-2",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
+                  alt_text: "Image 2-2",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/2-2",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/2-2",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: "Three features",
+            items: [
+              {
+                title: "",
+                href: "https://www.gov.uk/government/policies/3-1",
+                summary: "Story 3-1\r\n\r\nAnd a new line",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
+                  alt_text: "Image 3-1",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/3-1",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-1",
+                  },
+                ],
+              },
+              {
+                title: "",
+                href: "https://www.gov.uk/government/policies/3-3",
+                summary: "Story 3-2",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
+                  alt_text: "Image 3-2",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/3-2",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-2",
+                  },
+                ],
+              },
+              {
+                title: "An unexpected title",
+                href: "https://www.gov.uk/government/policies/3-3",
+                summary: "Story 3-3",
+                image: {
+                  url: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
+                  alt_text: "Image 3-3",
+                },
+                links: [
+                  {
+                    title: "Single departmental plans",
+                    href: "https://www.gov.uk/government/collections/3-3",
+                  },
+                  {
+                    title: "Prime Minister's and Cabinet Office ministers' transparency publications",
+                    href: "https://www.gov.uk/government/collections/ministers-transparency-publications/3-3",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    }.with_indifferent_access
+  end
+
   def organisation_with_featured_documents
     {
       title: "Attorney General's Office",


### PR DESCRIPTION
## What 

New partial for promotional features for No. 10 pages that only uses the first item of a promotional feature and renders it using the large variant of the image card. Update the `documents_presenter `to set `large` to true for an item if it is part of a promotional feature on the No. 10 page. Update the `documents_presenter `to set `extra_details_no_indent` to true for an item if it is part of a promotional feature on the No. 10 page.  This item gets passed to the image card component.

## Why

In the new redesign for the No. 10 organisation page, the promotional features are no longer in columns but take up entire rows. Each promotional item also no longer will show any other items than the first item. The extra details of each promotional item is no longer indented in the design, so this has been included in this PR.

## Visual Differences

### Before

![Screenshot 2022-12-16 at 12 14 22](https://user-images.githubusercontent.com/3727504/208096206-c7bce204-9954-4501-8d02-cb60b8e48467.png)

### After

![Screenshot 2022-12-16 at 15 05 18](https://user-images.githubusercontent.com/3727504/208127354-007f7957-e8e0-49f5-b12d-703c2f802eb1.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
