### PR TITLE
Remove Services and Information link from DfE's organisation page

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -111,7 +111,6 @@ module Organisations
 
     def has_services_and_information_link?
       orgs_with_services_and_information_link = %w[
-        department-for-education
         hm-revenue-customs
       ]
       return true if orgs_with_services_and_information_link.include?(org.slug)


### PR DESCRIPTION
Remove link to services and info for DfE as part of our work to retire specialist topics

https://trello.com/c/IQD8PfE8/2067-archive-and-redirect-services-and-info-page-dfe-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
