### PR TITLE
Add ga4 link tracking to topic lists

### DIFF
--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -17,11 +17,17 @@ module TopicListHelper
     }
   end
 
-  def topic_list_params(list, tracking_attributes: nil, list_index: nil, category: nil)
+  def topic_list_params(list, tracking_attributes: nil, list_index: nil, category: nil, list_count: nil, list_title: nil)
     tracking_attributes ||= topic_list_tracking_attributes(list.count, list_index, category)
+    ga4_data = {}
+    ga4_data[:index] = {}
+    ga4_data[:index][:index_section] = list_index + 1 if list_index
+    ga4_data[:index][:index_section_count] = list_count if list_count
+    ga4_data[:section] = list_title if list_title
 
     {
       items: topic_list_items(list, tracking_attributes),
+      ga4_data:,
     }
   end
 

--- a/app/views/components/_topic_list.html.erb
+++ b/app/views/components/_topic_list.html.erb
@@ -4,6 +4,7 @@
   see_more_link ||= false
   small ||= false
   margin_bottom ||= false
+  ga4_data ||= {}
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
@@ -15,13 +16,29 @@
 %>
 <% if items.any? %>
   <%= tag.ul(class: ul_classes, lang: "en") do %>
-    <% items.each do |item| %>
+    <% items.each_with_index do |item, index| %>
       <li class="app-c-topic-list__item">
+        <% 
+          ga4_link_data = ga4_data.empty? ? {} : {
+            ga4_link: {
+              event_name: "navigation",
+              type: "document list",
+              index: {
+                index_link: index + 1,
+                **ga4_data[:index] || {},
+              },
+              # As see_more_link is not included in the items array, we need to account for it here by adding 1 to items.count
+              # if see_more_link has been passed
+              index_total: (see_more_link ? items.count + 1 : items.count),
+              section: ga4_data[:section],
+            }
+          }
+        %>
         <%=
           link_to(
             item[:text],
             item[:path],
-            data: item[:data_attributes],
+            data: {**item[:data_attributes] || {}}.merge(ga4_link_data),
             "aria-label": item[:aria_label],
             class: "govuk-link govuk-link--no-underline app-c-topic-list__link #{brand_helper.color_class}"
           )
@@ -30,11 +47,25 @@
     <% end %>
     <% if see_more_link %>
       <li class="app-c-topic-list__item">
+        <% 
+          ga4_link_data = ga4_data.empty? ? {} : {
+            ga4_link: {
+              event_name: "navigation",
+              type: "document list",
+              index: {
+                index_link: items.count + 1,
+                **ga4_data[:index] || {},
+              },
+              index_total: items.count + 1,
+              section: ga4_data[:section],
+            }
+          }
+        %>
         <%=
           link_to(
             see_more_link[:text],
             see_more_link[:path],
-            data: see_more_link[:data_attributes],
+            data: {**see_more_link[:data_attributes] || {}}.merge(ga4_link_data),
             class: "govuk-link app-c-topic-list__link #{brand_helper.color_class}"
           )
         %>

--- a/app/views/services_and_information/_grouped_links.html.erb
+++ b/app/views/services_and_information/_grouped_links.html.erb
@@ -13,7 +13,7 @@
       <%
         list_item_count = group.see_more_link ? group.examples.count + 1 : group.examples.count
         tracking_attributes = topic_list_tracking_attributes(list_item_count, group_index, 'navServicesInformationLinkClicked')
-        topic_list_component_params = topic_list_params(group.examples, tracking_attributes: tracking_attributes)
+        topic_list_component_params = topic_list_params(group.examples, list_index: group_index, tracking_attributes: tracking_attributes, list_count: grouped_links.count, list_title: group.title)
 
         if group.see_more_link
           link = group.see_more_link.clone

--- a/app/views/services_and_information/index.html.erb
+++ b/app/views/services_and_information/index.html.erb
@@ -10,6 +10,6 @@
       } %>
 </header>
 
-<div class="browse-container full-width" data-module="gem-track-click">
+<div class="browse-container full-width" data-module="gem-track-click ga4-link-tracker">
   <%= render partial: 'grouped_links', locals: { grouped_links: grouped_links } %>
 </div>

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -31,6 +31,6 @@
   </div>
 </header>
 
-<div class="browse-container full-width" data-module="gem-track-click">
+<div class="browse-container full-width" data-module="gem-track-click ga4-link-tracker">
   <%= yield %>
 </div>

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -35,7 +35,9 @@
         } %>
       </div>
       <div class="govuk-grid-column-two-thirds">
-        <%= render 'components/topic_list', topic_list_params(list.contents, list_index: list_index, category: 'navSubtopicContentItemLinkClicked') %>
+        <%= render 'components/topic_list', 
+          topic_list_params(list.contents, list_index: list_index, category: 'navSubtopicContentItemLinkClicked', list_count: subtopic.lists.count, list_title: list.title)
+        %>
       </div>
     </div>
   <% end -%>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -16,9 +16,9 @@
   <%= render "govuk_publishing_components/components/title", title: title_with_suffix %>
 </header>
 
-<div class="browse-container full-width topics-page" data-module="gem-track-click">
+<div class="browse-container full-width topics-page" data-module="gem-track-click ga4-link-tracker">
   <nav class="topics">
     <% tracking_category = topic.base_path == '/topic' ? 'navTopicLinkClicked' : 'navSubtopicLinkClicked' %>
-    <%= render 'components/topic_list', topic_list_params(topic.children, category: tracking_category) %>
+    <%= render 'components/topic_list', topic_list_params(topic.children, category: tracking_category, list_title: title_with_suffix) %>
   </nav>
 </div>

--- a/spec/features/services_and_information_browsing_spec.rb
+++ b/spec/features/services_and_information_browsing_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Services and information browsing" do
   scenario "includes tracking attributes on all links" do
     visit "/government/organisations/hm-revenue-customs/services-information"
 
-    expect(page).to have_selector('.browse-container[data-module="gem-track-click"]')
+    expect(page).to have_selector('.browse-container[data-module="gem-track-click ga4-link-tracker"]')
 
     within ".govuk-grid-row:first-child .app-c-topic-list" do
       content_item_link = page.first("li a")
@@ -68,6 +68,38 @@ RSpec.feature "Services and information browsing" do
       expect(data_options["dimension28"]).to eq(page.all("li a").count.to_s)
 
       expect(data_options["dimension29"]).to eq(content_item_link.text)
+    end
+  end
+
+  scenario "includes GA4 tracking attributes on all links" do
+    visit "/government/organisations/hm-revenue-customs/services-information"
+
+    expect(page).to have_selector('.browse-container[data-module="gem-track-click ga4-link-tracker"]')
+
+    within ".govuk-grid-row:first-child .app-c-topic-list" do
+      content_item_link = page.first("li a")
+      ga4_data = JSON.parse(content_item_link["data-ga4-link"])
+
+      expect(ga4_data["event_name"]).to eq "navigation"
+      expect(ga4_data["type"]).to eq "document list"
+      expect(ga4_data["index"]["index_link"]).to eq 1
+      expect(ga4_data["index"]["index_section"]).to eq 1
+      expect(ga4_data["index"]["index_section_count"]).to eq 2
+      expect(ga4_data["index_total"]).to eq 5
+      expect(ga4_data["section"]).to eq "Environmental permits"
+    end
+
+    within ".govuk-grid-row:nth-child(2) .app-c-topic-list" do
+      content_item_link = page.first("li a")
+      ga4_data = JSON.parse(content_item_link["data-ga4-link"])
+
+      expect(ga4_data["event_name"]).to eq "navigation"
+      expect(ga4_data["type"]).to eq "document list"
+      expect(ga4_data["index"]["index_link"]).to eq 1
+      expect(ga4_data["index"]["index_section"]).to eq 2
+      expect(ga4_data["index"]["index_section_count"]).to eq 2
+      expect(ga4_data["index_total"]).to eq 5
+      expect(ga4_data["section"]).to eq "Waste"
     end
   end
 end

--- a/spec/features/subtopic_page_spec.rb
+++ b/spec/features/subtopic_page_spec.rb
@@ -250,7 +250,7 @@ RSpec.feature "Subtopic pages" do
 
     visit "/topic/oil-and-gas/offshore"
 
-    expect(page).to have_selector('.browse-container[data-module="gem-track-click"]')
+    expect(page).to have_selector('.browse-container[data-module="gem-track-click ga4-link-tracker"]')
 
     oil_rig_safety_requirements = page.find(
       "a",

--- a/spec/features/topic_browsing_spec.rb
+++ b/spec/features/topic_browsing_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Topic browsing" do
 
     visit "/topic"
 
-    expect(page).to have_selector('.topics-page[data-module="gem-track-click"]')
+    expect(page).to have_selector('.topics-page[data-module="gem-track-click ga4-link-tracker"]')
 
     topic_link = page.find("a", text: "Oil and Gas")
 
@@ -135,7 +135,7 @@ RSpec.feature "Topic browsing" do
 
     visit "/topic/oil-and-gas"
 
-    expect(page).to have_selector('.topics-page[data-module="gem-track-click"]')
+    expect(page).to have_selector('.topics-page[data-module="gem-track-click ga4-link-tracker"]')
 
     within ".app-c-topic-list" do
       within "li:nth-child(1)" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
This PR adds GA4 link tracking to topic lists.

Examples:

- [Topic page](https://www.gov.uk/topic)
- [Subtopic page level 1](https://www.gov.uk/topic/personal-tax)
- [Subtopic page level 2](https://www.gov.uk/topic/personal-tax/national-insurance)
- [Services and information page](https://www.gov.uk/government/organisations/hm-revenue-customs/services-information)

Approach:

All topic and services and information pages make use of the `_topic_list.html.erb` component in their respective templates. When `_topic_list.html.erb` is called, the templates can pass `list_index`, `list_count`, and `list_title` (along with other parameters) to it via `topic_list_helper.rb`.

`topic_list_helper.rb` uses `list_index`, `list_count`, and `list_title` to populate a `ga4_data` hash, which is ultimately what `_topic_list.html.erb` receives. Sometimes, `list_index` (which ultimately sets `index_section`) and `list_count` (which ultimately sets `index_section_count`) will not be available if there are no sections on the page since it is just a list of links [(example)](https://www.gov.uk/topic/personal-tax). This is why the `index_section` and `index_section_count` keys are conditionally rendered. But we would always expect the `list_title` (and hence `section` parameter) to be present.

## Why
Part of the GA4 migration.

[Trello card](https://trello.com/c/1TFIjPLq/595-add-tracking-navigation-topic-pages)

## Visual changes
N/A
