### PR TITLE
Update survey link for COL user research banner

### DIFF
--- a/app/helpers/user_research_banner_helper.rb
+++ b/app/helpers/user_research_banner_helper.rb
@@ -1,5 +1,5 @@
 module UserResearchBannerHelper
-  COST_OF_LIVING_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6".freeze
+  COST_OF_LIVING_SURVEY_URL = "https://gdsuserresearch.optimalworkshop.com/treejack/f49b8c01521bf45bd0a519fe02f5f913".freeze
 
   SURVEY_URL_MAPPINGS = {
     "/browse/working/state-pension" => COST_OF_LIVING_SURVEY_URL,

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Mainstream browsing" do
     visit "/browse/working/state-pension"
 
     expect(page.status_code).to eq(200)
-    expect(page).to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6"
+    expect(page).to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/f49b8c01521bf45bd0a519fe02f5f913"
   end
 
   scenario "other browse pages don't show the banner" do
@@ -63,6 +63,6 @@ RSpec.feature "Mainstream browsing" do
     visit "/browse/benefits/entitlement-with-list"
 
     expect(page.status_code).to eq(200)
-    expect(page).not_to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/ct80d1d6"
+    expect(page).not_to have_link "Take part in user research (opens in a new tab)", href: "https://gdsuserresearch.optimalworkshop.com/treejack/f49b8c01521bf45bd0a519fe02f5f913"
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/JNFBhMMR/1807-replace-survey-link-on-user-research-banner-for-col-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
