### PR TITLE
Past Foreign Secretaries List: Add James Cleverly

### DIFF
--- a/config/past_foreign_secretaries/content_item.yml
+++ b/config/past_foreign_secretaries/content_item.yml
@@ -4,6 +4,9 @@ title: Past Foreign Secretaries
 body:
   centuries:
     21st_century:
+      - name: James Cleverly
+        service:
+          - 2022 to 2023
       - name: Elizabeth Truss
         service:
           - 2021 to 2022


### PR DESCRIPTION
James Cleverly has moved to the Home Office, so should be added to this list here: https://www.gov.uk/government/history/past-foreign-secretaries