### PR TITLE
Render individual past pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ At time of writing, it also serves the priority campaign pages. See the [Campaig
 - Organisation index page: [gov.uk/government/organisations](https://www.gov.uk/government/organisations)
 - Organisation page: [gov.uk/government/organisations/cabinet-office](https://www.gov.uk/government/organisations/cabinet-office)
 - Step by step page: [gov.uk/learn-to-drive-a-car](https://www.gov.uk/learn-to-drive-a-car)
+- Past Prime Minister: [gov.uk/government/history/past-prime-ministers/tony-blair](https://www.gov.uk/government/history/past-prime-ministers/tony-blair)
 
 ## Nomenclature
 

--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -5,6 +5,7 @@ class DevelopmentController < ApplicationController
     @schema_names = %w[
       coronavirus_landing_page
       finder
+      historic_appointment
       mainstream_browse_page
       ministerial_role
       organisation

--- a/app/controllers/past_prime_ministers_controller.rb
+++ b/app/controllers/past_prime_ministers_controller.rb
@@ -1,0 +1,6 @@
+class PastPrimeMinistersController < ApplicationController
+  def show
+    @past_prime_minister = PastPrimeMinister.find!(request.path)
+    setup_content_item_and_navigation_helpers(@past_prime_minister)
+  end
+end

--- a/app/models/past_prime_minister.rb
+++ b/app/models/past_prime_minister.rb
@@ -1,0 +1,63 @@
+class PastPrimeMinister
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def page_title
+    "History of #{title}"
+  end
+
+  def title
+    @content_item.content_item_data["title"]
+  end
+
+  def political_party
+    @content_item.content_item_data.dig("details", "political_party")
+  end
+
+  def dates_in_office
+    @content_item.content_item_data.dig("details", "dates_in_office")
+                 .map { |d| "#{d['start_year']} to #{d['end_year']}" }
+                 .join(", ")
+  end
+
+  def description
+    @content_item.content_item_data["description"]
+  end
+
+  def biography
+    @content_item.content_item_data.dig("details", "body").html_safe
+  end
+
+  def image_data
+    @content_item.content_item_data.dig("links", "person", 0, "details", "image")
+  end
+
+  def appointment_info_array
+    %w[born died dates_in_office political_party major_acts interesting_facts].map do |field|
+      text = field == "dates_in_office" ? dates_in_office : @content_item.content_item_data.dig("details", field)
+      { title: field.gsub("_", " ").capitalize, text: }
+    end
+  end
+
+  def related_prime_ministers_nav
+    people = @content_item.content_item_data.dig("links", "ordered_related_items")
+    {
+      "links" => {
+        "ordered_related_items" => people.map do |person|
+          {
+            "title" => person["title"],
+            "base_path" => person["base_path"],
+          }
+        end,
+      },
+    }
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/models/past_prime_minister.rb
+++ b/app/models/past_prime_minister.rb
@@ -38,7 +38,7 @@ class PastPrimeMinister
   def appointment_info_array
     %w[born died dates_in_office political_party major_acts interesting_facts].map do |field|
       text = field == "dates_in_office" ? dates_in_office : @content_item.content_item_data.dig("details", field)
-      { title: field.gsub("_", " ").capitalize, text: }
+      { title: I18n.t("past_prime_ministers.headings.#{field}"), text: }
     end
   end
 

--- a/app/views/past_prime_ministers/show.html.erb
+++ b/app/views/past_prime_ministers/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
-      context: "Past Prime Ministers",
+      context: I18n.t("past_prime_ministers.context"),
       title: @past_prime_minister.title,
     } %>
 
@@ -43,7 +43,7 @@
     <% end %>
 
     <%=  render "govuk_publishing_components/components/heading", {
-      text: "Biography",
+      text: I18n.t("past_prime_ministers.headings.biography"),
       font_size: "m",
       margin_bottom: 1,
     } %>
@@ -61,7 +61,7 @@
       ga4_tracking: true
     } %>
     <p class="govuk-body">
-      <a class="govuk-link" href="/government/history/past-prime-ministers">View all past prime ministers</a>
+      <a class="govuk-link" href="/government/history/past-prime-ministers"><%= I18n.t("past_prime_ministers.view_all")  %></a>
     </p>
   </div>
 </div>

--- a/app/views/past_prime_ministers/show.html.erb
+++ b/app/views/past_prime_ministers/show.html.erb
@@ -1,0 +1,67 @@
+<% content_for :title, @past_prime_minister.page_title %>
+<% page_class "govuk-width-container" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/title", {
+      context: "Past Prime Ministers",
+      title: @past_prime_minister.title,
+    } %>
+
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "#{@past_prime_minister.political_party} #{@past_prime_minister.dates_in_office}",
+    } %>
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: @past_prime_minister.description,
+    } %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-bottom-4">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <%= image_tag(
+              @past_prime_minister.image_data["url"],
+              alt: @past_prime_minister.image_data["alt_text"],
+              class: "govuk-!-margin-bottom-4 govuk-!-width-full"
+        ) %>
+      </div>
+    </div>
+
+    <% @past_prime_minister.appointment_info_array.each do |info| %>
+      <% if info[:text].present? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: info[:title],
+          font_size: "m",
+          margin_bottom: 1,
+        } %>
+        <p class="govuk-body"><%= info[:text] %></p>
+      <% end %>
+    <% end %>
+
+    <%=  render "govuk_publishing_components/components/heading", {
+      text: "Biography",
+      font_size: "m",
+      margin_bottom: 1,
+    } %>
+
+    <%=  render "govuk_publishing_components/components/govspeak" do %>
+      <%= @past_prime_minister.biography %>
+    <%  end %>
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <p class="govuk-body">
+      <%=  render "govuk_publishing_components/components/related_navigation", {
+      content_item: @past_prime_minister.related_prime_ministers_nav,
+      ga4_tracking: true
+    } %>
+    <p class="govuk-body">
+      <a class="govuk-link" href="/government/history/past-prime-ministers">View all past prime ministers</a>
+    </p>
+  </div>
+</div>

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -4,6 +4,7 @@ finder: /government/organisations
 mainstream_browse_page: /browse/driving
 ministerial_role: /government/ministers/secretary-of-state-for-education
 organisation: /government/organisations/companies-house
+past_prime_minister: /government/history/past-prime-ministers/tony-blair
 person: /government/people/matthew-hancock
 services_and_information: /government/organisations/hm-revenue-customs/services-information
 step_by_step_nav: /get-tax-free-childcare

--- a/config/locales/ar/past_prime_ministers.yml
+++ b/config/locales/ar/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ar:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/az/past_prime_ministers.yml
+++ b/config/locales/az/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+az:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/be/past_prime_ministers.yml
+++ b/config/locales/be/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+be:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/bg/past_prime_ministers.yml
+++ b/config/locales/bg/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+bg:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/bn/past_prime_ministers.yml
+++ b/config/locales/bn/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+bn:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/cs/past_prime_ministers.yml
+++ b/config/locales/cs/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+cs:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/cy/past_prime_ministers.yml
+++ b/config/locales/cy/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+cy:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/da/past_prime_ministers.yml
+++ b/config/locales/da/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+da:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/de/past_prime_ministers.yml
+++ b/config/locales/de/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+de:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/dr/past_prime_ministers.yml
+++ b/config/locales/dr/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+dr:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/el/past_prime_ministers.yml
+++ b/config/locales/el/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+el:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/en/past_prime_ministers.yml
+++ b/config/locales/en/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+en:
+  past_prime_ministers:
+    context: Past Prime Ministers
+    view_all: View all past prime ministers
+    headings:
+      born: Born
+      died: Died
+      dates_in_office: Dates in office
+      political_party: Political party
+      major_acts: Major acts
+      interesting_facts: Interesting facts
+      biography: Biography

--- a/config/locales/es-419/past_prime_ministers.yml
+++ b/config/locales/es-419/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+es-419:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/es/past_prime_ministers.yml
+++ b/config/locales/es/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+es:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/et/past_prime_ministers.yml
+++ b/config/locales/et/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+et:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/fa/past_prime_ministers.yml
+++ b/config/locales/fa/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+fa:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/fi/past_prime_ministers.yml
+++ b/config/locales/fi/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+fi:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/fr/past_prime_ministers.yml
+++ b/config/locales/fr/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+fr:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/gd/past_prime_ministers.yml
+++ b/config/locales/gd/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+gd:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/gu/past_prime_ministers.yml
+++ b/config/locales/gu/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+gu:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/he/past_prime_ministers.yml
+++ b/config/locales/he/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+he:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/hi/past_prime_ministers.yml
+++ b/config/locales/hi/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+hi:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/hr/past_prime_ministers.yml
+++ b/config/locales/hr/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+hr:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/hu/past_prime_ministers.yml
+++ b/config/locales/hu/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+hu:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/hy/past_prime_ministers.yml
+++ b/config/locales/hy/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+hy:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/id/past_prime_ministers.yml
+++ b/config/locales/id/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+id:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/is/past_prime_ministers.yml
+++ b/config/locales/is/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+is:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/it/past_prime_ministers.yml
+++ b/config/locales/it/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+it:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ja/past_prime_ministers.yml
+++ b/config/locales/ja/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ja:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ka/past_prime_ministers.yml
+++ b/config/locales/ka/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ka:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/kk/past_prime_ministers.yml
+++ b/config/locales/kk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+kk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ko/past_prime_ministers.yml
+++ b/config/locales/ko/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ko:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/lt/past_prime_ministers.yml
+++ b/config/locales/lt/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+lt:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/lv/past_prime_ministers.yml
+++ b/config/locales/lv/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+lv:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ms/past_prime_ministers.yml
+++ b/config/locales/ms/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ms:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/mt/past_prime_ministers.yml
+++ b/config/locales/mt/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+mt:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ne/past_prime_ministers.yml
+++ b/config/locales/ne/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ne:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/nl/past_prime_ministers.yml
+++ b/config/locales/nl/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+nl:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/no/past_prime_ministers.yml
+++ b/config/locales/no/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+'no':
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/pa-pk/past_prime_ministers.yml
+++ b/config/locales/pa-pk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+pa-pk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/pa/past_prime_ministers.yml
+++ b/config/locales/pa/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+pa:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/pl/past_prime_ministers.yml
+++ b/config/locales/pl/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+pl:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ps/past_prime_ministers.yml
+++ b/config/locales/ps/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ps:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/pt/past_prime_ministers.yml
+++ b/config/locales/pt/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+pt:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ro/past_prime_ministers.yml
+++ b/config/locales/ro/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ro:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ru/past_prime_ministers.yml
+++ b/config/locales/ru/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ru:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/si/past_prime_ministers.yml
+++ b/config/locales/si/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+si:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sk/past_prime_ministers.yml
+++ b/config/locales/sk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sl/past_prime_ministers.yml
+++ b/config/locales/sl/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sl:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/so/past_prime_ministers.yml
+++ b/config/locales/so/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+so:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sq/past_prime_ministers.yml
+++ b/config/locales/sq/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sq:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sr/past_prime_ministers.yml
+++ b/config/locales/sr/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sr:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sv/past_prime_ministers.yml
+++ b/config/locales/sv/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sv:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/sw/past_prime_ministers.yml
+++ b/config/locales/sw/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+sw:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ta/past_prime_ministers.yml
+++ b/config/locales/ta/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ta:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/th/past_prime_ministers.yml
+++ b/config/locales/th/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+th:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/tk/past_prime_ministers.yml
+++ b/config/locales/tk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+tk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/tr/past_prime_ministers.yml
+++ b/config/locales/tr/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+tr:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/uk/past_prime_ministers.yml
+++ b/config/locales/uk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+uk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/ur/past_prime_ministers.yml
+++ b/config/locales/ur/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+ur:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/uz/past_prime_ministers.yml
+++ b/config/locales/uz/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+uz:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/vi/past_prime_ministers.yml
+++ b/config/locales/vi/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+vi:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/yi/past_prime_ministers.yml
+++ b/config/locales/yi/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+yi:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/zh-hk/past_prime_ministers.yml
+++ b/config/locales/zh-hk/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+zh-hk:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/zh-tw/past_prime_ministers.yml
+++ b/config/locales/zh-tw/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+zh-tw:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/locales/zh/past_prime_ministers.yml
+++ b/config/locales/zh/past_prime_ministers.yml
@@ -1,0 +1,13 @@
+---
+zh:
+  past_prime_ministers:
+    context:
+    headings:
+      biography:
+      born:
+      dates_in_office:
+      died:
+      interesting_facts:
+      major_acts:
+      political_party:
+    view_all:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
   get "/government/history/past-chancellors", to: "past_chancellors#index"
   get "/government/history/past-foreign-secretaries", to: "past_foreign_secretaries#index"
   get "/government/history/past-foreign-secretaries/:id", to: "past_foreign_secretaries#show"
+  get "/government/history/past-prime-ministers/:id", to: "past_prime_ministers#show"
 
   get "/government/people/:name(.:locale)", to: "people#show"
   get "/government/ministers(.:locale)", to: "ministers#index"

--- a/spec/controllers/past_prime_ministers_controller_spec.rb
+++ b/spec/controllers/past_prime_ministers_controller_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe PastPrimeMinistersController do
+  let(:base_path) { "/government/history/past-prime-ministers" }
+  let(:past_pm_id) { "a-pm" }
+  let(:content_item) do
+    {
+      base_path: "#{base_path}/#{past_pm_id}",
+      title: "a past PM",
+      details: {
+        born: "1900",
+        died: "2000",
+        interesting_facts: "a fact",
+        major_acts: "an act",
+        political_party: "A party",
+        dates_in_office: [{ end_year: 2005, start_year: 2000 }],
+      },
+      links: { ordered_related_items: [] },
+    }
+  end
+
+  describe "GET show" do
+    it "has a success response for an existent pm" do
+      stub_content_store_has_item("#{base_path}/#{past_pm_id}", content_item)
+
+      get :show, params: { id: "a-pm" }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "has a not found response for a non-existent pm" do
+      id = "not-a-pm"
+      stub_content_store_does_not_have_item("#{base_path}/#{id}")
+      get :show, params: { id: }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/features/past_prime_minister_spec.rb
+++ b/spec/features/past_prime_minister_spec.rb
@@ -1,0 +1,109 @@
+require "integration_spec_helper"
+
+RSpec.feature "Past Prime Minister pages" do
+  let(:base_path) { "/government/history/past-prime-ministers/test-pm" }
+  let(:content_item) do
+    {
+      base_path:,
+      title: "The Rt Hon Test Pm",
+      description: "Not a real person",
+      details: {
+        political_party: "Fake Party",
+        dates_in_office: [
+          {
+            end_year: 2005,
+            start_year: 2000,
+          },
+        ],
+        body: "<p class=body_text>Some body text</p>",
+        born: "1 January 1900, Laceby, Lincolnshire",
+        died: "31st December 2005, Hundalee, Jedburgh, Scotland",
+        major_acts: "Played King Lear in a local production in Carmarthen, Wales",
+        interesting_facts: "Opened a village hall in Tullyhogue, Northern Island, in 1964",
+      },
+      links: {
+        person: [
+          details: {
+            image: {
+              url: "/test/pm",
+              alt_text: "A picture of test PM",
+            },
+          },
+        ],
+        ordered_related_items: [
+          { title: "Another PM",
+            base_path: "/another-pm" },
+        ],
+      },
+    }
+  end
+
+  context "when a past prime minister has all fields" do
+    before do
+      stub_content_store_has_item(base_path, content_item)
+      visit base_path
+    end
+
+    it "sets the page title" do
+      expect(page).to have_title("#{content_item[:title]} - GOV.UK")
+    end
+
+    it "renders the relevant text field from the top level content item fields" do
+      top_level_fields = %i[title description]
+      top_level_fields.each { |field| expect(page).to have_text(content_item[field]) }
+    end
+
+    it "renders the relevant text fields from the content item's details" do
+      expected_details_fields = %i[born died major_acts interesting_facts political_party]
+      expected_details_fields.each do |field|
+        expect(page).to have_css("h2", text: field.to_s.gsub("_", " ").capitalize)
+        expect(page).to have_text(content_item.dig(:details, field))
+      end
+    end
+
+    it "renders the biography on the page" do
+      expect(page).to have_text("Some body text")
+      expect(page).to have_css(".body_text")
+    end
+
+    it "renders the dates served along with the political party on the page" do
+      expect(page).to have_text("Fake Party 2000 to 2005")
+    end
+
+    it "renders the image on the page" do
+      image = find("img")
+      expect(image["src"]).to eq("/test/pm")
+      expect(image["alt"]).to eq("A picture of test PM")
+    end
+
+    it "renders the related pms on the page" do
+      within ".gem-c-related-navigation" do
+        expect(page).to have_link("Another PM", href: "/another-pm")
+      end
+    end
+  end
+
+  context "when a past prime minister does not have all optional fields" do
+    let(:base_path) { "/government/history/past-prime-ministers/test-pm" }
+    let(:fields_to_exclude) { %i[born died major_acts interesting_facts] }
+    let(:shortened_content_item) do
+      content_item.tap do |content|
+        content[:details] = content[:details].map { |k, v| fields_to_exclude.include?(k) ? [k, ""] : [k, v] }.to_h
+      end
+    end
+
+    before do
+      stub_content_store_has_item(base_path, shortened_content_item)
+      visit base_path
+    end
+
+    it "renders the relevant text field from the top level content item fields" do
+      top_level_fields = %i[title description]
+      top_level_fields.each { |field| expect(page).to have_text(content_item[field]) }
+    end
+
+    it "does not render the excluded fields" do
+      fields_to_exclude.each { |field| expect(page).not_to have_css("h2", text: field.to_s.gsub("_", " ").capitalize) }
+    end
+  end
+end

--- a/spec/models/past_prime_minister_spec.rb
+++ b/spec/models/past_prime_minister_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe PastPrimeMinister do
+  let(:api_data) do
+    {
+      "details" => {
+        "born" => "1900",
+        "died" => "2000",
+        "interesting_facts" => "a fact",
+        "major_acts" => "an act",
+        "political_party" => "A party",
+        "dates_in_office" => [
+          {
+            "end_year" => 2005,
+            "start_year" => 2000,
+          },
+          {
+            "end_year" => 1992,
+            "start_year" => 1987,
+          },
+        ],
+      },
+    }
+  end
+
+  let(:content_item) { ContentItem.new(api_data) }
+  let(:appointment) { described_class.new(content_item) }
+
+  describe "dates_in_office" do
+    it "interpolates previous dates in office" do
+      output = "2000 to 2005, 1987 to 1992"
+      expect(appointment.dates_in_office).to eq(output)
+    end
+  end
+
+  describe "appointment_info_array" do
+    it "creates an array of all the info" do
+      expected_info = [
+        { title: "Born", text: "1900" },
+        { title: "Died", text: "2000" },
+        { title: "Dates in office", text: "2000 to 2005, 1987 to 1992" },
+        { title: "Political party", text: "A party" },
+        { title: "Major acts", text: "an act" },
+        { title: "Interesting facts", text: "a fact" },
+      ]
+      expect(appointment.appointment_info_array).to eq(expected_info)
+    end
+  end
+end


### PR DESCRIPTION
This adds the code to render the individual past prime ministers pages in collections (such as [Teresa May](https://www.gov.uk/government/history/past-prime-ministers/theresa-may) and [William Pitt the Younger](https://www.gov.uk/government/history/past-prime-ministers/william-pitt)). This forms part of the overall work to move rendering out of whitehall.

Screenshots:

| Whitehall | Collections |
| ---- | --- |
|<img width="501" alt="Screenshot 2023-02-27 at 16 20 55" src="https://user-images.githubusercontent.com/25515510/221620542-a4671f32-bb73-4feb-9ff5-940433d5da18.png">|<img width="483" alt="Screenshot 2023-02-27 at 16 20 21" src="https://user-images.githubusercontent.com/25515510/221620475-9d10811c-90bc-4d61-9112-56454a627a84.png">|
|<img width="517" alt="Screenshot 2023-02-27 at 16 29 58" src="https://user-images.githubusercontent.com/25515510/221622613-9322f319-356f-45b6-9725-49509238b0ac.png">|<img width="513" alt="Screenshot 2023-02-27 at 16 30 54" src="https://user-images.githubusercontent.com/25515510/221622561-b02470eb-911f-4353-9aaa-bd0b523d6ae5.png">|

Note that there is a slight difference in that we no longer render links to all past prime minister pages on the individual pages - just to the 5 closest PMs who have historical accounts. This decision was made on the Whitehall side, to simplify the content item and presenting code, and also simplify what appears on the page. We've also fixed an issue with older PMs not displaying the prime ministers adjacent to them in term (see William Pitt the Younger above).

[Trello](https://trello.com/c/YJ4RzyVl/424-render-individual-past-prime-ministers-pages-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
