### PR TITLE
Render Past Prime Ministers

### DIFF
--- a/app/controllers/past_prime_ministers_controller.rb
+++ b/app/controllers/past_prime_ministers_controller.rb
@@ -3,4 +3,45 @@ class PastPrimeMinistersController < ApplicationController
     @past_prime_minister = PastPrimeMinister.find!(request.path)
     setup_content_item_and_navigation_helpers(@past_prime_minister)
   end
+
+  helper_method :pm_dates_in_office
+
+  def index
+    @past_pms = PastPrimeMinistersIndex.find!("/government/history/past-prime-ministers")
+    @recent_appointments = all_recent_pms.unshift(@past_pms.pms_without_historical_accounts).flatten(1)
+    @twentieth_century_appointments = all_twentieth_century_pms
+    @eighteenth_and_nineteenth_century_appointments = all_eighteenth_and_nineteenth_century_pms
+    setup_content_item_and_navigation_helpers(@past_pms)
+  end
+
+  def pm_dates_in_office(appointment, political_party = nil)
+    if @past_pms.pms_without_historical_accounts.include?(appointment)
+      appointment["dates_in_office"].map do |d|
+        {
+          text: "#{d['start_year']} to #{d['end_year']}",
+        }
+      end
+    else
+      appointment.dig("details", "dates_in_office")
+                 .map do |d|
+        {
+          text: "#{political_party} #{d['start_year']} to #{d['end_year']}",
+        }
+      end
+    end
+  end
+
+private
+
+  def all_recent_pms
+    @past_pms.pms_with_historical_accounts.select { |pm| pm.dig("details", "dates_in_office").last["start_year"] > 2001 }
+  end
+
+  def all_twentieth_century_pms
+    @past_pms.pms_with_historical_accounts.select { |pm| pm.dig("details", "dates_in_office").last["start_year"].between?(1901, 2000) }
+  end
+
+  def all_eighteenth_and_nineteenth_century_pms
+    @past_pms.pms_with_historical_accounts.select { |pm| pm.dig("details", "dates_in_office").last["start_year"].between?(1701, 1900) }
+  end
 end

--- a/app/models/past_prime_ministers_index.rb
+++ b/app/models/past_prime_ministers_index.rb
@@ -1,0 +1,26 @@
+require "active_model"
+
+class PastPrimeMinistersIndex
+  include ActiveModel::Model
+
+  attr_accessor :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+
+  def pms_with_historical_accounts
+    @content_item.content_item_data.dig("links", "historical_accounts")
+              .sort_by! { |pm| -pm.dig("details", "dates_in_office").last["start_year"] }
+  end
+
+  def pms_without_historical_accounts
+    @content_item.content_item_data.dig("details", "appointments_without_historical_accounts")
+                                   .sort_by! { |pm| -pm["dates_in_office"].last["start_year"] }
+  end
+end

--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 </div>
 
-<%= render partial: "featured_past_foreign_secretaries", locals: { past_foreign_secretaries_image: @selection_of_profiles } %>
+<%= render partial: "shared/featured_historical_figures", locals: { historical_figures_with_image: @selection_of_profiles, heading: "Selection of profiles"} %>
 
 <%= render partial: "shared/historical_figures_by_century", locals: { people: @twenty_first_century, heading: "21st century" } %>
 

--- a/app/views/past_prime_ministers/_historic_appointment.html.erb
+++ b/app/views/past_prime_ministers/_historic_appointment.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-column-one-quarter">
+  <% if @past_pms.pms_with_historical_accounts.include?(historic_appointment) %>
+    <% political_party = historic_appointment["details"]["political_party"] %>
+    <%= render "govuk_publishing_components/components/image_card", {
+      href: historic_appointment["base_path"],
+      image_src: historic_appointment["links"]["person"][0]["details"]["image"]["url"],
+      image_loading: "lazy",
+      heading_text: historic_appointment["title"],
+      extra_details: pm_dates_in_office(historic_appointment, political_party),
+      extra_details_no_indent: true,
+      height: "auto"
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/image_card", {
+      image_src: historic_appointment["image_url"],
+      image_loading: "lazy",
+      heading_text: historic_appointment["title"],
+      extra_details: pm_dates_in_office(historic_appointment),
+      extra_details_no_indent: true,
+      height: "auto"
+    } %>
+  <% end %>
+</div>

--- a/app/views/past_prime_ministers/index.html.erb
+++ b/app/views/past_prime_ministers/index.html.erb
@@ -1,0 +1,91 @@
+<% content_for :title, @content_item["title"] %>
+<% page_class "historic-appointments-index govuk-width-container" %>
+
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+  breadcrumbs: [
+    {
+      title: "Home",
+      url: "/",
+    },
+    {
+      title: "How government works",
+      url: "/government/how-government-works",
+    },
+    {
+      title: "History of the UK government",
+      url: "/government/history",
+    },
+  ]
+} %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "History",
+      title: @content_item["title"],
+    } %>
+  </div>
+</div>
+
+<%# 21st century section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "21st century",
+      padding: true,
+      border_top: 2,
+      font_size: "l"
+    } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<% @recent_appointments.in_groups_of(4, false) do |people| %>
+  <div class="govuk-grid-row historic-people-index__section-row-header" role="list">
+    <%= render partial: 'historic_appointment', collection: people %>  
+  </div>
+<% end %>
+
+<%# 20th century section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "20th century",
+      padding: true,
+      border_top: 2,
+      font_size: "l",
+    } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<div role="list">
+  <% @twentieth_century_appointments.in_groups_of(4, false) do |people| %>
+    <div class="govuk-grid-row historic-people-index__section-row-header">
+      <%= render partial: 'historic_appointment', collection: people %>  
+    </div>
+  <% end %>
+</div>
+
+<%# 18th & 19th centuries section %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "18th & 19th centuries",
+        padding: true,
+        border_top: 2,
+        font_size: "l",
+        margin_bottom: 2,
+      } %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  </div>
+</div>
+
+<div role="list">
+  <% @eighteenth_and_nineteenth_century_appointments.in_groups_of(4, false) do |people| %>
+  <div class="govuk-grid-row historic-people-index__section-row-header">
+    <%= render partial: 'historic_appointment', collection: people %>  
+  </div>
+  <% end %>
+</div>

--- a/app/views/shared/_featured_historical_figures.erb
+++ b/app/views/shared/_featured_historical_figures.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Selection of profiles",
+      text: heading,
       padding: true,
       border_top: 2,
       font_size: "l",
@@ -11,7 +11,7 @@
 </div>
 
 <div class="historic-people-index__section-row-header" role="list">
-  <% past_foreign_secretaries_image.each_slice(4) do |row| %>
+  <% historical_figures_with_image.each_slice(4) do |row| %>
   <div class="govuk-grid-row">
     <% row.each do | _, info| %>
       <div role="listitem" class="govuk-grid-column-one-quarter">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
   get "/government/history/past-foreign-secretaries", to: "past_foreign_secretaries#index"
   get "/government/history/past-foreign-secretaries/:id", to: "past_foreign_secretaries#show"
   get "/government/history/past-prime-ministers/:id", to: "past_prime_ministers#show"
+  get "/government/history/past-prime-ministers", to: "past_prime_ministers#index"
 
   get "/government/people/:name(.:locale)", to: "people#show"
   get "/government/ministers(.:locale)", to: "ministers#index"

--- a/spec/controllers/past_prime_ministers_controller_spec.rb
+++ b/spec/controllers/past_prime_ministers_controller_spec.rb
@@ -1,23 +1,23 @@
 RSpec.describe PastPrimeMinistersController do
-  let(:base_path) { "/government/history/past-prime-ministers" }
-  let(:past_pm_id) { "a-pm" }
-  let(:content_item) do
-    {
-      base_path: "#{base_path}/#{past_pm_id}",
-      title: "a past PM",
-      details: {
-        born: "1900",
-        died: "2000",
-        interesting_facts: "a fact",
-        major_acts: "an act",
-        political_party: "A party",
-        dates_in_office: [{ end_year: 2005, start_year: 2000 }],
-      },
-      links: { ordered_related_items: [] },
-    }
-  end
-
   describe "GET show" do
+    let(:base_path) { "/government/history/past-prime-ministers" }
+    let(:past_pm_id) { "a-pm" }
+    let(:content_item) do
+      {
+        base_path: "#{base_path}/#{past_pm_id}",
+        title: "a past PM",
+        details: {
+          born: "1900",
+          died: "2000",
+          interesting_facts: "a fact",
+          major_acts: "an act",
+          political_party: "A party",
+          dates_in_office: [{ end_year: 2005, start_year: 2000 }],
+        },
+        links: { ordered_related_items: [] },
+      }
+    end
+
     it "has a success response for an existent pm" do
       stub_content_store_has_item("#{base_path}/#{past_pm_id}", content_item)
 
@@ -32,6 +32,20 @@ RSpec.describe PastPrimeMinistersController do
       get :show, params: { id: }
 
       expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "GET index" do
+    let(:content_item) { fetch_fixture("past_prime_ministers") }
+    let(:base_path) { content_item["base_path"] }
+
+    before do
+      stub_content_store_has_item(base_path, content_item)
+    end
+
+    it "has a success response" do
+      get :index
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/features/past_prime_ministers_index_spec.rb
+++ b/spec/features/past_prime_ministers_index_spec.rb
@@ -1,0 +1,27 @@
+require "integration_spec_helper"
+
+RSpec.feature "Past Prime Mininsters page" do
+  let(:content_item) { fetch_fixture("past_prime_ministers") }
+  let(:base_path) { content_item["base_path"] }
+
+  before do
+    stub_content_store_has_item(base_path, content_item)
+  end
+
+  it "sets the page title" do
+    visit base_path
+    expect(page).to have_title(content_item[:title])
+  end
+
+  it "sets renders the title on the page" do
+    visit base_path
+    expect(page).to have_text(content_item[:title])
+  end
+
+  it "includes headers for each century" do
+    visit base_path
+    expect(page).to have_text("21st century")
+    expect(page).to have_text("20th century")
+    expect(page).to have_text("18th & 19th centuries")
+  end
+end

--- a/spec/fixtures/content_store/past_prime_ministers.json
+++ b/spec/fixtures/content_store/past_prime_ministers.json
@@ -1,0 +1,204 @@
+{
+  "base_path": "/government/history/past-prime-ministers",
+  "content_id": "a258e45a-acbe-4d70-ad2c-a2a20761536a",
+  "document_type": "historic_appointments",
+  "title": "Past Prime Ministers",
+  "links": {
+    "historical_accounts": [
+      {
+        "title": "The Rt Hon John Smith",
+        "api_path": "/api/content/government/history/past-prime-ministers/john-smith",
+        "base_path": "/government/history/past-prime-ministers/john-smith",
+        "document_type": "historic_appointment",
+        "schema_name": "historic_appointment",
+        "details": {
+          "political_party": "Jazz Party",
+          "dates_in_office": [
+            {
+              "end_year": 2010,
+              "start_year": 2007
+            }
+          ]
+        },
+        "links": {
+          "person": [
+            {
+              "title": "The Rt Hon John Smith",
+              "api_path": "/api/content/government/people/john-smith",
+              "base_path": "/government/people/john-smith",
+              "document_type": "person",
+              "schema_name": "person",
+              "details": {
+                "body": "Something about John Smith",
+                "image": {
+                  "url": "www.gov.uk/image_of_john_smith.png"
+                }
+              }
+            }
+          ]
+        }  
+      },
+      {
+        "title": "The Rt Hon Bobby B",
+        "api_path": "/api/content/government/history/past-prime-ministers/bobby-b",
+        "base_path": "/government/history/past-prime-ministers/bobby-b",
+        "document_type": "historic_appointment",
+        "schema_name": "historic_appointment",
+        "details": {
+          "political_party": "Funk Party",
+          "dates_in_office": [
+            {
+              "end_year": 2007,
+              "start_year": 1997
+            }
+          ]
+        },
+        "links": {
+          "person": [
+            {
+              "title": "The Rt Hon Bobby B",
+              "api_path": "/api/content/government/people/bobby-b",
+              "base_path": "/government/people/bobby-b",
+              "document_type": "person",
+              "schema_name": "person",
+              "details": {
+                "body": "Something about Bobby B",
+                "image": {
+                  "url": "www.gov.uk/image_of_bobby_b.png"
+                }
+              }
+            }
+          ]
+        }  
+      },
+      {
+        "title": "The Rt Hon Timmy T",
+        "api_path": "/api/content/government/history/past-prime-ministers/timmy-t",
+        "base_path": "/government/history/past-prime-ministers/timmy-t",
+        "document_type": "historic_appointment",
+        "schema_name": "historic_appointment",
+        "details": {
+          "political_party": "Took a break Party",
+          "dates_in_office": [
+            {
+              "end_year": 1997,
+              "start_year": 1993
+            },
+            {
+                "end_year": 2015,
+                "start_year": 2010
+            }
+          ]
+        },
+        "links": {
+          "person": [
+            {
+              "title": "The Rt Hon Timmy T",
+              "api_path": "/api/content/government/people/timmy-t",
+              "base_path": "/government/people/timmy-t",
+              "document_type": "person",
+              "schema_name": "person",
+              "details": {
+                "body": "Something about Timmy T",
+                "image": {
+                  "url": "www.gov.uk/image_of_timmy_t.png"
+                }
+              }
+            }
+          ]
+        }  
+      },
+      {
+        "title": "The Rt Hon Jimmy J",
+        "api_path": "/api/content/government/history/past-prime-ministers/jimmy-j",
+        "base_path": "/government/history/past-prime-ministers/jimmy-j",
+        "document_type": "historic_appointment",
+        "schema_name": "historic_appointment",
+        "details": {
+          "political_party": "The 80's Party",
+          "dates_in_office": [
+            {
+              "end_year": 1985,
+              "start_year": 1981
+            }
+          ]
+        },
+        "links": {
+          "person": [
+            {
+              "title": "The Rt Hon Jimmy J",
+              "api_path": "/api/content/government/people/jimmy-j",
+              "base_path": "/government/people/jimmy-j",
+              "document_type": "person",
+              "schema_name": "person",
+              "details": {
+                "body": "Something about Jimmy J",
+                "image": {
+                  "url": "www.gov.uk/image_of_jimmy_j.png"
+                }
+              }
+            }
+          ]
+        }  
+      },
+      {
+        "title": "The Rt Hon Reginald R",
+        "api_path": "/api/content/government/history/past-prime-ministers/reginald-r",
+        "base_path": "/government/history/past-prime-ministers/reginald-r",
+        "document_type": "historic_appointment",
+        "schema_name": "historic_appointment",
+        "details": {
+          "political_party": "The 18th century Party",
+          "dates_in_office": [
+            {
+              "end_year": 1897,
+              "start_year": 1893
+            }
+          ]
+        },
+        "links": {
+          "person": [
+            {
+              "title": "The Rt Hon Reginald R",
+              "api_path": "/api/content/government/people/reginald-r",
+              "base_path": "/government/people/reginald-r",
+              "document_type": "person",
+              "schema_name": "person",
+              "details": {
+                "body": "Something about Reginald R",
+                "image": {
+                  "url": "www.gov.uk/image_of_reginald-r.png"
+                }
+              }
+            }
+          ]
+        }  
+      }
+    ]
+  },
+  "details": {
+    "appointments_without_historical_accounts": [
+      {
+        "title": "The Rt Hon No Biography MP",
+        "image_url": "www.gov.uk/image_of_no_bio_mp.png",
+        "dates_in_office": [
+          {
+            "end_year": 2022,
+            "start_year": 2022
+          }
+        ]
+      },
+      {
+        "title": "The Rt Hon Older No Biography MP",
+        "image_url": "www.gov.uk/image_of_older_no_bio_mp.png",
+        "dates_in_office": [
+          {
+            "end_year": 2022,
+            "start_year": 2020
+          }
+        ]
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
This PR adds the Past Prime Ministers index page into collections. Not to be confused with the individual past PM pages, already added in https://github.com/alphagov/collections/pull/3191

Once the PR is merged, the rendering app in the content item will need to be updated PR - [here](https://github.com/alphagov/whitehall/pull/7400)

Trello: https://trello.com/c/LSd8y4zg/421-render-past-prime-ministers-index-page-in-collections

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
