### PR TITLE
Add user research banner

### DIFF
--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,0 +1,17 @@
+module RecruitmentBannerHelper
+  SURVERY_URL = "https://surveys.publishing.service.gov.uk/s/SNFVW1/".freeze
+
+  SURVEY_URL_MAPPINGS = {
+    "/browse/tax" => SURVERY_URL,
+    "/browse/tax/self-assessment" => SURVERY_URL,
+    "/topic/personal-tax/self-assessment" => SURVERY_URL,
+  }.freeze
+
+  def recruitment_survey_url
+    user_research_test_url
+  end
+
+  def user_research_test_url
+    SURVEY_URL_MAPPINGS[base_path]
+  end
+end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -1,4 +1,6 @@
 class MainstreamBrowsePage
+  include RecruitmentBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,4 +1,6 @@
 class Topic
+  include RecruitmentBannerHelper
+
   attr_reader :content_item
 
   delegate(

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -20,7 +20,7 @@
   } %>
 <% end %>
 
-<%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
+<%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" || page.recruitment_survey_url ? 7 : 9 } do %>
   <h1 class="browse__heading govuk-heading-xl">
     <%= page.title %>
   </h1>
@@ -29,6 +29,17 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+<% if page.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve a new GOV.UK tool",
+      suggestion_link_text: "Sign up to take part in user research",
+      suggestion_link_url: page.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <% if page.slug == "benefits" %>

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -17,8 +17,8 @@
   <%= render "shared/browse_breadcrumbs" %>
 <% end %>
 
-<%= render "shared/browse_header", { two_thirds: true, margin_bottom: 8 } do %>
-
+<% margin_bottom = page.recruitment_survey_url ? 7 : 8 %>
+<%= render "shared/browse_header", { two_thirds: true, margin_bottom: margin_bottom } do %>
   <%= render "govuk_publishing_components/components/heading", {
     font_size: "xl",
     heading_level: 1,
@@ -31,6 +31,17 @@
     margin_bottom: 2,
     inverse: true
   } %>
+<% end %>
+
+<% if page.recruitment_survey_url %>
+  <div class="govuk-width-container">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve a new GOV.UK tool",
+      suggestion_link_text: "Sign up to take part in user research",
+      suggestion_link_url: page.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/subtopics/show.html.erb
+++ b/app/views/subtopics/show.html.erb
@@ -18,6 +18,17 @@
   <%= render "govuk_publishing_components/components/title", title_params %>
 <% end %>
 
+<% if subtopic.recruitment_survey_url %>
+  <div class="govuk-!-static-margin-top-4">
+    <%= render "govuk_publishing_components/components/intervention", {
+      suggestion_text: "Help improve a new GOV.UK tool",
+      suggestion_link_text: "Sign up to take part in user research",
+      suggestion_link_url: subtopic.recruitment_survey_url,
+      new_tab: true,
+    } %>
+  </div>
+<% end %>
+
 <%= render(
   layout: "subtopic",
   locals: {

--- a/spec/features/research_panel_banner_spec.rb
+++ b/spec/features/research_panel_banner_spec.rb
@@ -1,0 +1,29 @@
+require "integration_spec_helper"
+
+RSpec.feature "Research panel banner" do
+  include SearchApiHelpers
+  include RecruitmentBannerHelper
+
+  scenario "browse pages where we want to display User Research banner" do
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    schema["base_path"] = "/browse/tax"
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_selector(".gem-c-intervention")
+  end
+
+  scenario "pages where we don't want to display User Research banner" do
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to_not have_selector(".gem-c-intervention")
+  end
+end


### PR DESCRIPTION
The banner will be applied on the following pages:
- [/browse/tax/self-assessment](https://www.gov.uk/browse/tax/self-assessment)
- [/browse/tax](https://www.gov.uk/browse/tax)
- [/topic/personal-tax/self-assessment](https://www.gov.uk/topic/personal-tax/self-assessment)

Before:
<img width="995" alt="Screenshot 2023-09-26 at 10 07 02" src="https://github.com/alphagov/collections/assets/96050928/12836d11-f591-47af-a72b-d757758239af">

After:
<img width="1021" alt="Screenshot 2023-09-26 at 10 06 20" src="https://github.com/alphagov/collections/assets/96050928/c8eec48d-4577-4aa2-8dc9-f002b26d81db">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
