### PR TITLE
Adds action link for browse benefits page

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -20,7 +20,7 @@
   } %>
 <% end %>
 
-<%= render "shared/browse_header", { margin_bottom: 9 } do %>
+<%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
   <h1 class="browse__heading govuk-heading-xl">
     <%= page.title %>
   </h1>
@@ -29,6 +29,21 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+<% if page.slug == "benefits" %>
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/action_link", {
+          text: t("browse.check_benefits_and_financial_support"),
+          href: "/check-benefits-financial-support",
+          dark_large_icon: true,
+          margin_bottom: 7,
+        } %>
+      </div>
+    </div>
+  </div>
 <% end %>
 
 <% total_links = page.second_level_browse_pages.count.to_s %>

--- a/config/locales/ar/browse.yml
+++ b/config/locales/ar/browse.yml
@@ -2,5 +2,6 @@
 ar:
   browse:
     all_categories: جميع الفئات
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/az/browse.yml
+++ b/config/locales/az/browse.yml
@@ -2,5 +2,6 @@
 az:
   browse:
     all_categories: Bütün kateqoriyalar
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/be/browse.yml
+++ b/config/locales/be/browse.yml
@@ -2,5 +2,6 @@
 be:
   browse:
     all_categories: Усе катэгорыі
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/bg/browse.yml
+++ b/config/locales/bg/browse.yml
@@ -2,5 +2,6 @@
 bg:
   browse:
     all_categories: Всички категории
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/bn/browse.yml
+++ b/config/locales/bn/browse.yml
@@ -2,5 +2,6 @@
 bn:
   browse:
     all_categories: সকল শ্রেণিবিভাগ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/cs/browse.yml
+++ b/config/locales/cs/browse.yml
@@ -2,5 +2,6 @@
 cs:
   browse:
     all_categories: Všechny kategorie
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/cy/browse.yml
+++ b/config/locales/cy/browse.yml
@@ -2,5 +2,6 @@
 cy:
   browse:
     all_categories: Pob categori
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/da/browse.yml
+++ b/config/locales/da/browse.yml
@@ -2,5 +2,6 @@
 da:
   browse:
     all_categories: Alle kategorier
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/de/browse.yml
+++ b/config/locales/de/browse.yml
@@ -2,5 +2,6 @@
 de:
   browse:
     all_categories: Alle Kategorien
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/dr/browse.yml
+++ b/config/locales/dr/browse.yml
@@ -2,5 +2,6 @@
 dr:
   browse:
     all_categories: تمام کتگوری ها
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/el/browse.yml
+++ b/config/locales/el/browse.yml
@@ -2,5 +2,6 @@
 el:
   browse:
     all_categories: Όλες οι κατηγορίες
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/en/browse.yml
+++ b/config/locales/en/browse.yml
@@ -2,5 +2,6 @@
 en:
   browse:
     all_categories: All categories
+    check_benefits_and_financial_support: Check benefits and financial support you can get
     description: Find the government services, forms and accounts you need to use
     title: Services and information

--- a/config/locales/es-419/browse.yml
+++ b/config/locales/es-419/browse.yml
@@ -2,5 +2,6 @@
 es-419:
   browse:
     all_categories: Todas las categorías
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/es/browse.yml
+++ b/config/locales/es/browse.yml
@@ -2,5 +2,6 @@
 es:
   browse:
     all_categories: Todas las categorías
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/et/browse.yml
+++ b/config/locales/et/browse.yml
@@ -2,5 +2,6 @@
 et:
   browse:
     all_categories: Kõik kategooriad
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/fa/browse.yml
+++ b/config/locales/fa/browse.yml
@@ -2,5 +2,6 @@
 fa:
   browse:
     all_categories: تمام دسته‌بندی‌ها
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/fi/browse.yml
+++ b/config/locales/fi/browse.yml
@@ -2,5 +2,6 @@
 fi:
   browse:
     all_categories: Kaikki kategoriat
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/fr/browse.yml
+++ b/config/locales/fr/browse.yml
@@ -2,5 +2,6 @@
 fr:
   browse:
     all_categories: Toutes catégories
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/gd/browse.yml
+++ b/config/locales/gd/browse.yml
@@ -2,5 +2,6 @@
 gd:
   browse:
     all_categories: Gach cineál táirgí
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/gu/browse.yml
+++ b/config/locales/gu/browse.yml
@@ -2,5 +2,6 @@
 gu:
   browse:
     all_categories: તમામ શ્રેણીઓ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/he/browse.yml
+++ b/config/locales/he/browse.yml
@@ -2,5 +2,6 @@
 he:
   browse:
     all_categories: כל הקטגוריות
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/hi/browse.yml
+++ b/config/locales/hi/browse.yml
@@ -2,5 +2,6 @@
 hi:
   browse:
     all_categories: सभी वर्ग
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/hr/browse.yml
+++ b/config/locales/hr/browse.yml
@@ -2,5 +2,6 @@
 hr:
   browse:
     all_categories: Sve kategorije
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/hu/browse.yml
+++ b/config/locales/hu/browse.yml
@@ -2,5 +2,6 @@
 hu:
   browse:
     all_categories: Minden kategória
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/hy/browse.yml
+++ b/config/locales/hy/browse.yml
@@ -2,5 +2,6 @@
 hy:
   browse:
     all_categories: Բոլոր կատեգորիաները
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/id/browse.yml
+++ b/config/locales/id/browse.yml
@@ -2,5 +2,6 @@
 id:
   browse:
     all_categories: Semua kategori
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/is/browse.yml
+++ b/config/locales/is/browse.yml
@@ -2,5 +2,6 @@
 is:
   browse:
     all_categories: Allir flokkar
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/it/browse.yml
+++ b/config/locales/it/browse.yml
@@ -2,5 +2,6 @@
 it:
   browse:
     all_categories: Tutte le categorie
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ja/browse.yml
+++ b/config/locales/ja/browse.yml
@@ -2,5 +2,6 @@
 ja:
   browse:
     all_categories: すべてのカテゴリ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ka/browse.yml
+++ b/config/locales/ka/browse.yml
@@ -2,5 +2,6 @@
 ka:
   browse:
     all_categories: ყველა კატეგორია
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/kk/browse.yml
+++ b/config/locales/kk/browse.yml
@@ -2,5 +2,6 @@
 kk:
   browse:
     all_categories: Барлық санаттар
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ko/browse.yml
+++ b/config/locales/ko/browse.yml
@@ -2,5 +2,6 @@
 ko:
   browse:
     all_categories: 모든 범주
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/lt/browse.yml
+++ b/config/locales/lt/browse.yml
@@ -2,5 +2,6 @@
 lt:
   browse:
     all_categories: Visos kategorijos
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/lv/browse.yml
+++ b/config/locales/lv/browse.yml
@@ -2,5 +2,6 @@
 lv:
   browse:
     all_categories: Visas kategorijas
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ms/browse.yml
+++ b/config/locales/ms/browse.yml
@@ -2,5 +2,6 @@
 ms:
   browse:
     all_categories: Semua kategori
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/mt/browse.yml
+++ b/config/locales/mt/browse.yml
@@ -2,5 +2,6 @@
 mt:
   browse:
     all_categories: Kategoriji kollha
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ne/browse.yml
+++ b/config/locales/ne/browse.yml
@@ -2,5 +2,6 @@
 ne:
   browse:
     all_categories:
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/nl/browse.yml
+++ b/config/locales/nl/browse.yml
@@ -2,5 +2,6 @@
 nl:
   browse:
     all_categories: Alle categorieën
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/no/browse.yml
+++ b/config/locales/no/browse.yml
@@ -2,5 +2,6 @@
 'no':
   browse:
     all_categories: Alle kategorier
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/pa-pk/browse.yml
+++ b/config/locales/pa-pk/browse.yml
@@ -2,5 +2,6 @@
 pa-pk:
   browse:
     all_categories: سارے گروہ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/pa/browse.yml
+++ b/config/locales/pa/browse.yml
@@ -2,5 +2,6 @@
 pa:
   browse:
     all_categories: ਸਾਰੀਆਂ ਸ਼੍ਰੇਣੀਆਂ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/pl/browse.yml
+++ b/config/locales/pl/browse.yml
@@ -2,5 +2,6 @@
 pl:
   browse:
     all_categories: Wszystkie kategorie
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ps/browse.yml
+++ b/config/locales/ps/browse.yml
@@ -2,5 +2,6 @@
 ps:
   browse:
     all_categories: ټولې کټګورۍ
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/pt/browse.yml
+++ b/config/locales/pt/browse.yml
@@ -2,5 +2,6 @@
 pt:
   browse:
     all_categories: Todas as categorias
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ro/browse.yml
+++ b/config/locales/ro/browse.yml
@@ -2,5 +2,6 @@
 ro:
   browse:
     all_categories: Toate categoriile
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ru/browse.yml
+++ b/config/locales/ru/browse.yml
@@ -2,5 +2,6 @@
 ru:
   browse:
     all_categories: Все категории
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/si/browse.yml
+++ b/config/locales/si/browse.yml
@@ -2,5 +2,6 @@
 si:
   browse:
     all_categories: සියලු ප්රවර්ග
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sk/browse.yml
+++ b/config/locales/sk/browse.yml
@@ -2,5 +2,6 @@
 sk:
   browse:
     all_categories: Všetky kategórie
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sl/browse.yml
+++ b/config/locales/sl/browse.yml
@@ -2,5 +2,6 @@
 sl:
   browse:
     all_categories: Vse kategorije
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/so/browse.yml
+++ b/config/locales/so/browse.yml
@@ -2,5 +2,6 @@
 so:
   browse:
     all_categories: Dhamaan qeybaha
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sq/browse.yml
+++ b/config/locales/sq/browse.yml
@@ -2,5 +2,6 @@
 sq:
   browse:
     all_categories: Të gjitha kategoritë
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sr/browse.yml
+++ b/config/locales/sr/browse.yml
@@ -2,5 +2,6 @@
 sr:
   browse:
     all_categories: Sve kategorije
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sv/browse.yml
+++ b/config/locales/sv/browse.yml
@@ -2,5 +2,6 @@
 sv:
   browse:
     all_categories: Alla kategorier
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/sw/browse.yml
+++ b/config/locales/sw/browse.yml
@@ -2,5 +2,6 @@
 sw:
   browse:
     all_categories: Aina zote
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ta/browse.yml
+++ b/config/locales/ta/browse.yml
@@ -2,5 +2,6 @@
 ta:
   browse:
     all_categories: அனைத்து வகையினங்கள்
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/th/browse.yml
+++ b/config/locales/th/browse.yml
@@ -2,5 +2,6 @@
 th:
   browse:
     all_categories: ทุกหมวดหมู่
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/tk/browse.yml
+++ b/config/locales/tk/browse.yml
@@ -2,5 +2,6 @@
 tk:
   browse:
     all_categories: Ähli toparlar
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/tr/browse.yml
+++ b/config/locales/tr/browse.yml
@@ -2,5 +2,6 @@
 tr:
   browse:
     all_categories: Tüm kategoriler
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/uk/browse.yml
+++ b/config/locales/uk/browse.yml
@@ -2,5 +2,6 @@
 uk:
   browse:
     all_categories: Всі категорії
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/ur/browse.yml
+++ b/config/locales/ur/browse.yml
@@ -2,5 +2,6 @@
 ur:
   browse:
     all_categories: تمام زمرہ جات
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/uz/browse.yml
+++ b/config/locales/uz/browse.yml
@@ -2,5 +2,6 @@
 uz:
   browse:
     all_categories: Барча тоифалар
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/vi/browse.yml
+++ b/config/locales/vi/browse.yml
@@ -2,5 +2,6 @@
 vi:
   browse:
     all_categories: Tất cả danh mục
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/yi/browse.yml
+++ b/config/locales/yi/browse.yml
@@ -2,5 +2,6 @@
 yi:
   browse:
     all_categories:
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/zh-hk/browse.yml
+++ b/config/locales/zh-hk/browse.yml
@@ -2,5 +2,6 @@
 zh-hk:
   browse:
     all_categories: 所有種類
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/zh-tw/browse.yml
+++ b/config/locales/zh-tw/browse.yml
@@ -2,5 +2,6 @@
 zh-tw:
   browse:
     all_categories: 所有類別
+    check_benefits_and_financial_support:
     description:
     title:

--- a/config/locales/zh/browse.yml
+++ b/config/locales/zh/browse.yml
@@ -2,5 +2,6 @@
 zh:
   browse:
     all_categories: 全部分类
+    check_benefits_and_financial_support:
     description:
     title:


### PR DESCRIPTION
We're now linking from the mainstream browse benefits page to the the financial support calculator. More info in commits ->

Depends on: https://github.com/alphagov/govuk_publishing_components/pull/3596

## Before

<img width="1509" alt="Screenshot 2023-08-30 at 12 57 22" src="https://github.com/alphagov/collections/assets/24479188/06da764d-0194-4f3d-89d3-0d169f8ee5ae">
<img width="435" alt="Screenshot 2023-08-30 at 12 57 32" src="https://github.com/alphagov/collections/assets/24479188/eae7a9b4-e1c9-46a2-84b5-0ea8ff56dd88">

## After

<img width="1343" alt="Screenshot 2023-09-13 at 10 39 04" src="https://github.com/alphagov/collections/assets/24479188/3aa28b30-f7c2-4989-b965-4ade44c5e503">
<img width="462" alt="Screenshot 2023-09-13 at 10 39 39" src="https://github.com/alphagov/collections/assets/24479188/f2313213-29a3-4c63-953d-98db1ad93401">

Trello:
https://trello.com/c/mwQET0e0/2153-add-link-to-the-benefits-smart-answer-to-the-browse-benefits-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
