### PR TITLE
Use Heading Component Instead of H2 in CoL Hub

### DIFF
--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -100,7 +100,11 @@
       <div class="browse__section">
         <div data-module="toggle-attribute">
           <% content.body[:non_accordion_content].each_with_index do |list, list_index| %>
-            <h2><%= list[:heading] %></h2>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: list[:heading],
+              font_size: "m",
+              padding: true,
+            } %>
             <%= render(partial: "links", locals: {
                   presenter: content,
                   list_heading: list[:heading],


### PR DESCRIPTION
"If you’re finding things difficult" section header was using an H2 element with no class. This meant that the font size would stay the same at all viewports. This has been replaced to use the heading component instead which will apply responsive font size styles.

## Visual Differences

These are on mobile viewports, the desktop viewport is unchanged.

### Before

![Screenshot 2023-01-16 at 10 57 19](https://user-images.githubusercontent.com/3727504/212662960-9a89b3c7-ce02-4f50-a6c6-36face18723d.png)

### After

![Screenshot 2023-01-16 at 10 57 11](https://user-images.githubusercontent.com/3727504/212662945-8fa7d73c-1a9d-43c6-909d-e51e400c6be8.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/KtvQCaqj/1574-fix-text-size-scaling-on-cost-of-living-if-youre-finding-things-difficult-section-s)
