### PR TITLE
Add GA4 tracking to browse action link

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -40,6 +40,16 @@
           href: "/check-benefits-financial-support",
           dark_large_icon: true,
           margin_bottom: 7,
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_track_links_only: "",
+            ga4_link: {
+              event_name: "navigation",
+              type: "action",
+              index_link: "1",
+              index_total: "1",
+            }
+          }
         } %>
       </div>
     </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- the action link appears on the [/browse/benefits](https://www.gov.uk/browse/benefits) page to signpost to a highlighted link
- adds GA4 tracking to this link

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/lstNprcf/717-add-tracking-to-action-link
