### PR TITLE
Remove links to Service Information pages for HS2 and DVSA

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -114,7 +114,6 @@ module Organisations
         department-for-education
         department-for-environment-food-rural-affairs
         driver-and-vehicle-standards-agency
-        high-speed-two-limited
         hm-revenue-customs
         marine-management-organisation
         maritime-and-coastguard-agency

--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -113,7 +113,6 @@ module Organisations
       orgs_with_services_and_information_link = %w[
         department-for-education
         department-for-environment-food-rural-affairs
-        driver-and-vehicle-standards-agency
         hm-revenue-customs
         marine-management-organisation
         maritime-and-coastguard-agency


### PR DESCRIPTION
Removes links to the service information pages for HS2 and DVSA as those pages are being retired. Redirection will happen after delivery.

https://trello.com/c/oaKl9FnH/1664-archive-and-redirect-high-speed-2-services-and-info-page-s
https://trello.com/c/aIjqUpSZ/1665-archive-and-redirect-dvsa-services-and-info-page-s



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
