### PR TITLE
Add Brand recruitment banner

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,6 +4,7 @@
 
 //= link components/_taxon-list.css
 //= link components/_topic-list.css
+//= link components/_intervention.css
 
 //= link views/_browse.css
 //= link views/_bunting.css

--- a/app/assets/stylesheets/components/_intervention.scss
+++ b/app/assets/stylesheets/components/_intervention.scss
@@ -1,0 +1,5 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.gem-c-intervention {
+  margin-top: govuk-spacing(4);
+}

--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,0 +1,18 @@
+module RecruitmentBannerHelper
+  BRAND_SURVEY_URL = "https://surveys.publishing.service.gov.uk/s/5G06FO/".freeze
+
+  SURVEY_URL_MAPPINGS = {
+    "/browse/births-deaths-marriages/child-adoption" => BRAND_SURVEY_URL,
+    "/browse/business/imports" => BRAND_SURVEY_URL,
+    "/topic/business-tax/vat" => BRAND_SURVEY_URL,
+    "/learn-to-drive-a-car" => BRAND_SURVEY_URL,
+  }.freeze
+
+  def recruitment_survey_url
+    brand_user_research_test_url
+  end
+
+  def brand_user_research_test_url
+    SURVEY_URL_MAPPINGS[base_path]
+  end
+end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,4 +1,6 @@
 class MainstreamBrowsePage
+  include RecruitmentBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -1,4 +1,6 @@
 class StepNav
+  include RecruitmentBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,4 +1,6 @@
 class Topic
+  include RecruitmentBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -17,8 +17,10 @@
   <%= render "shared/browse_breadcrumbs" %>
 <% end %>
 
+<% margin_bottom = page.recruitment_survey_url ? 7 : 8 %>
+
 <%= render "shared/browse_header", {
-  margin_bottom: 8,
+  margin_bottom: margin_bottom,
   two_thirds: true,
 } do %>
   <%= render "govuk_publishing_components/components/heading", {
@@ -33,6 +35,17 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+<% if page.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve GOV.UK",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: page.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -17,7 +17,8 @@
   <%= render "shared/browse_breadcrumbs" %>
 <% end %>
 
-<%= render "shared/browse_header", { two_thirds: true, margin_bottom: 8 } do %>
+<% margin_bottom = page.recruitment_survey_url ? 7 : 8 %>
+<%= render "shared/browse_header", { two_thirds: true, margin_bottom: margin_bottom } do %>
 
   <%= render "govuk_publishing_components/components/heading", {
     font_size: "xl",
@@ -31,6 +32,17 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+<% if page.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve GOV.UK",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: page.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -1,4 +1,15 @@
+<% add_app_component_stylesheet("intervention") %>
 <% content_for :title, step_by_step.title %>
+<% if step_by_step.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve GOV.UK",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: step_by_step.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
+<% end %>
 <%= render 'structured_data', step_by_step: step_by_step %>
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= step_by_step.description %>">

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -1,3 +1,4 @@
+<% add_app_component_stylesheet("intervention") %>
 <% content_for :title, subtopic.combined_title %>
 <%= render 'shared/tag_meta', tag: subtopic %>
 <% content_for :meta_tags do %>
@@ -16,6 +17,17 @@
     end
   %>
   <%= render "govuk_publishing_components/components/title", title_params %>
+<% end %>
+
+<% if subtopic.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve GOV.UK",
+      suggestion_link_text: "Take part in user research",
+      suggestion_link_url: subtopic.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <%= render(

--- a/spec/features/research_panel_banner_spec.rb
+++ b/spec/features/research_panel_banner_spec.rb
@@ -1,0 +1,36 @@
+require "integration_spec_helper"
+
+RSpec.feature "Research panel banner" do
+  include SearchApiHelpers
+  include RecruitmentBannerHelper
+
+  scenario "browse pages where we want to display Brand User Research banner" do
+    pages_of_interest = [
+      "/browse/births-deaths-marriages/child-adoption",
+      "/browse/business/imports",
+    ]
+
+    pages_of_interest.each do |base_path|
+      schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+      schema["base_path"] = base_path
+      stub_content_store_has_item(schema["base_path"], schema)
+      search_api_has_documents_for_browse_page(schema["content_id"], [base_path], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+      visit schema["base_path"]
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector(".gem-c-intervention")
+    end
+  end
+
+  scenario "pages where we don't want to display Brand User Research banner" do
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to_not have_selector(".gem-c-intervention")
+  end
+end

--- a/spec/features/step_nav_page_spec.rb
+++ b/spec/features/step_nav_page_spec.rb
@@ -27,6 +27,10 @@ RSpec.feature "Step by step nav pages" do
     expect(page).to have_selector(".gem-c-step-nav__panel", visible: false)
   end
 
+  it "shows the brand user research banner" do
+    expect(page).to have_selector(".gem-c-intervention")
+  end
+
   it "works for a generated example" do
     content_item = step_nav_example
 


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/browse/births-deaths-marriages/child-adoption](https://www.gov.uk/browse/births-deaths-marriages/child-adoption)
- [/browse/business/imports](https://www.gov.uk/browse/business/imports)
- [/topic/business-tax/vat](https://www.gov.uk/topic/business-tax/vat)
- [/learn-to-drive-a-car](https://www.gov.uk/learn-to-drive-a-car)

Trello card: https://trello.com/c/EVjvHjqE/2090-brand-team-govuk-user-research-banner-request-to-set-up-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
