### PR TITLE
Remove services and information link for DEFRA

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -112,7 +112,6 @@ module Organisations
     def has_services_and_information_link?
       orgs_with_services_and_information_link = %w[
         department-for-education
-        department-for-environment-food-rural-affairs
         hm-revenue-customs
         natural-england
       ]


### PR DESCRIPTION
Remove link to services and information page from Department for Environment, Food & Rural Affairs page
Trello card: https://trello.com/c/osKx0Y0e/2003-archive-and-redirect-services-and-info-page-for-defra

Before:
<img width="841" alt="Screenshot 2023-08-24 at 11 48 30" src="https://github.com/alphagov/collections/assets/96050928/48f0ed43-8454-468d-abd7-0b031e12c841">

After:
<img width="1015" alt="Screenshot 2023-08-24 at 11 48 19" src="https://github.com/alphagov/collections/assets/96050928/b37c9914-cd79-46bc-8495-260e25530cf4">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
