### PR TITLE
[DO NOT MERGE!!!] Practice setting up an AB test

### DIFF
--- a/app/controllers/coronavirus_landing_page_controller.rb
+++ b/app/controllers/coronavirus_landing_page_controller.rb
@@ -4,6 +4,16 @@ class CoronavirusLandingPageController < ApplicationController
   def show
     breadcrumbs = [{ title: t("shared.breadcrumbs_home"), url: "/", is_page_parent: true }]
 
+    ab_test = GovukAbTesting::AbTest.new(
+      "UxmPracticeTest",
+      dimension: 68,
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+
     render "show",
            locals: {
              breadcrumbs:,

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -1,5 +1,9 @@
 <% add_view_stylesheet("covid") %>
 
+<% content_for :meta_tags do %>
+  <%= @requested_variant.analytics_meta_tag.html_safe %>
+<% end %>
+
 <%= render partial: "coronavirus_landing_page/components/shared/meta_tags", locals: {
   metadata: details.metadata,
   corona_opengraph_images: true
@@ -71,4 +75,11 @@
       background: true
     }
   end %>
+  <% if @requested_variant.variant?("A") %>
+    <br>
+  <% end %>
+  <% if @requested_variant.variant?("B") %>
+    <br>
+    <br>
+  <% end %>
 </div>

--- a/spec/controllers/coronavirus_landing_page_controller_spec.rb
+++ b/spec/controllers/coronavirus_landing_page_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe CoronavirusLandingPageController do
   include CoronavirusContentItemHelper
+  include GovukAbTesting::RspecHelpers
 
   describe "GET show" do
     before do
@@ -12,7 +13,46 @@ RSpec.describe CoronavirusLandingPageController do
 
     it "has a success response" do
       get :show
+
       expect(response).to have_http_status(:success)
+    end
+
+    context "User Experience Measurement practice AB test" do
+      render_views
+      it "should render the A version of the page" do
+        @request.headers["HTTP_GOVUK_ABTEST_UXMPRACTICETEST"] = "A"
+        get :show
+        expect(response).to have_http_status(:success)
+        expect(response.header["Vary"]).to eq("GOVUK-ABTest-UxmPracticeTest")
+        expect(response.body).to include("<meta name=\"govuk:ab-test\"  content=\"UxmPracticeTest:A\"  data-analytics-dimension=\"68\"  data-allowed-variants=\"A,B,Z\">")
+      end
+
+      it "should render the B version of the page" do
+        @request.headers["HTTP_GOVUK_ABTEST_UXMPRACTICETEST"] = "B"
+        get :show
+        expect(response).to have_http_status(:success)
+        expect(response.header["Vary"]).to eq("GOVUK-ABTest-UxmPracticeTest")
+        assert_equal("GOVUK-ABTest-UxmPracticeTest", response.headers["Vary"])
+        expect(response.body).to include(
+          "<meta name=\"govuk:ab-test\"  content=\"UxmPracticeTest:B\"  data-analytics-dimension=\"68\"  data-allowed-variants=\"A,B,Z\">",
+        )
+      end
+
+      it "should render the Z version of the page" do
+        @request.headers["HTTP_GOVUK_ABTEST_UXMPRACTICETEST"] = "Z"
+        get :show
+        expect(response).to have_http_status(:success)
+        expect(response.header["Vary"]).to eq("GOVUK-ABTest-UxmPracticeTest")
+        expect(response.body).to include("<meta name=\"govuk:ab-test\"  content=\"UxmPracticeTest:Z\"  data-analytics-dimension=\"68\"  data-allowed-variants=\"A,B,Z\">")
+      end
+
+      it "should render the page without an AB test variant" do
+        get :show
+        expect(response).to have_http_status(:success)
+
+        expect(response.header["Vary"]).to eq("GOVUK-ABTest-UxmPracticeTest")
+        expect(response.body).not_to include("<meta name=\"govuk:ab-test\">")
+      end
     end
   end
 end

--- a/spec/features/ab_testing_spec.rb
+++ b/spec/features/ab_testing_spec.rb
@@ -1,0 +1,34 @@
+require "integration_spec_helper"
+
+feature "Viewing a page with the UxmPracticeTest test" do
+  include CoronavirusContentItemHelper
+  include GovukAbTesting::RspecHelpers
+
+  before do
+    stub_content_store_has_item(
+      "/coronavirus",
+      coronavirus_content_item,
+      { max_age: 900, private: false },
+    )
+  end
+
+  scenario "viewing the A version of the page" do
+    with_variant UxmPracticeTest: "A" do
+      visit "/coronavirus"
+
+      expect(page.driver.options[:headers]).to eql({ "HTTP_GOVUK_ABTEST_UXMPRACTICETEST" => "A" })
+
+      expect(page.body).to include("<br>").once
+    end
+  end
+
+  scenario "viewing the B version of the page" do
+    with_variant UxmPracticeTest: "B" do
+      visit "/coronavirus"
+
+      expect(page.driver.options[:headers]).to eql({ "HTTP_GOVUK_ABTEST_UXMPRACTICETEST" => "B" })
+
+      expect(page.body).to include("<br>").twice
+    end
+  end
+end

--- a/spec/integration_spec_helper.rb
+++ b/spec/integration_spec_helper.rb
@@ -7,6 +7,10 @@ GovukTest.configure
 
 Capybara.javascript_driver = :headless_chrome
 
+GovukAbTesting.configure do |config|
+  config.acceptance_test_framework = :capybara
+end
+
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/gADp9GVM/445-define-configure-and-write-ab-test)

- Displays different versions of the /coronavirus landing page depending on the test variant.
- The different versions will not be noticeably different to the user which minimises the risk if this branch reaches production.
- Please note - the plan is just to push this this branch to integration. The lack of visual change is cautionary!

You can test this out locally by:

1. Run the app using `./startup.sh --live`
2.  Use Postman to send a GET request to `http://localhost:3070/coronavirus` and add a header `GOVUK_ABTEST_UXMPRACTICETEST` with a value of `A` or `B`. 
3. You will see that the `<meta name="govuk:ab-test" content="UxmPracticeTest:B"` content changes depending on the header value. The HTML body will also change to have either one or two <br> tags. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
