### PR TITLE
Add GA4 tracking to related navigation

### DIFF
--- a/app/views/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/past_foreign_secretaries/_show_person.html.erb
@@ -71,7 +71,8 @@
 
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/related_navigation", {
-      content_item: past_foreign_secretary_nav
+      content_item: past_foreign_secretary_nav,
+      ga4_tracking: true
     } %>
     <p class="govuk-body">
       <a class="govuk-link" href="/government/history/past-foreign-secretaries">View all past foreign secretaries</a>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Add GA4 tracking to the related navigation component on https://www.gov.uk/government/history/past-foreign-secretaries/george-gower

## Why

Part of the GA4 rollout.

## Visual changes
None.

Trello card: https://trello.com/c/IMjw2dHg/382-add-tracking-related-links-contextual-sidebar-and-contextual-footer
