### PR TITLE
Add image_srcset generated from image_url, use in topical events logo

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -27,6 +27,21 @@ class TopicalEvent
     @content_item.content_item_data.dig("details", "image", "alt_text")
   end
 
+  def image_srcset
+    [
+      { url: sized_image_url(960), size: "960w" },
+      { url: sized_image_url(712), size: "712w" },
+      { url: sized_image_url(630), size: "630w" },
+      { url: sized_image_url(465), size: "465w" },
+      { url: sized_image_url(300), size: "300w" },
+      { url: sized_image_url(216), size: "216w" },
+    ]
+  end
+
+  def sized_image_url(width)
+    image_url.gsub("/s300_", "/s#{width}_")
+  end
+
   def body
     @content_item.content_item_data.dig("details", "body")
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -49,7 +49,7 @@
 
     <% if @topical_event.image_url %>
       <div class="topical-events__image">
-      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text) %>
+      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text, srcset: { @topical_event.image_srcset[2][:url] => "2x", @topical_event.image_srcset[0][:url] => "3x",}) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
Generates information about other image sizes suitable for using in a srcset

https://trello.com/c/uW5kvqga/1961-using-srcset-functionality-to-make-images-less-blurry-on-govuk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
