### PR TITLE
Remove services and information link for MMO

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -114,7 +114,6 @@ module Organisations
         department-for-education
         department-for-environment-food-rural-affairs
         hm-revenue-customs
-        marine-management-organisation
         natural-england
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)


### PR DESCRIPTION
Remove link to services and information page from Marine Management Organisation page

Trello card: https://trello.com/c/aKUxfLBU/1909-archive-and-redirect-marine-management-organisation-mmo-services-and-info-page-s

Before:
![Screenshot 2023-07-19 at 11 17 48](https://github.com/alphagov/collections/assets/96050928/2b9406d0-4756-4423-8d5f-ba6f0aab19e8)

After:

![Screenshot 2023-07-19 at 11 17 18](https://github.com/alphagov/collections/assets/96050928/bddab6e0-d860-40b8-a459-43e6518a492c)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
