### PR TITLE
Promotional features on organisation pages

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -31,33 +31,6 @@
   }
 }
 
-.organisation__promotions {
-  @include govuk-media-query($from: tablet) {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-direction: row;
-    flex-direction: row;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-    margin-left: -(govuk-spacing(3));
-    margin-right: -(govuk-spacing(3));
-
-    .column-1 {
-      padding: 0 govuk-spacing(3);
-      width: calc(100% / 3 - 30px);
-    }
-
-    .column-2 {
-      width: 50%;
-    }
-
-    .column-3 {
-      padding: 0 govuk-spacing(3);
-      width: 100%;
-    }
-  }
-}
-
 .organisation__contact-section {
   word-wrap: break-word;
 

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -76,6 +76,7 @@ module Organisations
           end,
           brand: org.brand,
           heading_level: 3,
+          extra_details_no_indent: true,
         }.merge(make_full_width(number_of_items))
 
         if item["title"].present?
@@ -89,10 +90,7 @@ module Organisations
     def make_full_width(number_of_items)
       return {} unless number_of_items == 1
 
-      {
-        large: true,
-        extra_details_no_indent: true,
-      }
+      { large: true }
     end
 
     def featured_news(featured, first_featured: false)

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -30,7 +30,6 @@ module Organisations
     def promotional_features
       org.ordered_promotional_features.map do |feature|
         number_of_items = feature["items"].length
-
         {
           title: feature["title"],
           number_of_items:,
@@ -62,6 +61,7 @@ module Organisations
   private
 
     def items_for_a_promotional_feature(feature)
+      number_of_items = feature["items"].length
       feature["items"].map do |item|
         data = {
           description: item["summary"].gsub("\r\n", "<br/>").html_safe,
@@ -76,7 +76,7 @@ module Organisations
           end,
           brand: org.brand,
           heading_level: 3,
-        }
+        }.merge(make_full_width(number_of_items))
 
         if item["title"].present?
           data[:heading_text] = item["title"]
@@ -84,6 +84,15 @@ module Organisations
 
         data
       end
+    end
+
+    def make_full_width(number_of_items)
+      return {} unless number_of_items == 1
+
+      {
+        large: true,
+        extra_details_no_indent: true,
+      }
     end
 
     def featured_news(featured, first_featured: false)

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -33,7 +33,6 @@ module Organisations
         {
           title: feature["title"],
           number_of_items:,
-          parent_column_class: "column-#{number_of_items}",
           child_column_class: promotions_child_column_class(number_of_items),
           items: items_for_a_promotional_feature(feature),
         }

--- a/app/views/organisations/_promotional_features.html.erb
+++ b/app/views/organisations/_promotional_features.html.erb
@@ -1,7 +1,7 @@
 <% if @documents.has_promotional_features? %>
 <section class="organisation__margin-bottom organisation__section-wrap">
   <% @documents.promotional_features.each do |feature| %>
-    <div>
+    <div class="organisation__promotion">
       <%= render "govuk_publishing_components/components/heading", {
         text: feature[:title],
         heading_level: 2,

--- a/app/views/organisations/_promotional_features.html.erb
+++ b/app/views/organisations/_promotional_features.html.erb
@@ -1,7 +1,7 @@
 <% if @documents.has_promotional_features? %>
-<section class="organisation__margin-bottom organisation__promotions">
+<section class="organisation__margin-bottom organisation__section-wrap">
   <% @documents.promotional_features.each do |feature| %>
-    <div class="<%= feature[:parent_column_class] %>">
+    <div>
       <%= render "govuk_publishing_components/components/heading", {
         text: feature[:title],
         heading_level: 2,

--- a/app/views/organisations/_promotional_features.html.erb
+++ b/app/views/organisations/_promotional_features.html.erb
@@ -9,14 +9,19 @@
         border_top: 5,
         brand: @organisation.brand
       } %>
-
-      <div class="<%= "govuk-grid-row" if feature[:number_of_items] > 1 %>">
+      <% if feature[:number_of_items] > 1 %>
+        <div class="govuk-grid-row">
+          <% feature[:items].each do |item| %>
+            <div class="<%= feature[:child_column_class] %>">
+              <%= render "govuk_publishing_components/components/image_card", item %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
         <% feature[:items].each do |item| %>
-          <div class="<%= feature[:child_column_class] %>">
-            <%= render "govuk_publishing_components/components/image_card", item %>
-          </div>
+          <%= render "govuk_publishing_components/components/image_card", item %>
         <% end %>
-      </div>
+      <% end %>
     </div>
   <% end %>
 </section>

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -123,6 +123,8 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            large: true,
+            extra_details_no_indent: true,
           },
         ],
       },

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            extra_details_no_indent: true,
           },
           {
             description: "Story 2-2",
@@ -169,6 +170,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            extra_details_no_indent: true,
           },
         ],
       },
@@ -195,6 +197,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            extra_details_no_indent: true,
           },
           {
             description: "Story 3-2",
@@ -213,6 +216,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            extra_details_no_indent: true,
           },
           {
             description: "Story 3-3",
@@ -232,6 +236,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             ],
             brand: nil,
             heading_level: 3,
+            extra_details_no_indent: true,
           },
         ],
       },

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe Organisations::DocumentsPresenter do
       {
         title: "One feature",
         number_of_items: 1,
-        parent_column_class: "column-1",
         child_column_class: nil,
         items: [
           {
@@ -131,7 +130,6 @@ RSpec.describe Organisations::DocumentsPresenter do
       {
         title: "Two features",
         number_of_items: 2,
-        parent_column_class: "column-2",
         child_column_class: "govuk-grid-column-one-half",
         items: [
           {
@@ -177,7 +175,6 @@ RSpec.describe Organisations::DocumentsPresenter do
       {
         title: "Three features",
         number_of_items: 3,
-        parent_column_class: "column-3",
         child_column_class: "govuk-grid-column-one-third",
         items: [
           {


### PR DESCRIPTION
When a promotional feature contains only one item, expand the column to fill the whole row.

When it contains many items, no change in current behaviour. ie split into columns.

This change was requested as part of the number 10 page redesign, but is being rolled out to all organisation pages.

Trello: https://trello.com/c/nLPbdLc9/36-use-featured-section-for-meet-the-prime-minister-speech-history-m-l

### Review app
- https://collections-pr-3096.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
- https://collections-pr-3096.herokuapp.com/government/organisations/civil-service

### Before
<img width="542" alt="Screenshot 2022-12-19 at 18 14 14" src="https://user-images.githubusercontent.com/17908089/208492460-20cbbca3-f83e-449e-9dbc-e7b41720f562.png">

---
### After
<img width="586" alt="Screenshot 2022-12-20 at 14 57 48" src="https://user-images.githubusercontent.com/17908089/208696803-c3ba4e41-af4e-4d11-b71d-35127e386ddc.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
