### PR TITLE
Add scroll tracking to departments page

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :meta_tags do %>
   <%= auto_discovery_link_tag(:json, api_organisations_url, title: @presented_organisations.title) %>
+  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
 <% end %>
 
 <div data-module="filter-organisations">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds percentage scroll tracking to https://www.gov.uk/government/organisations

## Why
Part of the GA4 migration

## Visual changes
None.

Trello card: https://trello.com/c/r75BqxiW/608-scroll-tracking-percent-type-finders
