### PR TITLE
Remove Environment Agency Services Page

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -114,7 +114,6 @@ module Organisations
         department-for-education
         department-for-environment-food-rural-affairs
         driver-and-vehicle-standards-agency
-        environment-agency
         high-speed-two-limited
         hm-revenue-customs
         marine-management-organisation


### PR DESCRIPTION
We're deprecating the Services and Information page for the EA, and this removes the link from the org page.

https://trello.com/c/tFV0b9sx/1615-archive-and-redirect-environment-agencys-services-and-info-page-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
