### PR TITLE
Add youtube_video_id & handle images not being present for promotional features

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -65,8 +65,9 @@ module Organisations
         data = {
           description: item["summary"].gsub("\r\n", "<br/>").html_safe,
           href: promotional_feature_link(item["href"]),
-          image_src: item["image"]["url"],
-          image_alt: item["image"]["alt_text"],
+          image_src: item.dig("image", "url"),
+          image_alt: item.dig("image", "alt_text"),
+          youtube_video_id: item["youtube_video_id"],
           extra_details: item["links"].map do |link|
             {
               text: link["title"],

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -110,6 +110,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/1-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
             image_alt: "Image 1-1",
+            youtube_video_id: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -137,6 +138,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/2-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
             image_alt: "Image 2-1",
+            youtube_video_id: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -156,6 +158,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/2-2",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
             image_alt: "Image 2-2",
+            youtube_video_id: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -182,6 +185,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/3-1",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
             image_alt: "Image 3-1",
+            youtube_video_id: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -201,6 +205,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             href: "https://www.gov.uk/government/policies/3-3",
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
             image_alt: "Image 3-2",
+            youtube_video_id: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -218,8 +223,9 @@ RSpec.describe Organisations::DocumentsPresenter do
           {
             description: "Story 3-3",
             href: "https://www.gov.uk/government/policies/3-3",
-            image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
-            image_alt: "Image 3-3",
+            image_src: nil,
+            image_alt: nil,
+            youtube_video_id: "fFmDQn9Lbl4",
             heading_text: "An unexpected title",
             extra_details: [
               {

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -753,10 +753,7 @@ module OrganisationHelpers
                 title: "An unexpected title",
                 href: "https://www.gov.uk/government/policies/3-3",
                 summary: "Story 3-3",
-                image: {
-                  url: "https://assets.publishing.service.gov.uk/government/uploads/3-3.jpg",
-                  alt_text: "Image 3-3",
-                },
+                youtube_video_id: "fFmDQn9Lbl4",
                 links: [
                   {
                     title: "Single departmental plans",


### PR DESCRIPTION
## Description

We're adding the ability for PromotionalFeatureItems to have an image or a youtube_video_id.

This PR does two things:

1. Stops the DocumentsPresenter from blowing up when a
PromotionalFeature doesn't have an image.
2. Sets the youtube_video_id for a PromotionalFeatureItem when present

If an image or youtube video id is missing it sets the corresponding attrs to nil.

Once merged nothing will change until we merge these PRs

Whitehall - https://github.com/alphagov/whitehall/pull/7193
Publishing API ContentSchema changes - https://github.com/alphagov/publishing-api/pull/2237

For now the Whitehall changes are hidden behind a permission so we don't have to worry about youtube video ids showing up on ContentItems. For now, they will continue to always have an image.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
