### PR TITLE
Assume reshuffle message is already HTML

### DIFF
--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -20,7 +20,7 @@
 
 <% if @presented_ministers.is_during_reshuffle? %>
   <%= render "govuk_publishing_components/components/notice", {
-    description_govspeak: sanitize(@presented_ministers.reshuffle_messaging),
+    description: sanitize(@presented_ministers.reshuffle_messaging),
   } %>
 <% else %>
 

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -103,7 +103,8 @@ RSpec.feature "Ministers index page" do
 
     scenario "renders the reshuffle messaging instead of the usual contents" do
       within(".gem-c-notice") do
-        expect(page).to have_text("Reshuffle in progress")
+        expect(page).to have_text("Check latest appointments")
+        expect(page).to have_link("latest appointments", href: "/government/news/ministerial-appointments-february-2023", class: "govuk-link")
       end
       expect(page).not_to have_selector(".gem-c-lead-paragraph")
       expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))


### PR DESCRIPTION
Previously, collections was trying to render the govspeak from the reshuffle message.

I have updated whitehall to [convert govspeak to HTML](https://github.com/alphagov/whitehall/pull/7712) before storing the reshuffle message in the content item, and [updated the example](https://github.com/alphagov/publishing-api/pull/2383) in publishing-api.

Potential issue: the notice component appears visually imbalanced (too much blank space on top) due to the `p` tag around the converted message, and possibly due to the lack of a title.

![Screenshot 2023-05-24 at 14 22 43](https://github.com/alphagov/collections/assets/579522/9f924209-e702-40a6-b201-87ad1933cfe8)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
