### PR TITLE
Change "Topics" on /browse to "Services and Information" [DO NOT MERGE]

### DIFF
--- a/config/locales/en/browse.yml
+++ b/config/locales/en/browse.yml
@@ -2,5 +2,5 @@
 en:
   browse:
     all_categories: All categories
-    description: Find information and services
-    title: Topics
+    description: Find the government services, forms and accounts you need to use
+    title: Services and information

--- a/spec/features/topic_browsing_spec.rb
+++ b/spec/features/topic_browsing_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Topic browsing" do
     stub_content_store_has_item(
       "/topic",
       base_path: "/topic",
-      title: "Topics",
+      title: "Services and information",
       format: "topic",
       public_updated_at: 10.days.ago.iso8601,
       details: {},
@@ -86,7 +86,7 @@ RSpec.feature "Topic browsing" do
     stub_content_store_has_item(
       "/topic",
       base_path: "/topic",
-      title: "Topics",
+      title: "Services and information",
       format: "topic",
       public_updated_at: 10.days.ago.iso8601,
       details: {},


### PR DESCRIPTION
## What

Change "Topics" on `/browse` to "Services and Information". Change the description to "Find the government services, forms and accounts you need to use" on /browse.

## Why

As part of several small changes to the homepage.

[Relevant Trello Card](https://trello.com/c/uUTQPB0r/1991-live-test-3-change-topics-to-services-and-information-on-homepage-header-footer-m)

## Visual Differences

### Before

![Screenshot 2023-08-23 at 15 57 11](https://github.com/alphagov/collections/assets/3727504/b8cfb46d-6642-46b7-a7d2-b397bfd3d061)

### After

![Screenshot 2023-08-30 at 11 40 46](https://github.com/alphagov/collections/assets/3727504/9653bccd-777c-4e31-8ec8-24723379fdd1)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
