### PR TITLE
Don't install yarn in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ FROM $builder_image AS builder
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
-COPY package.json yarn.lock ./
-RUN yarn set version berry && yarn install --immutable
 COPY . .
 RUN rails assets:precompile && rm -fr log
 RUN bootsnap precompile --gemfile .


### PR DESCRIPTION
Reverts https://github.com/alphagov/collections/pull/3198/commits/cd5bb611e672befc85f31100bd195aefa8a4130c
 We don't need to install yarn as there is no build time dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
