### PR TITLE
Remove services and information link for Natural England

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -114,7 +114,6 @@ module Organisations
         department-for-education
         department-for-environment-food-rural-affairs
         hm-revenue-customs
-        natural-england
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)
     end


### PR DESCRIPTION
Remove link to services and information page from Natural England page.
Trello card: https://trello.com/c/KuLhRnUh/2004-archive-and-redirect-services-and-info-page-natural-england-s

Before:
![Screenshot 2023-08-24 at 12 06 21](https://github.com/alphagov/collections/assets/96050928/03cbf38b-88fc-4ce9-b8d3-a1222c580236)

After:
![Screenshot 2023-08-24 at 12 06 06](https://github.com/alphagov/collections/assets/96050928/0a174d31-94a8-42c3-a185-dac95aeaa32a)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
