### PR TITLE
Add new non-accordion section to Cost of living navigation page

### DIFF
--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -20,7 +20,7 @@
                  link_item[:href],
                  class: "govuk-link",
                  data: presenter.link_clicked_track_data(
-                  track_action: accordion_heading,
+                  track_action: list_heading,
                   href: link_item[:href]
                  ),
                ) %>
@@ -40,7 +40,7 @@
             content_item[:href],
             class: "govuk-link",
             data: presenter.link_clicked_track_data(
-              track_action: accordion_heading,
+              track_action: list_heading,
               href: content_item[:href]
              ),
           ) %>

--- a/app/views/cost_of_living_landing_page/_links.html.erb
+++ b/app/views/cost_of_living_landing_page/_links.html.erb
@@ -1,3 +1,5 @@
+<% dashes_before_important_info ||= nil %>
+
 <ul role="list" class="govuk-list browse__list" data-module="gem-track-click">
   <% list.each_with_index do |content_item, index| %>
     <% if content_item[:links] %>
@@ -24,7 +26,9 @@
                   href: link_item[:href]
                  ),
                ) %>
-               <% if link_item[:important_info] %>- <%= link_item[:important_info] %><% end %>
+               <% if link_item[:important_info] %>
+                 <% if dashes_before_important_info %>- <% end %><%= link_item[:important_info] %>
+               <% end %>
              </li>
               <% end %>
             <% end %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -13,7 +13,7 @@
       content: {
         html: render(partial: "links", locals: {
           presenter: content,
-          accordion_heading: list[:heading],
+          list_heading: list[:heading],
           list: list[:content],
           list_index: list_index,
         }),
@@ -110,7 +110,7 @@
             <h2><%= list[:heading] %></h2>
             <%= render(partial: "links", locals: {
                   presenter: content,
-                  accordion_heading: list[:heading],
+                  list_heading: list[:heading],
                   list: list[:content],
                   list_index: list_index,
                 } ) %>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -84,8 +84,6 @@
   </div>
 </div>
 
-
-
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -97,6 +95,26 @@
             ga4_tracking: true,
             items: accordion_contents,
           } %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="browse__section">
+        <div data-module="toggle-attribute">
+          <% content.body[:non_accordion_content].each_with_index do |list, list_index| %>
+            <h2><%= list[:heading] %></h2>
+            <%= render(partial: "links", locals: {
+                  presenter: content,
+                  accordion_heading: list[:heading],
+                  list: list[:content],
+                  list_index: list_index,
+                } ) %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -16,6 +16,7 @@
           list_heading: list[:heading],
           list: list[:content],
           list_index: list_index,
+          dashes_before_important_info: true,
         }),
       },
       data_attributes: {
@@ -113,6 +114,7 @@
                   list_heading: list[:heading],
                   list: list[:content],
                   list_index: list_index,
+                  dashes_before_important_info: false,
                 } ) %>
           <% end %>
         </div>

--- a/config/cost_of_living_landing_page/content_item.yml
+++ b/config/cost_of_living_landing_page/content_item.yml
@@ -338,3 +338,21 @@ body:
         href: /business-finance-support?keywords=energy
       - link_text: Find out about support with your energy bills on the Citizens Advice website
         href: https://www.citizensadvice.org.uk/consumer/energy/energy-supply/your-small-businesss-energy-supply/your-small-business-cant-afford-its-energy-bills/
+  non_accordion_content:
+  - heading: If you’re finding things difficult
+    content:
+    - subheading:
+      links:
+      - link_text: Get support with money and mental health from the Mind website
+        href: https://www.mind.org.uk/information-support/tips-for-everyday-living/money-and-mental-health/
+      - link_text: Call the Samaritans on 116 123
+        important_info: to talk to a trained volunteer anonymously for free. Welsh speakers can call 0808 164 0123 between 7pm and 11pm
+        href: https://www.samaritans.org/
+      - link_text: Text ‘SHOUT’ to 85258
+        important_info: to message with a trained volunteer anonymously for free
+        href: https://giveusashout.org/
+      - link_text: Call Refuge on 0808 2000 247
+        important_info: for support with domestic abuse
+        href: https://www.nationaldahelpline.org.uk/
+      - link_text: Get urgent support with mental health on the NHS website
+        href: https://www.nhs.uk/nhs-services/mental-health-services/where-to-get-urgent-help-for-mental-health/

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "Cost of Living hub page" do
       and_there_is_an_important_info_suffix_on_some_link
       and_there_is_link_tracking
       and_there_is_accordion_section_tracking
+      and_there_is_non_accordion_section
     end
 
     def when_i_visit_the_cost_of_living_landing_page
@@ -68,6 +69,10 @@ RSpec.feature "Cost of Living hub page" do
       accordion_section = page.first(".govuk-accordion__section-heading")
 
       expect(accordion_section["data-track-count"]).to eq("accordionSection")
+    end
+
+    def and_there_is_non_accordion_section
+      expect(page).to have_text("If you’re finding things difficult")
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/wdi4icPC/1535-add-a-new-static-section-at-the-bottom-of-the-page-for-wellbeing)

## New section

<kbd><img width="538" alt="Screenshot 2022-12-20 at 08 33 48" src="https://user-images.githubusercontent.com/38078064/208626610-eff977be-f43e-41f3-9698-05b0ee6738dc.png"></kbd>

We are reusing the existing partial. It was requested by a content designer that there are no dashes in the links on
the "If you’re finding things difficult" section so I had to add this option.

Example with dashes in the accordion section (unchanged):
-  <kbd><img width="486" alt="Screenshot 2022-12-20 at 14 56 39" src="https://user-images.githubusercontent.com/38078064/208696540-48feb1ba-fea6-4700-b778-d6bfbfcd6123.png"></kbd>


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
