### PR TITLE
Reshuffle banners

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -42,6 +42,15 @@ class Organisation
     slug == "prime-ministers-office-10-downing-street"
   end
 
+  # Temporary banner for Feb 2023 reshuffle
+  def is_being_reshuffled?
+    %w[
+      department-for-digital-culture-media-sport
+      department-for-international-trade
+      department-for-business-energy-and-industrial-strategy
+    ].include?(slug)
+  end
+
   def is_promotional_org?
     is_no_10? || organisation_type == "civil_service"
   end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -1,6 +1,15 @@
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
+<% if @organisation.is_being_reshuffled? %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: sanitize(
+      "This organisation is changing.
+      Read the <a href=\"/government/news/making-government-deliver-for-the-british-people\">latest updates on government departments</a>
+      or visit the <a href=\"https://twitter.com/10DowningStreet\">10 Downing Street Twitter feed</a>.
+      ")
+  } %>
+<% end %>
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',
            schema: :organisation,
            content_item: @organisation.content_item.content_item_data %>

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -430,4 +430,18 @@ RSpec.describe "Organisation pages" do
     org_schema = schemas.detect { |schema| schema["@type"] == "GovernmentOrganization" }
     expect("Student Loans Company").to eq(org_schema["name"])
   end
+
+  it "displays reshuffle banner on subset of org pages" do
+    %w[
+      department-for-digital-culture-media-sport
+      department-for-international-trade
+      department-for-business-energy-and-industrial-strategy
+    ].each do |slug|
+      base_path = "/government/organisations/#{slug}"
+      content_item = content_item_attorney_general.deep_merge("base_path" => base_path)
+      stub_content_and_search(content_item)
+      visit base_path
+      expect(page).to have_css(".govuk-notification-banner", text: "This organisation is changing.")
+    end
+  end
 end


### PR DESCRIPTION
Add temp reshuffle banner to:

- [department-for-digital-culture-media-sport](https://collections-pr-3172.herokuapp.com/government/organisations/department-for-digital-culture-media-sport)
- [department-for-international-trade](https://collections-pr-3172.herokuapp.com/government/organisations/department-for-international-trade)
- [department-for-business-energy-and-industrial-strategy](https://collections-pr-3172.herokuapp.com/government/organisations/department-for-business-energy-and-industrial-strategy)


### Before

<img width="1013" alt="Screenshot 2023-02-07 at 12 53 18" src="https://user-images.githubusercontent.com/17908089/217250231-8a7a54a7-aaff-497c-81ae-9810ca57ce1b.png">


### After

<img width="1029" alt="Screenshot 2023-02-07 at 12 52 40" src="https://user-images.githubusercontent.com/17908089/217250114-3b46b4a7-f9ef-429d-9e29-a976f521a969.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
