### PR TITLE
Remove link to services and information page

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -115,7 +115,6 @@ module Organisations
         department-for-environment-food-rural-affairs
         hm-revenue-customs
         marine-management-organisation
-        maritime-and-coastguard-agency
         natural-england
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)


### PR DESCRIPTION
Remove link to services and information page from the Marine and Coastguard Agency org page

[Trello](https://trello.com/c/l3EJo0kB/1908-archive-and-redirect-the-maritime-and-coastguard-agency-mca-services-and-info-page-s)

| Before | After |
| ------ | ---- |
| <img width="1020" alt="Screenshot 2023-07-19 at 10 58 12" src="https://github.com/alphagov/collections/assets/17908089/163a9219-6e5e-40b0-abb3-e93df3601768"> | <img width="1025" alt="Screenshot 2023-07-19 at 11 01 49" src="https://github.com/alphagov/collections/assets/17908089/ea250811-0f31-4154-9118-55eee87425e4">

[Review app](https://collections-pr-3331.herokuapp.com/government/organisations/maritime-and-coastguard-agency)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.



