### PR TITLE
Remove org changing banner code for DIT BEIS DCMS

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -42,15 +42,6 @@ class Organisation
     slug == "prime-ministers-office-10-downing-street"
   end
 
-  # Temporary banner for Feb 2023 reshuffle
-  def is_being_reshuffled?
-    %w[
-      department-for-digital-culture-media-sport
-      department-for-international-trade
-      department-for-business-energy-and-industrial-strategy
-    ].include?(slug)
-  end
-
   def is_promotional_org?
     is_no_10? || organisation_type == "civil_service"
   end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -3,14 +3,6 @@
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
-<% if @organisation.is_being_reshuffled? %>
-  <%= render "govuk_publishing_components/components/notice", {
-    title: sanitize(
-      "This organisation is changing.
-      Read about <a href=\"/government/publications/making-government-deliver-for-the-british-people/making-government-deliver-for-the-british-people-html\">recent government updates</a>.
-      ")
-  } %>
-<% end %>
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',
            schema: :organisation,
            content_item: @organisation.content_item.content_item_data %>

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -429,18 +429,4 @@ RSpec.describe "Organisation pages" do
     org_schema = schemas.detect { |schema| schema["@type"] == "GovernmentOrganization" }
     expect("Student Loans Company").to eq(org_schema["name"])
   end
-
-  it "displays reshuffle banner on subset of org pages" do
-    %w[
-      department-for-digital-culture-media-sport
-      department-for-international-trade
-      department-for-business-energy-and-industrial-strategy
-    ].each do |slug|
-      base_path = "/government/organisations/#{slug}"
-      content_item = content_item_attorney_general.deep_merge("base_path" => base_path)
-      stub_content_and_search(content_item)
-      visit base_path
-      expect(page).to have_css(".govuk-notification-banner", text: "This organisation is changing.")
-    end
-  end
 end


### PR DESCRIPTION
This was asked by content.

DIT, BEIS. DCMS have now closed which means we can remove the transitory banner code on the org pages.

This change won't have any visual difference on the org page as the orgs have already been closed closed in Whitehall, which results in a bespoke banner replacing the transitory banner automatically due to a different view being rendered [2] vs [3].

[2]: https://github.com/alphagov/collections/blob/6ded61a31a81b7c053151bf74c80c2cd84d001e8/app/views/organisations/separate_website.html.erb#L11-L13
[3]: https://github.com/alphagov/collections/blob/6ded61a31a81b7c053151bf74c80c2cd84d001e8/app/views/organisations/show.html.erb#L7-L13

Trello:
https://trello.com/c/ZATeFciM/5-remove-temporary-banner-for-certain-org-about-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
