### PR TITLE
Add GA4 tracking to taxonomy pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.7.0)
+    govuk_publishing_components (35.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -258,7 +258,7 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     mocha (2.0.4)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.6.0)
@@ -493,7 +493,7 @@ GEM
     thor (1.2.2)
     tilt (2.0.11)
     timecop (0.9.6)
-    timeout (0.3.2)
+    timeout (0.4.0)
     tins (1.32.1)
       sync
     tzinfo (2.0.6)

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -23,7 +23,7 @@
 
 .taxon-page__section-group {
   border-top: 2px solid $govuk-brand-colour;
-  margin-top: 60px;
+  margin-top: 45px;
   padding-top: govuk-spacing(3);
 }
 
@@ -62,11 +62,6 @@
   padding-top: govuk-spacing(4);
   padding-left: govuk-spacing(3);
   clear: both;
-}
-
-.taxon-page__see-more {
-  position: relative;
-  top: govuk-spacing(3);
 }
 
 .taxon-page__show-more-toggle {
@@ -127,6 +122,7 @@
 }
 
 .taxon-page__organisations {
+  margin-bottom: 35px;
   list-style-type: none;
 
   .taxon-page__organisation {

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -3,8 +3,10 @@ class TaxonOrganisationsPresenter
 
   attr_reader :organisations
 
-  def initialize(organisations)
+  def initialize(organisations, index_section, index_section_count)
     @organisations = organisations
+    @index_section = index_section + 1
+    @index_section_count = index_section_count
   end
 
   def show_organisations?
@@ -41,7 +43,6 @@ private
   def organisation_list_with_logos
     organisations_with_logos.map.with_index do |org, index|
       {
-
         name: org.logo_formatted_title,
         url: org.link,
         brand: org.brand,
@@ -74,6 +75,17 @@ private
       track_label: base_path,
       track_options: {
         dimension29: link_text,
+      },
+      ga4_link: {
+        event_name: "navigation",
+        type: "organisation logo",
+        index: {
+          index_link: index,
+          index_section: @index_section,
+          index_section_count: @index_section_count,
+        },
+        index_total: organisations.count,
+        section: "Organisations",
       },
     }
   end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -36,6 +36,17 @@ class TaxonPresenter
       track_action: (index + 1).to_s,
       track_label: child_taxons[index].preferred_url,
       track_options: {},
+      ga4_link: {
+        event_name: "navigation",
+        type: "document list",
+        index: {
+          index_link: (index + 1).to_s,
+          index_section: page_section_total.to_s,
+          index_section_count: page_section_total.to_s,
+        },
+        index_total: child_taxons.count,
+        section: I18n.t("taxons.explore_sub_topics"),
+      },
     }
   end
 

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -45,7 +45,7 @@ class TaxonPresenter
           index_section_count: page_section_total.to_s,
         },
         index_total: child_taxons.count,
-        section: I18n.t("taxons.explore_sub_topics"),
+        section: I18n.t("taxons.explore_sub_topics", locale: :en),
       },
     }
   end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -22,7 +22,7 @@ class TaxonPresenter
   end
 
   def organisations_section
-    @organisations_section ||= TaxonOrganisationsPresenter.new(organisations)
+    @organisations_section ||= TaxonOrganisationsPresenter.new(organisations, count_sections, page_section_total)
   end
 
   def show_subtopic_grid?
@@ -37,5 +37,16 @@ class TaxonPresenter
       track_label: child_taxons[index].preferred_url,
       track_options: {},
     }
+  end
+
+  def count_sections
+    sections.select { |s| s[:show_section] }.count
+  end
+
+  def page_section_total
+    count = count_sections
+    count += 1 if organisations.any?
+    count += 1 if show_subtopic_grid?
+    count
   end
 end

--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -21,8 +21,8 @@
         </a>
       </p>
 
-      <div 
-        data-module="ga4-link-tracker" 
+      <div
+        data-module="ga4-link-tracker"
         data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
         data-ga4-track-links-only
       >

--- a/app/views/taxons/_organisation_logos_and_list.html.erb
+++ b/app/views/taxons/_organisation_logos_and_list.html.erb
@@ -1,21 +1,38 @@
-<div class="taxon-page__organisations">
+<div class="taxon-page__organisations" data-module="ga4-link-tracker">
   <ul class="govuk-list">
-    <% organisations_with_logos.each do |promoted_organisation| %>
-      <li class="taxon-page__organisation">
-        <%= render 'govuk_publishing_components/components/organisation_logo', {
-            organisation: promoted_organisation
+    <% organisations_with_logos.each_with_index do |promoted_organisation, index| %>
+      <%= content_tag(
+        :li,
+        class: "taxon-page__organisation",
+        data: {
+          ga4_link: {
+            event_name: "navigation",
+            type: "organisation logo",
+            index: {
+              index_link: index_link + index,
+              index_section: index_section,
+              index_section_count: index_section_count
+            },
+            index_total: organisations_with_logos.count,
+            section: "Organisations"
           }
-        %>
-      </li>
+        }) do %>
+          <%= render 'govuk_publishing_components/components/organisation_logo', {
+              organisation: promoted_organisation
+            }
+          %>
+      <% end %>
     <% end %>
   </ul>
 </div>
 
 <% if organisations_without_logos.any? %>
-  <div <%= "data-module=gem-track-click" if track_click?(organisations_without_logos) %>>
+  <div
+    data-module="ga4-link-tracker <%= "gem-track-click" if track_click?(organisations_without_logos) %>"
+    data-ga4-link="{'index':{'index_section':<%= index_section %>,'index_section_count':<%= index_section_count %>}}"
+  >
     <%= render 'govuk_publishing_components/components/document_list',
-      items: organisations_without_logos,
-      margin_bottom: true
+      items: organisations_without_logos
     %>
   </div>
 <% end %>

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -1,36 +1,67 @@
 <% if presented_organisations.show_organisations? %>
-  <div id="organisations" class="taxon-page__section-group taxon-page__section-group--organisation" data-module="gem-toggle">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/heading", {
-              text: t('taxons.organisations'),
-              heading_level: 2,
-              margin_bottom: 3
+  <%= content_tag(
+    :div,
+    id: "organisations",
+    class: "taxon-page__section-group taxon-page__section-group--organisation",
+    data: {
+      module: "gem-toggle",
+    }) do %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render "govuk_publishing_components/components/heading", {
+            text: t('taxons.organisations'),
+            heading_level: 2,
+            margin_bottom: 3
           } %>
 
+          <%= render partial: 'organisation_logos_and_list', locals: {
+            organisations_with_logos: presented_organisations.promoted_organisation_list[:promoted_with_logos],
+            organisations_without_logos: presented_organisations.promoted_organisation_list[:promoted_without_logos],
+            index_link: 1,
+            index_section: index_section,
+            index_section_count: index_section_count
+          } %>
 
-        <%= render partial: 'organisation_logos_and_list', locals: {
-              organisations_with_logos: presented_organisations.promoted_organisation_list[:promoted_with_logos],
-              organisations_without_logos: presented_organisations.promoted_organisation_list[:promoted_without_logos]
-        } %>
-
-        <% if presented_organisations.show_more_organisations? %>
+          <% if presented_organisations.show_more_organisations? %>
+            <%
+              ga4_attributes = {
+                event_name: "select_content",
+                type: "organisation",
+                index: {
+                  index_section: index_section,
+                  index_section_count: index_section_count
+                },
+                section: "Organisations",
+              }
+            %>
             <div class="taxon-page__show-more-toggle taxon-page__see-more">
               <a href="#"
-              class="govuk-link"
-              data-controls="more-organisations"
-              data-expanded="false"
-              data-toggled-text="<%= t("taxons.show_fewer_orgs") %>"><%= t("taxons.show_more_orgs") %></a>
+                class="govuk-link"
+                data-controls="more-organisations"
+                data-expanded="false"
+                data-ga4-expandable=""
+                data-toggled-text="<%= t("taxons.show_fewer_orgs") %>"
+                data-module="ga4-event-tracker"
+                data-ga4-event="<%= ga4_attributes.to_json %>"
+              >
+                <%= t("taxons.show_more_orgs") %>
+              </a>
             </div>
 
-          <div id="more-organisations" class="js-hidden taxon-page__more-organisations">
-            <%= render partial: 'organisation_logos_and_list', locals: {
-                  organisations_with_logos: presented_organisations.show_more_organisation_list[:organisations_with_logos],
-                  organisations_without_logos: presented_organisations.show_more_organisation_list[:organisations_without_logos]
-            } %>
-          </div>
-        <% end %>
+            <div id="more-organisations" class="js-hidden taxon-page__more-organisations">
+              <%
+                index_link = presented_organisations.promoted_organisation_list[:promoted_with_logos].count + presented_organisations.promoted_organisation_list[:promoted_without_logos].count
+              %>
+              <%= render partial: 'organisation_logos_and_list', locals: {
+                organisations_with_logos: presented_organisations.show_more_organisation_list[:organisations_with_logos],
+                organisations_without_logos: presented_organisations.show_more_organisation_list[:organisations_without_logos],
+                index_link: index_link,
+                index_section: index_section,
+                index_section_count: index_section_count
+              } %>
+            </div>
+          <% end %>
+        </div>
       </div>
-    </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,5 +1,6 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:documents]
+  items: section[:documents],
+  margin_bottom: 7
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -28,8 +28,7 @@
   <div>
     <%= render 'govuk_publishing_components/components/document_list',
       items: section[:documents_with_promoted],
-      margin_top: true,
-      margin_bottom: true
+      margin_bottom: 7
     %>
 <% else %>
   <div class="taxon-page__featured-see-more">

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,5 +1,6 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:documents]
+  items: section[:documents],
+  margin_bottom: 7
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -1,5 +1,6 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:documents]
+  items: section[:documents],
+  margin_bottom: 7
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_see_more_link.html.erb
+++ b/app/views/taxons/sections/_see_more_link.html.erb
@@ -1,6 +1,6 @@
 <%= link_to(
-    section[:see_more_link][:text],
-    section[:see_more_link][:url],
-    data: section[:see_more_link][:data],
-    class: "govuk-link taxon-page__see-more"
+  section[:see_more_link][:text],
+  section[:see_more_link][:url],
+  data: section[:see_more_link][:data],
+  class: "govuk-link"
 )%>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,5 +1,6 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:documents]
+  items: section[:documents],
+  margin_bottom: 7
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,5 +1,6 @@
 <%= render 'govuk_publishing_components/components/document_list',
-    items: section[:documents]
+  items: section[:documents],
+  margin_bottom: 7
 %>
 
 <% if section[:see_more_link] %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -18,23 +18,42 @@
       } %>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <% presented_taxon.sections.each do |section| %>
+      <%
+        index_section_count = presented_taxon.sections.count
+        index_section_count += 1 if presented_taxon.organisations_section
+        index_section_count += 1 if presented_taxon.show_subtopic_grid?
+      %>
+      <% presented_taxon.sections.each_with_index do |section, index| %>
         <% if section[:show_section] %>
+          <% title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title]) %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
                 <%= render "govuk_publishing_components/components/heading", {
-                    text: t(section[:id], scope: :content_purpose_supergroup, default: section[:title]),
-                    heading_level: 2,
-                    margin_bottom: 3
+                  text: title,
+                  heading_level: 2,
+                  margin_bottom: 3
                 } %>
               </div>
             </div>
-            <%= render(
-                    partial: section[:partial_template],
-                    locals: { section: section }
-                )
-            %>
+            <%= content_tag(
+              :div,
+              data: {
+                module: "ga4-link-tracker",
+                ga4_track_links_only: "",
+                ga4_set_indexes: "",
+                ga4_link: {
+                  event_name: "navigation",
+                  type: "document list",
+                  index: {
+                    index_section: index + 1,
+                    index_section_count: index_section_count
+                  },
+                  section: title
+                }
+              }) do %>
+              <%= render(partial: section[:partial_template], locals: { section: section }) %>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -26,7 +26,7 @@
         <% if section[:show_section] %>
           <%
             index += 1 # increment index if section should be shown (otherwise could use each_with_index)
-            title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title])
+            title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title], locale: :en)
           %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
             <div class="govuk-grid-row">

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -63,7 +63,7 @@
       <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section, index_section: presented_taxon.count_sections + 1, index_section_count: index_section_count } %>
 
       <% if presented_taxon.show_subtopic_grid? %>
-        <div id="sub-topics" class="taxon-page__section-group">
+        <div id="sub-topics" class="taxon-page__section-group" data-module="ga4-link-tracker">
           <%= render "govuk_publishing_components/components/heading", {
             text: t('taxons.explore_sub_topics'),
             heading_level: 2,

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -3,10 +3,10 @@
 <% content_for :page_class, "taxon-page taxon-page--grid" %>
 <%=
   render(
-      partial: 'common',
-      locals: {
-          presented_taxon: presented_taxon
-      }
+    partial: 'common',
+    locals: {
+      presented_taxon: presented_taxon
+    }
   )
 %>
 
@@ -14,18 +14,20 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third content-list__sticky">
       <%= render "govuk_publishing_components/components/contents_list", {
-          contents: @presentable_section_items
+        contents: @presentable_section_items
       } %>
     </div>
     <div class="govuk-grid-column-two-thirds">
       <%
-        index_section_count = presented_taxon.sections.count
-        index_section_count += 1 if presented_taxon.organisations_section
-        index_section_count += 1 if presented_taxon.show_subtopic_grid?
+        index_section_count = presented_taxon.page_section_total
+        index = 0
       %>
-      <% presented_taxon.sections.each_with_index do |section, index| %>
+      <% presented_taxon.sections.each do |section| %>
         <% if section[:show_section] %>
-          <% title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title]) %>
+          <%
+            index += 1 # increment index if section should be shown (otherwise could use each_with_index)
+            title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title])
+          %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-two-thirds">
@@ -46,7 +48,7 @@
                   event_name: "navigation",
                   type: "document list",
                   index: {
-                    index_section: index + 1,
+                    index_section: index,
                     index_section_count: index_section_count
                   },
                   section: title
@@ -58,21 +60,19 @@
         <% end %>
       <% end %>
 
-      <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section} %>
+      <%= render partial: 'organisations', locals: { presented_organisations: presented_taxon.organisations_section, index_section: presented_taxon.count_sections + 1, index_section_count: index_section_count } %>
 
       <% if presented_taxon.show_subtopic_grid? %>
         <div id="sub-topics" class="taxon-page__section-group">
           <%= render "govuk_publishing_components/components/heading", {
-              text: t('taxons.explore_sub_topics'),
-              heading_level: 2,
-              margin_bottom: 3
+            text: t('taxons.explore_sub_topics'),
+            heading_level: 2,
+            margin_bottom: 3
           } %>
 
           <%= render 'govuk_publishing_components/components/document_list',
-                     items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| { link: { text: child_taxon.title, path: child_taxon.preferred_url, data_attributes: presented_taxon.options_for_child_taxon(index: index) }} },
-                     margin_bottom: true
+            items: presented_taxon.child_taxons.each_with_index.map { |child_taxon, index| { link: { text: child_taxon.title, path: child_taxon.preferred_url, data_attributes: presented_taxon.options_for_child_taxon(index: index) }} }
           %>
-
         </div>
       <% end %>
     </div>

--- a/spec/presenters/taxon_organisations_presenter_spec.rb
+++ b/spec/presenters/taxon_organisations_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TaxonOrganisationsPresenter do
   let(:content_hash) { funding_and_finance_for_students_taxon }
   let(:content_item) { ContentItem.new(content_hash) }
   let(:taxon) { Taxon.new(ContentItem.new(content_hash)) }
-  let(:taxon_organisations_presenter) { TaxonOrganisationsPresenter.new(taxon.organisations) }
+  let(:taxon_organisations_presenter) { TaxonOrganisationsPresenter.new(taxon.organisations, 5, 7) }
 
   it "checks whether organisations should be shown" do
     allow_any_instance_of(TaggedOrganisations).to receive(:fetch).and_return([])
@@ -34,6 +34,17 @@ RSpec.describe TaxonOrganisationsPresenter do
               track_label: "/government/organisations/department-for-education",
               track_options: {
                 dimension29: "Department for Education",
+              },
+              ga4_link: {
+                event_name: "navigation",
+                type: "organisation logo",
+                index: {
+                  index_link: 1,
+                  index_section: 6,
+                  index_section_count: 7,
+                },
+                index_total: 1,
+                section: "Organisations",
               },
             },
           },
@@ -64,6 +75,17 @@ RSpec.describe TaxonOrganisationsPresenter do
             track_options: {
               dimension29: "Department for Education",
             },
+            ga4_link: {
+              event_name: "navigation",
+              type: "organisation logo",
+              index: {
+                index_link: 1,
+                index_section: 6,
+                index_section_count: 7,
+              },
+              index_total: 1,
+              section: "Organisations",
+            },
           },
         },
       ]
@@ -90,6 +112,17 @@ RSpec.describe TaxonOrganisationsPresenter do
               track_label: "/government/organisations/department-for-education",
               track_options: {
                 dimension29: "Department for Education",
+              },
+              ga4_link: {
+                event_name: "navigation",
+                type: "organisation logo",
+                index: {
+                  index_link: 1,
+                  index_section: 6,
+                  index_section_count: 7,
+                },
+                index_total: 1,
+                section: "Organisations",
               },
             },
           },
@@ -122,6 +155,17 @@ RSpec.describe TaxonOrganisationsPresenter do
             track_options: {
               dimension29: "Department for Education",
             },
+            ga4_link: {
+              event_name: "navigation",
+              type: "organisation logo",
+              index: {
+                index_link: index + 1,
+                index_section: 6,
+                index_section_count: 7,
+              },
+              index_total: 5,
+              section: "Organisations",
+            },
           },
         )
       end
@@ -150,6 +194,17 @@ RSpec.describe TaxonOrganisationsPresenter do
               track_label: "/government/organisations/department-for-education",
               track_options: {
                 dimension29: "Department for Education",
+              },
+              ga4_link: {
+                event_name: "navigation",
+                type: "organisation logo",
+                index: {
+                  index_link: index + 1,
+                  index_section: 6,
+                  index_section_count: 7,
+                },
+                index_total: 5,
+                section: "Organisations",
               },
             },
           },
@@ -184,6 +239,17 @@ RSpec.describe TaxonOrganisationsPresenter do
             track_options: {
               dimension29: "Department for Education",
             },
+            ga4_link: {
+              event_name: "navigation",
+              type: "organisation logo",
+              index: {
+                index_link: index + 1,
+                index_section: 6,
+                index_section_count: 7,
+              },
+              index_total: 4,
+              section: "Organisations",
+            },
           },
         )
       end
@@ -199,6 +265,17 @@ RSpec.describe TaxonOrganisationsPresenter do
               track_label: "/government/organisations/department-for-education",
               track_options: {
                 dimension29: "Department for Education",
+              },
+              ga4_link: {
+                event_name: "navigation",
+                type: "organisation logo",
+                index: {
+                  index_link: 4,
+                  index_section: 6,
+                  index_section_count: 7,
+                },
+                index_total: 4,
+                section: "Organisations",
               },
             },
           },
@@ -233,6 +310,17 @@ RSpec.describe TaxonOrganisationsPresenter do
             track_options: {
               dimension29: "Department for Education",
             },
+            ga4_link: {
+              event_name: "navigation",
+              type: "organisation logo",
+              index: {
+                index_link: 6,
+                index_section: 6,
+                index_section_count: 7,
+              },
+              index_total: 6,
+              section: "Organisations",
+            },
           },
         },
       ]
@@ -261,6 +349,17 @@ RSpec.describe TaxonOrganisationsPresenter do
               track_label: "/government/organisations/department-for-education",
               track_options: {
                 dimension29: "Department for Education",
+              },
+              ga4_link: {
+                event_name: "navigation",
+                type: "organisation logo",
+                index: {
+                  index_link: 6,
+                  index_section: 6,
+                  index_section_count: 7,
+                },
+                index_total: 6,
+                section: "Organisations",
               },
             },
           },

--- a/spec/presenters/taxon_presenter_spec.rb
+++ b/spec/presenters/taxon_presenter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe TaxonPresenter do
     describe "#options_for_child_taxon" do
       describe "root options" do
         before do
+          allow(taxon_presenter).to receive(:page_section_total).and_return(nil)
           stub_content_for_taxon([taxon.content_id], generate_search_results(15))
         end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

**NOTE** this PR depends on https://github.com/alphagov/govuk_publishing_components/pull/3454 for some changes to the document list component.

## What
**NOTE** this PR somewhat relies upon these changes: https://github.com/alphagov/govuk_publishing_components/pull/3454 and ideally should include them when merging.

Adds GA4 tracking to taxonomy pages, using various trackers (event tracker, link tracker).

Examples of taxonomy pages:

- [with organisations and sub topics](https://www.gov.uk/entering-staying-uk/refugees-asylum-human-rights)
- [without subtopics](https://www.gov.uk/entering-staying-uk/border-control)
- [without subtopics and organisation list doesn't expand](https://www.gov.uk/education/primary-curriculum-key-stage-2-maths)
- [with organisations without logo in the initial list, and only 5 initial sections](https://www.gov.uk/entering-staying-uk/immigration-adviser-services)
- [with a small number of sub-topics](https://www.gov.uk/entering-staying-uk/permanent-stay-uk)


## Why
Part of the GA4 migration on GOV.UK.

## Visual changes
Surprisingly, some. Note that these changes will only look like this with the PR mentioned above included in a new gem release attached to this PR. Otherwise, results may vary.

Fixes an inconsistency with one of the section headings, so it now matches all the others:

Before | After
------ | -------
![Screenshot 2023-06-22 at 17 11 19](https://github.com/alphagov/collections/assets/861310/62340a97-e327-4e12-8419-c12f7f77345d) | ![Screenshot 2023-06-22 at 17 11 24](https://github.com/alphagov/collections/assets/861310/088a8596-3b25-4ddd-9dc5-627740256633)

Fixes a spacing issue underneath the 'show more organisations' toggle:

Before | After
------ | -------
![Screenshot 2023-06-22 at 17 13 19](https://github.com/alphagov/collections/assets/861310/3dd79b9c-b081-44dc-84ba-fd5eead688ee) | ![Screenshot 2023-06-22 at 17 14 11](https://github.com/alphagov/collections/assets/861310/f069c350-e821-4245-b215-e9dc8ed5d12e)



Trello card: https://trello.com/c/c4HGXy8X/594-add-tracking-navigation-selectcontent-taxonomy-pages
