### PR TITLE
Update list of API consumers in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,4 +26,5 @@ Please [add your application to this list](https://github.com/alphagov/collectio
 - [Smokey](https://github.com/alphagov/smokey/blob/7183e1a5fa44b3d53c7a0f39786fddfb62417e9a/features/public_api.feature#L23)
 - [Signon](https://github.com/alphagov/signon/blob/53302a17ccfedca9914d15937a040d6b586dbebd/lib/organisations_fetcher.rb#L24)
 - [Support API](https://github.com/alphagov/support-api/blob/e6f4b9db213c6dd7b75aef832f12bf1da7070d4d/lib/organisation_importer.rb#L67)
+- [Transition](https://github.com/alphagov/transition/blob/v50/lib/transition/import/whitehall_orgs.rb#L51)
 - [Knowledge graph](https://github.com/alphagov/govuk-knowledge-graph/blob/9f51774c1cbaf9a9fe4121f94249940ff3446b7c/src/data/extract_organisation_api.py)

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,5 +26,4 @@ Please [add your application to this list](https://github.com/alphagov/collectio
 - [Smokey](https://github.com/alphagov/smokey/blob/7183e1a5fa44b3d53c7a0f39786fddfb62417e9a/features/public_api.feature#L23)
 - [Signon](https://github.com/alphagov/signon/blob/53302a17ccfedca9914d15937a040d6b586dbebd/lib/organisations_fetcher.rb#L24)
 - [Support API](https://github.com/alphagov/support-api/blob/e6f4b9db213c6dd7b75aef832f12bf1da7070d4d/lib/organisation_importer.rb#L67)
-- [Transition config](https://github.com/alphagov/transition-config/blob/5c6e76f76646ff5e4db62b77bf6681d92d86f503/lib/redirector/organisations.rb#L9)
 - [Knowledge graph](https://github.com/alphagov/govuk-knowledge-graph/blob/9f51774c1cbaf9a9fe4121f94249940ff3446b7c/src/data/extract_organisation_api.py)


### PR DESCRIPTION
https://trello.com/c/8lQCsx3y/862-identify-all-things-related-to-transition-config-elsewhere-in-alphagov-and-update-or-remove-the-references

The [transition-config project](https://github.com/alphagov/transition-config) has recently been retired, so this change removes it from the list of API consumers in the docs.

In case this list is still considered useful (?) I've also added a missing entry that I noticed in the process.