### PR TITLE
Revert "Temporary changes for Global Bar [DO NOT MERGE]"

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -13,20 +13,9 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 }
 
-@include govuk-media-query($from: desktop) {
-  .covid__page-header {
-    border-top: solid govuk-spacing(2) $c19-landing-page-header-background;
-  }
-}
-
-@include govuk-media-query($until: desktop) {
-  .covid__page-header {
-    margin-top: govuk-spacing(-3);
-  }
-}
-
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
+  border-top: solid govuk-spacing(2) $covid-yellow;
   background-color: $c19-landing-page-header-background;
   color: govuk-colour("white");
 }

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,6 +7,7 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
+    <div class="gem-c-layout-for-public__blue-bar"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
Reverts alphagov/collections#3226. These were temporary changes which were to be live until the Emergency Alert test took place. The test has now happened so these changes can now be removed.