### PR TITLE
Render past prime ministers index

### DIFF
--- a/app/views/past_foreign_secretaries/index.html.erb
+++ b/app/views/past_foreign_secretaries/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 </div>
 
-<%= render partial: "featured_past_foreign_secretaries", locals: { past_foreign_secretaries_image: @selection_of_profiles } %>
+<%= render partial: "shared/featured_historical_figures", locals: { historical_figures_with_image: @selection_of_profiles, heading: "Selection of profiles"} %>
 
 <%= render partial: "shared/historical_figures_by_century", locals: { people: @twenty_first_century, heading: "21st century" } %>
 

--- a/app/views/shared/_featured_historical_figures.erb
+++ b/app/views/shared/_featured_historical_figures.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Selection of profiles",
+      text: heading,
       padding: true,
       border_top: 2,
       font_size: "l",
@@ -11,7 +11,7 @@
 </div>
 
 <div class="historic-people-index__section-row-header" role="list">
-  <% past_foreign_secretaries_image.each_slice(4) do |row| %>
+  <% historical_figures_with_image.each_slice(4) do |row| %>
   <div class="govuk-grid-row">
     <% row.each do | _, info| %>
       <div role="listitem" class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
We will be able to re-use this for past prime ministers

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
