### PR TITLE
Remove link to Planning Inspectorate services information

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -122,7 +122,6 @@ module Organisations
         maritime-and-coastguard-agency
         medicines-and-healthcare-products-regulatory-agency
         natural-england
-        planning-inspectorate
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)
     end


### PR DESCRIPTION
We're archiving the page and redirecting it back to the organisation homepage. This link is no longer needed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
