### PR TITLE
Remove pinning mail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "govuk_ab_testing"
 gem "govuk_app_config"
 gem "govuk_document_types"
 gem "govuk_publishing_components"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "rails-i18n"
 gem "rails_translation_manager"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   i18n-coverage
-  mail (~> 2.8.0)
   mocha
   pact
   pact_broker-client


### PR DESCRIPTION
Issue that made us do it is gone [1]

[1]: mikel/mail#1489

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
