### PR TITLE
Flatten GA4 attributes

### DIFF
--- a/app/helpers/topic_list_helper.rb
+++ b/app/helpers/topic_list_helper.rb
@@ -20,9 +20,8 @@ module TopicListHelper
   def topic_list_params(list, tracking_attributes: nil, list_index: nil, category: nil, list_count: nil, list_title: nil)
     tracking_attributes ||= topic_list_tracking_attributes(list.count, list_index, category)
     ga4_data = {}
-    ga4_data[:index] = {}
-    ga4_data[:index][:index_section] = list_index + 1 if list_index
-    ga4_data[:index][:index_section_count] = list_count if list_count
+    ga4_data[:index_section] = list_index + 1 if list_index
+    ga4_data[:index_section_count] = list_count if list_count
     ga4_data[:section] = list_title if list_title
 
     {

--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -79,11 +79,9 @@ private
       ga4_link: {
         event_name: "navigation",
         type: "organisation logo",
-        index: {
-          index_link: index,
-          index_section: @index_section,
-          index_section_count: @index_section_count,
-        },
+        index_link: index,
+        index_section: @index_section,
+        index_section_count: @index_section_count,
         index_total: organisations.count,
         section: "Organisations",
       },

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -39,11 +39,9 @@ class TaxonPresenter
       ga4_link: {
         event_name: "navigation",
         type: "subtopic list",
-        index: {
-          index_link: (index + 1).to_s,
-          index_section: page_section_total.to_s,
-          index_section_count: page_section_total.to_s,
-        },
+        index_link: (index + 1).to_s,
+        index_section: page_section_total.to_s,
+        index_section_count: page_section_total.to_s,
         index_total: child_taxons.count,
         section: I18n.t("taxons.explore_sub_topics", locale: :en),
       },

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -48,9 +48,7 @@
             ga4_link: {
               event_name: "navigation",
               type: "browse card",
-              index: {
-                index_link: index + 1,
-              },
+              index_link: index + 1,
               index_total: total_links,
             },
           }

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -78,9 +78,7 @@
             ga4_link: {
               event_name: "navigation",
               type: "browse card",
-              index: {
-                index_link: index + 1,
-              },
+              index_link: index + 1,
               index_total: total_links,
             },
           },

--- a/app/views/components/_topic_list.html.erb
+++ b/app/views/components/_topic_list.html.erb
@@ -18,21 +18,19 @@
   <%= tag.ul(class: ul_classes, lang: "en") do %>
     <% items.each_with_index do |item, index| %>
       <li class="app-c-topic-list__item">
-        <% 
+        <%
           ga4_link_data = ga4_data.empty? ? {} : {
             ga4_link: {
               event_name: "navigation",
               type: "document list",
-              index: {
-                index_link: index + 1,
-                **ga4_data[:index] || {},
-              },
+              index_link: index + 1,
               # As see_more_link is not included in the items array, we need to account for it here by adding 1 to items.count
               # if see_more_link has been passed
               index_total: (see_more_link ? items.count + 1 : items.count),
               section: ga4_data[:section],
             }
           }
+          ga4_link_data[:ga4_link] = ga4_link_data[:ga4_link].merge(ga4_data) unless ga4_data.empty?
         %>
         <%=
           link_to(
@@ -47,19 +45,17 @@
     <% end %>
     <% if see_more_link %>
       <li class="app-c-topic-list__item">
-        <% 
+        <%
           ga4_link_data = ga4_data.empty? ? {} : {
             ga4_link: {
               event_name: "navigation",
               type: "document list",
-              index: {
-                index_link: items.count + 1,
-                **ga4_data[:index] || {},
-              },
+              index_link: items.count + 1,
               index_total: items.count + 1,
               section: ga4_data[:section],
             }
           }
+          ga4_link_data[:ga4_link] = ga4_link_data[:ga4_link].merge(ga4_data) unless ga4_data.empty?
         %>
         <%=
           link_to(

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -58,16 +58,14 @@
     </div>
   </section>
 
-  <%= content_tag :section, 
-    class: "covid__topic-wrapper", 
-    data: { 
-      module: "ga4-link-tracker", 
+  <%= content_tag :section,
+    class: "covid__topic-wrapper",
+    data: {
+      module: "ga4-link-tracker",
       ga4_link: {
         event_name: "navigation",
         type: "subscribe",
-        index: {
-          index_link: 1
-        },
+        index_link: 1,
         index_total: 1,
         section: "Footer"
       },

--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -23,7 +23,7 @@
 
       <div
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
         data-ga4-track-links-only
       >
         <%= render "govuk_publishing_components/components/subscription_links", @show.subscription_links %>

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -21,11 +21,9 @@
           ga4_link: {
             event_name: "navigation",
             type: "browse list",
-            index: {
-              index_link: index + 1,
-              index_section: list_index + 1,
-              index_section_count: index_section_count,
-            },
+            index_link: index + 1,
+            index_section: list_index + 1,
+            index_section_count: index_section_count,
             index_total: total_links,
             section: section,
           },

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -6,9 +6,9 @@
         margin_bottom: 5,
     } %>
 
-    <div 
-      data-module="ga4-link-tracker" 
-      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+    <div
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
       data-ga4-track-links-only
     >
       <%= render "govuk_publishing_components/components/subscription_links", {

--- a/app/views/subtopics/_subtopic.html.erb
+++ b/app/views/subtopics/_subtopic.html.erb
@@ -14,7 +14,7 @@
     <div class="govuk-grid-column-one-third govuk-!-margin-top-8 govuk-!-margin-bottom-3">
       <span
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
         data-ga4-track-links-only
       >
         <%= render "govuk_publishing_components/components/subscription_links", {

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -17,7 +17,7 @@
     <div
       class="full-page-width-wrapper"
       data-module="ga4-link-tracker"
-      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+      data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
       data-ga4-track-links-only
     >
       <%= render "govuk_publishing_components/components/signup_link", {

--- a/app/views/taxons/_organisation_logos_and_list.html.erb
+++ b/app/views/taxons/_organisation_logos_and_list.html.erb
@@ -8,11 +8,9 @@
           ga4_link: {
             event_name: "navigation",
             type: "organisation logo",
-            index: {
-              index_link: index_link + index,
-              index_section: index_section,
-              index_section_count: index_section_count
-            },
+            index_link: index_link + index,
+            index_section: index_section,
+            index_section_count: index_section_count,
             index_total: organisations_with_logos.count,
             section: "Organisations"
           }
@@ -29,7 +27,7 @@
 <% if organisations_without_logos.any? %>
   <div
     data-module="ga4-link-tracker <%= "gem-track-click" if track_click?(organisations_without_logos) %>"
-    data-ga4-link="{'index':{'index_section':<%= index_section %>,'index_section_count':<%= index_section_count %>}}"
+    data-ga4-link="{'index_section':<%= index_section %>,'index_section_count':<%= index_section_count %>}"
   >
     <%= render 'govuk_publishing_components/components/document_list',
       items: organisations_without_logos

--- a/app/views/taxons/_organisations.html.erb
+++ b/app/views/taxons/_organisations.html.erb
@@ -27,10 +27,8 @@
               ga4_attributes = {
                 event_name: "select_content",
                 type: "organisation logo",
-                index: {
-                  index_section: index_section,
-                  index_section_count: index_section_count
-                },
+                index_section: index_section,
+                index_section_count: index_section_count,
                 section: "Organisations",
               }
             %>

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -55,10 +55,8 @@
                 ga4_link: {
                   event_name: "navigation",
                   type: "document list",
-                  index: {
-                    index_section: index,
-                    index_section_count: index_section_count
-                  },
+                  index_section: index,
+                  index_section_count: index_section_count,
                   index_total: index_total,
                   section: title
                 }
@@ -68,12 +66,11 @@
               <%= render(partial: section[:partial_template], locals: { section: section }) %>
             <% end %>
             <% if section[:see_more_link] %>
-              <%= ga4_data[:ga4_link][:index][:index_link] %>
               <%
                 ga4_data.except!(:ga4_set_indexes)
                 ga4_data[:ga4_link][:type] = 'see all'
                 docs = section[:documents_with_promoted] || section[:documents]
-                ga4_data[:ga4_link][:index][:index_link] = docs.length + 1
+                ga4_data[:ga4_link][:index_link] = docs.length + 1
               %>
               <%= content_tag(:div, data: ga4_data) do %>
                 <%= link_to(

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,9 +1,7 @@
 <% ga4_link_attributes = {
     event_name: "navigation",
     type: "subscribe",
-    index: {
-      index_link: 1
-    },
+    index_link: 1,
     index_total: 1,
     section: "Content"
   }.to_json
@@ -129,7 +127,7 @@
 
       <div
         data-module="ga4-link-tracker"
-        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+        data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
         data-ga4-track-links-only
       >
         <%= render "govuk_publishing_components/components/subscription_links", {

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -71,9 +71,9 @@
           <p class="govuk-body"><%= I18n.t("world_location_news.no_updates") %></p>
         <% end %>
 
-        <div 
-          data-module="ga4-link-tracker" 
-          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Content" }'
+        <div
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
           data-ga4-track-links-only
         >
           <%= render "govuk_publishing_components/components/subscription_links", {

--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -1,7 +1,7 @@
 <% if taxon_is_live?(presented_taxon) %>
-  <div 
-    data-module="ga4-link-tracker" 
-    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index": { "index_link": 1 }, "index_total": 1, "section": "Top" }'
+  <div
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
     data-ga4-track-links-only
   >
     <% if presented_taxon.renders_as_accordion? %>

--- a/spec/components/topic_list_spec.rb
+++ b/spec/components/topic_list_spec.rb
@@ -39,23 +39,19 @@ RSpec.describe "topic_list component", type: :view do
 
   it "sets GA4 data attributes correctly" do
     ga4_data = {
-      index: {
-        index_section: 1,
-        index_section_count: 1,
-      },
+      index_section: 1,
+      index_section_count: 1,
       section: "Simple item",
     }
 
     expected = {
       "event_name": "navigation",
       "type": "document list",
-      "index": {
-        "index_link": 1,
-        "index_section": 1,
-        "index_section_count": 1,
-      },
+      "index_link": 1,
       "index_total": 1,
       "section": "Simple item",
+      "index_section": 1,
+      "index_section_count": 1,
     }.to_json
 
     render_component(items: [simple_item], ga4_data:)
@@ -73,9 +69,7 @@ RSpec.describe "topic_list component", type: :view do
     expected = {
       "event_name": "navigation",
       "type": "document list",
-      "index": {
-        "index_link": 1,
-      },
+      "index_link": 1,
       "index_total": 1,
       "section": "Simple item",
     }.to_json
@@ -99,9 +93,7 @@ RSpec.describe "topic_list component", type: :view do
         expected = {
           "event_name": "navigation",
           "type": "document list",
-          "index": {
-            "index_link": index + 1,
-          },
+          "index_link": index + 1,
           "index_total": 2,
           "section": "Simple item",
         }.to_json

--- a/spec/features/services_and_information_browsing_spec.rb
+++ b/spec/features/services_and_information_browsing_spec.rb
@@ -82,9 +82,9 @@ RSpec.feature "Services and information browsing" do
 
       expect(ga4_data["event_name"]).to eq "navigation"
       expect(ga4_data["type"]).to eq "document list"
-      expect(ga4_data["index"]["index_link"]).to eq 1
-      expect(ga4_data["index"]["index_section"]).to eq 1
-      expect(ga4_data["index"]["index_section_count"]).to eq 2
+      expect(ga4_data["index_link"]).to eq 1
+      expect(ga4_data["index_section"]).to eq 1
+      expect(ga4_data["index_section_count"]).to eq 2
       expect(ga4_data["index_total"]).to eq 5
       expect(ga4_data["section"]).to eq "Environmental permits"
     end
@@ -95,9 +95,9 @@ RSpec.feature "Services and information browsing" do
 
       expect(ga4_data["event_name"]).to eq "navigation"
       expect(ga4_data["type"]).to eq "document list"
-      expect(ga4_data["index"]["index_link"]).to eq 1
-      expect(ga4_data["index"]["index_section"]).to eq 2
-      expect(ga4_data["index"]["index_section_count"]).to eq 2
+      expect(ga4_data["index_link"]).to eq 1
+      expect(ga4_data["index_section"]).to eq 2
+      expect(ga4_data["index_section_count"]).to eq 2
       expect(ga4_data["index_total"]).to eq 5
       expect(ga4_data["section"]).to eq "Waste"
     end

--- a/spec/presenters/taxon_organisations_presenter_spec.rb
+++ b/spec/presenters/taxon_organisations_presenter_spec.rb
@@ -38,11 +38,9 @@ RSpec.describe TaxonOrganisationsPresenter do
               ga4_link: {
                 event_name: "navigation",
                 type: "organisation logo",
-                index: {
-                  index_link: 1,
-                  index_section: 6,
-                  index_section_count: 7,
-                },
+                index_link: 1,
+                index_section: 6,
+                index_section_count: 7,
                 index_total: 1,
                 section: "Organisations",
               },
@@ -78,11 +76,9 @@ RSpec.describe TaxonOrganisationsPresenter do
             ga4_link: {
               event_name: "navigation",
               type: "organisation logo",
-              index: {
-                index_link: 1,
-                index_section: 6,
-                index_section_count: 7,
-              },
+              index_link: 1,
+              index_section: 6,
+              index_section_count: 7,
               index_total: 1,
               section: "Organisations",
             },
@@ -116,11 +112,9 @@ RSpec.describe TaxonOrganisationsPresenter do
               ga4_link: {
                 event_name: "navigation",
                 type: "organisation logo",
-                index: {
-                  index_link: 1,
-                  index_section: 6,
-                  index_section_count: 7,
-                },
+                index_link: 1,
+                index_section: 6,
+                index_section_count: 7,
                 index_total: 1,
                 section: "Organisations",
               },
@@ -158,11 +152,9 @@ RSpec.describe TaxonOrganisationsPresenter do
             ga4_link: {
               event_name: "navigation",
               type: "organisation logo",
-              index: {
-                index_link: index + 1,
-                index_section: 6,
-                index_section_count: 7,
-              },
+              index_link: index + 1,
+              index_section: 6,
+              index_section_count: 7,
               index_total: 5,
               section: "Organisations",
             },
@@ -198,11 +190,9 @@ RSpec.describe TaxonOrganisationsPresenter do
               ga4_link: {
                 event_name: "navigation",
                 type: "organisation logo",
-                index: {
-                  index_link: index + 1,
-                  index_section: 6,
-                  index_section_count: 7,
-                },
+                index_link: index + 1,
+                index_section: 6,
+                index_section_count: 7,
                 index_total: 5,
                 section: "Organisations",
               },
@@ -242,11 +232,9 @@ RSpec.describe TaxonOrganisationsPresenter do
             ga4_link: {
               event_name: "navigation",
               type: "organisation logo",
-              index: {
-                index_link: index + 1,
-                index_section: 6,
-                index_section_count: 7,
-              },
+              index_link: index + 1,
+              index_section: 6,
+              index_section_count: 7,
               index_total: 4,
               section: "Organisations",
             },
@@ -269,11 +257,9 @@ RSpec.describe TaxonOrganisationsPresenter do
               ga4_link: {
                 event_name: "navigation",
                 type: "organisation logo",
-                index: {
-                  index_link: 4,
-                  index_section: 6,
-                  index_section_count: 7,
-                },
+                index_link: 4,
+                index_section: 6,
+                index_section_count: 7,
                 index_total: 4,
                 section: "Organisations",
               },
@@ -313,11 +299,9 @@ RSpec.describe TaxonOrganisationsPresenter do
             ga4_link: {
               event_name: "navigation",
               type: "organisation logo",
-              index: {
-                index_link: 6,
-                index_section: 6,
-                index_section_count: 7,
-              },
+              index_link: 6,
+              index_section: 6,
+              index_section_count: 7,
               index_total: 6,
               section: "Organisations",
             },
@@ -353,11 +337,9 @@ RSpec.describe TaxonOrganisationsPresenter do
               ga4_link: {
                 event_name: "navigation",
                 type: "organisation logo",
-                index: {
-                  index_link: 6,
-                  index_section: 6,
-                  index_section_count: 7,
-                },
+                index_link: 6,
+                index_section: 6,
+                index_section_count: 7,
                 index_total: 6,
                 section: "Organisations",
               },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- we no longer need to nest GA4 attributes attached to elements, notably the index attributes
- these attributes when collected by trackers are automatically nested based on the structure of the GA4 schema, held in the gem
- flattening them here saves code and complexity

## Visual changes
None.

Trello card: https://trello.com/c/IseA05Fd/644-remove-nesting-of-ga4-attributes