### PR TITLE
Change GA4 type organisation to organisation logo

### DIFF
--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -26,7 +26,7 @@
             <%
               ga4_attributes = {
                 event_name: "select_content",
-                type: "organisation",
+                type: "organisation logo",
                 index: {
                   index_section: index_section,
                   index_section_count: index_section_count


### PR DESCRIPTION
Would you be able to approve this if everything is OK? Thanks :+1:

This trello card https://trello.com/c/j8kRCQJl/624-switch-organisation-to-organisation-logo-type-on-selectcontent-event requested we change the GA4 type on the 'Show more organisations' link. You can see the 'Show more organisations' link on this page: https://www.gov.uk/entering-staying-uk/refugees-asylum-human-rights

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
