### PR TITLE
Add 'Past Chancellors of the Exchequer' page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -37,6 +37,7 @@ $govuk-include-default-font-face: false;
 @import "components/*";
 
 @import "views/browse";
+@import "views/history_people";
 @import "views/topics";
 @import "views/topical_events";
 @import "views/taxons";

--- a/app/assets/stylesheets/views/_history_people.scss
+++ b/app/assets/stylesheets/views/_history_people.scss
@@ -1,0 +1,20 @@
+.historic-people-index__section-row-header {
+  @include govuk-media-query($from: tablet) {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
+.historic-people-index__section-row {
+  .govuk-body {
+    color: $govuk-secondary-text-colour;
+
+    // Targets all of the years / periods of service but the last one.
+    &:nth-last-child(n+2) {
+      margin-bottom: 0;
+    }
+
+    // Targets the last set of years in the list
+    @include govuk-responsive-margin(7, "bottom");
+  }
+}

--- a/app/controllers/past_chancellors_controller.rb
+++ b/app/controllers/past_chancellors_controller.rb
@@ -1,0 +1,347 @@
+class PastChancellorsController < ApplicationController
+  def index
+    setup_content_item_and_navigation_helpers(PastChancellors.find!(request.path))
+
+    @twentyfirst_century_chancellors = {
+      "Kwasi Kwarteng" => {
+        service: %w[2022],
+      },
+      "Nadhim Zahawi" => {
+        service: %w[2022],
+      },
+      "Rishi Sunak" => {
+        service: ["2020 to 2022"],
+      },
+      "Sajid Javid" => {
+        service: ["2019 to 2020"],
+      },
+      "Philip Hammond" => {
+        service: ["2016 to 2019"],
+      },
+      "George Osborne" => {
+        service: ["2010 to 2016"],
+      },
+      "Alistair Darling" => {
+        service: ["2007 to 2010"],
+      },
+      "Gordon Brown" => {
+        service: ["1997 to 2007"],
+      },
+    }
+
+    @twentieth_century_chancellors = {
+      "Kenneth Clarke" => {
+        service: ["1993 to 1997"],
+      },
+      "Norman Lamont" => {
+        service: ["1990 to 1993"],
+      },
+      "John Major" => {
+        service: ["1989 to 1990"],
+      },
+      "Nigel Lawson" => {
+        service: ["1983 to 1989"],
+      },
+      "Sir Geoffrey Howe" => {
+        service: ["1979 to 1983"],
+      },
+      "Denis Healey" => {
+        service: ["1974 to 1979"],
+      },
+      "Anthony Barber" => {
+        service: ["1970 to 1974"],
+      },
+      "Ian Macleod" => {
+        service: %w[1970],
+      },
+      "Roy Jenkins" => {
+        service: ["1967 to 1970"],
+      },
+      "James Callaghan" => {
+        service: ["1964 to 1967"],
+      },
+      "Reginald Maudling" => {
+        service: ["1962 to 1964"],
+      },
+      "Selwyn Lloyd" => {
+        service: ["1960 to 1962"],
+      },
+      "Derick Heathcoat-Amory" => {
+        service: ["1958 to 1960"],
+      },
+      "Peter Thorneycroft" => {
+        service: ["1957 to 1958"],
+      },
+      "Harold Macmillan" => {
+        service: ["1955 to 1957"],
+      },
+      "Rab Butler" => {
+        service: ["1951 to 1955"],
+      },
+      "Hugh Gaitskell" => {
+        service: ["1950 to 1951"],
+      },
+      "Sir Stafford Cripps" => {
+        service: ["1947 to 1950"],
+      },
+      "Hugh Dalton" => {
+        service: ["1945 to 1947"],
+      },
+      "Sir John Anderson" => {
+        service: ["1943 to 1945"],
+      },
+      "Sir Kingsley Wood" => {
+        service: ["1940 to 1943"],
+      },
+      "Sir John Simon" => {
+        service: ["1937 to 1940"],
+      },
+      "Neville Chamberlain" => {
+        service: ["1931 to 1937", "1923 to 1924"],
+      },
+      "Philip Snowden" => {
+        service: ["1929 to 1931", "1924"],
+      },
+      "Winston Churchill" => {
+        service: ["1924 to 1929"],
+      },
+      "Stanley Baldwin" => {
+        service: ["1922 to 1923"],
+      },
+      "Sir Robert Horne" => {
+        service: ["1921 to 1922"],
+      },
+      "Austen Chamberlain" => {
+        service: ["1919 to 1921", "1903 to 1905"],
+      },
+      "Bonar Law" => {
+        service: ["1916 to 1919"],
+      },
+      "Reginald McKenna" => {
+        service: ["1915 to 1916"],
+      },
+      "David Lloyd George" => {
+        service: ["1908 to 1915"],
+      },
+      "H. H. Asquith" => {
+        service: ["1905 to 1908"],
+      },
+      "Charles Ritchie" => {
+        service: ["1902 to 1903"],
+      },
+    }
+
+    @nineteenth_century_chancellors = {
+      "Sir Michael Hicks Beach, Bt" => {
+        service: ["1895 to 1902", "1885 to 1886"],
+      },
+      "Sir William Vernon Harcourt" => {
+        service: ["1892 to 1895", "1886"],
+      },
+      "George Goschen" => {
+        service: ["1887 to 1892"],
+      },
+      "Lord Randolph Churchill" => {
+        service: %w[1886],
+      },
+      "Hugh Childers" => {
+        service: ["1882 to 1885"],
+      },
+      "William Gladstone" => {
+        service: ["1880 to 1882", "1873 to 1874", "1859 to 1866", "1852 to 1855"],
+      },
+      "Sir Stafford Henry Northcote, Bt" => {
+        service: ["1874 to 1880"],
+      },
+      "Robert Lowe" => {
+        service: ["1868 to 1873"],
+      },
+      "George Ward Hunt" => {
+        service: %w[1868],
+      },
+      "Benjamin Disraeli" => {
+        service: ["1866 to 1868", "1858 to 1859", "1852"],
+      },
+      "Sir George Cornewall Lewis, Bt" => {
+        service: ["1855 to 1858"],
+      },
+      "Sir Charles Wood" => {
+        service: ["1846 to 1852"],
+      },
+      "Henry Goulburn" => {
+        service: ["1841 to 1846", "1828 to 1830"],
+      },
+      "Francis Baring" => {
+        service: ["1839 to 1841"],
+      },
+      "Thomas Spring Rice" => {
+        service: ["1835 to 1839"],
+      },
+      "Sir Robert Peel, Bt" => {
+        service: ["1834 to 1835"],
+      },
+      "Thomas Denman, 1st Baron Denman" => {
+        service: %w[1834],
+      },
+      "Viscount Althorp" => {
+        service: ["1830 to 1834"],
+      },
+      "John Charles Herries" => {
+        service: ["1827 to 1828"],
+      },
+      "The Lord Tenterden" => {
+        service: %w[1827],
+      },
+      "George Canning" => {
+        service: %w[1827],
+      },
+      "Hon. Frederick John Robinson" => {
+        service: ["1823 to 1827"],
+      },
+      "Nicholas Vansittart" => {
+        service: ["1812 to 1823"],
+      },
+      "Spencer Perceval" => {
+        service: ["1807 to 1812"],
+      },
+      "Lord Henry Petty" => {
+        service: ["1806 to 1807"],
+      },
+      "Edward Law, 1st Baron Ellenborough" => {
+        service: %w[1806],
+      },
+      "William Pitt the Younge" => {
+        service: ["1804 to 1806", "1783 to 1801", "1782 to 1783"],
+      },
+      "Henry Addington" => {
+        service: ["1801 to 1804"],
+      },
+    }
+
+    @eighteenth_century_chancellors = {
+      "Lord John Cavendish" => {
+        service: %w[1783],
+      },
+      "Lord North" => {
+        service: ["1767 to 1782"],
+      },
+      "Charles Townshend" => {
+        service: ["1766 to 1767"],
+      },
+      "William Dowdeswell" => {
+        service: ["1765 to 1766"],
+      },
+      "George Grenville" => {
+        service: ["1763 to 1765"],
+      },
+      "Sir Francis Dashwood" => {
+        service: ["1762 to 1763"],
+      },
+      "Viscount Barrington" => {
+        service: ["1761 to 1762"],
+      },
+      "Henry Bilson Legge" => {
+        service: ["1757 to 1761", "1756 to 1757", "1754 to 1755"],
+      },
+      "Lord Mansfield" => {
+        service: %w[1757],
+      },
+      "Sir George Lyttleton" => {
+        service: ["1755 to 1756"],
+      },
+      "Sir William Lee" => {
+        service: %w[1754],
+      },
+      "Henry Pelham" => {
+        service: ["1743 to 1754"],
+      },
+      "Samuel Sandys" => {
+        service: ["1742 to 1743"],
+      },
+      "Sir Robert Walpole" => {
+        service: ["1721 to 1742", "1715 to 1717"],
+      },
+      "Sir John Pratt" => {
+        service: %w[1721],
+      },
+      "John Aislabie" => {
+        service: ["1718 to 1721"],
+      },
+      "Viscount Stanhope" => {
+        service: ["1717 to 1718"],
+      },
+      "Sir Richard Onslow" => {
+        service: ["1714 to 1715"],
+      },
+      "Sir William Wyndhan" => {
+        service: ["1713 to 1714"],
+      },
+      "Robert Benson" => {
+        service: ["1711 to 1713"],
+      },
+      "Robert Harley" => {
+        service: ["1710 to 1711"],
+      },
+      "Sir John Smith" => {
+        service: ["1708 to 1710", "1699 to 1701"],
+      },
+      "Henry Boyle" => {
+        service: ["1701 to 1708"],
+      },
+    }
+
+    @sixteenth_and_seventeenth_century_chancellors = {
+      "Charles Montagu" => {
+        service: ["1694 to 1699"],
+      },
+      "Richard Hampden" => {
+        service: ["1690 to 1694"],
+      },
+      "Henry Booth" => {
+        service: ["1689 to 1690"],
+      },
+      "Sir John Ernle" => {
+        service: ["1676 to 1689"],
+      },
+      "Sir John Duncombe" => {
+        service: ["1672 to 1676"],
+      },
+      "Lord Ashley" => {
+        service: ["1661 to 1672"],
+      },
+      "Sir Edward Hyde" => {
+        service: ["1643 to 1646"],
+      },
+      "Sir John Colepepper" => {
+        service: ["1642 to 1643"],
+      },
+      "Lord Cottington" => {
+        service: ["1629 to 1642"],
+      },
+      "Lord Barrett" => {
+        service: ["1628 to 1629"],
+      },
+      "Sir Richard Weston" => {
+        service: ["1621 to 1628"],
+      },
+      "Sir Fulke Greville" => {
+        service: ["1614 to 1621"],
+      },
+      "Sir Julius Caesar" => {
+        service: ["1606 to 1614"],
+      },
+      "Earl of Dunbar" => {
+        service: ["1603 to 1606"],
+      },
+      "Sir John Fortescue" => {
+        service: ["1589 to 1603"],
+      },
+      "Sir Walter Mildmay" => {
+        service: ["1566 to 1589"],
+      },
+      "Sir Richard Sackville" => {
+        service: ["1559 to 1566"],
+      },
+    }
+  end
+end

--- a/app/models/past_chancellors.rb
+++ b/app/models/past_chancellors.rb
@@ -1,0 +1,16 @@
+require "active_model"
+
+class PastChancellors
+  include ActiveModel::Model
+
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/views/past_chancellors/_century.html.erb
+++ b/app/views/past_chancellors/_century.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row historic-people-index__section-row-header">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: heading,
+      padding: true,
+      border_top: 2,
+      font_size: "l"
+    } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<% people.each_slice(4) do |row| %>
+  <%= render partial: "row", locals: {
+    row: row,
+  } %>
+<% end %>

--- a/app/views/past_chancellors/_person.html.erb
+++ b/app/views/past_chancellors/_person.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-grid-column-one-quarter" role="listitem">
+  <%= render "govuk_publishing_components/components/heading", {
+    text: name,
+    heading_level: 3,
+    font_size: "s"
+  } %>
+  <% info[:service].each do | service | %>
+    <p class="govuk-body"><%= service %></p>
+  <% end %>
+</div>

--- a/app/views/past_chancellors/_row.html.erb
+++ b/app/views/past_chancellors/_row.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-grid-row historic-people-index__section-row">
+  <% row.each do | name, info | %>
+    <%= render partial: "person", locals: {
+      name: name,
+      info: info,
+    } %>
+  <%end%>
+</div>

--- a/app/views/past_chancellors/index.html.erb
+++ b/app/views/past_chancellors/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, @content_item["title"] %>
+
+<% page_class "historic-appointments-index historical-past-chancellors govuk-width-container" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "History",
+      title: @content_item["title"],
+    } %>
+  </div>
+</div>
+
+<%= render partial: "century", locals: { heading: "21st century", people: @twentyfirst_century_chancellors } %>
+
+<%= render partial: "century", locals: { heading: "20th century", people: @twentieth_century_chancellors } %>
+
+<%= render partial: "century", locals: { heading: "19th century", people: @nineteenth_century_chancellors } %>
+
+<%= render partial: "century", locals: { heading: "18th century", people: @eighteenth_century_chancellors } %>
+
+<%= render partial: "century", locals: { heading: "16th & 17th centuries", people: @sixteenth_and_seventeenth_century_chancellors } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       to: "services_and_information#index",
       as: :services_and_information
 
+  get "/government/history/past-chancellors", to: "past_chancellors#index"
   get "/government/people/:name(.:locale)", to: "people#show"
   get "/government/ministers(.:locale)", to: "ministers#index"
   get "/government/ministers/:name(.:locale)", to: "roles#show"

--- a/spec/controllers/past_chancellors_spec.rb
+++ b/spec/controllers/past_chancellors_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe PastChancellorsController do
+  let(:base_path) { "/government/history/past-chancellors" }
+  let(:content_item) do
+    {
+      base_path:,
+      title: "Past Chancellors of the Exchequer",
+    }
+  end
+
+  before do
+    stub_content_store_has_item(base_path, content_item)
+  end
+
+  describe "GET index" do
+    it "has a success response" do
+      get :index
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/features/past_chancellors_spec.rb
+++ b/spec/features/past_chancellors_spec.rb
@@ -1,0 +1,34 @@
+require "integration_spec_helper"
+
+RSpec.feature "Past Chancellors pages" do
+  let(:base_path) { "/government/history/past-chancellors" }
+  let(:content_item) do
+    {
+      base_path:,
+      title: "Past Chancellors of the Exchequer",
+    }
+  end
+
+  before do
+    stub_content_store_has_item(base_path, content_item)
+  end
+
+  it "sets the page title" do
+    visit base_path
+    expect(page).to have_title("#{content_item[:title]} - GOV.UK")
+  end
+
+  it "sets renders the title on the page" do
+    visit base_path
+    expect(page).to have_text(content_item[:title])
+  end
+
+  it "includes headers for each century" do
+    visit base_path
+    expect(page).to have_text("21st century")
+    expect(page).to have_text("20th century")
+    expect(page).to have_text("19th century")
+    expect(page).to have_text("18th century")
+    expect(page).to have_text("16th & 17th centuries")
+  end
+end


### PR DESCRIPTION
This code has mostly been ported over from Whitehall with few changes.

It depends on a content item being published for this route, which is covered by https://github.com/alphagov/special-route-publisher/pull/240.  Once this code is merged, we'll then need to change the rendering app to Collections, which is included in https://github.com/alphagov/special-route-publisher/pull/241.

I've split the `past_chancellors_person` partial into two parts to make it more intuitive, as this was rendering a table rather than an individual person as the name would suggest.

Screenshots showing rendering:
| Whitehall | Collections |
| --- | --- |
| ![Screenshot showing the past chancellors page rendered by Whitehall.](https://user-images.githubusercontent.com/6329861/211006008-7cb13f0d-0844-44ba-8d09-09979a7dbae9.png) | ![Screenshot showing the past chancellors page rendered by Collections.  It is visually identical to Whitehall.](https://user-images.githubusercontent.com/6329861/211006022-d081b3e5-0c7f-4415-993f-2a07f89b39b7.png)  |


[Trello card](https://trello.com/c/PgJxJILW)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
