### PR TITLE
Add cost of living banner to state pension browse page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@ $govuk-include-default-font-face: false;
 @import "govuk_publishing_components/components/govspeak";
 @import "govuk_publishing_components/components/image-card";
 @import "govuk_publishing_components/components/inset-text";
+@import "govuk_publishing_components/components/intervention";
 @import "govuk_publishing_components/components/inverse-header";
 @import "govuk_publishing_components/components/lead-paragraph";
 @import "govuk_publishing_components/components/metadata";

--- a/app/helpers/cost_of_living_banner_helper.rb
+++ b/app/helpers/cost_of_living_banner_helper.rb
@@ -1,0 +1,11 @@
+module CostOfLivingBannerHelper
+  COST_OF_LIVING_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/XS2YWV/".freeze
+
+  SURVEY_URL_MAPPINGS = {
+    "/browse/working/state-pension" => COST_OF_LIVING_SURVEY_URL,
+  }.freeze
+
+  def survey_url
+    SURVEY_URL_MAPPINGS[base_path]
+  end
+end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,4 +1,6 @@
 class MainstreamBrowsePage
+  include CostOfLivingBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -15,10 +15,8 @@
   <%= render "shared/browse_breadcrumbs" %>
 <% end %>
 
-<%= render "shared/browse_header", {
-  two_thirds: true,
-  margin_bottom: 8
-} do %>
+<%= render "shared/browse_header", page.survey_url ? { margin_bottom: 6 } : { margin_bottom: 8 } do %>
+
   <%= render "govuk_publishing_components/components/heading", {
     font_size: "xl",
     heading_level: 1,
@@ -31,6 +29,18 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+
+<% if page.survey_url %>
+<div class="govuk-width-container">
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help make GOV.UK better",
+    suggestion_link_text: "Take part in user research",
+    suggestion_link_url: page.survey_url,
+    new_tab: true,
+  } %>
+</div>
 <% end %>
 
 <div class="govuk-width-container">

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -29,4 +29,40 @@ RSpec.feature "Mainstream browsing" do
       expect(page).to have_selector(".gem-c-breadcrumbs")
     end
   end
+
+  scenario "State pension second level browse page displays the Cost of living survey banner" do
+    content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "curated_level_2_page")
+    content_item["base_path"] = "/browse/working/state-pension"
+
+    stub_content_store_has_item("/browse/working/state-pension", content_item)
+
+    search_api_has_documents_for_browse_page(
+      content_item["content_id"],
+      ["/browse/working/state-pension"],
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+    )
+
+    visit "/browse/working/state-pension"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_selector(".gem-c-intervention")
+  end
+
+  scenario "other browse pages don't show the banner" do
+    content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "curated_level_2_page")
+    content_item["base_path"] = "/browse/benefits/entitlement-with-list"
+
+    stub_content_store_has_item("/browse/benefits/entitlement-with-list", content_item)
+
+    search_api_has_documents_for_browse_page(
+      content_item["content_id"],
+      ["/browse/benefits/entitlement-with-list"],
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+    )
+
+    visit "/browse/benefits/entitlement-with-list"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to_not have_selector(".gem-c-intervention")
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / Why

Add an intervention banner that links to the Cost of living survey banner.

[Trello](https://trello.com/c/XozIyJgB/1670-cost-of-living-col-1-of-2-surveys-user-research-banner-request-m)

## Screenshots

### Before

![www gov uk_browse_working_state-pension](https://user-images.githubusercontent.com/424772/222148562-d1eae726-c66d-4f10-99ca-9c55be5335d4.png)


### After

![localhost_3070_browse_working_state-pension](https://user-images.githubusercontent.com/424772/222148580-82b6666e-9217-4bfb-809e-0b57e997f48d.png)

