### PR TITLE
Update DocumentsPresenter to handle youtube_video_alt

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -67,7 +67,8 @@ module Organisations
           href: promotional_feature_link(item["href"]),
           image_src: item.dig("image", "url"),
           image_alt: item.dig("image", "alt_text"),
-          youtube_video_id: item["youtube_video_id"],
+          youtube_video_id: item.dig("youtube_video", "id"),
+          youtube_video_alt: item.dig("youtube_video", "alt_text"),
           extra_details: item["links"].map do |link|
             {
               text: link["title"],

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/1-1.jpg",
             image_alt: "Image 1-1",
             youtube_video_id: nil,
+            youtube_video_alt: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -139,6 +140,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-1.jpg",
             image_alt: "Image 2-1",
             youtube_video_id: nil,
+            youtube_video_alt: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -159,6 +161,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/2-2.jpg",
             image_alt: "Image 2-2",
             youtube_video_id: nil,
+            youtube_video_alt: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -186,6 +189,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-1.jpg",
             image_alt: "Image 3-1",
             youtube_video_id: nil,
+            youtube_video_alt: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -206,6 +210,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: "https://assets.publishing.service.gov.uk/government/uploads/3-2.jpg",
             image_alt: "Image 3-2",
             youtube_video_id: nil,
+            youtube_video_alt: nil,
             extra_details: [
               {
                 text: "Single departmental plans",
@@ -226,6 +231,7 @@ RSpec.describe Organisations::DocumentsPresenter do
             image_src: nil,
             image_alt: nil,
             youtube_video_id: "fFmDQn9Lbl4",
+            youtube_video_alt: "YouTube video alt text.",
             heading_text: "An unexpected title",
             extra_details: [
               {

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -753,7 +753,10 @@ module OrganisationHelpers
                 title: "An unexpected title",
                 href: "https://www.gov.uk/government/policies/3-3",
                 summary: "Story 3-3",
-                youtube_video_id: "fFmDQn9Lbl4",
+                youtube_video: {
+                  id: "fFmDQn9Lbl4",
+                  alt_text: "YouTube video alt text.",
+                },
                 links: [
                   {
                     title: "Single departmental plans",


### PR DESCRIPTION
## Description 

A Youtube video alt text needs to be provided for situations when a promotional feature items YouTube video embed fails. This exposes it on the DocumentsPresenter.

Follow up PRs to Publishing API and Whitehall will follow shortly.

## Trello card

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
