### PR TITLE
GA4 tracking on person and roles

### DIFF
--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -1,5 +1,6 @@
 <div <%= t_lang("people.biography") %>>
   <%= render "govuk_publishing_components/components/contents_list", {
+    ga4_tracking: true,
     contents: [
       {
         text: t("people.biography"),

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -1,5 +1,6 @@
 <div <%= t_lang("roles.headings.responsibilities") %>>
   <%= render "govuk_publishing_components/components/contents_list", {
+    ga4_tracking: true,
     contents: [
       {
         text: t("roles.headings.responsibilities"),


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enables GA4 tracking on contents lists on person and role pages, for example:

- https://www.gov.uk/government/ministers/secretary-of-state-for-defence (role)
- https://www.gov.uk/government/people/grant-shapps (person)

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/f03bi6MM/692-add-contents-list-selectcontent-events-to-people-pages
