### PR TITLE
Add dev page

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -4,18 +4,25 @@ class DevelopmentController < ApplicationController
   def index
     @schema_names = %w[
       coronavirus_landing_page
+      embassies
+      embassy
       finder
+      government_feed
       historic_appointment
       mainstream_browse_page
       ministerial_role
       organisation
+      organisation_feed
+      past_prime_ministers
       person
       services_and_information
       step_by_step_nav
       taxon
       topic
       topical_event
+      world_embassies
       world_location_news
+      world_wide_taxon
     ]
 
     @paths = YAML.load_file(Rails.root.join("config/govuk_examples.yml"))

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -4,7 +4,6 @@
 <head>
   <title><%= t('development.title') %></title>
   <meta name="robots" content="noindex, nofollow">
-  <%= stylesheet_link_tag "application", integrity: false %>
 </head>
 <body>
 <div id="wrapper">

--- a/config/govuk_examples.yml
+++ b/config/govuk_examples.yml
@@ -1,14 +1,21 @@
 ---
 coronavirus_landing_page: /coronavirus
+embassies: /world/embassies
+embassy: /world/organisations/british-embassy-kabul
 finder: /government/organisations
+government_feed: /government/feed
+historic_appointments: /government/history/past-chancellors
 mainstream_browse_page: /browse/driving
 ministerial_role: /government/ministers/secretary-of-state-for-education
 organisation: /government/organisations/companies-house
-past_prime_minister: /government/history/past-prime-ministers/tony-blair
+organisation_feed: /government/organisations/companies-house.atom
+past_prime_ministers: /government/history/past-prime-ministers
 person: /government/people/matthew-hancock
 services_and_information: /government/organisations/hm-revenue-customs/services-information
 step_by_step_nav: /get-tax-free-childcare
 taxon: /transport/driving-and-motorcycle-tests
 topic: /topic/personal-tax/self-assessment
+topic_latest_docs: /topic/personal-tax/self-assessment/latest
 topical_event: /government/topical-events/autumn-statement-2022
 world_location_news: /world/ukraine/news
+world_wide_taxon: /world/ukraine

--- a/config/locales/en/development.yml
+++ b/config/locales/en/development.yml
@@ -1,5 +1,5 @@
 ---
 en:
   development:
-    header: Here is a list of the content types that collections renders and an example page
+    header: Here is a list of the content types and pages that collections renders and an example page
     title: collections development page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # content-store (by collections-publisher) - whenever the routes below
   # change, also change the routes claimed by collections-publisher.
 
-  get "/", to: redirect(path: :browse)
+  root to: "development#index"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 


### PR DESCRIPTION
Help devs to find pages that are rendered by the app. This is inspired by the same in government-frontend.

This PR is a continuation of work that was started in the previous GIFT week.

This page is only viewable when running collections locally or or Heroku and visting the app directly.

## Screenshot

![collections-pr-3320 herokuapp com_(iPad Air)](https://github.com/alphagov/collections/assets/424772/ca39ed20-b4b8-42f5-a81b-ed73b2f485cd)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
