### PR TITLE
Add routes for legacy organisation-related redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,14 @@ Rails.application.routes.draw do
       to: "services_and_information#index",
       as: :services_and_information
 
+  get "/government/organisations/:organisation_id/chiefs-of-staff" => redirect("/government/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/consultations" => redirect("/government/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/groups" => redirect("/government/organisations/%{organisation_id}")
+  get "/government/organisations/:organisation_id/groups/:id" => redirect("/government/organisations/%{organisation_id}")
+
+  get "/government/organisations/:organisation_id/series(.:locale)" => redirect("/government/publications")
+  get "/government/organisations/:organisation_id/series/:slug(.:locale)" => redirect("/government/collections/%{slug}")
+
   get "/government/history/past-chancellors", to: "historic_appointments#index"
   get "/government/history/past-foreign-secretaries", to: "historic_appointments#index"
   get "/government/history/past-foreign-secretaries/:id", to: "historic_appointments#show"

--- a/spec/requests/redirection_spec.rb
+++ b/spec/requests/redirection_spec.rb
@@ -20,4 +20,52 @@ RSpec.describe "Redirection of encoded urls" do
     expect(response).to have_http_status(:redirect)
     expect("http://www.example.com/government/people/cornelius-fudge?associates=higgs%26mclaggen%2Fshacklebolt%26tonks").to eq(response.header["Location"])
   end
+
+  it "redirects organisation chiefs-of-staff path to the organisation path" do
+    get "/government/organisations/organisation-1/chiefs-of-staff"
+
+    expect(response).to redirect_to("/government/organisations/organisation-1")
+  end
+
+  it "redirects organisation consultations path to the organisation path" do
+    get "/government/organisations/organisation-1/consultations"
+
+    expect(response).to redirect_to("/government/organisations/organisation-1")
+  end
+
+  it "redirects organisation groups path to the organisation path" do
+    get "/government/organisations/organisation-1/groups"
+
+    expect(response).to redirect_to("/government/organisations/organisation-1")
+  end
+
+  it "redirects organisation group path to the organisation path" do
+    get "/government/organisations/organisation-1/groups/group-1"
+
+    expect(response).to redirect_to("/government/organisations/organisation-1")
+  end
+
+  it "redirects organisation series index path to the publications path" do
+    get "/government/organisations/organisation-1/series"
+
+    expect(response).to redirect_to("/government/publications")
+  end
+
+  it "redirects organisation localised series index path to the publications path" do
+    get "/government/organisations/organisation-1/series.cy"
+
+    expect(response).to redirect_to("/government/publications")
+  end
+
+  it "redirects organisation series path to the corresponding collections path" do
+    get "/government/organisations/organisation-1/series/series-1"
+
+    expect(response).to redirect_to("/government/collections/series-1")
+  end
+
+  it "redirects organisation localised series path to the correspondong collections path" do
+    get "/government/organisations/organisation-1/series/series-1.cy"
+
+    expect(response).to redirect_to("/government/collections/series-1")
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/sajxUZnZ

This will be used in conjunction with [this whitehall PR][1] which changes the main route for an organisation content item to be a "prefix" route rather than a "exact" route. This change will mean that the router will send the relevant URLs to collections instead of whitehall-frontend. This PR adds the necessary routes which are closely based on [those currently in whitehall][2] so that collections can do the redirects. I've added them after all the other routes which start with `/government/organisations` so they won't interfere with any of those existing Rails routes.

### Notes/Questions

* Adding the redirects to `/government/publications` in the collections app Rails routes doesn't seem great, because that path to the publications index page is handled by a different app (finder-frontend), but maybe it's not a big deal.
* We can't easily re-use the `valid_locales_regex` constraint from the whitehall routes, because it's generated by `Locale` data from the whitehall database. However, it doesn't seem too terrible to do with out it for these redirects.
* The optional locale suffix is not preserved in the redirect for the individual "series" but it wasn't being preserved by the redirect in whitehall anyway.

**Important**: this PR should be merged *before* https://github.com/alphagov/whitehall/pull/7621

[1]: https://github.com/alphagov/whitehall/pull/7621
[2]: https://github.com/alphagov/whitehall/blob/9afe523ed2f3eca7771c5510056b4bbb2cfa29a1/config/routes.rb#L66-L73

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
