### PR TITLE
Add Aria Label to Details of Organisations Page

### DIFF
--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -53,7 +53,10 @@
             <% if @presented_organisations.works_with_statement(organisation) %>
               <div class="govuk-!-margin-bottom-3">
                 <%= render "govuk_publishing_components/components/details", {
-                  title: @presented_organisations.works_with_statement(organisation)
+                  title: @presented_organisations.works_with_statement(organisation),
+                  summary_aria_attributes: {
+                    label: "#{organisation["title"]} #{@presented_organisations.works_with_statement(organisation)}"
+                  }
                 } do %>
                   <%= render partial: 'expanded_works_with_organisations',
                     locals: {


### PR DESCRIPTION
## What

Add aria-label to the summary of the details components used on the organisations index page. The aria-label is composed of `[NAME OF ORGANISATION] works with [X] agencies and public bodies`.

## Why

Screen reader users may struggle to differentiate between the numerous Works with X agencies and public bodies details components because their names do not reference the Departments, agencies and public bodies that they’re related to. 

[Relevant Trello Card](https://trello.com/c/NepoUk7x/1533-form-elements-on-departments-page-are-not-descriptive-of-their-function-or-purpose-9-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
