### PR TITLE
Align person's role to work with rtl locale

### DIFF
--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/title", {
       context: person.current_roles_title,
       title: person.title


### PR DESCRIPTION
As flagged in [this ticket](https://govuk.zendesk.com/agent/tickets/5091639), a person's role wasn't being aligned to be right-to-left if required by the locale (compare this to the body of the bio on the person page which is aligned correctly).

See an example on https://collections-pr-3098.herokuapp.com/government/people/simon-penney.ar

(We've split request 1. from the above ticket to a [separate ticket](https://trello.com/c/o0kP6R0s/193-remove-space-between-and-and-the-following-word-for-arabic-when-person-has-multiple-roles) as it requires an Arabic speaker to confirm the correct behaviour in all the contexts.)

Fixes https://trello.com/c/GhM9scaZ/1491-fix-arabic-translations-in-people-and-roles-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
