### PR TITLE
Use gem_layout_full_width_browse_header for Browse pages 

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,5 +1,5 @@
 class BrowseController < ApplicationController
-  slimmer_template "gem_layout_full_width"
+  slimmer_template "gem_layout_full_width_browse_header"
 
   def index
     page = MainstreamBrowsePage.find("/browse")

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,7 +7,6 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
-    <div class="gem-c-layout-for-public__blue-bar"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
## What

Use new gem_layout_full_width_browse template for Browse pages. Remove blue bar from browse_breadcrumbs partial. 

## Why

There are instances of pages on collections that have a coloured background in the heading section. This meant that the the blue bar (which is rendered in the public_layout) had to be rendered by collections otherwise it would result in a gap between the blue bar and coloured section. This solution seemed fine until we had a recent deployment of the global bar. As the global bar includes a blue bar, it meant that the Browse pages had two blue bars. They therefore needed to be removed while the global bar was present and then added back again when the global bar was removed. 

To avoid this needing to happen the next time the bar is deployed, a new template has been implemented. It means that if a page has a coloured background heading it can be specified in the template and then it will be applied to the blue bar. This means the blue bar can be rendered in public_layout and so applications don't need to render the blue bar if they have a heading section with a background colour.

To accomplish this in collections, we need to change the template to the new `gem_layout_full_width_browse_header` and remove the blue bar from the breadcrumbs partial.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/pT7Sh8Yn/1793-update-layoutforpublic-template-so-that-global-bar-is-independent-of-requiring-changes-in-the-browse-template-l)