### PR TITLE
Update Pact Broker URL

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -25,7 +25,7 @@ def url_encode(str)
 end
 
 def pact_broker_base_url
-  "https://pact-broker.cloudapps.digital"
+  "https://govuk-pact-broker-6991351eca05.herokuapp.com"
 end
 
 Pact.service_provider "Collections Organisation API" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are currently migrating our Pact Broker instance from PaaS to Heroku. `gds-api-adapters` has already been updated to publish pacts to both instances, now we need to update each of our API providers to fetch from the new instance instead of the old one.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️