### PR TITLE
Make all the news in No. 10 large

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -114,7 +114,7 @@ module Organisations
           description: news["summary"].html_safe,
           brand: org.brand,
           heading_level: 3,
-        }
+        }.merge(org.is_no_10? ? { large: true } : {})
       end
 
       news_stories

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -18,9 +18,13 @@
   <% @documents.remaining_featured_news.in_groups_of(3, false) do |news| %>
     <div class="govuk-grid-row">
       <% news.each do |news_item| %>
-        <div class="govuk-grid-column-one-third">
+        <% classes = %w[] %>
+        <% classes << "govuk-grid-column-one-third" unless news_item[:large] %>
+        <% classes << "govuk-grid-column-full" if news_item[:large] %>
+
+        <%= content_tag(:div, class: classes) do %>
           <%= render "govuk_publishing_components/components/image_card", news_item %>
-        </div>
+        <% end %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
This PR changes the featured documents in No. 10 to use the large variant of the image card component instead of the small variant. This means that each image card is now in it's own row, instead of all the featured news being on the same row.

[Relevant Figma Design
](https://www.figma.com/file/OLtydvhClrUzLPcGodS7JS/Number-10-organisation-page?node-id=1085%3A28505&t=QnFn5iFo3XgpwkJX-0)

## Visual Differences

### Before

#### Mobile

![Screenshot 2023-01-17 at 14 56 02](https://user-images.githubusercontent.com/3727504/212931915-f2eab173-76ec-4eac-8e97-27f1207cd7a7.png)

#### Desktop

![Screenshot 2023-01-17 at 14 56 07](https://user-images.githubusercontent.com/3727504/212932036-987f2030-9428-4ab0-b870-78f24ed01e98.png)

### After

#### Mobile

![Screenshot 2023-01-17 at 14 55 46](https://user-images.githubusercontent.com/3727504/212932189-2468c340-36bf-451a-85f8-c41913a9a85e.png)

#### Desktop

![Screenshot 2023-01-17 at 14 55 40](https://user-images.githubusercontent.com/3727504/212932166-e84eb12d-0353-4538-a6b1-3bfe3376a44a.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
