### PR TITLE
Enable GA4 tracking on taxon pages

### DIFF
--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -14,6 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third content-list__sticky">
       <%= render "govuk_publishing_components/components/contents_list", {
+        ga4_tracking: true,
         contents: @presentable_section_items
       } %>
     </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the contents list on taxon pages, such as https://www.gov.uk/welfare

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/pWP26ZKI/691-add-contents-list-selectcontent-events-to-taxon-pages
