### PR TITLE
Render ministers index page

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -9,6 +9,7 @@
 //= link views/_bunting.css
 //= link views/_covid.css
 //= link views/_history_people.css
+//= link views/_ministers.css
 //= link views/_organisation.css
 //= link views/_organisations.css
 //= link views/_taxons.css

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -1,0 +1,7 @@
+.ministers-index h2 {
+  border-bottom: 5px solid #005ea5;
+}
+
+.clear-column {
+  clear: both;
+}

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -5,3 +5,8 @@
 .clear-column {
   clear: both;
 }
+
+.footnotes {
+  color: #505a5f;
+  display: block;
+}

--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -2,7 +2,8 @@ class MinistersController < ApplicationController
   around_action :switch_locale
 
   def index
-    @ministers = MinistersIndex.find!(request.path)
-    setup_content_item_and_navigation_helpers(@ministers)
+    ministers_index = MinistersIndex.find!(request.path)
+    @presented_ministers = MinistersIndexPresenter.new(ministers_index)
+    setup_content_item_and_navigation_helpers(ministers_index)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,4 +70,13 @@ module ApplicationHelper
       raw(Govspeak::Document.new(content, sanitize: false).to_html)
     end
   end
+
+  def joined_list(elements)
+    separator = if elements.any? { |word| word.include?(",") }
+                  "; "
+                else
+                  ", "
+                end
+    elements.join(separator)
+  end
 end

--- a/app/helpers/ministers_index_helper.rb
+++ b/app/helpers/ministers_index_helper.rb
@@ -1,0 +1,16 @@
+module MinistersIndexHelper
+  def role_link(role)
+    link_to role.title, role.url, class: "govuk-link"
+  end
+
+  def cabinet_minister_description(minister)
+    list_of_roles = joined_list(minister.roles.map { |role| role_link(role) }).html_safe
+    footnotes = tag.span(minister.role_payment_info.join(". "), class: "footnotes")
+
+    if minister.role_payment_info.any?
+      content_tag(:p, safe_join([list_of_roles, footnotes]))
+    else
+      content_tag(:p, list_of_roles)
+    end
+  end
+end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -10,4 +10,8 @@ class MinistersIndexPresenter
   def is_during_reshuffle?
     @ministers_index.content_item.details.fetch("reshuffle", nil)
   end
+
+  def reshuffle_messaging
+    @ministers_index.content_item.details.dig("reshuffle", "message")
+  end
 end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -1,0 +1,13 @@
+class MinistersIndexPresenter
+  def initialize(ministers_index)
+    @ministers_index = ministers_index
+  end
+
+  def lead_paragraph
+    @ministers_index.content_item.details.fetch("body", nil)
+  end
+
+  def is_during_reshuffle?
+    @ministers_index.content_item.details.fetch("reshuffle", nil)
+  end
+end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -45,5 +45,30 @@ class MinistersIndexPresenter
     def image_alt
       @data.dig("details", "image", "alt_text")
     end
+
+    def roles
+      current_role_appointments.map { |role_app|
+        Role.new(
+          title: role_app.dig("links", "role").first.fetch("title"),
+          url: role_app.dig("links", "role").first["web_url"],
+          seniority: role_app.dig("links", "role").first.fetch("details").fetch("seniority", 1000),
+          payment_info: role_app.dig("links", "role").first.dig("details", "role_payment_type"),
+        )
+      }.sort_by(&:seniority)
+    end
+
+    def role_payment_info
+      roles.map(&:payment_info).compact.uniq
+    end
+
+    Role = Struct.new(:title, :url, :seniority, :payment_info, keyword_init: true)
+
+  private
+
+    def current_role_appointments
+      @data.dig("links", "role_appointments").select do |role_app|
+        role_app.dig("details", "current") && role_app.dig("links", "role").first["web_url"].present?
+      end
+    end
   end
 end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -21,6 +21,12 @@ class MinistersIndexPresenter
     end
   end
 
+  def also_attends_cabinet
+    @ministers_index.content_item.content_item_data.dig("links", "ordered_also_attends_cabinet").map do |minister_data|
+      Minister.new(minister_data)
+    end
+  end
+
   class Minister
     def initialize(data)
       @data = data

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -14,4 +14,36 @@ class MinistersIndexPresenter
   def reshuffle_messaging
     @ministers_index.content_item.details.dig("reshuffle", "message")
   end
+
+  def cabinet_ministers
+    @ministers_index.content_item.content_item_data.dig("links", "ordered_cabinet_ministers").map do |minister_data|
+      Minister.new(minister_data)
+    end
+  end
+
+  class Minister
+    def initialize(data)
+      @data = data
+    end
+
+    def person_url
+      @data["web_url"]
+    end
+
+    def name
+      @data.fetch("title").gsub("The Rt Hon", "").strip
+    end
+
+    def honorific
+      @data.dig("details", "privy_counsellor") ? "The Rt Hon" : ""
+    end
+
+    def image_url
+      @data.dig("details", "image", "url")
+    end
+
+    def image_alt
+      @data.dig("details", "image", "alt_text")
+    end
+  end
 end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -1,34 +1,34 @@
 class MinistersIndexPresenter
   def initialize(ministers_index)
-    @ministers_index = ministers_index
+    @ministers_index = ministers_index.content_item
   end
 
   def lead_paragraph
-    @ministers_index.content_item.details.fetch("body", nil)
+    @ministers_index.details.fetch("body", nil)
   end
 
   def is_during_reshuffle?
-    @ministers_index.content_item.details.fetch("reshuffle", nil)
+    @ministers_index.details.fetch("reshuffle", nil)
   end
 
   def reshuffle_messaging
-    @ministers_index.content_item.details.dig("reshuffle", "message")
+    @ministers_index.details.dig("reshuffle", "message")
   end
 
   def cabinet_ministers
-    @ministers_index.content_item.content_item_data.dig("links", "ordered_cabinet_ministers").map do |minister_data|
+    @ministers_index.content_item_data.dig("links", "ordered_cabinet_ministers").map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def also_attends_cabinet
-    @ministers_index.content_item.content_item_data.dig("links", "ordered_also_attends_cabinet").map do |minister_data|
+    @ministers_index.content_item_data.dig("links", "ordered_also_attends_cabinet").map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def by_organisation
-    @ministers_index.content_item.content_item_data.dig("links", "ordered_ministerial_departments").map do |department_data|
+    @ministers_index.content_item_data.dig("links", "ordered_ministerial_departments").map do |department_data|
       Department.new(
         url: department_data.fetch("web_url"),
         title: department_data.fetch("title"),
@@ -46,7 +46,7 @@ class MinistersIndexPresenter
 
   def whips
     ordered_whip_organisations.each do |whip_org|
-      whip_org.ministers = @ministers_index.content_item.content_item_data.dig("links", whip_org.item_key).map do |minister_data|
+      whip_org.ministers = @ministers_index.content_item_data.dig("links", whip_org.item_key).map do |minister_data|
         Minister.new(minister_data, whip_only: true)
       end
     end

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -104,5 +104,37 @@
       padding: true,
     } %>
   </div>
+
+  <% @presented_ministers.whips.each do |whip_organisation| %>
+    <%= content_tag :div, id: "whip-#{t("ministers.whip_organisations.#{whip_organisation.name_key}").parameterize}" do %>
+      <div class="govuk-grid-column-one-quarter">
+        <%= render "govuk_publishing_components/components/heading", {
+          font_size: 24,
+          text: t("ministers.whip_organisations.#{whip_organisation.name_key}"),
+          heading_level: 3,
+          margin_bottom: 2,
+        } %>
+      </div>
+
+      <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-8">
+        <ul class="govuk-list">
+          <% whip_organisation.ministers.each.with_index do |minister, i| %>
+            <% extra_class = (i % 3 == 0) ? " clear-column" : "" %>
+            <li class="govuk-grid-column-one-quarter govuk-grid-column-one-third<%= extra_class %>">
+              <div>
+                <%= render "govuk_publishing_components/components/image_card", {
+                  href: minister.person_url,
+                  heading_text: minister.name,
+                  heading_level: 3,
+                  context: { text: minister.honorific },
+                  description: cabinet_minister_description(minister)
+                } %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
 </section>
 <% end %>

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -45,7 +45,8 @@
             image_alt: minister.image_alt,
             heading_text: minister.name,
             heading_level: 3,
-            context: { text: minister.honorific }
+            context: { text: minister.honorific },
+            description: cabinet_minister_description(minister)
           } %>
         </div>
       </li>

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -63,6 +63,25 @@
       padding: true,
     } %>
   </div>
+
+  <ul id="also-attends-cabinet" class="govuk-list">
+    <% @presented_ministers.also_attends_cabinet.each_with_index do |minister, i| %>
+    <% extra_class = (i % 4 == 0) ? " clear-column" : "" %>
+    <li class="govuk-grid-column-one-quarter<%= extra_class %>">
+      <div>
+        <%= render "govuk_publishing_components/components/image_card", {
+          href: minister.person_url,
+          image_src: minister.image_url,
+          image_alt: minister.image_alt,
+          heading_text: minister.name,
+          heading_level: 3,
+          context: { text: minister.honorific },
+          description: cabinet_minister_description(minister)
+        } %>
+      </div>
+    </li>
+    <% end %>
+  </ul>
 </section>
 
 <section class="govuk-grid-row govuk-!-padding-top-9">

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -5,6 +5,12 @@
     <%= render "govuk_publishing_components/components/title", {
       title: t("ministers.title"),
     } %>
+
+    <% unless @presented_ministers.is_during_reshuffle? %>
+      <%= render "govuk_publishing_components/components/lead_paragraph", {
+        text: sanitize(@presented_ministers.lead_paragraph)
+      } %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -93,6 +93,40 @@
       padding: true,
     } %>
   </div>
+
+  <% @presented_ministers.by_organisation.each do |organisation| %>
+    <%= content_tag :section, id: organisation.title.parameterize do %>
+      <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
+        <%= render "govuk_publishing_components/components/organisation_logo", {
+          organisation: {
+            name: organisation.formatted_title.html_safe,
+            url: organisation.url,
+            brand: organisation.brand,
+            crest: organisation.crest,
+          },
+          heading_level: 3,
+        } %>
+      </div>
+      <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
+        <ul class="govuk-list govuk-grid-row">
+          <% organisation.ministers.each.with_index do |minister, i| %>
+            <% extra_class = (i % 3 == 0) ? " clear-column" : "" %>
+            <li class="govuk-grid-column-one-quarter govuk-grid-column-one-third<%= extra_class %>">
+              <div>
+                <%= render "govuk_publishing_components/components/image_card", {
+                  href: minister.person_url,
+                  heading_text: minister.name,
+                  heading_level: 3,
+                  context: { text: minister.honorific },
+                  description: cabinet_minister_description(minister),
+                } %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  <% end %>
 </section>
 
 <section class="govuk-grid-row govuk-!-padding-top-9">

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -14,6 +14,12 @@
   </div>
 </div>
 
+<% if @presented_ministers.is_during_reshuffle? %>
+  <%= render "govuk_publishing_components/components/notice", {
+    description_govspeak: sanitize(@presented_ministers.reshuffle_messaging),
+  } %>
+<% else %>
+
 <section class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/heading", {
@@ -57,3 +63,4 @@
     } %>
   </div>
 </section>
+<% end %>

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -1,4 +1,8 @@
+<% add_view_stylesheet("ministers") %>
+
 <% content_for :title, t("ministers.govuk_title") %>
+
+<% page_class "ministers-index" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -29,6 +33,24 @@
       padding: true,
     } %>
   </div>
+
+  <ul id="cabinet" class="govuk-list">
+    <% @presented_ministers.cabinet_ministers.each_with_index do |minister, i| %>
+      <% extra_class = (i % 4 == 0) ? " clear-column" : "" %>
+      <li class="govuk-grid-column-one-quarter<%= extra_class %>">
+        <div>
+          <%= render "govuk_publishing_components/components/image_card", {
+            href: minister.person_url,
+            image_src: minister.image_url,
+            image_alt: minister.image_alt,
+            heading_text: minister.name,
+            heading_level: 3,
+            context: { text: minister.honorific }
+          } %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
 </section>
 
 <section class="govuk-grid-row govuk-!-padding-top-9">

--- a/config/locales/ar/ministers.yml
+++ b/config/locales/ar/ministers.yml
@@ -6,4 +6,10 @@ ar:
     cabinet: وزراء المجلس
     govuk_title: الوزراء - GOV.UK
     title: الوزراء
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: ممثلي الكتل البرلمانية

--- a/config/locales/az/ministers.yml
+++ b/config/locales/az/ministers.yml
@@ -6,4 +6,10 @@ az:
     cabinet: Nazirlər kabineti
     govuk_title: Nazirlər - GOV.UK
     title: Nazirlər
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Təşkilatçı üzvlər

--- a/config/locales/be/ministers.yml
+++ b/config/locales/be/ministers.yml
@@ -6,4 +6,10 @@ be:
     cabinet: Міністры кабінета міністраў
     govuk_title: Міністры - GOV.UK
     title: Міністры
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Партыйны арганізатар

--- a/config/locales/bg/ministers.yml
+++ b/config/locales/bg/ministers.yml
@@ -6,4 +6,10 @@ bg:
     cabinet: Министри от кабинета
     govuk_title: Министри - GOV.UK
     title: Министри
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Спешни съобщения

--- a/config/locales/bn/ministers.yml
+++ b/config/locales/bn/ministers.yml
@@ -6,4 +6,10 @@ bn:
     cabinet: মন্ত্রিপরিষদের সদস্য
     govuk_title: মন্ত্রীগণ - GOV.UK
     title: মন্ত্রীগণ
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: হুইপগণ

--- a/config/locales/cs/ministers.yml
+++ b/config/locales/cs/ministers.yml
@@ -6,4 +6,10 @@ cs:
     cabinet: Ministři vlády
     govuk_title: Ministři - GOV.UK
     title: Ministři
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Parlamentní sekretáři

--- a/config/locales/cy/ministers.yml
+++ b/config/locales/cy/ministers.yml
@@ -6,4 +6,10 @@ cy:
     cabinet: Gweinidogion y Cabinet
     govuk_title: Gweinidogion - GOV.UK
     title: Gweinidogion
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Chwipiau

--- a/config/locales/da/ministers.yml
+++ b/config/locales/da/ministers.yml
@@ -6,4 +6,10 @@ da:
     cabinet: Kabinetsministre
     govuk_title: Ministre - GOV.UK
     title: Ministere
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Piske

--- a/config/locales/de/ministers.yml
+++ b/config/locales/de/ministers.yml
@@ -6,4 +6,10 @@ de:
     cabinet: Minister des Kabinetts
     govuk_title: Minister - GOV.UK
     title: Minister
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Fraktionsvorsitzende

--- a/config/locales/dr/ministers.yml
+++ b/config/locales/dr/ministers.yml
@@ -6,4 +6,10 @@ dr:
     cabinet: وزرأی کابینه
     govuk_title: وزرأ- GOV.UK
     title: وزرأ
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: تبدیل

--- a/config/locales/el/ministers.yml
+++ b/config/locales/el/ministers.yml
@@ -6,4 +6,10 @@ el:
     cabinet: Υπουργοί υπουργικού συμβουλίου
     govuk_title: Υπουργοί - GOV.UK
     title: Υπουργοί
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Μαστίγια

--- a/config/locales/en/ministers.yml
+++ b/config/locales/en/ministers.yml
@@ -6,4 +6,10 @@ en:
     cabinet: Cabinet ministers
     govuk_title: Ministers - GOV.UK
     title: Ministers
+    whip_organisations:
+      assistant_whips: Assistant Whips
+      baronesses_and_lords_in_waiting: Baronesses and Lords in Waiting
+      house_of_commons: House of Commons
+      house_of_lords: House of Lords
+      junior_lords_of_the_treasury: Junior Lords of the Treasury
     whips: Whips

--- a/config/locales/en/ministers.yml
+++ b/config/locales/en/ministers.yml
@@ -2,7 +2,7 @@
 en:
   ministers:
     also_attends: Also attends Cabinet
-    by_department: Minsters by department
+    by_department: Ministers by department
     cabinet: Cabinet ministers
     govuk_title: Ministers - GOV.UK
     title: Ministers

--- a/config/locales/es-419/ministers.yml
+++ b/config/locales/es-419/ministers.yml
@@ -6,4 +6,10 @@ es-419:
     cabinet: Ministros del Gabinete
     govuk_title: Ministros - GOV.UK
     title: Ministros
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Jefe del grupo parlamentario

--- a/config/locales/es/ministers.yml
+++ b/config/locales/es/ministers.yml
@@ -6,4 +6,10 @@ es:
     cabinet: Ministros del Gabinete
     govuk_title: Ministros - GOV.UK
     title: Ministros
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Jefes de grupos parlamentarios

--- a/config/locales/et/ministers.yml
+++ b/config/locales/et/ministers.yml
@@ -6,4 +6,10 @@ et:
     cabinet: Kabinetiministrid
     govuk_title: Ministrid - GOV.UK
     title: Ministrid
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Varundus

--- a/config/locales/fa/ministers.yml
+++ b/config/locales/fa/ministers.yml
@@ -6,4 +6,10 @@ fa:
     cabinet: وزرای کابینه
     govuk_title: وزرا - GOV.UK
     title: وزرا
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: لابی‌ها

--- a/config/locales/fi/ministers.yml
+++ b/config/locales/fi/ministers.yml
@@ -6,4 +6,10 @@ fi:
     cabinet: Valtioneuvoston ministerit
     govuk_title: Ministerit - GOV.UK
     title: Ministerit
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Piiskat

--- a/config/locales/fr/ministers.yml
+++ b/config/locales/fr/ministers.yml
@@ -6,4 +6,10 @@ fr:
     cabinet: Ministres du Cabinet
     govuk_title: Ministres - GOV.UK
     title: Ministres
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/gd/ministers.yml
+++ b/config/locales/gd/ministers.yml
@@ -6,4 +6,10 @@ gd:
     cabinet: Airí Comh-Aireachta
     govuk_title: Airí - GOV.UK
     title: Airí
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Aoire

--- a/config/locales/gu/ministers.yml
+++ b/config/locales/gu/ministers.yml
@@ -6,4 +6,10 @@ gu:
     cabinet: કેબિનેટ મંત્રીઓ
     govuk_title: મંત્રીઓ - GOV.UK
     title: મંત્રીઓ
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: ઉપસ્થિત રહેવા માટે લેખિત આદેશો

--- a/config/locales/he/ministers.yml
+++ b/config/locales/he/ministers.yml
@@ -6,4 +6,10 @@ he:
     cabinet: קבינט השרים
     govuk_title: שרים - GOV.UK
     title: שרים
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: שוטים

--- a/config/locales/hi/ministers.yml
+++ b/config/locales/hi/ministers.yml
@@ -6,4 +6,10 @@ hi:
     cabinet: केबिनेट मंत्री
     govuk_title: मंत्री - GOV.UK
     title: मंत्री
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: सचेतक

--- a/config/locales/hr/ministers.yml
+++ b/config/locales/hr/ministers.yml
@@ -6,4 +6,10 @@ hr:
     cabinet: Ministri u kabinetu
     govuk_title: Ministri - GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Vođa

--- a/config/locales/hu/ministers.yml
+++ b/config/locales/hu/ministers.yml
@@ -6,4 +6,10 @@ hu:
     cabinet: Kabinetminiszterek
     govuk_title: Miniszterek - GOV.UK
     title: Miniszterek
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Korbácsok

--- a/config/locales/hy/ministers.yml
+++ b/config/locales/hy/ministers.yml
@@ -6,4 +6,10 @@ hy:
     cabinet: Կաբինետի անդամ նախարարներ
     govuk_title: Նախարարներ- GOV.UK
     title: Նախարարներ
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Պառլամենտական կազմակերպիչներ

--- a/config/locales/id/ministers.yml
+++ b/config/locales/id/ministers.yml
@@ -6,4 +6,10 @@ id:
     cabinet: Menteri kabinet
     govuk_title: Menteri - GOV.UK
     title: Menteri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/is/ministers.yml
+++ b/config/locales/is/ministers.yml
@@ -6,4 +6,10 @@ is:
     cabinet: Ráðherrar í ríkisstjórn
     govuk_title: Ráðherrar - GOV.UK
     title: Ráðherrar
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Þingflokksformenn

--- a/config/locales/it/ministers.yml
+++ b/config/locales/it/ministers.yml
@@ -6,4 +6,10 @@ it:
     cabinet: Ministri di gabinetto
     govuk_title: Ministri - GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Fruste

--- a/config/locales/ja/ministers.yml
+++ b/config/locales/ja/ministers.yml
@@ -6,4 +6,10 @@ ja:
     cabinet: 閣僚
     govuk_title: 大臣 - GOV.UK
     title: 大臣
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: 院内幹事

--- a/config/locales/ka/ministers.yml
+++ b/config/locales/ka/ministers.yml
@@ -6,4 +6,10 @@ ka:
     cabinet: კაბინეტის მინისტრები
     govuk_title: მინისტრები - GOV.UK
     title: მინისტრები
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: ვიპები

--- a/config/locales/kk/ministers.yml
+++ b/config/locales/kk/ministers.yml
@@ -6,4 +6,10 @@ kk:
     cabinet: Кабинет министрлері
     govuk_title: Министрлер - GOV.UK
     title: Министрлер
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Қамшылар

--- a/config/locales/ko/ministers.yml
+++ b/config/locales/ko/ministers.yml
@@ -6,4 +6,10 @@ ko:
     cabinet: 내각
     govuk_title: 장관 - GOV.UK
     title: 장관
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: 원내대표단

--- a/config/locales/lt/ministers.yml
+++ b/config/locales/lt/ministers.yml
@@ -6,4 +6,10 @@ lt:
     cabinet: Ministrų kabineto ministrai
     govuk_title: Ministrai – GOV.UK
     title: Ministrai
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Drausmintojai

--- a/config/locales/lv/ministers.yml
+++ b/config/locales/lv/ministers.yml
@@ -6,4 +6,10 @@ lv:
     cabinet: Kabineta ministri
     govuk_title: Ministri - GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Parlamentārie uzraugi

--- a/config/locales/ms/ministers.yml
+++ b/config/locales/ms/ministers.yml
@@ -6,4 +6,10 @@ ms:
     cabinet: Menteri Kabinet
     govuk_title: Menteri - GOV.UK
     title: Menteri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Ahli Dewan Undangan

--- a/config/locales/mt/ministers.yml
+++ b/config/locales/mt/ministers.yml
@@ -6,4 +6,10 @@ mt:
     cabinet: Ministri fil-Kabinett
     govuk_title: Ministri - GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Kritiċi

--- a/config/locales/ne/ministers.yml
+++ b/config/locales/ne/ministers.yml
@@ -6,4 +6,10 @@ ne:
     cabinet:
     govuk_title:
     title:
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips:

--- a/config/locales/nl/ministers.yml
+++ b/config/locales/nl/ministers.yml
@@ -6,4 +6,10 @@ nl:
     cabinet: Kabinetsministers
     govuk_title: Ministers - GOV.UK
     title: Ministers
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/no/ministers.yml
+++ b/config/locales/no/ministers.yml
@@ -6,4 +6,10 @@
     cabinet: Kabinettministrene
     govuk_title: Ministre - GOV.UK
     title: Ministre
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Innpiskere

--- a/config/locales/pa-pk/ministers.yml
+++ b/config/locales/pa-pk/ministers.yml
@@ -6,4 +6,10 @@ pa-pk:
     cabinet: کابینہ دے وزیر
     govuk_title: 'وزیر-  GOV.UK '
     title: 'وزیر-  '
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: چابک

--- a/config/locales/pa/ministers.yml
+++ b/config/locales/pa/ministers.yml
@@ -6,4 +6,10 @@ pa:
     cabinet: ਕੈਬਨਿਟ ਮੰਤਰੀ
     govuk_title: ਮੰਤਰੀ - GOV.UK
     title: ਮੰਤਰੀ
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: ਕੋਰੜੇ

--- a/config/locales/pl/ministers.yml
+++ b/config/locales/pl/ministers.yml
@@ -6,4 +6,10 @@ pl:
     cabinet: Ministrowie gabinetu
     govuk_title: Ministrowie - GOV.UK
     title: Ministrowie
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/ps/ministers.yml
+++ b/config/locales/ps/ministers.yml
@@ -6,4 +6,10 @@ ps:
     cabinet: د کابینې وزیران
     govuk_title: وزیران - GOV.UK
     title: وزیران
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: څپې

--- a/config/locales/pt/ministers.yml
+++ b/config/locales/pt/ministers.yml
@@ -6,4 +6,10 @@ pt:
     cabinet: Ministros de Gabinete
     govuk_title: Ministros - GOV.UK
     title: Ministros
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Funcionários

--- a/config/locales/ro/ministers.yml
+++ b/config/locales/ro/ministers.yml
@@ -6,4 +6,10 @@ ro:
     cabinet: Miniștrii cabinetului
     govuk_title: Miniștri - GOV.UK
     title: Miniștri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/ru/ministers.yml
+++ b/config/locales/ru/ministers.yml
@@ -6,4 +6,10 @@ ru:
     cabinet: Кабинет Министров
     govuk_title: Министры - GOV.UK
     title: Министры
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Повестки

--- a/config/locales/si/ministers.yml
+++ b/config/locales/si/ministers.yml
@@ -6,4 +6,10 @@ si:
     cabinet: කැබිනට් අමාත්යවරු
     govuk_title: අමාත්යවරු - GOV.UK
     title: අමාත්‍යවරු
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: කස

--- a/config/locales/sk/ministers.yml
+++ b/config/locales/sk/ministers.yml
@@ -6,4 +6,10 @@ sk:
     cabinet: Ministri kabinetu
     govuk_title: Ministri - GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whipovia

--- a/config/locales/sl/ministers.yml
+++ b/config/locales/sl/ministers.yml
@@ -6,4 +6,10 @@ sl:
     cabinet: Vladni ministri
     govuk_title: Ministri − GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Nadzorniki

--- a/config/locales/so/ministers.yml
+++ b/config/locales/so/ministers.yml
@@ -6,4 +6,10 @@ so:
     cabinet: Golaha wasiirada
     govuk_title: Ministers - GOV.UK
     title: Wasiirada
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Xisbiyada

--- a/config/locales/sq/ministers.yml
+++ b/config/locales/sq/ministers.yml
@@ -6,4 +6,10 @@ sq:
     cabinet: Ministrat e kabinetit
     govuk_title: Ministers - GOV.UK
     title: Ministrat
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Përfaqësuesit

--- a/config/locales/sr/ministers.yml
+++ b/config/locales/sr/ministers.yml
@@ -6,4 +6,10 @@ sr:
     cabinet: Ministri iz kabineta
     govuk_title: Ministri – GOV.UK
     title: Ministri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Parlamentarni organizatori

--- a/config/locales/sv/ministers.yml
+++ b/config/locales/sv/ministers.yml
@@ -6,4 +6,10 @@ sv:
     cabinet: Kabinettets ministrar
     govuk_title: Ministrar - GOV.UK
     title: Ministrar
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/sw/ministers.yml
+++ b/config/locales/sw/ministers.yml
@@ -6,4 +6,10 @@ sw:
     cabinet: Baraza la mawaziri
     govuk_title: Mawaziri - GOV.UK
     title: Mawaziri
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Wabunge

--- a/config/locales/ta/ministers.yml
+++ b/config/locales/ta/ministers.yml
@@ -6,4 +6,10 @@ ta:
     cabinet: மத்திய அமைச்சர்கள்
     govuk_title: அமைச்சர்கள் - GOV.UK
     title: அமைச்சர்கள்
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: கொறடாக்கள்

--- a/config/locales/th/ministers.yml
+++ b/config/locales/th/ministers.yml
@@ -6,4 +6,10 @@ th:
     cabinet: รัฐมนตรีในคณะรัฐมนตรี
     govuk_title: รัฐมนตรี - GOV.UK
     title: รัฐมนตรี
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: วิป

--- a/config/locales/tk/ministers.yml
+++ b/config/locales/tk/ministers.yml
@@ -6,4 +6,10 @@ tk:
     cabinet: Kabinet ministrleri
     govuk_title: Ministrler - GOV.UK
     title: Ministrler
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Gözegçiler

--- a/config/locales/tr/ministers.yml
+++ b/config/locales/tr/ministers.yml
@@ -6,4 +6,10 @@ tr:
     cabinet: Kabinedeki bakanlar
     govuk_title: Bakanlar - GOV.UK
     title: Bakanlar
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Milletvekilleri

--- a/config/locales/uk/ministers.yml
+++ b/config/locales/uk/ministers.yml
@@ -6,4 +6,10 @@ uk:
     cabinet: Кабінет міністрів
     govuk_title: Міністри - GOV.UK
     title: Міністри
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Порядок денний

--- a/config/locales/ur/ministers.yml
+++ b/config/locales/ur/ministers.yml
@@ -6,4 +6,10 @@ ur:
     cabinet: کیبنٹ کے وزراء
     govuk_title: وزراء - GOV.UK
     title: وزراء
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Whips

--- a/config/locales/uz/ministers.yml
+++ b/config/locales/uz/ministers.yml
@@ -6,4 +6,10 @@ uz:
     cabinet: Вазирлар Маҳкамаси аъзолари
     govuk_title: Вазирлар - GOV.UK
     title: Вазирлар
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Чапаклар

--- a/config/locales/vi/ministers.yml
+++ b/config/locales/vi/ministers.yml
@@ -6,4 +6,10 @@ vi:
     cabinet: Bộ trưởng Nội các
     govuk_title: Bộ trưởng - GOV.UK
     title: Các bộ trưởng
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: Các nghị viên kỷ luật

--- a/config/locales/yi/ministers.yml
+++ b/config/locales/yi/ministers.yml
@@ -6,4 +6,10 @@ yi:
     cabinet:
     govuk_title:
     title:
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips:

--- a/config/locales/zh-hk/ministers.yml
+++ b/config/locales/zh-hk/ministers.yml
@@ -6,4 +6,10 @@ zh-hk:
     cabinet: 內閣大臣
     govuk_title: 各大臣 - GOV.UK
     title: 大臣
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: 黨鞭

--- a/config/locales/zh-tw/ministers.yml
+++ b/config/locales/zh-tw/ministers.yml
@@ -6,4 +6,10 @@ zh-tw:
     cabinet: 內閣部長
     govuk_title: 部長－英國政府網站
     title: 部長
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: 黨鞭

--- a/config/locales/zh/ministers.yml
+++ b/config/locales/zh/ministers.yml
@@ -6,4 +6,10 @@ zh:
     cabinet: 内阁成员
     govuk_title: 部长 - GOV.UK
     title: 部长
+    whip_organisations:
+      assistant_whips:
+      baronesses_and_lords_in_waiting:
+      house_of_commons:
+      house_of_lords:
+      junior_lords_of_the_treasury:
     whips: 政党纪律委员

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -35,10 +35,18 @@ RSpec.feature "Ministers index page" do
   end
 
   scenario "renders cabinet ministers in the relevant section" do
-    within("#cabinet") do
+    within("#cabinet li", match: :first) do
       expect(page).to have_text("The Rt Hon")
       expect(page).to have_text("Rishi Sunak MP")
+      expect(page).to have_text("Prime Minister, First Lord of the Treasury, Minister for the Civil Service, Minister for the Union")
     end
+  end
+
+  scenario "cabinet section shows ministers' role payment type info where required" do
+    greg_hands = all("#cabinet li")[1]
+    expect(greg_hands).to have_text("Greg Hands MP")
+    expect(greg_hands).to have_text("Minister without Portfolio")
+    expect(greg_hands).to have_text("Unpaid")
   end
 
   context "during a reshuffle" do

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -34,6 +34,13 @@ RSpec.feature "Ministers index page" do
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
   end
 
+  scenario "renders cabinet ministers in the relevant section" do
+    within("#cabinet") do
+      expect(page).to have_text("The Rt Hon")
+      expect(page).to have_text("Rishi Sunak MP")
+    end
+  end
+
   context "during a reshuffle" do
     let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -64,6 +64,19 @@ RSpec.feature "Ministers index page" do
     expect(john_glen).to have_text("Unpaid")
   end
 
+  scenario "renders whips by whip organisation in the relevant section" do
+    within("#whip-house-of-commons") do
+      expect(page).to have_text("House of Commons")
+    end
+  end
+
+  scenario "the whip section shows only ministers' whip roles" do
+    lord_caine = all("#whip-baronesses-and-lords-in-waiting li")[1]
+    expect(lord_caine).to have_text("Lord Caine")
+    expect(lord_caine).to have_text("Lord in Waiting")
+    expect(lord_caine).to_not have_text("Parliamentary Under Secretary of State")
+  end
+
   context "during a reshuffle" do
     let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -33,4 +33,19 @@ RSpec.feature "Ministers index page" do
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
   end
+
+  context "during a reshuffle" do
+    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
+
+    scenario "renders the reshuffle messaging instead of the usual contents" do
+      within(".gem-c-notice") do
+        expect(page).to have_text("Reshuffle in progress")
+      end
+      expect(page).not_to have_selector(".gem-c-lead-paragraph")
+      expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
+      expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
+      expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
+      expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
+    end
+  end
 end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -49,6 +49,21 @@ RSpec.feature "Ministers index page" do
     expect(greg_hands).to have_text("Unpaid")
   end
 
+  scenario "renders ministers who also attend cabinet in the relevant section" do
+    within("#also-attends-cabinet li", match: :first) do
+      expect(page).to have_text("The Rt Hon")
+      expect(page).to have_text("Simon Hart MP")
+      expect(page).to have_text("Parliamentary Secretary to the Treasury (Chief Whip)")
+    end
+  end
+
+  scenario "also attends cabinet section shows ministers' role payment type info where required" do
+    john_glen = all("#also-attends-cabinet li")[1]
+    expect(john_glen).to have_text("John Glen MP")
+    expect(john_glen).to have_text("Chief Secretary to the Treasury")
+    expect(john_glen).to have_text("Unpaid")
+  end
+
   context "during a reshuffle" do
     let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -1,8 +1,10 @@
 require "integration_spec_helper"
 
-RSpec.feature "Minister pages" do
+RSpec.feature "Ministers index page" do
+  let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
+
   before do
-    stub_content_store_has_item("/government/ministers", ministers_content_hash)
+    stub_content_store_has_item("/government/ministers", document)
     visit "/government/ministers"
   end
 
@@ -18,19 +20,17 @@ RSpec.feature "Minister pages" do
     expect(page).to have_selector(".gem-c-title__text", text: I18n.t("ministers.title"))
   end
 
+  scenario "renders the lead paragraph with anchor links" do
+    expect(page).to have_selector(".gem-c-lead-paragraph")
+    within(".gem-c-lead-paragraph") do
+      expect(page).to have_link("Cabinet ministers", href: "#cabinet-ministers", class: "govuk-link")
+    end
+  end
+
   scenario "renders section headers" do
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
     expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
-  end
-
-private
-
-  def ministers_content_hash
-    @content_hash = {
-      title: I18n.t("ministers.title"),
-      details: {},
-    }
   end
 end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -77,6 +77,27 @@ RSpec.feature "Ministers index page" do
     expect(lord_caine).to_not have_text("Parliamentary Under Secretary of State")
   end
 
+  scenario "renders ministers by department in the relevant section" do
+    cabinet_office = find("#cabinet-office")
+    expect(cabinet_office).to have_text("Cabinet Office")
+    expect(cabinet_office.find("li", match: :first)).to have_text("Rishi Sunak")
+  end
+
+  scenario "the ministers by department section show only ministers' roles within that department" do
+    dbt = find("#department-for-business-and-trade")
+    expect(dbt).to have_text("Business & Trade")
+    kemi_badenoch_dbt = dbt.find("li", match: :first)
+    expect(kemi_badenoch_dbt).to have_text("Kemi Badenoch")
+    expect(kemi_badenoch_dbt).to have_text("Secretary of State for Business and Trade, President of the Board of Trade")
+
+    uef = find("#uk-export-finance")
+    expect(uef).to have_text("UK Export Finance")
+    kemi_badenoch_uef = uef.find("li", match: :first)
+    expect(kemi_badenoch_uef).to have_text("Kemi Badenoch")
+    expect(kemi_badenoch_uef).to have_text("President of the Board of Trade")
+    expect(kemi_badenoch_uef).to_not have_text("Secretary of State for Business and Trade")
+  end
+
   context "during a reshuffle" do
     let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -126,4 +126,18 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "joined_list" do
+    context "when none of the elements contain a comma" do
+      it "joins the elements using a comma separator" do
+        expect(helper.joined_list(["Element 1", "Element 2"])).to eql("Element 1, Element 2")
+      end
+    end
+
+    context "when one of the elements contains a comma" do
+      it "joins the elements using a semicolon separator" do
+        expect(helper.joined_list(["Element 1, 2, and 3", "Element 4"])).to eql("Element 1, 2, and 3; Element 4")
+      end
+    end
+  end
 end

--- a/spec/helpers/ministers_index_helper_spec.rb
+++ b/spec/helpers/ministers_index_helper_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe MinistersIndexHelper do
+  describe "role_link" do
+    it "returns a link element with govuk-link style" do
+      role = double(title: "Minister of Walks", url: "an-url")
+      expect(helper.role_link(role)).to eql("<a class=\"govuk-link\" href=\"an-url\">Minister of Walks</a>")
+    end
+  end
+
+  describe "cabinet_minister_description" do
+    before { allow(helper).to receive(:joined_list).and_return("joined list") }
+
+    context "when the minister has no footnotes" do
+      let(:minister) { double(roles: [], role_payment_info: []) }
+
+      it "returns a paragraph with the minister's roles as a joined list" do
+        expect(helper.cabinet_minister_description(minister)).to eql("<p>joined list</p>")
+      end
+    end
+
+    context "when the minister has footnotes" do
+      let(:minister) { double(roles: [], role_payment_info: %w[one two]) }
+
+      it "returns a paragraph with the minister's roles as a joined list and the roles as a span with the footnotes class" do
+        expect(helper.cabinet_minister_description(minister)).to eql("<p>joined list<span class=\"footnotes\">one. two</span></p>")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are building upon the work started 3 years ago to bring rendering of the Ministers index page from whitehall into collections.

We have completed some additional work to add more data to the content item[1].

We have used a standard component (the [image card](https://components.publishing.service.gov.uk/component-guide/image_card)) to render each minister's information, which has made the text bigger than it is in the current whitehall rendering.

[1] https://github.com/alphagov/publishing-api/pull/2359
https://github.com/alphagov/whitehall/pull/7624
https://github.com/alphagov/publishing-api/pull/2370

## Current whitehall page
![Screenshot 2023-05-22 at 11 32 51](https://github.com/alphagov/collections/assets/579522/9330c6b7-fbc3-4f19-9ef8-c11cd32d22f0)

## Collections page
![Screenshot 2023-05-22 at 11 33 02](https://github.com/alphagov/collections/assets/579522/9e9228ce-3e26-40b9-9b87-4739cdbabf78)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
