### PR TITLE
Change contact_form in en/organisations.yml

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -8,7 +8,7 @@ en:
       organisations: Organisations
     contact:
       contact_details: Contact details
-      contact_form: 'Contact Form: %{title}'
+      contact_form: 'Contact: %{title}'
       contact_organisation: Contact %{organisation}
       email: Email
       telephone: Telephone

--- a/spec/presenters/organisations/contacts_presenter_spec.rb
+++ b/spec/presenters/organisations/contacts_presenter_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Organisations::ContactsPresenter do
             "<a class=\"govuk-link brand__color\" href=\"mailto:enquiries@trade.gov.uk\">enquiries@trade.gov.uk</a>",
           ],
           links: [
-            "<a class=\"govuk-link brand__color\" href=\"/contact\">Contact Form: Department for International Trade</a>",
+            "<a class=\"govuk-link brand__color\" href=\"/contact\">Contact: Department for International Trade</a>",
           ],
           description: nil,
         },


### PR DESCRIPTION
## What

The link to the contact form on organisation pages has been changed to 'Contact:' from 'Contact form:'. This is because sometimes the title of the contact form would include 'form' already.

## Why 

As part of the changes to the number 10 organisation page.

## Visual Differences

### Before

![Screenshot 2023-01-11 at 10 27 40](https://user-images.githubusercontent.com/3727504/211782806-1a12b5fb-08eb-4c40-82cb-f67d36d4ca62.png)

### After

![Screenshot 2023-01-11 at 10 28 01](https://user-images.githubusercontent.com/3727504/211782901-1e6bb303-a3b2-49bf-aa27-e07a35da5bee.png)





⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
