### PR TITLE
Update 'business' page links

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -59,13 +59,13 @@
               </li>
             <% elsif page.slug == "business" %>
               <li>
-                <%= render "shared/browse_action_link", locals: { text: t("browse.file_your_self_assessment"), href: "/log-in-file-self-assessment-tax-return" } %>
+                <%= render "shared/browse_action_link", locals: { text: t("browse.hmrc_online_services"), href: "/log-in-register-hmrc-online-services" } %>
               </li>
               <li>
-                <%= render "shared/browse_action_link", locals: { text: t("browse.pay_your_self_assessment_tax_bill"), href: "/pay-self-assessment-tax-bill" } %>
+                <%= render "shared/browse_action_link", locals: { text: t("browse.self_assessment_tax_returns"), href: "/self-assessment-tax-returns" } %>
               </li>
               <li>
-                <%= render "shared/browse_action_link", locals: { text: t("browse.employing_people"), href: "/browse/employing-people" } %>
+                <%= render "shared/browse_action_link", locals: { text: t("browse.pay_employers_paye"), href: "/pay-paye-tax" } %>
               </li>
             <% end%>
           </ul>

--- a/config/locales/ar/browse.yml
+++ b/config/locales/ar/browse.yml
@@ -4,9 +4,9 @@ ar:
     all_categories: جميع الفئات
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/az/browse.yml
+++ b/config/locales/az/browse.yml
@@ -4,9 +4,9 @@ az:
     all_categories: Bütün kateqoriyalar
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/be/browse.yml
+++ b/config/locales/be/browse.yml
@@ -4,9 +4,9 @@ be:
     all_categories: Усе катэгорыі
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/bg/browse.yml
+++ b/config/locales/bg/browse.yml
@@ -4,9 +4,9 @@ bg:
     all_categories: Всички категории
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/bn/browse.yml
+++ b/config/locales/bn/browse.yml
@@ -4,9 +4,9 @@ bn:
     all_categories: সকল শ্রেণিবিভাগ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/cs/browse.yml
+++ b/config/locales/cs/browse.yml
@@ -4,9 +4,9 @@ cs:
     all_categories: Všechny kategorie
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/cy/browse.yml
+++ b/config/locales/cy/browse.yml
@@ -4,9 +4,9 @@ cy:
     all_categories: Pob categori
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/da/browse.yml
+++ b/config/locales/da/browse.yml
@@ -4,9 +4,9 @@ da:
     all_categories: Alle kategorier
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/de/browse.yml
+++ b/config/locales/de/browse.yml
@@ -4,9 +4,9 @@ de:
     all_categories: Alle Kategorien
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/dr/browse.yml
+++ b/config/locales/dr/browse.yml
@@ -4,9 +4,9 @@ dr:
     all_categories: تمام کتگوری ها
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/el/browse.yml
+++ b/config/locales/el/browse.yml
@@ -4,9 +4,9 @@ el:
     all_categories: Όλες οι κατηγορίες
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/en/browse.yml
+++ b/config/locales/en/browse.yml
@@ -5,8 +5,8 @@ en:
     popular_tasks: Popular tasks
     topics: Topics
     check_benefits_and_financial_support: Check benefits and financial support you can get
-    file_your_self_assessment: File your Self Assessment tax return online
-    pay_your_self_assessment_tax_bill: Pay your Self Assessment tax bill
-    employing_people: Employing people
+    hmrc_online_services: "HMRC online services: sign in or set up an account"
+    self_assessment_tax_returns: Self Assessment tax returns
+    pay_employers_paye: "Pay employers' PAYE"
     description: Find the government services, forms and accounts you need to use
     title: Services and information

--- a/config/locales/es-419/browse.yml
+++ b/config/locales/es-419/browse.yml
@@ -4,9 +4,9 @@ es-419:
     all_categories: Todas las categorías
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/es/browse.yml
+++ b/config/locales/es/browse.yml
@@ -4,9 +4,9 @@ es:
     all_categories: Todas las categorías
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/et/browse.yml
+++ b/config/locales/et/browse.yml
@@ -4,9 +4,9 @@ et:
     all_categories: Kõik kategooriad
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fa/browse.yml
+++ b/config/locales/fa/browse.yml
@@ -4,9 +4,9 @@ fa:
     all_categories: تمام دسته‌بندی‌ها
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fi/browse.yml
+++ b/config/locales/fi/browse.yml
@@ -4,9 +4,9 @@ fi:
     all_categories: Kaikki kategoriat
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fr/browse.yml
+++ b/config/locales/fr/browse.yml
@@ -4,9 +4,9 @@ fr:
     all_categories: Toutes catégories
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/gd/browse.yml
+++ b/config/locales/gd/browse.yml
@@ -4,9 +4,9 @@ gd:
     all_categories: Gach cineál táirgí
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/gu/browse.yml
+++ b/config/locales/gu/browse.yml
@@ -4,9 +4,9 @@ gu:
     all_categories: તમામ શ્રેણીઓ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/he/browse.yml
+++ b/config/locales/he/browse.yml
@@ -4,9 +4,9 @@ he:
     all_categories: כל הקטגוריות
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hi/browse.yml
+++ b/config/locales/hi/browse.yml
@@ -4,9 +4,9 @@ hi:
     all_categories: सभी वर्ग
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hr/browse.yml
+++ b/config/locales/hr/browse.yml
@@ -4,9 +4,9 @@ hr:
     all_categories: Sve kategorije
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hu/browse.yml
+++ b/config/locales/hu/browse.yml
@@ -4,9 +4,9 @@ hu:
     all_categories: Minden kategória
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hy/browse.yml
+++ b/config/locales/hy/browse.yml
@@ -4,9 +4,9 @@ hy:
     all_categories: Բոլոր կատեգորիաները
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/id/browse.yml
+++ b/config/locales/id/browse.yml
@@ -4,9 +4,9 @@ id:
     all_categories: Semua kategori
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/is/browse.yml
+++ b/config/locales/is/browse.yml
@@ -4,9 +4,9 @@ is:
     all_categories: Allir flokkar
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/it/browse.yml
+++ b/config/locales/it/browse.yml
@@ -4,9 +4,9 @@ it:
     all_categories: Tutte le categorie
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ja/browse.yml
+++ b/config/locales/ja/browse.yml
@@ -4,9 +4,9 @@ ja:
     all_categories: すべてのカテゴリ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ka/browse.yml
+++ b/config/locales/ka/browse.yml
@@ -4,9 +4,9 @@ ka:
     all_categories: ყველა კატეგორია
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/kk/browse.yml
+++ b/config/locales/kk/browse.yml
@@ -4,9 +4,9 @@ kk:
     all_categories: Барлық санаттар
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ko/browse.yml
+++ b/config/locales/ko/browse.yml
@@ -4,9 +4,9 @@ ko:
     all_categories: 모든 범주
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/lt/browse.yml
+++ b/config/locales/lt/browse.yml
@@ -4,9 +4,9 @@ lt:
     all_categories: Visos kategorijos
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/lv/browse.yml
+++ b/config/locales/lv/browse.yml
@@ -4,9 +4,9 @@ lv:
     all_categories: Visas kategorijas
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ms/browse.yml
+++ b/config/locales/ms/browse.yml
@@ -4,9 +4,9 @@ ms:
     all_categories: Semua kategori
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/mt/browse.yml
+++ b/config/locales/mt/browse.yml
@@ -4,9 +4,9 @@ mt:
     all_categories: Kategoriji kollha
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ne/browse.yml
+++ b/config/locales/ne/browse.yml
@@ -4,9 +4,9 @@ ne:
     all_categories:
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/nl/browse.yml
+++ b/config/locales/nl/browse.yml
@@ -4,9 +4,9 @@ nl:
     all_categories: Alle categorieën
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/no/browse.yml
+++ b/config/locales/no/browse.yml
@@ -4,9 +4,9 @@
     all_categories: Alle kategorier
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pa-pk/browse.yml
+++ b/config/locales/pa-pk/browse.yml
@@ -4,9 +4,9 @@ pa-pk:
     all_categories: سارے گروہ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pa/browse.yml
+++ b/config/locales/pa/browse.yml
@@ -4,9 +4,9 @@ pa:
     all_categories: ਸਾਰੀਆਂ ਸ਼੍ਰੇਣੀਆਂ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pl/browse.yml
+++ b/config/locales/pl/browse.yml
@@ -4,9 +4,9 @@ pl:
     all_categories: Wszystkie kategorie
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ps/browse.yml
+++ b/config/locales/ps/browse.yml
@@ -4,9 +4,9 @@ ps:
     all_categories: ټولې کټګورۍ
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pt/browse.yml
+++ b/config/locales/pt/browse.yml
@@ -4,9 +4,9 @@ pt:
     all_categories: Todas as categorias
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ro/browse.yml
+++ b/config/locales/ro/browse.yml
@@ -4,9 +4,9 @@ ro:
     all_categories: Toate categoriile
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ru/browse.yml
+++ b/config/locales/ru/browse.yml
@@ -4,9 +4,9 @@ ru:
     all_categories: Все категории
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/si/browse.yml
+++ b/config/locales/si/browse.yml
@@ -4,9 +4,9 @@ si:
     all_categories: සියලු ප්රවර්ග
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sk/browse.yml
+++ b/config/locales/sk/browse.yml
@@ -4,9 +4,9 @@ sk:
     all_categories: Všetky kategórie
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sl/browse.yml
+++ b/config/locales/sl/browse.yml
@@ -4,9 +4,9 @@ sl:
     all_categories: Vse kategorije
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/so/browse.yml
+++ b/config/locales/so/browse.yml
@@ -4,9 +4,9 @@ so:
     all_categories: Dhamaan qeybaha
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sq/browse.yml
+++ b/config/locales/sq/browse.yml
@@ -4,9 +4,9 @@ sq:
     all_categories: Të gjitha kategoritë
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sr/browse.yml
+++ b/config/locales/sr/browse.yml
@@ -4,9 +4,9 @@ sr:
     all_categories: Sve kategorije
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sv/browse.yml
+++ b/config/locales/sv/browse.yml
@@ -4,9 +4,9 @@ sv:
     all_categories: Alla kategorier
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sw/browse.yml
+++ b/config/locales/sw/browse.yml
@@ -4,9 +4,9 @@ sw:
     all_categories: Aina zote
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ta/browse.yml
+++ b/config/locales/ta/browse.yml
@@ -4,9 +4,9 @@ ta:
     all_categories: அனைத்து வகையினங்கள்
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/th/browse.yml
+++ b/config/locales/th/browse.yml
@@ -4,9 +4,9 @@ th:
     all_categories: ทุกหมวดหมู่
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/tk/browse.yml
+++ b/config/locales/tk/browse.yml
@@ -4,9 +4,9 @@ tk:
     all_categories: Ähli toparlar
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/tr/browse.yml
+++ b/config/locales/tr/browse.yml
@@ -4,9 +4,9 @@ tr:
     all_categories: Tüm kategoriler
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/uk/browse.yml
+++ b/config/locales/uk/browse.yml
@@ -4,9 +4,9 @@ uk:
     all_categories: Всі категорії
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ur/browse.yml
+++ b/config/locales/ur/browse.yml
@@ -4,9 +4,9 @@ ur:
     all_categories: تمام زمرہ جات
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/uz/browse.yml
+++ b/config/locales/uz/browse.yml
@@ -4,9 +4,9 @@ uz:
     all_categories: Барча тоифалар
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/vi/browse.yml
+++ b/config/locales/vi/browse.yml
@@ -4,9 +4,9 @@ vi:
     all_categories: Tất cả danh mục
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/yi/browse.yml
+++ b/config/locales/yi/browse.yml
@@ -4,9 +4,9 @@ yi:
     all_categories:
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh-hk/browse.yml
+++ b/config/locales/zh-hk/browse.yml
@@ -4,9 +4,9 @@ zh-hk:
     all_categories: 所有種類
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh-tw/browse.yml
+++ b/config/locales/zh-tw/browse.yml
@@ -4,9 +4,9 @@ zh-tw:
     all_categories: 所有類別
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh/browse.yml
+++ b/config/locales/zh/browse.yml
@@ -4,9 +4,9 @@ zh:
     all_categories: 全部分类
     check_benefits_and_financial_support:
     description:
-    employing_people:
-    file_your_self_assessment:
-    pay_your_self_assessment_tax_bill:
+    hmrc_online_services:
+    pay_employers_paye:
     popular_tasks:
+    self_assessment_tax_returns:
     title:
     topics:


### PR DESCRIPTION
## What

Update 'business' page links

## Why

> They should be:
> - [HMRC online services: sign in or set up an account](https://www.gov.uk/log-in-register-hmrc-online-services)
> - [Self Assessment tax returns](https://www.gov.uk/self-assessment-tax-returns)
> - [Pay employers' PAYE](https://www.gov.uk/pay-paye-tax)