### PR TITLE
Add missing survey banner from Cost of living

### DIFF
--- a/app/helpers/cost_of_living_banner_helper.rb
+++ b/app/helpers/cost_of_living_banner_helper.rb
@@ -2,6 +2,7 @@ module CostOfLivingBannerHelper
   COST_OF_LIVING_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/XS2YWV/".freeze
 
   SURVEY_URL_MAPPINGS = {
+    "/cost-of-living" => COST_OF_LIVING_SURVEY_URL,
     "/browse/working/state-pension" => COST_OF_LIVING_SURVEY_URL,
   }.freeze
 

--- a/app/presenters/cost_of_living_landing_page_presenter.rb
+++ b/app/presenters/cost_of_living_landing_page_presenter.rb
@@ -1,4 +1,6 @@
 class CostOfLivingLandingPagePresenter
+  include CostOfLivingBannerHelper
+
   COMPONENTS = %i[
     base_path
     page_title

--- a/app/views/cost_of_living_landing_page/show.html.erb
+++ b/app/views/cost_of_living_landing_page/show.html.erb
@@ -51,6 +51,15 @@
 
 <div class="colhub__announcement" data-module="gem-track-click">
   <div class="govuk-width-container">
+    <% if content.survey_url %>
+      <%= render "govuk_publishing_components/components/intervention", {
+        suggestion_text: "Help improve GOV.UK",
+        suggestion_link_text: "Take part in user research",
+        suggestion_link_url: content.survey_url,
+        new_tab: true,
+      } %>
+    <% end %>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
           <%= render "govuk_publishing_components/components/heading", {

--- a/spec/features/cost_of_living_landing_page_spec.rb
+++ b/spec/features/cost_of_living_landing_page_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Cost of Living hub page" do
       then_i_can_see_the_breadcrumbs
       and_there_are_metatags
       and_there_is_the_announcements_section
+      and_there_is_a_survey_banner
       and_there_is_an_important_info_suffix_on_some_link
       and_there_is_link_tracking
       and_there_is_accordion_section_tracking
@@ -47,9 +48,9 @@ RSpec.feature "Cost of Living hub page" do
       expect(page).to have_text("Announcements")
     end
 
-    def and_there_is_a_recruitment_survey_banner
+    def and_there_is_a_survey_banner
       expect(page).to have_text("Help improve GOV.UK")
-      expect(page).to have_link("https://GDSUserResearch.optimalworkshop.com/treejack/cbd7a696cbf57c683cbb2e95b4a36c8a")
+      expect(page).to have_link(href: "https://surveys.publishing.service.gov.uk/s/XS2YWV/")
     end
 
     def and_there_is_an_important_info_suffix_on_some_link

--- a/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
+++ b/spec/presenters/cost_of_living_landing_page_presenter_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe CostOfLivingLandingPagePresenter do
     described_class.new(content_item)
   end
 
+  it "returns the survey_url" do
+    expect(presenter.survey_url).to eq "https://surveys.publishing.service.gov.uk/s/XS2YWV/"
+  end
+
   it "provides getter methods for all component keys defined in the YAML" do
     # To keep the yaml and presenter in sync. If it fails update COMPONENTS in the presenter
     cost_of_living_hardcoded_content = YAML.load_file(Rails.root.join("config/cost_of_living_landing_page/content_item.yml")).deep_symbolize_keys


### PR DESCRIPTION
This was missing in the previous PR https://github.com/alphagov/collections/pull/3192

## Screenshots

### Before

![www gov uk_cost-of-living](https://user-images.githubusercontent.com/424772/222448893-5d193d08-20bd-457f-aaba-a9216426901d.png)

### After

![localhost_3070_cost-of-living (1)](https://user-images.githubusercontent.com/424772/222448904-31536283-2e54-45b8-90d7-318b84f8eb08.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

