### PR TITLE
Update action link data option

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -37,25 +37,6 @@
           </div>
         </div>
       </div>
-
-      <div class="govuk-grid-row covid__action-link-wrapper">
-        <div class="govuk-grid-column-two-thirds">
-          <%= render 'govuk_publishing_components/components/action_link', {
-            blue_arrow: true,
-            href: header["link"]["href"],
-            text: header["link"]["link_text"],
-            subtext: header["link"]["subtext"],
-            mobile_subtext: true,
-            nowrap_text: header["link"]["link_nowrap_text"],
-            data: {
-              module: "gem-track-click",
-              track_category: "pageElementInteraction",
-              track_action: "Header",
-              track_label: header["link"]["href"]
-            }
-          } %>
-        </div>
-      </div>
     </div>
   </div>
 </header>

--- a/app/views/coronavirus_landing_page/components/shared/_section.html.erb
+++ b/app/views/coronavirus_landing_page/components/shared/_section.html.erb
@@ -16,7 +16,7 @@
             href: item["url"],
             text: item["label"],
             margin_bottom: 1,
-            data: {
+            data_attributes: {
               track_category: "pageElementInteraction",
               track_action: "AccordionFeatureClick",
               track_label: item["url"],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Removes one unneeded instance of the action link component, and updates the options used on another. See individual commits for details.

## Why
The `data` option on this component is going to be removed and replaced with `data_attributes`.

## Visual changes
None.
