### PR TITLE
Simplify organisation view template

### DIFF
--- a/app/views/organisations/_standard_org_docs_people.html.erb
+++ b/app/views/organisations/_standard_org_docs_people.html.erb
@@ -1,0 +1,15 @@
+<% if @supergroups.has_groups? %>
+    <%= render partial: 'latest_documents_by_supergroup' %>
+<% end %>
+<% if @people.has_people? %>
+    <div id="people">
+        <% @people.all_people.each do |people_data| %>
+        <%= render partial: 'related_people', locals: {
+            people: people_data[:people],
+            title: people_data[:title],
+            lang: people_data[:lang],
+            brand: @organisation.brand
+        } %>
+        <% end %>
+    </div>
+<% end %>

--- a/app/views/organisations/_standard_org_foi_profiles.html.erb
+++ b/app/views/organisations/_standard_org_foi_profiles.html.erb
@@ -1,0 +1,13 @@
+<%= render partial: 'freedom_of_information' %>
+<% if @show.high_profile_groups[:items].present? %>
+    <section class="organisation__margin-bottom" id="high-profile-groups">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: @show.high_profile_groups[:title],
+        brand: @organisation.brand,
+        border_top: 5,
+        padding: true,
+        margin_bottom: 3
+    } %>
+    <%= render "components/topic-list", @show.high_profile_groups %>
+    </section>
+<% end %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -9,41 +9,14 @@
 <%= render partial: 'what_we_do' %>
 <% if @organisation.is_promotional_org? %>
   <%= render partial: 'promotional_features' %>
-<% end %>
-<% unless @organisation.is_promotional_org? %>
-  <% if @supergroups.has_groups? && !@organisation.is_promotional_org?  %>
-    <%= render partial: 'latest_documents_by_supergroup' %>
-  <% end %>
-  <% if @people.has_people? %>
-    <div id="people">
-      <% @people.all_people.each do |people_data| %>
-        <%= render partial: 'related_people', locals: {
-            people: people_data[:people],
-            title: people_data[:title],
-            lang: people_data[:lang],
-            brand: @organisation.brand
-        } %>
-      <% end %>
-    </div>
-  <% end %>
+<% else %>
+  <%= render partial: 'standard_org_docs_people' %>
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'org_contacts', locals: { contacts: @contacts } %>
     <% unless @organisation.is_promotional_org? %>
-      <%= render partial: 'freedom_of_information' %>
-    <% end %>
-    <% if @show.high_profile_groups[:items].present? && !@organisation.is_promotional_org? %>
-      <section class="organisation__margin-bottom" id="high-profile-groups">
-        <%= render "govuk_publishing_components/components/heading", {
-            text: @show.high_profile_groups[:title],
-            brand: @organisation.brand,
-            border_top: 5,
-            padding: true,
-            margin_bottom: 3
-        } %>
-        <%= render "components/topic-list", @show.high_profile_groups %>
-      </section>
+      <%= render partial: 'standard_org_foi_profiles' %>
     <% end %>
   </div>
   <% if @organisation.ordered_corporate_information.present? %>


### PR DESCRIPTION
## What
Move the non-organisational content into its own template files. Remove a few now redundant conditional checks for whether an organisation is promotional or not. 

## Why
The `show` template was becoming hard to follow partly because of the length of the file and also because of a large number of conditional blocks of logic depending on whether the organisation is promotional not. 

We're currently working on adding a new organisation header to collections so this work is to prep adding some more logic to `organisations/show`. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
