### PR TITLE
Add image-card.js to application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/step-by-step-nav
 


### PR DESCRIPTION
For the Youtube Embed in the Image Card component to work (https://github.com/alphagov/govuk_publishing_components/pull/3156), we need to include image-card.js.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
