### PR TITLE
Remove Services and Information link for MHRA

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -116,7 +116,6 @@ module Organisations
         hm-revenue-customs
         marine-management-organisation
         maritime-and-coastguard-agency
-        medicines-and-healthcare-products-regulatory-agency
         natural-england
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)


### PR DESCRIPTION
Deprecated and archived, see: https://trello.com/c/yTSdtHAu/1741-archive-and-redirect-medicines-and-healthcare-products-regulatory-agency-services-and-info-page-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
