### PR TITLE
Remove Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3070}


### PR DESCRIPTION
We've switched from Unicorn to Puma. Heroku is trying to call Unicorn to start the app with Unicorn and failing. As Puma is the default, we can get rid of the Procfile.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
