### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/models/step_nav.rb
+++ b/app/models/step_nav.rb
@@ -20,7 +20,7 @@ class StepNav
   end
 
   def payload_for_component
-    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id, ga4_tracking: true)
+    details["step_by_step_nav"].deep_symbolize_keys.merge(remember_last_step: true, tracking_id: content_id)
   end
 
   def self.find!(base_path)

--- a/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_accordion_sections.html.erb
@@ -48,7 +48,6 @@
   <div data-module="toggle-attribute">
     <%= render 'govuk_publishing_components/components/accordion', {
       heading_level: 3,
-      ga4_tracking: true,
       items: accordion_contents,
       margin_bottom: 3
     } %>

--- a/app/views/historic_appointments/past_foreign_secretaries/_show_person.html.erb
+++ b/app/views/historic_appointments/past_foreign_secretaries/_show_person.html.erb
@@ -71,8 +71,7 @@
 
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/related_navigation", {
-      content_item: past_foreign_secretary_nav,
-      ga4_tracking: true
+      content_item: past_foreign_secretary_nav
     } %>
     <p class="govuk-body">
       <a class="govuk-link" href="/government/history/past-foreign-secretaries"><%= t('past_foreign_secretaries.show_person.link_text') %></a>

--- a/app/views/past_prime_ministers/show.html.erb
+++ b/app/views/past_prime_ministers/show.html.erb
@@ -55,10 +55,8 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <p class="govuk-body">
-      <%=  render "govuk_publishing_components/components/related_navigation", {
-      content_item: @past_prime_minister.related_prime_ministers_nav,
-      ga4_tracking: true
+    <%=  render "govuk_publishing_components/components/related_navigation", {
+      content_item: @past_prime_minister.related_prime_ministers_nav
     } %>
     <p class="govuk-body">
       <a class="govuk-link" href="/government/history/past-prime-ministers"><%= I18n.t("past_prime_ministers.view_all")  %></a>

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -1,6 +1,5 @@
 <div <%= t_lang("people.biography") %>>
   <%= render "govuk_publishing_components/components/contents_list", {
-    ga4_tracking: true,
     contents: [
       {
         text: t("people.biography"),

--- a/app/views/roles/_contents.html.erb
+++ b/app/views/roles/_contents.html.erb
@@ -1,6 +1,5 @@
 <div <%= t_lang("roles.headings.responsibilities") %>>
   <%= render "govuk_publishing_components/components/contents_list", {
-    ga4_tracking: true,
     contents: [
       {
         text: t("roles.headings.responsibilities"),

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -14,7 +14,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third content-list__sticky">
       <%= render "govuk_publishing_components/components/contents_list", {
-        ga4_tracking: true,
         contents: @presentable_section_items
       } %>
     </div>

--- a/app/views/world_wide_taxons/_common.html.erb
+++ b/app/views/world_wide_taxons/_common.html.erb
@@ -29,8 +29,7 @@
   <% end %>
   <%= render "govuk_publishing_components/components/phase_banner", {
     message: beta_banner_message,
-    phase: "beta",
-    ga4_tracking: true,
+    phase: "beta"
   } %>
   <%= render "govuk_publishing_components/components/breadcrumbs", {
     breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,

--- a/app/views/world_wide_taxons/accordion.html.erb
+++ b/app/views/world_wide_taxons/accordion.html.erb
@@ -42,7 +42,6 @@
           %>
         <% end %>
         <%= render 'govuk_publishing_components/components/accordion', {
-          ga4_tracking: true,
           items: items
         } %>
       </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

Also includes a slight tweak to the past prime ministers page (e.g. https://www.gov.uk/government/history/past-prime-ministers/tony-blair) where the related navigation component was incorrectly wrapped in an opening (but no closing) `<p>` tag - this has been removed as unnecessary.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
