### PR TITLE
Dry up Recruitment Banner logic

### DIFF
--- a/app/helpers/recruitment_banner_helper.rb
+++ b/app/helpers/recruitment_banner_helper.rb
@@ -1,0 +1,27 @@
+module RecruitmentBannerHelper
+  def recruitment_banner
+    return false if recruitment_banners.nil?
+
+    current_path = request.path
+
+    recruitment_banners.find do |banner|
+      next unless valid?(banner)
+
+      banner["page_paths"]&.include?(current_path)
+    end
+  end
+
+  def recruitment_banners
+    recruitment_banners_urls_file_path = Rails.root.join("lib/data/recruitment_banners.yml")
+    recruitment_banners_data = YAML.load_file(recruitment_banners_urls_file_path)
+    recruitment_banners_data["banners"]
+  end
+
+  def valid?(banner)
+    required_fields.select { |field| banner[field].present? } == required_fields
+  end
+
+  def required_fields
+    %w[survey_url suggestion_text suggestion_link_text page_paths]
+  end
+end

--- a/app/views/shared/_intervention_banner.html.erb
+++ b/app/views/shared/_intervention_banner.html.erb
@@ -1,0 +1,10 @@
+<% if recruitment_banner.present? %>
+  <div class="govuk-width-container govuk-!-margin-top-4">
+    <%= render "govuk_publishing_components/components/intervention", {
+      new_tab: true,
+      suggestion_text: recruitment_banner["suggestion_text"],
+      suggestion_link_text: recruitment_banner["suggestion_link_text"],
+      suggestion_link_url: recruitment_banner["survey_url"],
+    } %>
+  </div>
+<% end %>

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -1,0 +1,11 @@
+# Example usage of adding a banner to the banners list:
+
+  # - name: Banner 1
+  #   suggestion_text: "Help improve GOV.UK"
+  #   suggestion_link_text: "Take part in user research"
+  #   survey_url: https://google.com
+  #   page_paths: 
+  #     - /
+  #     - /foreign-travel-advice
+
+banners:

--- a/spec/fixtures/recruitment_banners.yml
+++ b/spec/fixtures/recruitment_banners.yml
@@ -1,0 +1,14 @@
+banners: 
+  - name: Banner 1
+    suggestion_text: "Help improve GOV.UK"
+    suggestion_link_text: "Take part in user research"
+    survey_url: https://google.com
+    page_paths: 
+      - /
+
+  - name: Banner 2
+    suggestion_text: "Help improve GOV.UK"
+    suggestion_link_text: "Take part in user research"
+    survey_url: https://google.com
+    page_paths: 
+      - /some_path

--- a/spec/helpers/recruitment_banner_helper_test.rb
+++ b/spec/helpers/recruitment_banner_helper_test.rb
@@ -1,0 +1,51 @@
+equire "test_helper"
+
+class RecruitmentBannerHelperTest < ActionView::TestCase
+  include RecruitmentBannerHelper
+
+  def setup
+    @recruitment_banners_data = YAML.load_file(Rails.root.join("test/fixtures/recruitment_banners.yml"))
+  end
+
+  def request
+    OpenStruct.new(path: "/")
+  end
+
+  def recruitment_banners
+    @recruitment_banners_data["banners"]
+  end
+
+  test "recruitment_banner returns banners that include the current url" do
+    actual_banners = recruitment_banner
+
+    expected_banners =
+      {
+        "name" => "Banner 1",
+        "suggestion_text" => "Help improve GOV.UK",
+        "suggestion_link_text" => "Take part in user research",
+        "survey_url" => "https://google.com",
+        "page_paths" => ["/"],
+      }
+    assert_equal expected_banners, actual_banners
+  end
+
+  test "recruitment_banners yaml structure is valid" do
+    @recruitment_banners_data = YAML.load_file(Rails.root.join("lib/data/recruitment_banners.yml"))
+
+    if @recruitment_banners_data["banners"].present?
+      recruitment_banners.each do |banner|
+        assert banner.key?("suggestion_text"), "Banner is missing 'suggestion_text' key"
+        assert_not banner["suggestion_text"].blank?, "'suggestion_text' key should not be blank"
+
+        assert banner.key?("suggestion_link_text"), "Banner is missing 'suggestion_link_text' key"
+        assert_not banner["suggestion_link_text"].blank?, "'suggestion_link_text' key should not be blank"
+
+        assert banner.key?("survey_url"), "Banner is missing 'survey_url' key"
+        assert_not banner["survey_url"].blank?, "'survey_url' key should not be blank"
+
+        assert banner.key?("page_paths"), "Banner is missing 'page_paths' key"
+        assert_not banner["page_paths"].blank?, "'page_paths' key should not be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


What we want to closely follow: https://github.com/alphagov/frontend/pull/3890

## How
To add a yml file and dry up the code to make it easier to update banners

Only caveat is you will need to add:

`<%= render partial: 'shared/intervention_banner' %>` to the view you want the banner to be shown on 
and add `include RecruitmentBannerHelper` to the needed controller