### PR TITLE
Render /world/embassies

### DIFF
--- a/app/controllers/embassies_controller.rb
+++ b/app/controllers/embassies_controller.rb
@@ -1,0 +1,7 @@
+class EmbassiesController < ApplicationController
+  def index
+    embassies_index = EmbassiesIndex.find!("/world/embassies")
+    @presented_embassies = EmbassiesIndexPresenter.new(embassies_index)
+    setup_content_item_and_navigation_helpers(embassies_index)
+  end
+end

--- a/app/models/embassies_index.rb
+++ b/app/models/embassies_index.rb
@@ -1,0 +1,16 @@
+require "active_model"
+
+class EmbassiesIndex
+  include ActiveModel::Model
+
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    content_item = ContentItem.find!(base_path)
+    new(content_item)
+  end
+end

--- a/app/presenters/embassies_index_presenter.rb
+++ b/app/presenters/embassies_index_presenter.rb
@@ -4,7 +4,7 @@ class EmbassiesIndexPresenter
   end
 
   def title
-    "Find a British embassy, high commission or consulate"
+    I18n.t("embassies.title")
   end
 
   def details

--- a/app/presenters/embassies_index_presenter.rb
+++ b/app/presenters/embassies_index_presenter.rb
@@ -1,0 +1,54 @@
+class EmbassiesIndexPresenter
+  def initialize(embassies_index)
+    @embassies_index = embassies_index
+  end
+
+  def title
+    "Find a British embassy, high commission or consulate"
+  end
+
+  def details
+    @embassies_index.content_item.details
+  end
+
+  def embassies_by_location
+    details["world_locations"].map do |data|
+      Embassy.new(data)
+    end
+  end
+
+  class Embassy
+    def initialize(data)
+      @data = data
+    end
+
+    def name
+      @data["name"]
+    end
+
+    def can_assist_british_nationals?
+      %w[local remote].include?(@data["assistance_available"])
+    end
+
+    def can_assist_in_location?
+      @data["assistance_available"] == "local"
+    end
+
+    def remote_office
+      RemoteOffice.new(name: @data["remote_office"]["name"],
+                       location: @data["remote_office"]["country"],
+                       path: @data["remote_office"]["path"])
+    end
+
+    def organisations_with_embassy_offices
+      @data["organisations_with_embassy_offices"].map do |o|
+        Organisation.new(locality: o["locality"],
+                         name: o["name"],
+                         path: o["path"])
+      end
+    end
+
+    Organisation = Struct.new(:name, :locality, :path, keyword_init: true)
+    RemoteOffice = Struct.new(:name, :location, :path, keyword_init: true)
+  end
+end

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,6 +1,6 @@
 <li>
   <%= render "govuk_publishing_components/components/heading", {
-    text: ERB::Util.html_escape(organisation.locality),
+    text: organisation.locality,
     heading_level: 3,
     margin_bottom: 1
   } %>

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,0 +1,8 @@
+<li>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: ERB::Util.html_escape(organisation.locality),
+    heading_level: 3,
+    margin_bottom: 1
+  } %>
+  <%= link_to(organisation.name, organisation.path, class: "govuk-link") %>
+</li>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, @presented_embassies.title %>
 
 <%= render "govuk_publishing_components/components/title", {
-  context: "Worldwide",
+  context: t('embassies.context'),
   title: @presented_embassies.title,
   } %>
 
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <aside class="govuk-grid-column-one-quarter">
       <%= render "govuk_publishing_components/components/heading", {
-        text: raw("<span class=\" govuk-visually-hidden\">Countries ordered from </span> A–Z"),
+        text: raw("<span class=\" govuk-visually-hidden\">#{t('embassies.visually_hidden_ordering_hint')} </span> #{t('embassies.ordering_title')}"),
         font_size: "l",
         margin_bottom: 6,
         } %>
@@ -31,14 +31,14 @@
                   <% else %>
                     <li>
                       <p class="govuk-body">
-                        British nationals should contact the <%= embassy.remote_office.name %> in <%= embassy.remote_office.location %>.
+                        <%= t('embassies.contact_office_name_in_location', name: embassy.remote_office.name, location: embassy.remote_office.location) %>.
                       </p>
                       <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
                     </li>
                   <% end %>
                 </ul>
               <% else %>
-                <p class="govuk-body">British nationals should contact the local authorities.</p>
+                <p class="govuk-body"><%= t('embassies.contact_local_authorities') %>.</p>
               <% end %>
             </div>
           </li>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,0 +1,50 @@
+<% content_for :title, @presented_embassies.title %>
+
+<%= render "govuk_publishing_components/components/title", {
+  context: "Worldwide",
+  title: @presented_embassies.title,
+  } %>
+
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <aside class="govuk-grid-column-one-quarter">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: raw("<span class=\" govuk-visually-hidden\">Countries ordered from </span> A–Z"),
+        font_size: "l",
+        margin_bottom: 6,
+        } %>
+    </aside>
+    <section class="govuk-grid-column-three-quarters">
+      <ol class="govuk-list govuk-list--spaced">
+        <% @presented_embassies.embassies_by_location.each do |embassy| -%>
+          <li class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: embassy.name, margin_bottom: 1
+                } %>
+            </div>
+            <div class="govuk-grid-column-two-thirds">
+              <% if embassy.can_assist_british_nationals? %>
+                <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
+                  <% if embassy.can_assist_in_location? %>
+                    <%= render partial: "organisation", collection: embassy.organisations_with_embassy_offices %>
+                  <% else %>
+                    <li>
+                      <p class="govuk-body">
+                        British nationals should contact the <%= embassy.remote_office.name %> in <%= embassy.remote_office.location %>.
+                      </p>
+                      <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="govuk-body">British nationals should contact the local authorities.</p>
+              <% end %>
+            </div>
+          </li>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+      </ol>
+    </section>
+  </div>
+</div>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, @presented_embassies.title %>
+<% content_for :meta_tags do %>
+  <meta name="description" content="<%= t('embassies.meta_description') %>.">
+<% end %>
 
 <%= render "govuk_publishing_components/components/title", {
   context: t('embassies.context'),

--- a/config/locales/ar/embassies.yml
+++ b/config/locales/ar/embassies.yml
@@ -4,6 +4,7 @@ ar:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/ar/embassies.yml
+++ b/config/locales/ar/embassies.yml
@@ -1,0 +1,9 @@
+---
+ar:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/az/embassies.yml
+++ b/config/locales/az/embassies.yml
@@ -4,6 +4,7 @@ az:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/az/embassies.yml
+++ b/config/locales/az/embassies.yml
@@ -1,0 +1,9 @@
+---
+az:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/be/embassies.yml
+++ b/config/locales/be/embassies.yml
@@ -1,0 +1,9 @@
+---
+be:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/be/embassies.yml
+++ b/config/locales/be/embassies.yml
@@ -4,6 +4,7 @@ be:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/bg/embassies.yml
+++ b/config/locales/bg/embassies.yml
@@ -1,0 +1,9 @@
+---
+bg:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/bg/embassies.yml
+++ b/config/locales/bg/embassies.yml
@@ -4,6 +4,7 @@ bg:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/bn/embassies.yml
+++ b/config/locales/bn/embassies.yml
@@ -1,0 +1,9 @@
+---
+bn:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/bn/embassies.yml
+++ b/config/locales/bn/embassies.yml
@@ -4,6 +4,7 @@ bn:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/cs/embassies.yml
+++ b/config/locales/cs/embassies.yml
@@ -1,0 +1,9 @@
+---
+cs:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/cs/embassies.yml
+++ b/config/locales/cs/embassies.yml
@@ -4,6 +4,7 @@ cs:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/cy/embassies.yml
+++ b/config/locales/cy/embassies.yml
@@ -1,0 +1,9 @@
+---
+cy:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/cy/embassies.yml
+++ b/config/locales/cy/embassies.yml
@@ -4,6 +4,7 @@ cy:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/da/embassies.yml
+++ b/config/locales/da/embassies.yml
@@ -4,6 +4,7 @@ da:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/da/embassies.yml
+++ b/config/locales/da/embassies.yml
@@ -1,0 +1,9 @@
+---
+da:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/de/embassies.yml
+++ b/config/locales/de/embassies.yml
@@ -1,0 +1,9 @@
+---
+de:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/de/embassies.yml
+++ b/config/locales/de/embassies.yml
@@ -4,6 +4,7 @@ de:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/dr/embassies.yml
+++ b/config/locales/dr/embassies.yml
@@ -1,0 +1,9 @@
+---
+dr:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/dr/embassies.yml
+++ b/config/locales/dr/embassies.yml
@@ -4,6 +4,7 @@ dr:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/el/embassies.yml
+++ b/config/locales/el/embassies.yml
@@ -4,6 +4,7 @@ el:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/el/embassies.yml
+++ b/config/locales/el/embassies.yml
@@ -1,0 +1,9 @@
+---
+el:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/en/embassies.yml
+++ b/config/locales/en/embassies.yml
@@ -1,0 +1,9 @@
+---
+en:
+  embassies:
+    contact_local_authorities: British nationals should contact the local authorities
+    contact_office_name_in_location: British nationals should contact the %{name} in %{location}
+    context: Worldwide
+    ordering_title: A–Z
+    title: Find a British embassy, high commission or consulate
+    visually_hidden_ordering_hint: Countries ordered from

--- a/config/locales/en/embassies.yml
+++ b/config/locales/en/embassies.yml
@@ -4,6 +4,7 @@ en:
     contact_local_authorities: British nationals should contact the local authorities
     contact_office_name_in_location: British nationals should contact the %{name} in %{location}
     context: Worldwide
+    meta_description: Contact details of British embassies, consulates, and high commissions around the world
     ordering_title: A–Z
     title: Find a British embassy, high commission or consulate
     visually_hidden_ordering_hint: Countries ordered from

--- a/config/locales/es-419/embassies.yml
+++ b/config/locales/es-419/embassies.yml
@@ -1,0 +1,9 @@
+---
+es-419:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/es-419/embassies.yml
+++ b/config/locales/es-419/embassies.yml
@@ -4,6 +4,7 @@ es-419:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/es/embassies.yml
+++ b/config/locales/es/embassies.yml
@@ -4,6 +4,7 @@ es:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/es/embassies.yml
+++ b/config/locales/es/embassies.yml
@@ -1,0 +1,9 @@
+---
+es:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/et/embassies.yml
+++ b/config/locales/et/embassies.yml
@@ -1,0 +1,9 @@
+---
+et:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/et/embassies.yml
+++ b/config/locales/et/embassies.yml
@@ -4,6 +4,7 @@ et:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/fa/embassies.yml
+++ b/config/locales/fa/embassies.yml
@@ -1,0 +1,9 @@
+---
+fa:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/fa/embassies.yml
+++ b/config/locales/fa/embassies.yml
@@ -4,6 +4,7 @@ fa:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/fi/embassies.yml
+++ b/config/locales/fi/embassies.yml
@@ -4,6 +4,7 @@ fi:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/fi/embassies.yml
+++ b/config/locales/fi/embassies.yml
@@ -1,0 +1,9 @@
+---
+fi:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/fr/embassies.yml
+++ b/config/locales/fr/embassies.yml
@@ -1,0 +1,9 @@
+---
+fr:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/fr/embassies.yml
+++ b/config/locales/fr/embassies.yml
@@ -4,6 +4,7 @@ fr:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/gd/embassies.yml
+++ b/config/locales/gd/embassies.yml
@@ -4,6 +4,7 @@ gd:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/gd/embassies.yml
+++ b/config/locales/gd/embassies.yml
@@ -1,0 +1,9 @@
+---
+gd:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/gu/embassies.yml
+++ b/config/locales/gu/embassies.yml
@@ -1,0 +1,9 @@
+---
+gu:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/gu/embassies.yml
+++ b/config/locales/gu/embassies.yml
@@ -4,6 +4,7 @@ gu:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/he/embassies.yml
+++ b/config/locales/he/embassies.yml
@@ -4,6 +4,7 @@ he:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/he/embassies.yml
+++ b/config/locales/he/embassies.yml
@@ -1,0 +1,9 @@
+---
+he:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/hi/embassies.yml
+++ b/config/locales/hi/embassies.yml
@@ -4,6 +4,7 @@ hi:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/hi/embassies.yml
+++ b/config/locales/hi/embassies.yml
@@ -1,0 +1,9 @@
+---
+hi:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/hr/embassies.yml
+++ b/config/locales/hr/embassies.yml
@@ -1,0 +1,9 @@
+---
+hr:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/hr/embassies.yml
+++ b/config/locales/hr/embassies.yml
@@ -4,6 +4,7 @@ hr:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/hu/embassies.yml
+++ b/config/locales/hu/embassies.yml
@@ -1,0 +1,9 @@
+---
+hu:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/hu/embassies.yml
+++ b/config/locales/hu/embassies.yml
@@ -4,6 +4,7 @@ hu:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/hy/embassies.yml
+++ b/config/locales/hy/embassies.yml
@@ -4,6 +4,7 @@ hy:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/hy/embassies.yml
+++ b/config/locales/hy/embassies.yml
@@ -1,0 +1,9 @@
+---
+hy:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/id/embassies.yml
+++ b/config/locales/id/embassies.yml
@@ -1,0 +1,9 @@
+---
+id:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/id/embassies.yml
+++ b/config/locales/id/embassies.yml
@@ -4,6 +4,7 @@ id:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/is/embassies.yml
+++ b/config/locales/is/embassies.yml
@@ -1,0 +1,9 @@
+---
+is:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/is/embassies.yml
+++ b/config/locales/is/embassies.yml
@@ -4,6 +4,7 @@ is:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/it/embassies.yml
+++ b/config/locales/it/embassies.yml
@@ -4,6 +4,7 @@ it:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/it/embassies.yml
+++ b/config/locales/it/embassies.yml
@@ -1,0 +1,9 @@
+---
+it:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ja/embassies.yml
+++ b/config/locales/ja/embassies.yml
@@ -4,6 +4,7 @@ ja:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/ja/embassies.yml
+++ b/config/locales/ja/embassies.yml
@@ -1,0 +1,9 @@
+---
+ja:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ka/embassies.yml
+++ b/config/locales/ka/embassies.yml
@@ -1,0 +1,9 @@
+---
+ka:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ka/embassies.yml
+++ b/config/locales/ka/embassies.yml
@@ -4,6 +4,7 @@ ka:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/kk/embassies.yml
+++ b/config/locales/kk/embassies.yml
@@ -4,6 +4,7 @@ kk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/kk/embassies.yml
+++ b/config/locales/kk/embassies.yml
@@ -1,0 +1,9 @@
+---
+kk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ko/embassies.yml
+++ b/config/locales/ko/embassies.yml
@@ -1,0 +1,9 @@
+---
+ko:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ko/embassies.yml
+++ b/config/locales/ko/embassies.yml
@@ -4,6 +4,7 @@ ko:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/lt/embassies.yml
+++ b/config/locales/lt/embassies.yml
@@ -1,0 +1,9 @@
+---
+lt:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/lt/embassies.yml
+++ b/config/locales/lt/embassies.yml
@@ -4,6 +4,7 @@ lt:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/lv/embassies.yml
+++ b/config/locales/lv/embassies.yml
@@ -4,6 +4,7 @@ lv:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/lv/embassies.yml
+++ b/config/locales/lv/embassies.yml
@@ -1,0 +1,9 @@
+---
+lv:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ms/embassies.yml
+++ b/config/locales/ms/embassies.yml
@@ -1,0 +1,9 @@
+---
+ms:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ms/embassies.yml
+++ b/config/locales/ms/embassies.yml
@@ -4,6 +4,7 @@ ms:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/mt/embassies.yml
+++ b/config/locales/mt/embassies.yml
@@ -4,6 +4,7 @@ mt:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/mt/embassies.yml
+++ b/config/locales/mt/embassies.yml
@@ -1,0 +1,9 @@
+---
+mt:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ne/embassies.yml
+++ b/config/locales/ne/embassies.yml
@@ -1,0 +1,9 @@
+---
+ne:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ne/embassies.yml
+++ b/config/locales/ne/embassies.yml
@@ -4,6 +4,7 @@ ne:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/nl/embassies.yml
+++ b/config/locales/nl/embassies.yml
@@ -4,6 +4,7 @@ nl:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/nl/embassies.yml
+++ b/config/locales/nl/embassies.yml
@@ -1,0 +1,9 @@
+---
+nl:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/no/embassies.yml
+++ b/config/locales/no/embassies.yml
@@ -1,0 +1,9 @@
+---
+'no':
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/no/embassies.yml
+++ b/config/locales/no/embassies.yml
@@ -4,6 +4,7 @@
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pa-pk/embassies.yml
+++ b/config/locales/pa-pk/embassies.yml
@@ -1,0 +1,9 @@
+---
+pa-pk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/pa-pk/embassies.yml
+++ b/config/locales/pa-pk/embassies.yml
@@ -4,6 +4,7 @@ pa-pk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pa/embassies.yml
+++ b/config/locales/pa/embassies.yml
@@ -1,0 +1,9 @@
+---
+pa:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/pa/embassies.yml
+++ b/config/locales/pa/embassies.yml
@@ -4,6 +4,7 @@ pa:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pl/embassies.yml
+++ b/config/locales/pl/embassies.yml
@@ -4,6 +4,7 @@ pl:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pl/embassies.yml
+++ b/config/locales/pl/embassies.yml
@@ -1,0 +1,9 @@
+---
+pl:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ps/embassies.yml
+++ b/config/locales/ps/embassies.yml
@@ -1,0 +1,9 @@
+---
+ps:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ps/embassies.yml
+++ b/config/locales/ps/embassies.yml
@@ -4,6 +4,7 @@ ps:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pt/embassies.yml
+++ b/config/locales/pt/embassies.yml
@@ -4,6 +4,7 @@ pt:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/pt/embassies.yml
+++ b/config/locales/pt/embassies.yml
@@ -1,0 +1,9 @@
+---
+pt:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ro/embassies.yml
+++ b/config/locales/ro/embassies.yml
@@ -1,0 +1,9 @@
+---
+ro:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ro/embassies.yml
+++ b/config/locales/ro/embassies.yml
@@ -4,6 +4,7 @@ ro:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/ru/embassies.yml
+++ b/config/locales/ru/embassies.yml
@@ -1,0 +1,9 @@
+---
+ru:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ru/embassies.yml
+++ b/config/locales/ru/embassies.yml
@@ -4,6 +4,7 @@ ru:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/si/embassies.yml
+++ b/config/locales/si/embassies.yml
@@ -4,6 +4,7 @@ si:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/si/embassies.yml
+++ b/config/locales/si/embassies.yml
@@ -1,0 +1,9 @@
+---
+si:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sk/embassies.yml
+++ b/config/locales/sk/embassies.yml
@@ -1,0 +1,9 @@
+---
+sk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sk/embassies.yml
+++ b/config/locales/sk/embassies.yml
@@ -4,6 +4,7 @@ sk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sl/embassies.yml
+++ b/config/locales/sl/embassies.yml
@@ -4,6 +4,7 @@ sl:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sl/embassies.yml
+++ b/config/locales/sl/embassies.yml
@@ -1,0 +1,9 @@
+---
+sl:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/so/embassies.yml
+++ b/config/locales/so/embassies.yml
@@ -4,6 +4,7 @@ so:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/so/embassies.yml
+++ b/config/locales/so/embassies.yml
@@ -1,0 +1,9 @@
+---
+so:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sq/embassies.yml
+++ b/config/locales/sq/embassies.yml
@@ -1,0 +1,9 @@
+---
+sq:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sq/embassies.yml
+++ b/config/locales/sq/embassies.yml
@@ -4,6 +4,7 @@ sq:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sr/embassies.yml
+++ b/config/locales/sr/embassies.yml
@@ -1,0 +1,9 @@
+---
+sr:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sr/embassies.yml
+++ b/config/locales/sr/embassies.yml
@@ -4,6 +4,7 @@ sr:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sv/embassies.yml
+++ b/config/locales/sv/embassies.yml
@@ -1,0 +1,9 @@
+---
+sv:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/sv/embassies.yml
+++ b/config/locales/sv/embassies.yml
@@ -4,6 +4,7 @@ sv:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sw/embassies.yml
+++ b/config/locales/sw/embassies.yml
@@ -4,6 +4,7 @@ sw:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/sw/embassies.yml
+++ b/config/locales/sw/embassies.yml
@@ -1,0 +1,9 @@
+---
+sw:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ta/embassies.yml
+++ b/config/locales/ta/embassies.yml
@@ -1,0 +1,9 @@
+---
+ta:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ta/embassies.yml
+++ b/config/locales/ta/embassies.yml
@@ -4,6 +4,7 @@ ta:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/th/embassies.yml
+++ b/config/locales/th/embassies.yml
@@ -1,0 +1,9 @@
+---
+th:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/th/embassies.yml
+++ b/config/locales/th/embassies.yml
@@ -4,6 +4,7 @@ th:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/tk/embassies.yml
+++ b/config/locales/tk/embassies.yml
@@ -4,6 +4,7 @@ tk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/tk/embassies.yml
+++ b/config/locales/tk/embassies.yml
@@ -1,0 +1,9 @@
+---
+tk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/tr/embassies.yml
+++ b/config/locales/tr/embassies.yml
@@ -4,6 +4,7 @@ tr:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/tr/embassies.yml
+++ b/config/locales/tr/embassies.yml
@@ -1,0 +1,9 @@
+---
+tr:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/uk/embassies.yml
+++ b/config/locales/uk/embassies.yml
@@ -1,0 +1,9 @@
+---
+uk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/uk/embassies.yml
+++ b/config/locales/uk/embassies.yml
@@ -4,6 +4,7 @@ uk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/ur/embassies.yml
+++ b/config/locales/ur/embassies.yml
@@ -1,0 +1,9 @@
+---
+ur:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/ur/embassies.yml
+++ b/config/locales/ur/embassies.yml
@@ -4,6 +4,7 @@ ur:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/uz/embassies.yml
+++ b/config/locales/uz/embassies.yml
@@ -1,0 +1,9 @@
+---
+uz:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/uz/embassies.yml
+++ b/config/locales/uz/embassies.yml
@@ -4,6 +4,7 @@ uz:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/vi/embassies.yml
+++ b/config/locales/vi/embassies.yml
@@ -1,0 +1,9 @@
+---
+vi:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/vi/embassies.yml
+++ b/config/locales/vi/embassies.yml
@@ -4,6 +4,7 @@ vi:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/yi/embassies.yml
+++ b/config/locales/yi/embassies.yml
@@ -1,0 +1,9 @@
+---
+yi:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/yi/embassies.yml
+++ b/config/locales/yi/embassies.yml
@@ -4,6 +4,7 @@ yi:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/zh-hk/embassies.yml
+++ b/config/locales/zh-hk/embassies.yml
@@ -1,0 +1,9 @@
+---
+zh-hk:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/zh-hk/embassies.yml
+++ b/config/locales/zh-hk/embassies.yml
@@ -4,6 +4,7 @@ zh-hk:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/zh-tw/embassies.yml
+++ b/config/locales/zh-tw/embassies.yml
@@ -1,0 +1,9 @@
+---
+zh-tw:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/zh-tw/embassies.yml
+++ b/config/locales/zh-tw/embassies.yml
@@ -4,6 +4,7 @@ zh-tw:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/locales/zh/embassies.yml
+++ b/config/locales/zh/embassies.yml
@@ -1,0 +1,9 @@
+---
+zh:
+  embassies:
+    contact_local_authorities:
+    contact_office_name_in_location:
+    context:
+    ordering_title:
+    title:
+    visually_hidden_ordering_hint:

--- a/config/locales/zh/embassies.yml
+++ b/config/locales/zh/embassies.yml
@@ -4,6 +4,7 @@ zh:
     contact_local_authorities:
     contact_office_name_in_location:
     context:
+    meta_description:
     ordering_title:
     title:
     visually_hidden_ordering_hint:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,10 @@ Rails.application.routes.draw do
     get "/:slug", to: "step_nav#show"
   end
 
+  get "/world/embassies",
+      to: "embassies#index",
+      as: :embassies
+
   get "/world/:name/news(.:locale).atom",
       to: "world_location_news#show",
       as: :world_location_news_feed

--- a/spec/controllers/embassies_controller_spec.rb
+++ b/spec/controllers/embassies_controller_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe EmbassiesController do
+  describe "GET index" do
+    before do
+      stub_content_store_has_item("/world/embassies", fetch_fixture("embassies_index"))
+    end
+
+    it "has a success response" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/features/embassies_spec.rb
+++ b/spec/features/embassies_spec.rb
@@ -1,0 +1,28 @@
+require "integration_spec_helper"
+
+RSpec.feature "Embassies index page" do
+  before do
+    stub_content_store_has_item("/world/embassies", fetch_fixture("embassies_index"))
+    visit "/world/embassies"
+  end
+
+  scenario "returns 200 when visiting embassies index page" do
+    expect(page.status_code).to eq(200)
+  end
+
+  scenario "renders advice for British nationals in locations without embassy offices" do
+    node = find("li", text: /^Anguilla$/)
+    expect(node).to have_text "British nationals should contact the local authorities"
+  end
+
+  scenario "renders advice for British nationals in locations with remote offices" do
+    node = find("li", text: /^Afghanistan$/)
+    expect(node).to have_text "British nationals should contact the British Embassy Kabul in Qatar"
+    expect(node).to have_link("British Embassy Kabul", href: "/world/organisations/british-embassy-kabul")
+  end
+
+  scenario "renders advice for British nationals in locations with local offices" do
+    node = find("li", text: /^Argentina$/)
+    expect(node).to have_link("British Embassy Buenos Aires", href: "/world/organisations/british-embassy-buenos-aires")
+  end
+end

--- a/spec/fixtures/content_store/embassies_index.json
+++ b/spec/fixtures/content_store/embassies_index.json
@@ -1,0 +1,56 @@
+{
+  "base_path": "/world/embassies",
+  "content_id": "8e2cb457-81c1-484e-baa5-d714538c7c66",
+  "description": "",
+  "details": {
+    "world_locations": [
+      {
+        "name": "Afghanistan",
+        "assistance_available": "remote",
+        "remote_office": {
+          "name": "British Embassy Kabul",
+          "country": "Qatar",
+          "path": "/world/organisations/british-embassy-kabul"
+        }
+      },
+      {
+        "name": "Anguilla",
+        "assistance_available": "none"
+      },
+      {
+        "name": "Argentina",
+        "assistance_available": "local",
+        "organisations_with_embassy_offices": [
+          {
+            "locality": "",
+            "name": "British Embassy Buenos Aires",
+            "path": "/world/organisations/british-embassy-buenos-aires"
+          },
+          {
+            "locality": "",
+            "name": "UK Science & Innovation Network in Argentina",
+            "path": "/world/organisations/uk-science-innovation-network-in-argentina--2"
+          }
+        ]
+      }
+    ]
+  },
+  "document_type": "embassies_index",
+  "links": {
+    "parent": [
+      {
+        "base_path": "/world",
+        "content_id": "369729ba-7776-4123-96be-2e3e98e153e1",
+        "locale": "en",
+        "title": ""
+      }
+    ]
+  },
+  "locale": "en",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "embassies_index",
+  "title": "Find a British embassy, high commission or consulate",
+  "public_updated_at": "2016-09-14T18:19:27+01:00",
+  "updated_at": "2016-09-14T10:37:00Z"
+}

--- a/spec/presenters/embassies_index_presenter_spec.rb
+++ b/spec/presenters/embassies_index_presenter_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe EmbassiesIndexPresenter::Embassy do
+  let(:embassy_data) { { "assistance_available" => assistance_available } }
+
+  subject(:embassy) { described_class.new(embassy_data) }
+
+  context "when assistance_available is local" do
+    let(:assistance_available) { "local" }
+
+    it "can assist british citizens" do
+      expect(embassy.can_assist_british_nationals?).to be_truthy
+    end
+
+    it "can assist in location" do
+      expect(embassy.can_assist_in_location?).to be_truthy
+    end
+  end
+
+  context "when assistance_available is remote" do
+    let(:assistance_available) { "remote" }
+
+    it "can assist british citizens" do
+      expect(embassy.can_assist_british_nationals?).to be_truthy
+    end
+
+    it "cannot assist in location" do
+      expect(embassy.can_assist_in_location?).to be_falsey
+    end
+  end
+
+  context "when assistance_available is none" do
+    let(:assistance_available) { "none" }
+
+    it "cannot assist british citizens" do
+      expect(embassy.can_assist_british_nationals?).to be_falsey
+    end
+
+    it "cannot assist in location" do
+      expect(embassy.can_assist_in_location?).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
## Todo

- [x] Investigate whether we need to escape `locality` in our organisation partial. See Becka's comment below.
- [x] Move hardcoded strings into locale yaml file. See Becka's comment below.

---

Trello: https://trello.com/c/MMUcRbIT

This commit adds rendering of /world/embassies, a page currently
rendered by Whitehall. When the embassies_index document is published
to the publishing API in production, we intend to switch over the
rendering of this route to this application (and remove the relevant
code from Whitehall).

We've designed the interface of EmbassiesIndexPresenter so that we can
reuse as much of the [existing Whitehall view template][1] as
possible. Hopefully this makes the correspondence between the two as
clear as possible.

We have added tests for the two methods in EmbassiesIndexPresenter
that contain some logic, but we're relying on the higher level feature
spec to exercise the wrapping of json into objects in that
presenter. The fixture file we're using in the feature test is taken
from the [example frontend embassies_index document in the publishing
api repo][2].

Although there are translations for the title of this embassies index
page in Whitehall (e.g. in [en.yml][3]), there's no way to access any of
those translations because the [/world/embassies route doesn't accept a
locale param][4]. Because of this we've chosen to hardcode the title of
the page in `EmbassiesIndexPresenter#title` to preserve the behaviour in
whitehall.

[1]: https://github.com/alphagov/whitehall/blob/a8a0634e6bf15596b43648e1f4cbcd302b73494d/app/views/embassies/index.html.erb
[2]: https://github.com/alphagov/publishing-api/blob/067cd760d76e91d97b47d5e8edecff2ac0fe5ea7/content_schemas/examples/embassies_index/frontend/embassies_index.json
[3]: https://github.com/alphagov/whitehall/blob/8ad388e7c9ad40283928df4baac0b5da8f172243/config/locales/en.yml#L446
[4]: https://github.com/alphagov/whitehall/blob/8ad388e7c9ad40283928df4baac0b5da8f172243/config/routes.rb#L48

## Screenshot before change (rendered by whitehall)

<img width="782" alt="Screenshot 2023-05-11 at 12 06 52" src="https://github.com/alphagov/collections/assets/16707/34326392-ea41-4d62-9465-e69cb57c39ba">

## Screenshot after change (rendered by collections)

<img width="782" alt="Screenshot 2023-05-11 at 12 06 30" src="https://github.com/alphagov/collections/assets/16707/9a5b45f0-2187-4c7c-9a89-bc5b6107253e">



