### PR TITLE
Details component tracking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.1.1)
+    govuk_publishing_components (37.2.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -286,14 +286,14 @@ GEM
     multi_test (1.1.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
-    net-imap (0.4.9)
+    net-imap (0.4.9.1)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.4.0)
+    net-smtp (0.4.0.1)
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
@@ -530,7 +530,7 @@ GEM
       racc
     parslet (2.0.0)
     plek (5.0.0)
-    prometheus_exporter (2.0.8)
+    prometheus_exporter (2.1.0)
       webrick
     pry (0.14.1)
       coderay (~> 1.1)
@@ -541,7 +541,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (5.0.4)
-    puma (6.4.1)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (3.0.8)
@@ -600,7 +600,7 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     regexp_parser (2.8.3)
-    reline (0.4.1)
+    reline (0.4.2)
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)

--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -56,6 +56,16 @@ module Organisations
       }
     end
 
+    def organisations_with_works_with_statement
+      count = 0
+      all_organisations.each do |_organisation_type, organisations|
+        organisations.each do |organisation|
+          count += 1 if works_with_statement(organisation)
+        end
+      end
+      count
+    end
+
     def filter_not_joining(organisations)
       organisations.filter do |organisation|
         organisation["govuk_status"] != "joining"

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -54,6 +54,10 @@
               <div class="govuk-!-margin-bottom-3">
                 <%= render "govuk_publishing_components/components/details", {
                   title: @presented_organisations.works_with_statement(organisation),
+                  ga4_attributes: {
+                    index_section_count: number_of_details_components,
+                    section: organisation["title"],
+                  },
                   summary_aria_attributes: {
                     label: "#{organisation["title"]} #{@presented_organisations.works_with_statement(organisation)}"
                   }

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -28,7 +28,8 @@
 
   <div class="organisations" id="search_results" role="region" aria-label="List of departments, agencies and public bodies">
     <%= render partial: 'organisations_list', locals: {
-      all_organisations: @presented_organisations.all_organisations
+      all_organisations: @presented_organisations.all_organisations,
+      number_of_details_components: @presented_organisations.organisations_with_works_with_statement,
     } %>
   </div>
 </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- changes for tracking details elements on https://www.gov.uk/government/organisations
- tracking for details component is mostly self contained but requires a total of number of details components on the page to be passed for `index_section_count`
- relies upon changes in https://github.com/alphagov/govuk_publishing_components/pull/3786 (do not merge until a new version of the gem is included here with that change)

I've got slightly creative with this beyond the implementation guide by also passing the name of the organisation to the component for the `section` parameter. The reason for this is that `section` defaults to the text of the details summary, which on this page would always be something like `Works with 4 agencies and public bodies` (slightly unhelpful).

![Screenshot 2023-12-22 at 09 31 45](https://github.com/alphagov/collections/assets/861310/faf1cd9a-e172-46b2-8139-1303b2173d70)


## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/xhASj1rp/765-add-tracking-to-details-component
