### PR TITLE
Add GA4 tracking to browse pages

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -27,6 +27,7 @@
   } %>
 <% end %>
 
+<% total_links = page.top_level_browse_pages.count.to_s %>
 <%= render "shared/browse_cards_container" do %>
   <%= render "govuk_publishing_components/components/cards", {
     items: page.top_level_browse_pages.map.with_index do |top_level_browse_page, index|
@@ -40,9 +41,17 @@
             track_label: top_level_browse_page.base_path,
             track_dimension: top_level_browse_page.title,
             track_options: {
-              dimension28: page.top_level_browse_pages.count.to_s,
+              dimension28: total_links,
               dimension29: top_level_browse_page.title,
               dimension114: index + 1,
+            },
+            ga4_link: {
+              event_name: "navigation",
+              type: "browse card",
+              index: {
+                index_link: index + 1,
+              },
+              index_total: total_links,
             },
           }
         },

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -31,6 +31,7 @@
   } %>
 <% end %>
 
+<% total_links = page.second_level_browse_pages.count.to_s %>
 <%= render "shared/browse_cards_container" do %>
   <%= render "govuk_publishing_components/components/cards", {
     items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
@@ -44,9 +45,17 @@
             track_label: second_level_browse_page.base_path,
             track_dimension: second_level_browse_page.title,
             track_options: {
-              dimension28: page.second_level_browse_pages.count.to_s,
+              dimension28: total_links,
               dimension29: second_level_browse_page.title,
               dimension114: index + 1,
+            },
+            ga4_link: {
+              event_name: "navigation",
+              type: "browse card",
+              index: {
+                index_link: index + 1,
+              },
+              index_total: total_links,
             },
           },
         },

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -1,5 +1,6 @@
 <% track_action ||= "contentLink" %>
 
+<% total_links = list.count.to_s %>
 <ul class="govuk-list browse__list" data-module="gem-track-click">
   <% list.each_with_index do |list_item, index| %>
     <li class="browse__list-item">
@@ -13,9 +14,19 @@
           track_action: track_action,
           track_label: list_item.base_path,
           track_options: {
-            dimension28: list.count.to_s,
+            dimension28: total_links,
             dimension29: list_item.title,
             dimension114: "#{list_index + 1}.#{index + 1}",
+          },
+          ga4_link: {
+            event_name: "navigation",
+            type: "browse list",
+            index: {
+              index_link: index + 1,
+              index_section: list_index + 1,
+              index_section_count: index_section_count,
+            },
+            index_total: total_links,
           },
         },
       ) %>

--- a/app/views/second_level_browse_page/_show_curated_list.html.erb
+++ b/app/views/second_level_browse_page/_show_curated_list.html.erb
@@ -1,3 +1,7 @@
+<%
+  index_section_count = page.lists.count
+  index_section_count += 1 if page.related_topics.any?
+%>
 <% page.lists.each_with_index do |list, list_index| %>
 
   <%# The first, or only, section should not have a top border. %>
@@ -6,8 +10,8 @@
   <div class="browse__section <%= 'browse__section--top-border' if is_not_first_section %>" >
     <%= render partial: "shared/browse_heading", locals: { title: list.title } %>
 
-    <%= render partial: "links", locals: { list: list.contents, list_index: list_index } %>
+    <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s } %>
   </div>
 <% end %>
 
-<%= render partial: "shared/browse_related_topics", locals: { page: page } %>
+<%= render partial: "shared/browse_related_topics", locals: { page: page, index_section_count: index_section_count.to_s } %>

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -37,15 +37,19 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2" data-module="ga4-link-tracker">
+      <%
+        index_section_count = page.lists.count
+        index_section_count += 1 if page.related_topics.any?
+      %>
       <% page.lists.each_with_index do |list, list_index| %>
         <div class="browse__section">
           <%= render partial: "shared/browse_heading", locals: { title: list.title } %>
 
-          <%= render partial: "links", locals: { list: list.contents, list_index: list_index } %>
+          <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s } %>
         </div>
       <% end %>
-      <%= render partial: "shared/browse_related_topics", locals: { page: page } %>
+      <%= render partial: "shared/browse_related_topics", locals: { page: page, index_section_count: index_section_count.to_s } %>
     </div>
   </div>
 </div>

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -35,7 +35,7 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" data-module="ga4-link-tracker">
       <%= render partial: curated_partial, locals: { page: page } %>
     </div>
   </div>

--- a/app/views/shared/_browse_cards_container.html.erb
+++ b/app/views/shared/_browse_cards_container.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full" data-module="gem-track-click">
+    <div class="govuk-grid-column-full" data-module="gem-track-click ga4-link-tracker">
       <%= yield %>
     </div>
   </div>

--- a/app/views/shared/_browse_related_topics.html.erb
+++ b/app/views/shared/_browse_related_topics.html.erb
@@ -10,6 +10,6 @@
       } %>
     </div>
 
-    <%= render partial: "links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink" } %>
+    <%= render partial: "links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink", index_section_count: index_section_count } %>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the various levels of the browse pages, using the GA4 link tracker. 

Browse pages start at https://www.gov.uk/browse (level 0) and are followed by level 1 and level 2. There are a few example variations within these browse pages that needed to be checked, because the presence or absence of related topics alters the values for `index_section_count`.

- level 0: https://www.gov.uk/browse
- level 1: https://www.gov.uk/browse/benefits
- level 2, curated: https://www.gov.uk/browse/births-deaths-marriages/death 
- level 2, curated with related topics: https://www.gov.uk/browse/business/setting-up
- level 2, A to Z: https://www.gov.uk/browse/births-deaths-marriages/lasting-power-attorney
- level 2, A to Z with related topics: https://www.gov.uk/browse/births-deaths-marriages/child

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/uBpt9Qrp/593-add-tracking-navigation-browse-pages
