### PR TITLE
SPIKE: Add routes for legacy org-related redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,14 @@ Rails.application.routes.draw do
       to: "services_and_information#index",
       as: :services_and_information
 
+  get "/government/organisations/:organisation_id/chiefs-of-staff" => redirect("/government/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/consultations" => redirect("/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/groups" => redirect("/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/groups/:id" => redirect("/organisations/%{organisation_id}")
+
+  get "/government/organisations/:organisation_id/series(.:locale)" => redirect("/publications")
+  get "/government/organisations/:organisation_id/series/:slug(.:locale)" => redirect("/collections/%{slug}")
+
   get "/government/history/past-chancellors", to: "historic_appointments#index"
   get "/government/history/past-foreign-secretaries", to: "historic_appointments#index"
   get "/government/history/past-foreign-secretaries/:id", to: "historic_appointments#show"


### PR DESCRIPTION
Trello: https://trello.com/c/sajxUZnZ

This would be used in conjunction with something like [this whitehall spike][1] which changes the main route for an organisation content item to be a "prefix" route rather than a "exact" route. This change would mean that the router would send the relevant URLs to collections instead of whitehall-frontend. This PR adds the necessary routes which are closely based on [those currently in whitehall][2] so that collections can do the redirects.

### Notes/Questions

* Adding the redirects to `/government/publications` in the collections app Rails routes doesn't seem great, because that path to the publications index page is handled by a different app (finder-frontend), but maybe it's not a big deal.
* We can't easily re-use the `valid_locales_regex` constraint from the whitehall routes, because it's generated by `Locale` data from the whitehall database. However, it doesn't seem too terrible to do with out it for these redirects.
* The optional locale suffix is not preserved in the redirect for the individual "series" but it wasn't being preserved by the redirect in whitehall anyway.

[1]: https://github.com/alphagov/whitehall/pull/7605
[2]: https://github.com/alphagov/whitehall/blob/9afe523ed2f3eca7771c5510056b4bbb2cfa29a1/config/routes.rb#L66-L73

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
