### PR TITLE
Remove Highways England services and information link

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -116,7 +116,6 @@ module Organisations
         driver-and-vehicle-standards-agency
         environment-agency
         high-speed-two-limited
-        highways-england
         hm-revenue-customs
         marine-management-organisation
         maritime-and-coastguard-agency


### PR DESCRIPTION
We're archiving the page this links to, so this should be removed.

https://trello.com/c/6CH2DHKM/1611-archive-and-redirect-highways-england-services-and-info-page-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
