### PR TITLE
Reorder No.10 Organisation Page

### DIFF
--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -5,13 +5,21 @@
            schema: :organisation,
            content_item: @organisation.content_item.content_item_data %>
 <%= render partial: 'featured_news' %>
-<%= render partial: 'latest_documents' %>
-<%= render partial: 'what_we_do' %>
-<% if @organisation.is_promotional_org? %>
+
+<% if @organisation.is_no_10? %>
   <%= render partial: 'promotional_features' %>
+  <%= render partial: 'what_we_do' %>
+  <%= render partial: 'latest_documents' %>
 <% else %>
-  <%= render partial: 'standard_org_docs_people' %>
+  <%= render partial: 'latest_documents' %>
+  <%= render partial: 'what_we_do' %>
+  <% if @organisation.is_promotional_org? %>
+    <%= render partial: 'promotional_features' %>
+  <% else %>
+    <%= render partial: 'standard_org_docs_people' %>
+  <% end %>
 <% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: 'org_contacts', locals: { contacts: @contacts } %>


### PR DESCRIPTION
## What

Display the partials of the organisation page in a specific order if the page is the No. 10 organisation page.

## Why

Request as part of the No. 10 organisation page redesign.

## Visual Differences

### Before

![Screenshot 2023-01-23 at 14 31 24](https://user-images.githubusercontent.com/3727504/214065181-478550d6-95ce-4d4e-a584-91c0fe2c8d63.png)

### After

![Screenshot 2023-01-23 at 14 30 49](https://user-images.githubusercontent.com/3727504/214065156-916e896d-af34-4587-a0f4-811738f8d530.png)

[Relevant Trello Card
](https://trello.com/c/Erjtrgy0/77-re-order-page-elements)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
