### PR TITLE
Stop guessing urls for Topical Event image srcset attribute

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -23,23 +23,23 @@ class TopicalEvent
     @content_item.content_item_data.dig("details", "image", "url")
   end
 
-  def image_alt_text
-    @content_item.content_item_data.dig("details", "image", "alt_text")
+  def image_medium_resolution_url
+    @content_item.content_item_data.dig("details", "image", "medium_resolution_url")
+  end
+
+  def image_high_resolution_url
+    @content_item.content_item_data.dig("details", "image", "high_resolution_url")
   end
 
   def image_srcset
-    [
-      { url: sized_image_url(960), size: "960w" },
-      { url: sized_image_url(712), size: "712w" },
-      { url: sized_image_url(630), size: "630w" },
-      { url: sized_image_url(465), size: "465w" },
-      { url: sized_image_url(300), size: "300w" },
-      { url: sized_image_url(216), size: "216w" },
-    ]
+    set = {}
+    set[image_medium_resolution_url] = "2x" if image_medium_resolution_url
+    set[image_high_resolution_url] = "3x" if image_high_resolution_url
+    set
   end
 
-  def sized_image_url(width)
-    image_url.gsub("/s300_", "/s#{width}_")
+  def image_alt_text
+    @content_item.content_item_data.dig("details", "image", "alt_text")
   end
 
   def body

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -58,7 +58,13 @@
 
     <% if @topical_event.image_url %>
       <div class="topical-events__image">
-      <%= image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text, srcset: { @topical_event.image_srcset[2][:url] => "2x", @topical_event.image_srcset[0][:url] => "3x",}) %>
+      <%=
+        if @topical_event.image_srcset.any?
+          image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text, srcset: @topical_event.image_srcset)
+        else
+          image_tag(@topical_event.image_url, alt: @topical_event.image_alt_text)
+        end
+      %>
       </div>
     <% end %>
 

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -30,6 +30,23 @@ RSpec.feature "Topical Event pages" do
     expect(page).to have_css("img[src='https://www.gov.uk/some-image.png'][alt='Text describing the image']")
   end
 
+  it "includes image srcset for various image sizes" do
+    visit base_path
+    expect(page).to have_css("img[srcset='https://www.gov.uk/some-medium-image.png 2x, https://www.gov.uk/some-high-image.png 3x']")
+  end
+
+  context "when the image has no variants" do
+    before do
+      content_item["details"]["image"].delete("medium_resolution_url")
+      content_item["details"]["image"].delete("high_resolution_url")
+      stub_content_store_has_item(base_path, content_item)
+    end
+    it "omits srcset if there are no higher res image sizes" do
+      visit base_path
+      expect(page).not_to have_css("img[srcset]")
+    end
+  end
+
   it "sets the body text" do
     visit base_path
     expect(page).to have_text(content_item.dig("details", "body"))

--- a/spec/fixtures/content_store/topical_event.json
+++ b/spec/fixtures/content_store/topical_event.json
@@ -33,6 +33,8 @@
     "body": "This is a very important topical event.",
     "image": {
       "url": "https://www.gov.uk/some-image.png",
+      "medium_resolution_url": "https://www.gov.uk/some-medium-image.png",
+      "high_resolution_url": "https://www.gov.uk/some-high-image.png",
       "alt_text": "Text describing the image"
     },
     "end_date": "2016-04-28T00:00:00+00:00",


### PR DESCRIPTION
Whitehall has changed to start using modern Asset Manager urls for each asset. This means that the image urls are no longer guessable. Each image variant has its own unique id. In order to have a srcset for images.

This pr gets the correct image urls from the topical event content.

[Trello](https://trello.com/c/l7AHikFh/233-story-implement-non-legacy-urls-for-topical-event-logo)

Specifically this change is about the following acceptance criteria:
```
GIVEN a Topical Event with a logo
WHEN I open the Topical Event on the live stack (View on website btn)
THEN I should see the Topical event logo on the page
AND the logo should be loaded without using legacy_url_path
AND the page should have the image srcset-attribute using asset-id urls instead of legacy_url_path
```

The background context for this work is that the wayhow Whitehall references assets in Asset Manager - including images is changing. Previously Whitehall would have a hardcoded configuration for urls such that  would make it possible for the various sizes of the same image urls to be guessable. 

The new behaviour is that each individual image will have its own url provided by Asset Manager. The urls are therefore no longer guessable as they all have a unique id in them.

Please see these 2 related prs that show how the urls will be carried from Whitehall to Collections.
https://github.com/alphagov/whitehall/pull/8432
https://github.com/alphagov/publishing-api/pull/2534


