### PR TITLE
Update text on the reshuffle banners

### DIFF
--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -5,8 +5,7 @@
   <%= render "govuk_publishing_components/components/notice", {
     title: sanitize(
       "This organisation is changing.
-      Read the <a href=\"/government/news/making-government-deliver-for-the-british-people\">latest updates on government departments</a>
-      or visit the <a href=\"https://twitter.com/10DowningStreet\">10 Downing Street Twitter feed</a>.
+      Read about <a href=\"/government/publications/making-government-deliver-for-the-british-people/making-government-deliver-for-the-british-people-html\">recent government updates</a>.
       ")
   } %>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Changes the text on the reshuffle banners on the following pages:

- https://www.gov.uk/government/organisations/department-for-international-trade
- https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport
- https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy

Preview links
- https://collections-pr-3185.herokuapp.com/government/organisations/department-for-international-trade
- https://collections-pr-3185.herokuapp.com/government/organisations/department-for-business-energy-and-industrial-strategy
- https://collections-pr-3185.herokuapp.com/government/organisations/department-for-digital-culture-media-sport

Those are defined here: https://github.com/alphagov/collections/blob/f2c99c82924428ee3f96831cfb572eb4e9bbcadb/app/models/organisation.rb#L45-L52

## Why

Requested via Slack: https://gds.slack.com/archives/CADKZN519/p1676976549729569

## Before
<img width="738" alt="Screenshot 2023-02-21 at 11 04 08" src="https://user-images.githubusercontent.com/38078064/220328374-e4e15ab9-1d2b-41c7-a713-162f4ca5e6ca.png">


## After
<img width="791" alt="Screenshot 2023-02-21 at 11 15 00" src="https://user-images.githubusercontent.com/38078064/220330343-6805dfca-88dc-4949-8c16-986ffa393f22.png">

