### PR TITLE
Add GA4 section parameter

### DIFF
--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -27,6 +27,7 @@
               index_section_count: index_section_count,
             },
             index_total: total_links,
+            section: section,
           },
         },
       ) %>

--- a/app/views/second_level_browse_page/_show_curated_list.html.erb
+++ b/app/views/second_level_browse_page/_show_curated_list.html.erb
@@ -10,7 +10,7 @@
   <div class="browse__section <%= 'browse__section--top-border' if is_not_first_section %>" >
     <%= render partial: "shared/browse_heading", locals: { title: list.title } %>
 
-    <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s } %>
+    <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s, section: list.title } %>
   </div>
 <% end %>
 

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -46,7 +46,7 @@
         <div class="browse__section">
           <%= render partial: "shared/browse_heading", locals: { title: list.title } %>
 
-          <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s } %>
+          <%= render partial: "links", locals: { list: list.contents, list_index: list_index, index_section_count: index_section_count.to_s, section: list.title } %>
         </div>
       <% end %>
       <%= render partial: "shared/browse_related_topics", locals: { page: page, index_section_count: index_section_count.to_s } %>

--- a/app/views/shared/_browse_related_topics.html.erb
+++ b/app/views/shared/_browse_related_topics.html.erb
@@ -10,6 +10,6 @@
       } %>
     </div>
 
-    <%= render partial: "links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink", index_section_count: index_section_count } %>
+    <%= render partial: "links", locals: { list: page.related_topics, list_index: page.lists.count, track_action: "moreLink", index_section_count: index_section_count, section: t("second_level_browse.more_on_this_topic", locale: :en) } %>
   </div>
 <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR adds the `section` parameter to links on second level browse pages.

## Why
Requested by PA's.

[Trello card](https://trello.com/c/RoeaFd1G/619-section-values-not-being-captured-on-browse-level-2-clicks)

## Visual changes
N/A