### PR TITLE
Fix "- GOV.UK - GOV.UK" in title tag

### DIFF
--- a/config/locales/ar/organisations.yml
+++ b/config/locales/ar/organisations.yml
@@ -61,7 +61,7 @@ ar:
     follow_us: تابعنا
     hidden_share_link: متابعة
     high_profile_groups: مجموعات بارزة ضمن %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: الوظائف والعقود
     latest_from: الأحدث من %{title}
     notices:

--- a/config/locales/az/organisations.yml
+++ b/config/locales/az/organisations.yml
@@ -61,7 +61,7 @@ az:
     follow_us: Bizi təqib edin
     hidden_share_link: Bizi burada təqib edin
     high_profile_groups: "%{title} üzrə məşhur qruplar"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: İşlər və müqavilələr
     latest_from: "%{title} üzrə ən son məlumat"
     notices:

--- a/config/locales/be/organisations.yml
+++ b/config/locales/be/organisations.yml
@@ -61,7 +61,7 @@ be:
     follow_us: Сачыце за намі
     hidden_share_link: Сачыце па
     high_profile_groups: Высокапастаўленыя групы ў%{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Праца і кантакты
     latest_from: Апошняе ад %{title}
     notices:

--- a/config/locales/bg/organisations.yml
+++ b/config/locales/bg/organisations.yml
@@ -61,7 +61,7 @@ bg:
     follow_us: Следвайте ни
     hidden_share_link: Следвайте
     high_profile_groups: Високопоставени групи в %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Работни места и договори
     latest_from: Най-новите от %{title}
     notices:

--- a/config/locales/bn/organisations.yml
+++ b/config/locales/bn/organisations.yml
@@ -61,7 +61,7 @@ bn:
     follow_us: আমাদেরকে অনুসরণ করুন
     hidden_share_link: এখানে অনুসরণ করুন
     high_profile_groups: "%{title}-এর মধ্যে উচ্চ প্রোফাইল গ্রুপ"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: চাকরী ও চুক্তিসমূহ
     latest_from: "%{title} থেকে সর্বশেষ"
     notices:

--- a/config/locales/cs/organisations.yml
+++ b/config/locales/cs/organisations.yml
@@ -61,7 +61,7 @@ cs:
     follow_us: Sledujte nás
     hidden_share_link: Sledujte
     high_profile_groups: Vysoce profilované skupiny v rámci %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Pracovní místa a smlouvy
     latest_from: Nejnovější z %{title}
     notices:

--- a/config/locales/cy/organisations.yml
+++ b/config/locales/cy/organisations.yml
@@ -61,7 +61,7 @@ cy:
     follow_us: Dilynwch ni
     hidden_share_link: Dilynwch ni ar
     high_profile_groups: Grwpiau proffil uchel o fewn %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Swyddi a chontractau
     latest_from: Y diweddaraf gan %{title}
     notices:

--- a/config/locales/da/organisations.yml
+++ b/config/locales/da/organisations.yml
@@ -61,7 +61,7 @@ da:
     follow_us: Følg os
     hidden_share_link: Følg på
     high_profile_groups: Højt profilerede grupper inden for %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Job og kontrakter
     latest_from: Seneste fra %{title}
     notices:

--- a/config/locales/de/organisations.yml
+++ b/config/locales/de/organisations.yml
@@ -61,7 +61,7 @@ de:
     follow_us: Folgen Sie uns
     hidden_share_link: Folgen auf
     high_profile_groups: Hochrangige Gruppen im Rahmen von %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Arbeitsplätze und Verträge
     latest_from: Aktuelles von %{title}
     notices:

--- a/config/locales/dr/organisations.yml
+++ b/config/locales/dr/organisations.yml
@@ -64,7 +64,7 @@ dr:
     follow_us: ما را دنبال نمایید
     hidden_share_link: دنبال نمایید
     high_profile_groups: گروه هایی مشهور{title}%
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: وظایف و قرار داد ها
     latest_from: جدید ترین از{title}%
     notices:

--- a/config/locales/el/organisations.yml
+++ b/config/locales/el/organisations.yml
@@ -61,7 +61,7 @@ el:
     follow_us: Ακολουθήστε μας
     hidden_share_link: Ακολουθήστε στο
     high_profile_groups: Ομάδες υψηλού προφίλ εντός %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Θέσεις εργασίας και συμβάσεις
     latest_from: Τελευταία από %{title}
     notices:

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -61,7 +61,7 @@ en:
     follow_us: Follow us
     hidden_share_link: Follow on
     high_profile_groups: High profile groups within %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Jobs and contracts
     latest_from: Latest from %{title}
     notices:

--- a/config/locales/es-419/organisations.yml
+++ b/config/locales/es-419/organisations.yml
@@ -61,7 +61,7 @@ es-419:
     follow_us: Síguenos
     hidden_share_link: Síguenos en
     high_profile_groups: Grupos de alto perfil dentro de %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Trabajos y contratos
     latest_from: Lo más reciente de %{title}
     notices:

--- a/config/locales/es/organisations.yml
+++ b/config/locales/es/organisations.yml
@@ -59,7 +59,7 @@ es:
     follow_us: Síganos
     hidden_share_link: Seguir
     high_profile_groups: Grupos de perfiles altos dentro de %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Trabajos y contratos
     latest_from: Más reciente de %{title}
     notices:

--- a/config/locales/et/organisations.yml
+++ b/config/locales/et/organisations.yml
@@ -61,7 +61,7 @@ et:
     follow_us: Jälgige meid
     hidden_share_link: Järgige
     high_profile_groups: Kõrge profiiliga rühmad jaotises %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Töökohad ja lepingud
     latest_from: Viimane jaotises %{title}
     notices:

--- a/config/locales/fa/organisations.yml
+++ b/config/locales/fa/organisations.yml
@@ -61,7 +61,7 @@ fa:
     follow_us: ما را دنبال کنید
     hidden_share_link: دنبال کردن در
     high_profile_groups: گروه‌های مشهور در %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: شغل‌ها و قراردادها
     latest_from: جدیدترین‌ها از %{title}
     notices:

--- a/config/locales/fi/organisations.yml
+++ b/config/locales/fi/organisations.yml
@@ -61,7 +61,7 @@ fi:
     follow_us: Seuraa meitä
     hidden_share_link: Seurata
     high_profile_groups: Korkean profiilin ryhmät %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Työt ja sopimukset
     latest_from: Latest from %{title}
     notices:

--- a/config/locales/fr/organisations.yml
+++ b/config/locales/fr/organisations.yml
@@ -59,7 +59,7 @@ fr:
     follow_us: Suivez-nous
     hidden_share_link: Suivre sur
     high_profile_groups: Groupes au profil élevé dans %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Emplois et contrats
     latest_from: Dernières nouvelles de %{title}
     notices:

--- a/config/locales/gd/organisations.yml
+++ b/config/locales/gd/organisations.yml
@@ -61,7 +61,7 @@ gd:
     follow_us: Lean orainn
     hidden_share_link: Lean ar aghaidh
     high_profile_groups: Grúpaí ardleibhéil laistigh de %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Poist agus conarthaí
     latest_from: An nuacht is déanaí ó %{title}
     notices:

--- a/config/locales/gu/organisations.yml
+++ b/config/locales/gu/organisations.yml
@@ -59,7 +59,7 @@ gu:
     follow_us: અમને ફોલો કરો
     hidden_share_link: પર ફોલો કરો
     high_profile_groups: "%{title} માં રહેલ ઉચ્ચ પ્રોફાઇલ વાળા ગ્રુપ્સ"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: નોકરીઓ અને કરારો
     latest_from: "%{title} થી નવીનતમ"
     notices:

--- a/config/locales/he/organisations.yml
+++ b/config/locales/he/organisations.yml
@@ -61,7 +61,7 @@ he:
     follow_us: עקוב אחרינו
     hidden_share_link: עקוב ב-
     high_profile_groups: קבוצות פרופיל גבוהות בתוך %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: משרות וחוזים
     latest_from: עדכון אחרון מתוך %{title}
     notices:

--- a/config/locales/hi/organisations.yml
+++ b/config/locales/hi/organisations.yml
@@ -59,7 +59,7 @@ hi:
     follow_us: हमें फॉलो करें
     hidden_share_link: इस पर फॉलो करें
     high_profile_groups: "%{title} के अंदर हाई प्रोफाइल समूह"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: नौकरी एवं अनुबंध
     latest_from: "%{title} से नवीनतम"
     notices:

--- a/config/locales/hr/organisations.yml
+++ b/config/locales/hr/organisations.yml
@@ -59,7 +59,7 @@ hr:
     follow_us: Prati nas
     hidden_share_link: Slijedi
     high_profile_groups: Grupe visokog profila unutar %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Poslovi i ugovori
     latest_from: Najnovije od %{title}
     notices:

--- a/config/locales/hu/organisations.yml
+++ b/config/locales/hu/organisations.yml
@@ -61,7 +61,7 @@ hu:
     follow_us: Kövessen minket
     hidden_share_link: Kövessen minket a következőn
     high_profile_groups: 'Magas rangú csoportok a következőn belül: %{title}'
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Állások és szerződések
     latest_from: 'A legfrissebb a következőtől: %{title}'
     notices:

--- a/config/locales/hy/organisations.yml
+++ b/config/locales/hy/organisations.yml
@@ -61,7 +61,7 @@ hy:
     follow_us: Հետևել մեզ
     hidden_share_link: Հետևել
     high_profile_groups: Կարևոր խմբեր %{title}-ի շրջանակում
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Աշխատանք և պայմանագրեր
     latest_from: Վերջին տվյալները %{title}-ից
     notices:

--- a/config/locales/id/organisations.yml
+++ b/config/locales/id/organisations.yml
@@ -61,7 +61,7 @@ id:
     follow_us: Ikuti kami
     hidden_share_link: Ikuti di
     high_profile_groups: Grup profil tinggi di %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Pekerjaan dan kontrak
     latest_from: Terbaru dari %{title}
     notices:

--- a/config/locales/is/organisations.yml
+++ b/config/locales/is/organisations.yml
@@ -61,7 +61,7 @@ is:
     follow_us: Fylgdu okkur
     hidden_share_link: Fylgja á
     high_profile_groups: Áberandi hópar innan %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Störf og samningar
     latest_from: Nýjasta frá %{title}
     notices:

--- a/config/locales/it/organisations.yml
+++ b/config/locales/it/organisations.yml
@@ -61,7 +61,7 @@ it:
     follow_us: Seguici
     hidden_share_link: Seguici su
     high_profile_groups: Gruppi di alto profilo in %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Lavori e contratti
     latest_from: Ultime notizie da %{title}
     notices:

--- a/config/locales/ka/organisations.yml
+++ b/config/locales/ka/organisations.yml
@@ -59,7 +59,7 @@ ka:
     follow_us: გამოგვყევით
     hidden_share_link: გამოგვყევით
     high_profile_groups: მაღალი პროფილის ჯგუფები %{title}-ს ფარგლებში
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: ვაკანსიები და კონტრაქტები
     latest_from: ბოლო %{title}-დან
     notices:

--- a/config/locales/kk/organisations.yml
+++ b/config/locales/kk/organisations.yml
@@ -61,7 +61,7 @@ kk:
     follow_us: Бізге жазылыңыз
     hidden_share_link: Жазылыңыз
     high_profile_groups: "%{title} ішіндегі жоғары профильді топтар"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Жұмыстар мен келісімшарттар
     latest_from: "%{title} соңғылары"
     notices:

--- a/config/locales/ko/organisations.yml
+++ b/config/locales/ko/organisations.yml
@@ -61,7 +61,7 @@ ko:
     follow_us: 팔로우하기
     hidden_share_link: 다음에서 팔로우 하기
     high_profile_groups: "%{title} 내 상위 프로필 그룹"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: 직업 및 계약
     latest_from: "%{title}의 최근 내용"
     notices:

--- a/config/locales/lv/organisations.yml
+++ b/config/locales/lv/organisations.yml
@@ -61,7 +61,7 @@ lv:
     follow_us: Sekojiet mums
     hidden_share_link: Sekot
     high_profile_groups: Augsta profila grupas %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Darbi un līgumi
     latest_from: Jaunumi no %{title}
     notices:

--- a/config/locales/ms/organisations.yml
+++ b/config/locales/ms/organisations.yml
@@ -61,7 +61,7 @@ ms:
     follow_us: Ikuti kami
     hidden_share_link: Ikuti di
     high_profile_groups: Kumpulan berprofil tinggi dalam %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Pekerjaan dan kontrak
     latest_from: Terkini daripada %{title}
     notices:

--- a/config/locales/mt/organisations.yml
+++ b/config/locales/mt/organisations.yml
@@ -59,7 +59,7 @@ mt:
     follow_us: Segwina
     hidden_share_link: Segwi fuq
     high_profile_groups: Gruppi ta' profil għoli fost %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Impjiegi u kuntratti
     latest_from: L-iktar riċenti minn %{title}
     notices:

--- a/config/locales/nl/organisations.yml
+++ b/config/locales/nl/organisations.yml
@@ -61,7 +61,7 @@ nl:
     follow_us: Volg ons
     hidden_share_link: Volgen op
     high_profile_groups: High profile groepen binnen %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Banen en contracten
     latest_from: Laatste van %{title}
     notices:

--- a/config/locales/no/organisations.yml
+++ b/config/locales/no/organisations.yml
@@ -61,7 +61,7 @@
     follow_us: Følg oss
     hidden_share_link: Følg på
     high_profile_groups: Høyprofilerte grupper innen %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Jobber og kontrakter
     latest_from: Siste fra %{title}
     notices:

--- a/config/locales/pa-pk/organisations.yml
+++ b/config/locales/pa-pk/organisations.yml
@@ -63,7 +63,7 @@ pa-pk:
     follow_us: ساڈے پچھے آؤ
     hidden_share_link: ساڈے پچھے اوندے جاو
     high_profile_groups: ایندے وچ وڈے ناں والے گروہ {title}%
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: نوکریاں تے ٹھیکے
     latest_from: تازہ ترین فارم {title}%
     notices:

--- a/config/locales/pa/organisations.yml
+++ b/config/locales/pa/organisations.yml
@@ -61,7 +61,7 @@ pa:
     follow_us: ਸਾਨੂੰ ਫਾਲੋ ਕਰੋ
     hidden_share_link: ਤੇ ਫਾਲੋ ਕਰੋ
     high_profile_groups: "%{title} ਦੇ ਅੰਦਰ ਉੱਚ ਪ੍ਰੋਫਾਈਲ ਸਮੂਹ"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: ਨੌਕਰੀਆਂ ਅਤੇ ਇਕਰਾਰਨਾਮੇ
     latest_from: "%{Title} ਤੋਂ ਨਵੀਨਤਮ"
     notices:

--- a/config/locales/pl/organisations.yml
+++ b/config/locales/pl/organisations.yml
@@ -61,7 +61,7 @@ pl:
     follow_us: Obserwuj nas
     hidden_share_link: Obserwuj nas na
     high_profile_groups: Grupy o wysokim profilu w %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Praca i kontrakty
     latest_from: Najnowsze od %{title}
     notices:

--- a/config/locales/ps/organisations.yml
+++ b/config/locales/ps/organisations.yml
@@ -61,7 +61,7 @@ ps:
     follow_us: مونږ تعقیب کړئ
     hidden_share_link: تعقیب کړئ
     high_profile_groups: ه%{title} کې د لوړ پروفایل ډلې
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: دندې او قراردادونه
     latest_from: له%{title} څخه وروستی
     notices:

--- a/config/locales/pt/organisations.yml
+++ b/config/locales/pt/organisations.yml
@@ -61,7 +61,7 @@ pt:
     follow_us: Siga-nos
     hidden_share_link: Seguir em
     high_profile_groups: Grupos de perfil destacado em%{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Empregos e contratos
     latest_from: Mais recentes de %{title}
     notices:

--- a/config/locales/ro/organisations.yml
+++ b/config/locales/ro/organisations.yml
@@ -61,7 +61,7 @@ ro:
     follow_us: Urmăriți-ne
     hidden_share_link: Urmăriți-ne pe
     high_profile_groups: Grupuri cu profil înalt în %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Locuri de muncă și contracte
     latest_from: Cele mai recente informații de la %{title}
     notices:

--- a/config/locales/ru/organisations.yml
+++ b/config/locales/ru/organisations.yml
@@ -59,7 +59,7 @@ ru:
     follow_us: Следите за нами
     hidden_share_link: Подпишитесь на
     high_profile_groups: Авторитетные группы в %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Вакансии и контракты
     latest_from: Свежие новости  %{title}
     notices:

--- a/config/locales/si/organisations.yml
+++ b/config/locales/si/organisations.yml
@@ -61,7 +61,7 @@ si:
     follow_us: අපව අනුගමනය කරන්න
     hidden_share_link: හි අනුගමනය කරන්න
     high_profile_groups: "%{title} තුළ උසස් පැතිකඩ කණ්ඩායම්"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: රැකියා සහ කොන්ත්රාත්තු
     latest_from: "%{title} වෙතින් නවතම"
     notices:

--- a/config/locales/sk/organisations.yml
+++ b/config/locales/sk/organisations.yml
@@ -61,7 +61,7 @@ sk:
     follow_us: Sledujte nás
     hidden_share_link: Sledujte nás na
     high_profile_groups: Vysokoprofilové skupiny v rámci %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Pracovné miesta a zmluvy
     latest_from: Najnovšie od %{title}
     notices:

--- a/config/locales/sl/organisations.yml
+++ b/config/locales/sl/organisations.yml
@@ -61,7 +61,7 @@ sl:
     follow_us: Sledite nam
     hidden_share_link: Sledite nam na
     high_profile_groups: Pomembne skupine znotraj %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Delovna mesta in pogodbe
     latest_from: Najnovejše od %{title}
     notices:

--- a/config/locales/so/organisations.yml
+++ b/config/locales/so/organisations.yml
@@ -61,7 +61,7 @@ so:
     follow_us: Nagala soco
     hidden_share_link: Nagalasoco
     high_profile_groups: Koxaaha heerka sare %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Shaqooyinka iyo qandaraasyada
     latest_from: Kasocda %{title}
     notices:

--- a/config/locales/sq/organisations.yml
+++ b/config/locales/sq/organisations.yml
@@ -59,7 +59,7 @@ sq:
     follow_us: Na ndiqni
     hidden_share_link: Na ndiqni
     high_profile_groups: Grupe të profilit të lartë brenda %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Punë dhe kontrata
     latest_from: I fundit nga %{title}
     notices:

--- a/config/locales/sv/organisations.yml
+++ b/config/locales/sv/organisations.yml
@@ -61,7 +61,7 @@ sv:
     follow_us: Följ oss
     hidden_share_link: Följ oss på
     high_profile_groups: Högprofilerade grupper inom %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Jobb och kontrakt
     latest_from: Senaste från %{title}
     notices:

--- a/config/locales/sw/organisations.yml
+++ b/config/locales/sw/organisations.yml
@@ -61,7 +61,7 @@ sw:
     follow_us: Tufuatilie
     hidden_share_link: Tufuatilie kwenye
     high_profile_groups: Makundi ya hadhi ya juu ndani ya %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Kazi na mikataba
     latest_from: Habari mpya kutoka %{title}
     notices:

--- a/config/locales/ta/organisations.yml
+++ b/config/locales/ta/organisations.yml
@@ -61,7 +61,7 @@ ta:
     follow_us: எங்களைப் பின்தொடர்க
     hidden_share_link: பின்தொடர்
     high_profile_groups: "%{title}-க்குள் பிரசித்தமான குழுக்கள்"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: வேலைகளும் ஒப்பந்தங்களும்
     latest_from: "%{title}-லிருந்து சமீபத்தியவை"
     notices:

--- a/config/locales/th/organisations.yml
+++ b/config/locales/th/organisations.yml
@@ -61,7 +61,7 @@ th:
     follow_us: ติดตามเรา
     hidden_share_link: ติดตามใน
     high_profile_groups: กลุ่มระดับสูงภายใน %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: งานและสัญญา
     latest_from: ล่าสุดจาก %{title}
     notices:

--- a/config/locales/tk/organisations.yml
+++ b/config/locales/tk/organisations.yml
@@ -61,7 +61,7 @@ tk:
     follow_us: Bizi yzarlaň
     hidden_share_link: Yzarlaň
     high_profile_groups: Ýokary derejeli toparlar %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Işler we şertnamalar
     latest_from: Iň täze forma %{title}
     notices:

--- a/config/locales/tr/organisations.yml
+++ b/config/locales/tr/organisations.yml
@@ -61,7 +61,7 @@ tr:
     follow_us: Bizi takip edin
     hidden_share_link: Bizi şuradan takip edin
     high_profile_groups: "%{title} içerisindeki yüksek profilli gruplar"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: İşler ve sözleşmeler
     latest_from: "%{title} kaynaklı en güncel olanlar"
     notices:

--- a/config/locales/uk/organisations.yml
+++ b/config/locales/uk/organisations.yml
@@ -61,7 +61,7 @@ uk:
     follow_us: Слідкуйте за нами
     hidden_share_link: Слідкуйте на
     high_profile_groups: Ключові групи в %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Вакансії та контракти
     latest_from: Актуальні новини з %{title}
     notices:

--- a/config/locales/ur/organisations.yml
+++ b/config/locales/ur/organisations.yml
@@ -61,7 +61,7 @@ ur:
     follow_us: ہمیں فالو کریں
     hidden_share_link: یہاں فالو کریں
     high_profile_groups: "%{title} کے اندر اعلیٰ سطح کے گروپس"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: نوکریاں اور معاہدے
     latest_from: "%{title} سے تازہ ترین"
     notices:

--- a/config/locales/uz/organisations.yml
+++ b/config/locales/uz/organisations.yml
@@ -61,7 +61,7 @@ uz:
     follow_us: Бизни кузатиб боринг
     hidden_share_link: Кузатиб боринг
     high_profile_groups: Доирасида кўп поғонали гуруҳлар %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Иш ва контрактлар
     latest_from: Дан охиргилар %{title}
     notices:

--- a/config/locales/vi/organisations.yml
+++ b/config/locales/vi/organisations.yml
@@ -61,7 +61,7 @@ vi:
     follow_us: Theo dõi chúng tôi
     hidden_share_link: Theo dõi trên
     high_profile_groups: Nhóm cấu hình cao trong %{title}
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: Việc làm và hợp đồng
     latest_from: Mới nhất từ %{title}
     notices:

--- a/config/locales/zh-hk/organisations.yml
+++ b/config/locales/zh-hk/organisations.yml
@@ -59,7 +59,7 @@ zh-hk:
     follow_us: 關注我們
     hidden_share_link: 關注
     high_profile_groups: "%{title} 以內的高知名度群組"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: 職位及聯絡方式
     latest_from: 來自 %{title} 的最新內容
     notices:

--- a/config/locales/zh/organisations.yml
+++ b/config/locales/zh/organisations.yml
@@ -59,7 +59,7 @@ zh:
     follow_us: 关注我们
     hidden_share_link: 关注
     high_profile_groups: "%{title} 内是高调组"
-    index_title: "%{title} - GOV.UK"
+    index_title: "%{title}"
     jobs_contracts: 工作和联系人
     latest_from: "%{title} 的最新消息"
     notices:


### PR DESCRIPTION
This was an oversight from when Organisation pages were ported over from Whitehall.

## Before
![Screenshot 2023-05-15 at 12 53 05 pm](https://github.com/alphagov/collections/assets/424772/de7e1365-a90a-4875-8402-6f0d867eb2b6)

## After
![Screenshot 2023-05-19 at 3 49 19 pm](https://github.com/alphagov/collections/assets/424772/845ae21f-9c1a-418e-aa83-08137e749996)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
