### PR TITLE
Remove scroll tracking

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -4,7 +4,6 @@
 
 <% content_for :meta_tags do %>
   <%= auto_discovery_link_tag(:json, api_organisations_url, title: @presented_organisations.title) %>
-  <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker"/>
 <% end %>
 
 <div data-module="list-filter">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes scroll tracking for GA4 from organisations page at `/government/organisations`

## Why
Scroll tracking is no longer required.

## Visual changes
None.

Trello card: https://trello.com/c/R6z5Hd3d/714-remove-scroll-tracking
