### PR TITLE
Fix issue when trying to preview app level component in the component guide

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,5 +1,6 @@
 if defined?(GovukPublishingComponents)
   GovukPublishingComponents.configure do |c|
     c.component_guide_title = "Collections Component Guide"
+    c.application_stylesheet = nil
   end
 end


### PR DESCRIPTION
## What

Fix issue when trying to preview app level components in the component guide.

Setting `application_stylesheet` to `nil` in `config/initializers/govuk_publishing_components.rb` ensures the component-guide does not try to load application.css when it is not being used.

## Why

Ensures that app level components can be previewed in the component guide for collections.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
