### PR TITLE
Fix spacing within notice on Ministerial page

### DIFF
--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -1,5 +1,11 @@
-.ministers-index h2 {
-  border-bottom: 5px solid #005ea5;
+.ministers-index {
+  h2 {
+    border-bottom: 5px solid #005ea5;
+  }
+
+  .gem-c-notice p {
+    margin-top: 0;
+  }
 }
 
 .clear-column {


### PR DESCRIPTION
The content now comes through as html, as Whitehall now parses the govspeak before saving it.

Fixes the issue introduced in https://github.com/alphagov/publishing-api/pull/2383

![collections dev gov uk_government_ministers](https://github.com/alphagov/collections/assets/424772/085e3391-a481-4ca4-8868-78de8df9e237)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
