### PR TITLE
Remove RSS feed link from subscription_links

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -18,9 +18,6 @@ module Organisations
         email_signup_link: "/email-signup?link=#{@org.base_path}",
         email_signup_link_text: I18n.t("organisations.subscription.email"),
         email_signup_link_text_locale: t_fallback("organisations.subscription.email"),
-        feed_link_box_value: "#{@org.web_url}.atom",
-        feed_link_text: I18n.t("organisations.subscription.feed"),
-        feed_link_text_locale: t_fallback("organisations.subscription.feed"),
         brand: @org.brand,
       }
     end

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -8,7 +8,6 @@
 
     <%= render "govuk_publishing_components/components/subscription_links", {
         email_signup_link: announcements.links[:email_signup],
-        feed_link: announcements.links[:subscribe_to_feed],
         margin_bottom: 5,
     } %>
 

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -118,7 +118,6 @@
 
       <%= render "govuk_publishing_components/components/subscription_links", {
         email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}",
-        feed_link_box_value: Plek.new.website_root + topical_event_path(@topical_event.slug, format: "atom")
       } %>
     </section>
   </div>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -76,7 +76,6 @@
 
         <%= render "govuk_publishing_components/components/subscription_links", {
           email_signup_link: "/email/subscriptions/new?topic_id=#{@world_location_news.slug}",
-          feed_link_box_value: Plek.new.website_root + world_location_news_path(@world_location_news.slug, format: "atom")
         } %>
       </section>
     </div>

--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -3,8 +3,6 @@
     <%= render "govuk_publishing_components/components/subscription_links", {
       email_signup_link: email_alert_frontend_signup_url(presented_taxon),
       email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
-      feed_link: whitehall_atom_url,
-      feed_link_box_value: whitehall_atom_url
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/subscription_links", {

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -190,7 +190,6 @@ RSpec.describe "Organisation pages" do
   it "shows subscription links" do
     visit "/government/organisations/attorney-generals-office"
     expect(page).to have_css("a[href='/email-signup?link=/government/organisations/attorney-generals-office']", text: "Get emails")
-    expect(page).to have_css("button", text: "Subscribe to feed")
   end
 
   it "shows the 'what we do' section" do

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -25,11 +25,6 @@ RSpec.feature "World Location News pages" do
     expect(page).to have_selector("meta[name='description'][content='Find out about the relations between the UK and Mock Country']", visible: :hidden)
   end
 
-  it "includes a link to the atom feed" do
-    visit base_path
-    expect(page).to have_field("Copy and paste this URL into your feed reader", with: "http://www.test.gov.uk/world/mock-country/news.atom")
-  end
-
   it "includes a link to signup for emails" do
     visit base_path
     expect(page).to have_link("Get emails", href: "/email/subscriptions/new?topic_id=mock-country")

--- a/spec/features/world_location_taxon_spec.rb
+++ b/spec/features/world_location_taxon_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "World location taxon page" do
   let(:feed_url) { "#{Plek.new.website_root}/world/usa.atom" }
   let(:email_url) { Plek.new.website_root + "/email-signup?link=#{base_path}" }
 
-  scenario "contains both the atom and email signup url if we are browsing a world location" do
+  scenario "contains email signup url if we are browsing a world location" do
     world_usa = world_usa_taxon(base_path:, phase: "live")
     world_usa_news_events = world_usa_news_events_taxon(base_path: child_taxon_base_path)
 
@@ -24,8 +24,6 @@ RSpec.feature "World location taxon page" do
     visit base_path
 
     expect(page).to have_selector("a[href='#{email_url}']", text: "Get emails for this topic")
-    expect(page).to have_selector("button", text: "Subscribe to feed")
-    expect(page).to have_selector(".gem-c-subscription-links input[value='#{feed_url}']")
   end
 
   scenario "does not contain the feed selector if we are browsing a world location leaf page" do


### PR DESCRIPTION
## What

Remove link to RSS feed on all instances of the subscription_links component.

## Why

Part of a redesign of the subscription links. Due to decreased usage and problematic emphasis of the RSS feed link, we are going to try removing it on pages of applications that Navigation & Presentation team are responsible for. 

## Visual Differences

### Before

![Screenshot 2023-04-27 at 11 16 23](https://user-images.githubusercontent.com/3727504/234833939-bb0cf61e-42f9-4f49-b953-fd9f374d966c.png)

![Screenshot 2023-04-27 at 11 17 24](https://user-images.githubusercontent.com/3727504/234833951-1a034b20-aac0-41aa-9de8-3d217b43f0d0.png)


### After

![Screenshot 2023-04-27 at 11 17 21](https://user-images.githubusercontent.com/3727504/234833964-dfa7474c-fde9-48da-b8d9-a635a612db86.png)

![Screenshot 2023-04-27 at 11 16 20](https://user-images.githubusercontent.com/3727504/234834147-47a00908-c6e2-4007-b969-1dd7b8dff15c.png)


[Relevant Trello Card](https://trello.com/c/lVsaCSRR/1722-remove-subscribe-to-feed-links-from-the-pages-we-own-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
