### PR TITLE
See more link change GA4 type on taxon pages

### DIFF
--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -38,7 +38,7 @@ class TaxonPresenter
       track_options: {},
       ga4_link: {
         event_name: "navigation",
-        type: "document list",
+        type: "subtopic list",
         index: {
           index_link: (index + 1).to_s,
           index_section: page_section_total.to_s,

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -14,8 +14,8 @@
 
 <% if taxon_is_live?(presented_taxon) %>
   <div class="taxon-page__email-link-wrapper">
-    <div 
-      class="full-page-width-wrapper" 
+    <div
+      class="full-page-width-wrapper"
       data-module="ga4-link-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
       data-ga4-track-links-only

--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -2,7 +2,3 @@
   items: section[:documents],
   margin_bottom: 7
 %>
-
-<% if section[:see_more_link] %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-<% end %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -1,7 +1,6 @@
 <%
   featured_item = section[:promoted_content].first
 %>
-
 <% if section[:documents].empty? %>
   <div class="taxon-page__featured-item taxon-page__featured-item--single">
     <%= render "govuk_publishing_components/components/image_card", {
@@ -25,14 +24,8 @@
 <% end %>
 
 <% if section[:documents].any? %>
-  <div>
-    <%= render 'govuk_publishing_components/components/document_list',
-      items: section[:documents_with_promoted],
-      margin_bottom: 7
-    %>
-<% else %>
-  <div class="taxon-page__featured-see-more">
+  <%= render 'govuk_publishing_components/components/document_list',
+    items: section[:documents_with_promoted],
+    margin_bottom: 7
+  %>
 <% end %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-
-</div>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -2,8 +2,3 @@
   items: section[:documents],
   margin_bottom: 7
 %>
-
-<% if section[:see_more_link] %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-<% end %>
-

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -2,7 +2,3 @@
   items: section[:documents],
   margin_bottom: 7
 %>
-
-<% if section[:see_more_link] %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-<% end %>

--- a/app/views/taxons/sections/_see_more_link.html.erb
+++ b/app/views/taxons/sections/_see_more_link.html.erb
@@ -1,6 +1,0 @@
-<%= link_to(
-  section[:see_more_link][:text],
-  section[:see_more_link][:url],
-  data: section[:see_more_link][:data],
-  class: "govuk-link"
-)%>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -2,7 +2,3 @@
   items: section[:documents],
   margin_bottom: 7
 %>
-
-<% if section[:see_more_link] %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-<% end %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -2,7 +2,3 @@
   items: section[:documents],
   margin_bottom: 7
 %>
-
-<% if section[:see_more_link] %>
-  <%= render partial: "taxons/sections/see_more_link", locals: { section: section } %>
-<% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -26,6 +26,10 @@
         <% if section[:show_section] %>
           <%
             index += 1 # increment index if section should be shown (otherwise could use each_with_index)
+            index_total = section[:documents].length
+            # news and communications uses section[:documents_with_promoted]
+            index_total = section[:documents_with_promoted].length if section[:documents_with_promoted]
+            index_total += 1 if section[:see_more_link]
             title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title], locale: :en)
           %>
           <div id="<%= section[:id] %>" class="taxon-page__section-group">
@@ -38,9 +42,8 @@
                 } %>
               </div>
             </div>
-            <%= content_tag(
-              :div,
-              data: {
+            <%
+              ga4_data = {
                 module: "ga4-link-tracker",
                 ga4_track_links_only: "",
                 ga4_set_indexes: "",
@@ -51,10 +54,30 @@
                     index_section: index,
                     index_section_count: index_section_count
                   },
+                  index_total: index_total,
                   section: title
                 }
-              }) do %>
+              }
+            %>
+            <%= content_tag(:div, data: ga4_data) do %>
               <%= render(partial: section[:partial_template], locals: { section: section }) %>
+            <% end %>
+            <% if section[:see_more_link] %>
+              <%= ga4_data[:ga4_link][:index][:index_link] %>
+              <%
+                ga4_data.except!(:ga4_set_indexes)
+                ga4_data[:ga4_link][:type] = 'see all'
+                docs = section[:documents_with_promoted] || section[:documents]
+                ga4_data[:ga4_link][:index][:index_link] = docs.length + 1
+              %>
+              <%= content_tag(:div, data: ga4_data) do %>
+                <%= link_to(
+                  section[:see_more_link][:text],
+                  section[:see_more_link][:url],
+                  data: section[:see_more_link][:data],
+                  class: "govuk-link"
+                )%>
+              <% end %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -27,8 +27,12 @@
           <%
             index += 1 # increment index if section should be shown (otherwise could use each_with_index)
             index_total = section[:documents].length
-            # news and communications uses section[:documents_with_promoted]
-            index_total = section[:documents_with_promoted].length if section[:documents_with_promoted]
+
+            # deals with the news and comms section
+            if section[:documents_with_promoted]
+              index_total = section[:documents_with_promoted].length
+              index_total = 1 if section[:documents].empty?
+            end
             index_total += 1 if section[:see_more_link]
             title = t(section[:id], scope: :content_purpose_supergroup, default: section[:title], locale: :en)
           %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Change the 'see more...' links on taxon pages so that their GA4 tracking type attribute is set to `see all`, but keep the original type on the links preceding them, as `document list`.

Example taxon page: https://www.gov.uk/welfare

This change is slightly complicated by the way this page is structured.

- each section of the page (Services, Guidance, etc.) is handled separately and has separate data
- potentially (and normally) 5 links are shown in each section, followed by a 'see more...' link
- since the data for the links is passed wholesale to the document list component we use the `data-set-indexes` option of the link tracker to wrap both the document list and the 'see more' link, and all of the indexes are calculated automatically
- this previously worked fine and gave us an `index_total` of 6
- however we don't want to do that anymore as now the two types of links need different `type` attribute values
- so instead we wrap the document list in one link tracker and the 'see more' link in another, setting the `type` independently for each
- but we still want the `index_total` to be (normally) 6 for all the links in that section, so we override the calculated `index_total` with our own calculation (length of links shown plus 1, which is normally 5 + 1)
- **related PR that this depends on**: https://github.com/alphagov/govuk_publishing_components/pull/3541
- only wrinkle is the `News and communications` section, which uses a different thing (`section[:documents_with_promoted]` rather than `section[:documents]`) for link data so we have to adjust for that

The news and comms section presents a further problem, which is that if no links are found it will display an image card with a promoted story, like this (I don't have a live example of it).

![Screenshot 2023-08-04 at 13 41 20](https://github.com/alphagov/collections/assets/861310/9babcbbe-9c6f-42fe-9d68-396329226d29)

The second commit addresses this. The logic is a bit strange but I've tried not to modify it too much. Basically in this instance the `index_total` should be 2.

## Why
Part of the GA4 migration.

## Visual changes
None

Trello cards: 

- https://trello.com/c/DqMNdDNz/652-change-type-of-explore-sub-topics-links-to-subtopic-list
- https://trello.com/c/p9YhuDB2/657-change-type-of-see-more-link-clicks-on-taxon-pages-to-see-all

