### PR TITLE
Don't show contacts section on international delegations page

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -15,4 +15,3 @@
 //= link views/_taxons.css
 //= link views/_topical_events.css
 //= link views/_topics.css
-//= link views/_world_location_news.css

--- a/app/assets/stylesheets/views/_world_location_news.scss
+++ b/app/assets/stylesheets/views/_world_location_news.scss
@@ -1,5 +1,0 @@
-.world-location-news-show {
-  .world_location_news__address {
-    font-style: normal;
-  }
-}

--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -90,8 +90,4 @@ class WorldLocationNews
   def worldwide_organisations
     @content_item.content_item_data.dig("links", "worldwide_organisations")
   end
-
-  def contacts
-    @content_item.content_item_data.dig("links", "ordered_contacts")
-  end
 end

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -164,7 +164,7 @@
         </p>
 
         <p class="govuk-body">
-          <%= link_to(I18n.t("world_location_news.find_out_more"), organisation["base_path"]) %>
+          <%= link_to I18n.t("world_location_news.find_out_more"), organisation["base_path"], class: "govuk-link" %>
         </p>
       <% end %>
     </div>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -1,7 +1,4 @@
-<% add_view_stylesheet("world_location_news") if @world_location_news.contacts %>
-
 <% content_for :title, @world_location_news.title %>
-<% page_class "world-location-news-show" %>
 
 <% content_for :meta_tags do %>
   <%= tag("meta", name: "description", content: @world_location_news.description) if @world_location_news.description %>
@@ -170,48 +167,6 @@
           <%= link_to(I18n.t("world_location_news.find_out_more"), organisation["base_path"]) %>
         </p>
       <% end %>
-    </div>
-  </div>
-<% end %>
-
-<% @world_location_news.contacts&.each do |contact| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: contact.dig("details", "title"),
-        padding: true,
-        border_top: 1,
-        margin_bottom: 3,
-        heading_level: 3,
-      } %>
-
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third">
-          <% contact.dig("details", "post_addresses")&.each do |address| %>
-            <address class="govuk-body world_location_news__address">
-              <%= Govspeak::HCardPresenter.new(address.symbolize_keys).render %>
-            </address>
-          <% end %>
-        </div>
-
-        <div class="govuk-grid-column-two-thirds">
-          <% contact.dig("details", "email_addresses")&.each do |email_address| %>
-            <p class="govuk-body">
-              <%= t('world_location_news.email') %>
-              <br>
-              <%= link_to(email_address["email"], "mailto:#{email_address['email']}", class: "govuk-link") %>
-            </p>
-          <% end %>
-
-          <% contact.dig("details", "phone_numbers")&.each do |phone_number| %>
-            <p class="govuk-body">
-              <%= phone_number["title"] %>
-              <br>
-              <span dir="ltr"><%= phone_number["number"] %></span>
-            </p>
-          <% end %>
-        </div>
-      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
We've received a request [1] from FCDO to remove the display of contacts from international delegation pages, since there's already a link to a separate page with contact details which appears just on it on the page. This removes a design that was ported over directly from Whitehall's rendering of the page.

This also fixes an issue with a link on the page not having the correct css class.

| Before | After |
|------|-------|
|<img width="737" alt="Screenshot 2023-06-13 at 16 01 49" src="https://github.com/alphagov/collections/assets/25515510/dac4d9b7-b760-4d64-86e5-202d50510932">|<img width="618" alt="Screenshot 2023-06-13 at 16 20 57" src="https://github.com/alphagov/collections/assets/25515510/54fe9f41-b280-4efe-9a19-da52b4f29743">|

Some links to the deployed PR vs live content for comparison:
UK mission to the EU - [live](https://www.gov.uk/world/uk-mission-to-the-eu) vs [new version](https://collections-pr-3291.herokuapp.com/world/uk-mission-to-the-eu)
UK mission to Asean - [live](https://www.gov.uk/world/uk-mission-to-asean) vs [new version](https://collections-pr-3291.herokuapp.com/world/uk-mission-to-asean)
UK and the commonwealth - [live](https://www.gov.uk/world/uk-and-the-commonwealth) vs [new version](https://collections-pr-3291.herokuapp.com/world/uk-and-the-commonwealth)
UK mission to the UN - [live](https://www.gov.uk/world/uk-mission-to-the-united-nations) vs [new version](https://collections-pr-3291.herokuapp.com/world/uk-mission-to-the-united-nations)


[Trello](https://trello.com/c/PLjY81fQ/1783-update-format-for-international-delegation-pages-s)

1: https://govuk.zendesk.com/agent/tickets/4772368

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
