### PR TITLE
Make ruby tests a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,3 @@ jobs:
         env:
           RAILS_ENV: test
         run: bundle exec rails cucumber
-

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,8 +3,8 @@ name: Run RSpec
 on:
   workflow_call:
     inputs:
-      collectionsRef:
-        description: 'The branch, tag or SHA to checkout Collections'
+      ref:
+        description: 'The branch, tag or SHA to checkout'
         required: false
         type: string
       publishingApiRef:
@@ -14,7 +14,7 @@ on:
         type: string
 
 jobs:
-  rspec:
+  run-rspec:
     name: Run RSpec
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: alphagov/collections
-          ref: ${{ inputs.collectionsRef || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
         uses: actions/checkout@v3


### PR DESCRIPTION
This application depends on the Content Schemas. Making the tests
reusable allows Publishing API to run the tests when the Content Schemas
are updated.
