### PR TITLE
Remove hard coded Afghanistan travel advice

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -92,13 +92,6 @@ class TopicalEvent
     end
   end
 
-  def travel_advice
-    return [] if slug != "afghanistan-uk-government-response"
-
-    advice = ContentItem.find!("/foreign-travel-advice/afghanistan").to_hash
-    [advice.slice("base_path", "title")]
-  end
-
   def latest
     @latest ||= @documents_service.fetch_related_documents_with_format
   end

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -127,8 +127,8 @@
         <p class="govuk-body"><%= I18n.t("topical_events.no_updates") %></p>
       <% end %>
 
-      <div 
-        data-module="ga4-link-tracker" 
+      <div
+        data-module="ga4-link-tracker"
         data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
         data-ga4-track-links-only
       >
@@ -154,30 +154,6 @@
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:topical_event, :announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
     <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.guidance_and_regulation, heading: I18n.t("topical_events.headings.guidance_and_regulation"), link_to: search_url(:topical_event, :guidance_and_regulation, @topical_event.slug) }) if @topical_event.guidance_and_regulation.any? %>
   </section>
-
-  <div class="govuk-grid-column-two-thirds">
-    <% if @topical_event.travel_advice.any? %>
-      <section id="travel-advice">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("topical_events.headings.travel_advice"),
-        font_size: "l",
-        margin_bottom: 4,
-        padding: true,
-        border_top: 2,
-      } %>
-      <%= render "govuk_publishing_components/components/document_list", {
-        items: @topical_event.travel_advice.map do |travel_advice|
-          {
-            link: {
-              text: travel_advice["title"],
-              path: travel_advice["base_path"]
-            }
-          }
-        end
-      } %>
-      </section>
-    <% end %>
-  </div>
 
   <div class="govuk-grid-column-two-thirds">
     <% if @topical_event.emphasised_organisations && @topical_event.emphasised_organisations.any? %>

--- a/config/locales/ar/topical_events.yml
+++ b/config/locales/ar/topical_events.yml
@@ -18,7 +18,6 @@ ar:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/az/topical_events.yml
+++ b/config/locales/az/topical_events.yml
@@ -18,7 +18,6 @@ az:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/be/topical_events.yml
+++ b/config/locales/be/topical_events.yml
@@ -18,7 +18,6 @@ be:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/bg/topical_events.yml
+++ b/config/locales/bg/topical_events.yml
@@ -18,7 +18,6 @@ bg:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/bn/topical_events.yml
+++ b/config/locales/bn/topical_events.yml
@@ -18,7 +18,6 @@ bn:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/cs/topical_events.yml
+++ b/config/locales/cs/topical_events.yml
@@ -18,7 +18,6 @@ cs:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/cy/topical_events.yml
+++ b/config/locales/cy/topical_events.yml
@@ -18,7 +18,6 @@ cy:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/da/topical_events.yml
+++ b/config/locales/da/topical_events.yml
@@ -18,7 +18,6 @@ da:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/de/topical_events.yml
+++ b/config/locales/de/topical_events.yml
@@ -18,7 +18,6 @@ de:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/dr/topical_events.yml
+++ b/config/locales/dr/topical_events.yml
@@ -18,7 +18,6 @@ dr:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/el/topical_events.yml
+++ b/config/locales/el/topical_events.yml
@@ -18,7 +18,6 @@ el:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/en/topical_events.yml
+++ b/config/locales/en/topical_events.yml
@@ -18,7 +18,6 @@ en:
       guidance_and_regulation: Guidance and regulation
       latest: Latest
       publications: Publications
-      travel_advice: Travel advice
     no_updates: There are no updates yet.
     organisations: Who’s involved
     platinum_jubilee_unboxed:

--- a/config/locales/es-419/topical_events.yml
+++ b/config/locales/es-419/topical_events.yml
@@ -18,7 +18,6 @@ es-419:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/es/topical_events.yml
+++ b/config/locales/es/topical_events.yml
@@ -18,7 +18,6 @@ es:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/et/topical_events.yml
+++ b/config/locales/et/topical_events.yml
@@ -18,7 +18,6 @@ et:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/fa/topical_events.yml
+++ b/config/locales/fa/topical_events.yml
@@ -18,7 +18,6 @@ fa:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/fi/topical_events.yml
+++ b/config/locales/fi/topical_events.yml
@@ -18,7 +18,6 @@ fi:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/fr/topical_events.yml
+++ b/config/locales/fr/topical_events.yml
@@ -18,7 +18,6 @@ fr:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/gd/topical_events.yml
+++ b/config/locales/gd/topical_events.yml
@@ -18,7 +18,6 @@ gd:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/gu/topical_events.yml
+++ b/config/locales/gu/topical_events.yml
@@ -18,7 +18,6 @@ gu:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/he/topical_events.yml
+++ b/config/locales/he/topical_events.yml
@@ -18,7 +18,6 @@ he:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/hi/topical_events.yml
+++ b/config/locales/hi/topical_events.yml
@@ -18,7 +18,6 @@ hi:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/hr/topical_events.yml
+++ b/config/locales/hr/topical_events.yml
@@ -18,7 +18,6 @@ hr:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/hu/topical_events.yml
+++ b/config/locales/hu/topical_events.yml
@@ -18,7 +18,6 @@ hu:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/hy/topical_events.yml
+++ b/config/locales/hy/topical_events.yml
@@ -18,7 +18,6 @@ hy:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/id/topical_events.yml
+++ b/config/locales/id/topical_events.yml
@@ -18,7 +18,6 @@ id:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/is/topical_events.yml
+++ b/config/locales/is/topical_events.yml
@@ -18,7 +18,6 @@ is:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/it/topical_events.yml
+++ b/config/locales/it/topical_events.yml
@@ -18,7 +18,6 @@ it:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ja/topical_events.yml
+++ b/config/locales/ja/topical_events.yml
@@ -18,7 +18,6 @@ ja:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ka/topical_events.yml
+++ b/config/locales/ka/topical_events.yml
@@ -18,7 +18,6 @@ ka:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/kk/topical_events.yml
+++ b/config/locales/kk/topical_events.yml
@@ -18,7 +18,6 @@ kk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ko/topical_events.yml
+++ b/config/locales/ko/topical_events.yml
@@ -18,7 +18,6 @@ ko:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/lt/topical_events.yml
+++ b/config/locales/lt/topical_events.yml
@@ -18,7 +18,6 @@ lt:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/lv/topical_events.yml
+++ b/config/locales/lv/topical_events.yml
@@ -18,7 +18,6 @@ lv:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ms/topical_events.yml
+++ b/config/locales/ms/topical_events.yml
@@ -18,7 +18,6 @@ ms:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/mt/topical_events.yml
+++ b/config/locales/mt/topical_events.yml
@@ -18,7 +18,6 @@ mt:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ne/topical_events.yml
+++ b/config/locales/ne/topical_events.yml
@@ -18,7 +18,6 @@ ne:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/nl/topical_events.yml
+++ b/config/locales/nl/topical_events.yml
@@ -18,7 +18,6 @@ nl:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/no/topical_events.yml
+++ b/config/locales/no/topical_events.yml
@@ -18,7 +18,6 @@
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/pa-pk/topical_events.yml
+++ b/config/locales/pa-pk/topical_events.yml
@@ -18,7 +18,6 @@ pa-pk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/pa/topical_events.yml
+++ b/config/locales/pa/topical_events.yml
@@ -18,7 +18,6 @@ pa:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/pl/topical_events.yml
+++ b/config/locales/pl/topical_events.yml
@@ -18,7 +18,6 @@ pl:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ps/topical_events.yml
+++ b/config/locales/ps/topical_events.yml
@@ -18,7 +18,6 @@ ps:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/pt/topical_events.yml
+++ b/config/locales/pt/topical_events.yml
@@ -18,7 +18,6 @@ pt:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ro/topical_events.yml
+++ b/config/locales/ro/topical_events.yml
@@ -18,7 +18,6 @@ ro:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ru/topical_events.yml
+++ b/config/locales/ru/topical_events.yml
@@ -18,7 +18,6 @@ ru:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/si/topical_events.yml
+++ b/config/locales/si/topical_events.yml
@@ -18,7 +18,6 @@ si:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sk/topical_events.yml
+++ b/config/locales/sk/topical_events.yml
@@ -18,7 +18,6 @@ sk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sl/topical_events.yml
+++ b/config/locales/sl/topical_events.yml
@@ -18,7 +18,6 @@ sl:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/so/topical_events.yml
+++ b/config/locales/so/topical_events.yml
@@ -18,7 +18,6 @@ so:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sq/topical_events.yml
+++ b/config/locales/sq/topical_events.yml
@@ -18,7 +18,6 @@ sq:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sr/topical_events.yml
+++ b/config/locales/sr/topical_events.yml
@@ -18,7 +18,6 @@ sr:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sv/topical_events.yml
+++ b/config/locales/sv/topical_events.yml
@@ -18,7 +18,6 @@ sv:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/sw/topical_events.yml
+++ b/config/locales/sw/topical_events.yml
@@ -18,7 +18,6 @@ sw:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ta/topical_events.yml
+++ b/config/locales/ta/topical_events.yml
@@ -18,7 +18,6 @@ ta:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/th/topical_events.yml
+++ b/config/locales/th/topical_events.yml
@@ -18,7 +18,6 @@ th:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/tk/topical_events.yml
+++ b/config/locales/tk/topical_events.yml
@@ -18,7 +18,6 @@ tk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/tr/topical_events.yml
+++ b/config/locales/tr/topical_events.yml
@@ -18,7 +18,6 @@ tr:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/uk/topical_events.yml
+++ b/config/locales/uk/topical_events.yml
@@ -18,7 +18,6 @@ uk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/ur/topical_events.yml
+++ b/config/locales/ur/topical_events.yml
@@ -18,7 +18,6 @@ ur:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/uz/topical_events.yml
+++ b/config/locales/uz/topical_events.yml
@@ -18,7 +18,6 @@ uz:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/vi/topical_events.yml
+++ b/config/locales/vi/topical_events.yml
@@ -18,7 +18,6 @@ vi:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/yi/topical_events.yml
+++ b/config/locales/yi/topical_events.yml
@@ -18,7 +18,6 @@ yi:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/zh-hk/topical_events.yml
+++ b/config/locales/zh-hk/topical_events.yml
@@ -18,7 +18,6 @@ zh-hk:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/zh-tw/topical_events.yml
+++ b/config/locales/zh-tw/topical_events.yml
@@ -18,7 +18,6 @@ zh-tw:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/config/locales/zh/topical_events.yml
+++ b/config/locales/zh/topical_events.yml
@@ -18,7 +18,6 @@ zh:
       guidance_and_regulation:
       latest:
       publications:
-      travel_advice:
     no_updates:
     organisations:
     platinum_jubilee_unboxed:

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -58,21 +58,6 @@ RSpec.feature "Topical Event pages" do
     end
   end
 
-  context "afghanistan response topical event" do
-    let(:base_path) { "/government/topical-events/afghanistan-uk-government-response" }
-    let(:afghanistan_travel_advice_base_path) { "/foreign-travel-advice/afghanistan" }
-
-    before do
-      stub_content_store_has_item(base_path)
-      stub_content_store_has_item(afghanistan_travel_advice_base_path)
-    end
-
-    it "includes travel advice for Afghanistan" do
-      visit base_path
-      expect(page).to have_link(titleize_base_path(afghanistan_travel_advice_base_path), href: afghanistan_travel_advice_base_path)
-    end
-  end
-
   context "documents list" do
     let(:related_consultations) { { "A consultation on Topicals" => "/foo/consultation_one", "Another consultation" => "/foo/consultation_two" } }
     let(:related_announcements) { { "An announcement on Topicals" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }


### PR DESCRIPTION
Remove tech debt: Hacks introduced to support travel advice on https://www.gov.uk/government/topical-events/afghanistan-uk-government-response are now no longer needed (confirmed with FCDO)

https://trello.com/c/YZLEOB8w/6-august-2021-afghanistan-topical-event-is-augmented-with-hacks

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


