### PR TITLE
Add cost of living user research banner

### DIFF
--- a/app/helpers/user_research_banner_helper.rb
+++ b/app/helpers/user_research_banner_helper.rb
@@ -1,0 +1,11 @@
+module UserResearchBannerHelper
+  COST_OF_LIVING_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6".freeze
+
+  SURVEY_URL_MAPPINGS = {
+    "/browse/working/state-pension" => COST_OF_LIVING_SURVEY_URL,
+  }.freeze
+
+  def survey_url
+    SURVEY_URL_MAPPINGS[base_path]
+  end
+end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,4 +1,6 @@
 class MainstreamBrowsePage
+  include UserResearchBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -33,6 +33,17 @@
   } %>
 <% end %>
 
+<% if page.survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help make GOV.UK better",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: page.survey_url,
+      new_tab: true,
+    } %>
+  </div>
+<% end %>
+
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -29,4 +29,40 @@ RSpec.feature "Mainstream browsing" do
       expect(page).to have_selector(".gem-c-breadcrumbs")
     end
   end
+
+  scenario "State pension second level browse page displays the Cost of living survey banner" do
+    content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "curated_level_2_page")
+    content_item["base_path"] = "/browse/working/state-pension"
+
+    stub_content_store_has_item("/browse/working/state-pension", content_item)
+
+    search_api_has_documents_for_browse_page(
+      content_item["content_id"],
+      ["/browse/working/state-pension"],
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+    )
+
+    visit "/browse/working/state-pension"
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6"
+  end
+
+  scenario "other browse pages don't show the banner" do
+    content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "curated_level_2_page")
+    content_item["base_path"] = "/browse/benefits/entitlement-with-list"
+
+    stub_content_store_has_item("/browse/benefits/entitlement-with-list", content_item)
+
+    search_api_has_documents_for_browse_page(
+      content_item["content_id"],
+      ["/browse/benefits/entitlement-with-list"],
+      page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING,
+    )
+
+    visit "/browse/benefits/entitlement-with-list"
+
+    expect(page.status_code).to eq(200)
+    expect(page).not_to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6"
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Add user research banner to /browse/working/state-pension

Trello card: https://trello.com/c/1O3pEivw/1777-govuk-user-research-banner-requests-for-col-tree-testing-study-1m

Before:

<img width="1011" alt="Screenshot 2023-04-17 at 17 35 54" src="https://user-images.githubusercontent.com/96050928/232552371-1e5bcfda-fbf2-4db7-b4ce-20aeae6ac274.png">

After:
<img width="1024" alt="Screenshot 2023-04-17 at 17 36 15" src="https://user-images.githubusercontent.com/96050928/232552402-8781df60-e659-4a36-b1fb-c868e0895a42.png">
