### PR TITLE
Add ga4 tracking to email alerts

### DIFF
--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -58,7 +58,21 @@
     </div>
   </section>
 
-  <%= content_tag :section, class: "covid__topic-wrapper" do
+  <%= content_tag :section, 
+    class: "covid__topic-wrapper", 
+    data: { 
+      module: "ga4-link-tracker", 
+      ga4_link: {
+        event_name: "navigation",
+        type: "subscribe",
+        index: {
+          index_link: 1
+        },
+        index_total: 1,
+        section: "Footer"
+      },
+      ga4_track_links_only: ""
+    } do
     render 'govuk_publishing_components/components/signup_link', {
       link_text:  "Sign up to get emails when we change any COVID-19 information on the GOV.UK website",
       link_href: "/email-signup?topic=/coronavirus-taxon",
@@ -66,7 +80,7 @@
       data: {
         "module": "gem-track-click",
         "track-category": "emailAlertLinkClicked",
-        "track-action": "/coronavirus",
+        "track-action": "/coronavirus"
       },
       background: true
     }

--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -21,7 +21,13 @@
         </a>
       </p>
 
-      <%= render "govuk_publishing_components/components/subscription_links", @show.subscription_links %>
+      <div 
+        data-module="ga4-link-tracker" 
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+        data-ga4-track-links-only
+      >
+        <%= render "govuk_publishing_components/components/subscription_links", @show.subscription_links %>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -6,10 +6,16 @@
         margin_bottom: 5,
     } %>
 
-    <%= render "govuk_publishing_components/components/subscription_links", {
-        email_signup_link: announcements.links[:email_signup],
-        margin_bottom: 5,
-    } %>
+    <div 
+      data-module="ga4-link-tracker" 
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+      data-ga4-track-links-only
+    >
+      <%= render "govuk_publishing_components/components/subscription_links", {
+          email_signup_link: announcements.links[:email_signup],
+          margin_bottom: 5
+      } %>
+    </div>
 
     <%= render "govuk_publishing_components/components/document_list", {
         items: announcements.items

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -11,10 +11,15 @@
       <% end %>
     </div>
 
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-3">
+    <div 
+      class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-3"
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+      data-ga4-track-links-only
+    >
       <%= render "govuk_publishing_components/components/subscription_links", {
         email_signup_link: "/email-signup?link=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
-        email_signup_link_text: t("shared.get_emails"),
+        email_signup_link_text: t("shared.get_emails")
       } %>
 
       <% if local_assigns[:link_to_latest_feed] %>

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -14,7 +14,12 @@
 
 <% if taxon_is_live?(presented_taxon) %>
   <div class="taxon-page__email-link-wrapper">
-    <div class="full-page-width-wrapper">
+    <div 
+      class="full-page-width-wrapper" 
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+      data-ga4-track-links-only
+    >
       <%= render "govuk_publishing_components/components/signup_link", {
         link_text: t("shared.get_emails"),
         link_href: "/email-signup/?link=#{presented_taxon.base_path}",

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,3 +1,14 @@
+<% ga4_link_attributes = {
+    event_name: "navigation",
+    type: "subscribe",
+    index: {
+      index_link: 1
+    },
+    index_total: 1,
+    section: "Content"
+  }.to_json
+%>
+
 <% add_view_stylesheet("topical_events") %>
 
 <% content_for :title, @topical_event.title %>
@@ -116,9 +127,15 @@
         <p class="govuk-body"><%= I18n.t("topical_events.no_updates") %></p>
       <% end %>
 
-      <%= render "govuk_publishing_components/components/subscription_links", {
-        email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}",
-      } %>
+      <div 
+        data-module="ga4-link-tracker" 
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+        data-ga4-track-links-only
+      >
+        <%= render "govuk_publishing_components/components/subscription_links", {
+          email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}"
+        } %>
+      </div>
     </section>
   </div>
 

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -71,9 +71,15 @@
           <p class="govuk-body"><%= I18n.t("world_location_news.no_updates") %></p>
         <% end %>
 
-        <%= render "govuk_publishing_components/components/subscription_links", {
-          email_signup_link: "/email/subscriptions/new?topic_id=#{@world_location_news.slug}",
-        } %>
+        <div 
+          data-module="ga4-link-tracker" 
+          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+          data-ga4-track-links-only
+        >
+          <%= render "govuk_publishing_components/components/subscription_links", {
+            email_signup_link: "/email/subscriptions/new?topic_id=#{@world_location_news.slug}"
+          } %>
+        </div>
       </section>
     </div>
   </div>

--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -1,13 +1,19 @@
 <% if taxon_is_live?(presented_taxon) %>
-  <% if presented_taxon.renders_as_accordion? %>
-    <%= render "govuk_publishing_components/components/subscription_links", {
-      email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
-    } %>
-  <% else %>
-    <%= render "govuk_publishing_components/components/subscription_links", {
-      email_signup_link: email_alert_frontend_signup_url(presented_taxon),
-      email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
-    } %>
-  <% end %>
+  <div 
+    data-module="ga4-link-tracker" 
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+    data-ga4-track-links-only
+  >
+    <% if presented_taxon.renders_as_accordion? %>
+      <%= render "govuk_publishing_components/components/subscription_links", {
+        email_signup_link: email_alert_frontend_signup_url(presented_taxon),
+        email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/subscription_links", {
+        email_signup_link: email_alert_frontend_signup_url(presented_taxon),
+        email_signup_link_text: "#{t("shared.get_emails")} <span class='govuk-visually-hidden'>#{presented_taxon.title}</span>".html_safe,
+      } %>
+    <% end %>
+  </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

This PR adds GA4 tracking to the `Get emails for this topic`/`Get emails` links (screenshot below).

`Get emails for this topic` link:

![image](https://github.com/alphagov/collections/assets/110391449/6caf68d3-b6c5-4fa5-bf4a-c6c723d74f16)

`Get emails` link:

![image](https://github.com/alphagov/collections/assets/110391449/d778deda-45cf-4225-9ca6-c6c10271803a)

Email alerts on the Coronavirus landing page:

![image](https://github.com/alphagov/collections/assets/110391449/255cf66e-1790-48bb-9232-a342fa01ca14)

As per the Implementation Guide, it is believed that these links only appear once on each page and therefore the `index_link` and `index_total` properties have been hardcoded to 1.

## Why

Part of the GA4 migration.

[Trello card](https://trello.com/c/Nil9XIqH/568-subscribe-get-email-alerts-for-this-topic-link)
[Trello card](https://trello.com/c/Df3jj1HF/567-subscribe-get-email-alerts-link)