### PR TITLE
Add GA4 tracking to step by step nav

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id)
+    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id, ga4_tracking: true)
   end
 
   def self.find!(base_path)


### PR DESCRIPTION
Hi @JamesCGDS,

Would you be able to approve this? No rush as I believe there won't be any analyst reviews until after Christmas.

It adds the `ga4_tracking: true` boolean to the Step by Step navigation. The "Show all steps" and "Headings" get the `data-ga4-event` attribute when this is set to true, and the parent element gets the `ga4-event-tracker` module loaded on it. All of this is handled within `govuk_publishing_components` so all we have to do here is add the boolean to the template render.

If you want to see it working the test page is http://127.0.0.1:3070/learn-to-drive-a-car or http://collections.dev.gov.uk/learn-to-drive-a-car - you'll need static running for collections to run properly. It doesn't matter which branch of static you're on, and you don't need a local publishing components, since everything required to make this work is in the `main` branch of publishing components already.

Thanks :+1: 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
