### PR TITLE
Use medium_resolution_url and high_resolution_url instead of constructing image urls based on size

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -8,14 +8,6 @@ module OrganisationHelper
     I18n.t("organisations.type.#{organisation_type}", default: I18n.t("organisations.type.other"))
   end
 
-  def image_url_by_size(image_url, size)
-    image_url_array = image_url.split("/")
-    image_by_size_name = "s#{size}_" + image_url_array[-1]
-    image_url_array[-1] = image_by_size_name
-
-    image_url_array.join("/")
-  end
-
   def search_results_to_documents(search_results, organisation, include_metadata: true)
     {
       brand: (organisation.brand if organisation.is_live?),

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -98,15 +98,16 @@ module Organisations
 
     def featured_news(featured, first_featured: false)
       news_stories = []
-      image_size = first_featured ? 712 : 465
 
       featured.each do |news|
         date = Date.parse(news["public_updated_at"]) if news["public_updated_at"]
         text = I18n.t("shared.schema_name.#{news['document_type']&.parameterize(separator: '_')}", count: 1, default: news["document_type"]) if news["document_type"]
+        image_src = first_featured ? news["image"]["high_resolution_url"] : news["image"]["medium_resolution_url"]
+        image_src ||= news["image"]["url"]
 
         news_stories << {
           href: news["href"],
-          image_src: image_url_by_size(news["image"]["url"], image_size),
+          image_src:,
           image_alt: news["image"]["alt_text"],
           context: {
             date:,

--- a/spec/fixtures/content_store/world_location_news.json
+++ b/spec/fixtures/content_store/world_location_news.json
@@ -10,7 +10,9 @@
       {
         "href": "https://www.gov.uk/somewhere",
         "image": {
-          "url": "https://www.gov.uk/someimage.png",
+          "url": "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/someimage.png",
+          "medium_resolution_url": "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_someimage.png",
+          "high_resolution_url": "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_someimage.png",
           "alt_text": "Alt text for the image"
         },
         "title": "A document related to this location",
@@ -21,7 +23,9 @@
       {
         "href": "https://www.gov.uk/somewhere-without-an-update-date",
         "image": {
-          "url": "https://www.gov.uk/someimage2.png",
+          "url": "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/someimage2.png",
+          "medium_resolution_url": "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_someimage2.png",
+          "high_resolution_url": "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_someimage2.png",
           "alt_text": "Alt text for the second image"
         },
         "title": "A document related to this location with no updated date",

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe WorldLocationNews do
     expect(world_location_news.ordered_featured_documents.first).to eq(
       {
         href: "https://www.gov.uk/somewhere",
-        image_src: "https://www.gov.uk/someimage.png",
+        image_src: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/someimage.png",
         image_alt: "Alt text for the image",
         heading_text: "A document related to this location",
         description: "Very interesting document content. However this goes over the 160 character limit so when displayed this should be truncated in order to display the content...",
@@ -32,7 +32,7 @@ RSpec.describe WorldLocationNews do
     expect(world_location_news.ordered_featured_documents.second).to eq(
       {
         href: "https://www.gov.uk/somewhere-without-an-update-date",
-        image_src: "https://www.gov.uk/someimage2.png",
+        image_src: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/someimage2.png",
         image_alt: "Alt text for the second image",
         heading_text: "A document related to this location with no updated date",
         description: "Very interesting document content.",

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Organisations::DocumentsPresenter do
     let(:documents) { organisation_with_featured_documents["details"]["ordered_featured_documents"] }
     let(:documents_of_no_10) { organisation_with_featured_documents_and_is_no_10["details"]["ordered_featured_documents"] }
     let(:documents_presenter) { presenter_from_organisation_hash(organisation_with_featured_documents) }
+    let(:documents_presenter_with_missing_urls) { presenter_from_organisation_hash(organisation_with_featured_documents_and_missing_urls) }
     let(:documents_presenter_no_10) { presenter_from_organisation_hash(organisation_with_featured_documents_and_is_no_10) }
     let(:no_documents_presenter) { presenter_from_organisation_hash(organisation_with_no_documents) }
 
@@ -24,7 +25,7 @@ RSpec.describe Organisations::DocumentsPresenter do
         expected = [
           {
             href: "/government/news/new-head-of-the-serious-fraud-office-announced",
-            image_src: "https://assets.publishing.service.gov.uk/s465_jeremy.jpg",
+            image_src: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_jeremy.jpg",
             image_alt: "Attorney General Jeremy Wright QC MP",
             context: {
               date: Date.parse(time_stamps[0]),
@@ -39,7 +40,7 @@ RSpec.describe Organisations::DocumentsPresenter do
           },
           {
             href: "/government/news/new-head-of-a-different-office-announced",
-            image_src: "https://assets.publishing.service.gov.uk/s465_john.jpg",
+            image_src: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_john.jpg",
             image_alt: "John Someone MP",
             context: {
               date: Date.parse(time_stamps[1]),
@@ -61,7 +62,7 @@ RSpec.describe Organisations::DocumentsPresenter do
       time_stamp = documents.first["public_updated_at"]
       expected = {
         href: "/government/news/new-head-of-the-serious-fraud-office-announced",
-        image_src: "https://assets.publishing.service.gov.uk/s712_jeremy.jpg",
+        image_src: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_jeremy.jpg",
         image_alt: "Attorney General Jeremy Wright QC MP",
         context: {
           date: Date.parse(time_stamp),
@@ -76,11 +77,17 @@ RSpec.describe Organisations::DocumentsPresenter do
       expect(documents_presenter.first_featured_news).to eq(expected)
     end
 
+    it "formats the main large news story with url field when high_resolution_url is not provided" do
+      expected = "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/jeremy.jpg"
+
+      expect(documents_presenter_with_missing_urls.first_featured_news[:image_src]).to eq(expected)
+    end
+
     it "formats the remaining news stories correctly" do
       time_stamp = documents.last["public_updated_at"]
       expected = [{
         href: "/government/news/new-head-of-a-different-office-announced",
-        image_src: "https://assets.publishing.service.gov.uk/s465_john.jpg",
+        image_src: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_john.jpg",
         image_alt: "John Someone MP",
         context: {
           date: Date.parse(time_stamp),
@@ -92,6 +99,12 @@ RSpec.describe Organisations::DocumentsPresenter do
         heading_level: 3,
       }]
       expect(documents_presenter.remaining_featured_news).to eq(expected)
+    end
+
+    it "formats the remaining news stories with url field when medium_resolution_url is not provided" do
+      expected = "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/john.jpg"
+
+      expect(documents_presenter_with_missing_urls.remaining_featured_news.first[:image_src]).to eq(expected)
     end
 
     it "returns true if there are latest documents" do

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -391,7 +391,9 @@ module OrganisationHelpers
             title: "New head of the Serious Fraud Office announced",
             href: "/government/news/new-head-of-the-serious-fraud-office-announced",
             image: {
-              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/jeremy.jpg",
+              medium_resolution_url: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_jeremy.jpg",
+              high_resolution_url: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_jeremy.jpg",
               alt_text: "Attorney General Jeremy Wright QC MP",
             },
             summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
@@ -402,7 +404,9 @@ module OrganisationHelpers
             title: "New head of a different office announced",
             href: "/government/news/new-head-of-a-different-office-announced",
             image: {
-              url: "https://assets.publishing.service.gov.uk/john.jpg",
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/john.jpg",
+              medium_resolution_url: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_john.jpg",
+              high_resolution_url: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_john.jpg",
               alt_text: "John Someone MP",
             },
             summary: "John Someone appointed new Director of the Other Office ",
@@ -429,7 +433,9 @@ module OrganisationHelpers
             title: "New head of the Serious Fraud Office announced",
             href: "/government/news/new-head-of-the-serious-fraud-office-announced",
             image: {
-              url: "https://assets.publishing.service.gov.uk/jeremy.jpg",
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/jeremy.jpg",
+              medium_resolution_url: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_jeremy.jpg",
+              high_resolution_url: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_jeremy.jpg",
               alt_text: "Attorney General Jeremy Wright QC MP",
             },
             summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
@@ -440,7 +446,49 @@ module OrganisationHelpers
             title: "New head of a different office announced",
             href: "/government/news/new-head-of-a-different-office-announced",
             image: {
-              url: "https://assets.publishing.service.gov.uk/john.jpg",
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/john.jpg",
+              medium_resolution_url: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_john.jpg",
+              high_resolution_url: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_john.jpg",
+              alt_text: "John Someone MP",
+            },
+            summary: "John Someone appointed new Director of the Other Office ",
+            public_updated_at: "2017-06-04T11:30:03.000+01:00",
+            document_type: "Policy paper",
+          },
+        ],
+      },
+    }.with_indifferent_access
+  end
+
+  def organisation_with_featured_documents_and_missing_urls
+    {
+      title: "Attorney General's Office",
+      base_path: "/government/organisations/attorney-generals-office",
+      details: {
+        organisation_govuk_status: {
+          status: "live",
+        },
+        brand: "attorney-generals-office",
+        organisation_featuring_priority: "news",
+        ordered_featured_documents: [
+          {
+            title: "New head of the Serious Fraud Office announced",
+            href: "/government/news/new-head-of-the-serious-fraud-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/jeremy.jpg",
+              medium_resolution_url: "https://assets.publishing.service.gov.uk/media/s465_asset_manager_id/s465_jeremy.jpg",
+              alt_text: "Attorney General Jeremy Wright QC MP",
+            },
+            summary: "Lisa Osofsky appointed new Director of the Serious Fraud Office ",
+            public_updated_at: "2018-06-04T11:30:03.000+01:00",
+            document_type: "Press release",
+          },
+          {
+            title: "New head of a different office announced",
+            href: "/government/news/new-head-of-a-different-office-announced",
+            image: {
+              url: "https://assets.publishing.service.gov.uk/media/original_asset_manager_id/john.jpg",
+              high_resolution_url: "https://assets.publishing.service.gov.uk/media/s712_asset_manager_id/s712_john.jpg",
               alt_text: "John Someone MP",
             },
             summary: "John Someone appointed new Director of the Other Office ",


### PR DESCRIPTION
These changes refer to urls of featured documents for `Organisation` and `WorldLocationNews`. This is due to changes in the way `whitehall` references assets in `asset-manager`, including feature images. Previously `whitehall` would have hardcoded urls in the legacy format of `/government/uploads/system/uploads/featured_image_data/file/:id/:filename` that would make it possible for the various sizes of the same image urls to be guessable by simply prefixing the filename in the url `/s465_filename`. The new behaviour is that each individual image will have its own url containing an ID from `asset-manager`, in the format `media/:id/:filename`.

`WorldLocationNews` only uses the original url so no code changes are required. We have nonetheless updated test data to better reflect the desired shape of the urls. `Organisation` uses `:s712` and `:s465` urls which we are now providing from `whitehall` rather than guessing them.

The `publishing-api` schema allows for 3 fields to be sent: `url`, `medium_resolution_url` and `high_resolution_url`. These changes ensure that the `url` is used where the original image asset is required, the `medium_resolution_url` is used when the `:s465` version is required and the `high_resolution_url` when the `:s712` is required. If additional sized are required, the `whitehall` presenters and `publishing-api` schemas would need to be updated. For now, the 3 allowed fields satisfy the user needs.

Since `url` is the only required field in `publishing-api`, it is used as fallback when the other 2 are not available.

These changes have no impact on how the page looks like for the user.

We intend to release these changes first, followed by the whitehall changes:
1. Deploy collections -> organisation and world location news will expect medium and high res url. No such urls are provided so it falls back to original url. This is a temporary solution while we deploy whitehall. 
2. Migrate all Features in whitehall to use assets (just populate DB with assets, no user-facing changes at this point). 
3. Release whitehall changes that use asset-id based urls and send url, medium-res url, and high-res urls to publishing api -> all new organisations and world location news features will now have the desired image version + modern asset-ID based urls ✅
4. Republish all Organisation and World Location News -> because we have migrated all to use assets, republishing them will ensure they use ID-based urls. All organisations and world location news now have modern urls in the size they expect (original, s712, s465)

We tested this branch in integration. Screenshots of a selection of organisations with original URLs instead of :s712 and :s465, rendering fine ✅

![New organisations with features](https://github.com/alphagov/collections/assets/91544378/4afa7e76-6cd5-4f12-a007-0ed9b5538c03)
New features using temporary original urls

![Existing organisation with s465](https://github.com/alphagov/collections/assets/91544378/836aa0f1-0701-44f6-a132-f3f7cbdaf74d)
Existing features using temporary original urls 


![No10 org features](https://github.com/alphagov/collections/assets/91544378/c0402cd1-2697-43a7-b013-ceedd0ad8311)
Existing organisation (No 10) using temporary original urls  

![Existing World location news with original urls](https://github.com/alphagov/collections/assets/91544378/19542c6c-c37b-4b99-ae41-8b60b92e10f9)
Existing world location news using temporary original urls 

![new world location news feature](https://github.com/alphagov/collections/assets/91544378/c5e2272b-5790-4c45-854a-fb193f67a63c)
New world location news using temporary original urls 

[Trello card](https://trello.com/c/JYIbvFb0/248-feature-to-use-assetids) containing the context of the changes and the release plan
[Whitehall PR](https://github.com/alphagov/whitehall/pull/8570)
[Specific Whitehall changes that provide the medium and high resolution urls](https://github.com/alphagov/whitehall/pull/8570/commits/ea6761676fd5bbb171e90a6a0e0b452bb85e4005)

