### PR TITLE
Make collections show default main language in analytics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def lang_attribute
-    "lang=#{I18n.locale}" unless I18n.locale == I18n.default_locale
+    "lang=#{I18n.locale}"
   end
 
   def t_lang(key, options = {})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
   lang = params["locale"]
 
   if content_item_h
-    unless (!content_item_h["locale"] || content_item_h["locale"].eql?("en"))
+    unless (!content_item_h["locale"])
       lang = content_item_h["locale"]
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ApplicationHelper do
   describe "lang_attribute" do
     it "returns nil for default language" do
       I18n.with_locale(:en) do
-        expect(lang_attribute).to be_nil
+        expect(lang_attribute).to eq("lang=#{I18n.default_locale}")
       end
     end
     it "returns a lang attribute string for non-default language" do


### PR DESCRIPTION
Previously we would filter out the language from analytics if it was our default `en` entry. While clean, it's inconsistent with other areas of GovUK, so this has been changed to return the current language regardless of whether it's the default.

The test was updated to ensure that `en` is the default locale, rather than looking for a nil entry. This matches other behaviour, wherein we rely on the default locale to be `en` rather than explicitly setting it.

https://trello.com/c/5D0FH2V5/1644-make-collections-show-default-main-language-in-analytics-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
