### PR TITLE
Prevent "latest changes" link from being tracked as an email subscription link

### DIFF
--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -11,17 +11,17 @@
       <% end %>
     </div>
 
-    <div 
-      class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-3"
-      data-module="ga4-link-tracker"
-      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
-      data-ga4-track-links-only
-    >
-      <%= render "govuk_publishing_components/components/subscription_links", {
-        email_signup_link: "/email-signup?link=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
-        email_signup_link_text: t("shared.get_emails")
-      } %>
-
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-3">
+      <span
+        data-module="ga4-link-tracker"
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+        data-ga4-track-links-only
+      >
+        <%= render "govuk_publishing_components/components/subscription_links", {
+          email_signup_link: "/email-signup?link=/topic/#{params[:topic_slug]}/#{params[:subtopic_slug]}",
+          email_signup_link_text: t("shared.get_emails")
+        } %>
+      </span>
       <% if local_assigns[:link_to_latest_feed] %>
         <div class="topics-page__latest">
           <%= link_to t("subtopics.get_latest"), latest_changes_path(topic_slug: params[:topic_slug], subtopic_slug: params[:subtopic_slug]), class: "govuk-link topics-page__latest-link" %>


### PR DESCRIPTION
## What

- On these types of pages https://www.gov.uk/topic/personal-tax/income-tax there is a "Get emails for this topic" link, and a  "See latest changes to this content" link at the top right of the page.
- Our GA4 tracking was added on a parent `<div>` which gave the tracking to the email link and the "See latest changes" link.
- We don't want the tracking on the "See latest changes" link, so I have wrapped the email link in a `<span>` and put the tracking on that instead.

## Why

https://trello.com/c/tbT92mSB/680-subscribe-link-click-firing-on-non-subscribe-events-on-topic-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
