### PR TITLE
Update 'Get emails' button text on Welsh content to reflect English-only email subscription

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -14,10 +14,17 @@ module Organisations
     end
 
     def subscription_links
+      if special_subscription_link_text?
+        email_signup_link_text = I18n.t("organisations.subscription.email_english_only")
+        email_signup_link_text_locale = t_fallback("organisations.subscription.email_english_only")
+      else
+        email_signup_link_text = I18n.t("organisations.subscription.email")
+        email_signup_link_text_locale = t_fallback("organisations.subscription.email")
+      end
       {
         email_signup_link: "/email-signup?link=#{@org.base_path}",
-        email_signup_link_text: I18n.t("organisations.subscription.email"),
-        email_signup_link_text_locale: t_fallback("organisations.subscription.email"),
+        email_signup_link_text:,
+        email_signup_link_text_locale:,
         brand: @org.brand,
       }
     end
@@ -125,6 +132,10 @@ module Organisations
 
     def has_definite_article?(phrase)
       phrase.downcase.strip[0..2] == "the"
+    end
+
+    def special_subscription_link_text?
+      I18n.locale.to_sym == :cy
     end
 
     def separate_job_links(corporate_information_links)

--- a/config/locales/ar/organisations.yml
+++ b/config/locales/ar/organisations.yml
@@ -90,6 +90,7 @@ ar:
     services_and_information: جميع معلومات وخدمات %{acronym}
     subscription:
       email: احصل على رسائل البريد الإلكتروني
+      email_english_only:
       feed: اشترك في التغذية
     type:
       adhoc_advisory_group: مجموعة استشارية مخصصة

--- a/config/locales/az/organisations.yml
+++ b/config/locales/az/organisations.yml
@@ -90,6 +90,7 @@ az:
     services_and_information: Bütün %{acronym} xidmətləri və məlumatları
     subscription:
       email: E-məktublar alın
+      email_english_only:
       feed: Veb-kanala abunə olun
     type:
       adhoc_advisory_group: Xüsusi məsləhətçilər qrupu

--- a/config/locales/be/organisations.yml
+++ b/config/locales/be/organisations.yml
@@ -90,6 +90,7 @@ be:
     services_and_information: Усе %{acronym} паслугі і інфармацыя
     subscription:
       email: Атрымваць электронныя лісты
+      email_english_only:
       feed: Падпісацца на канал
     type:
       adhoc_advisory_group: Адмысловая кансультацыйная група

--- a/config/locales/bg/organisations.yml
+++ b/config/locales/bg/organisations.yml
@@ -90,6 +90,7 @@ bg:
     services_and_information: Всички услуги и пълната информация на %{acronym}
     subscription:
       email: Получаване на имейли
+      email_english_only:
       feed: Абонирайте се за канал
     type:
       adhoc_advisory_group: Специална консултативна група

--- a/config/locales/bn/organisations.yml
+++ b/config/locales/bn/organisations.yml
@@ -90,6 +90,7 @@ bn:
     services_and_information: সকল %{acronym} পরিষেবা ও তথ্য
     subscription:
       email: ইমেইল পান
+      email_english_only:
       feed: ফিডে সাবস্ক্রাইব করুন
     type:
       adhoc_advisory_group: অ্যাড-হক পরামর্শক গোষ্ঠী

--- a/config/locales/cs/organisations.yml
+++ b/config/locales/cs/organisations.yml
@@ -90,6 +90,7 @@ cs:
     services_and_information: Všechny služby a informace %{akronym}
     subscription:
       email: Získat e-maily
+      email_english_only:
       feed: Přihlásit se k odběru
     type:
       adhoc_advisory_group: Ad-hoc poradní skupina

--- a/config/locales/cy/organisations.yml
+++ b/config/locales/cy/organisations.yml
@@ -90,6 +90,7 @@ cy:
     services_and_information: Pob %{acronym} gwasanaeth a gwybodaeth
     subscription:
       email: I gael e-byst
+      email_english_only: I gael e-byst (Saesneg yn unig)
       feed: Tanysgrifio i'r ffrwd
     type:
       adhoc_advisory_group: Grŵp cynghori ad-hoc

--- a/config/locales/da/organisations.yml
+++ b/config/locales/da/organisations.yml
@@ -90,6 +90,7 @@ da:
     services_and_information: All %{acronym} tjenester og information
     subscription:
       email: Få e-mails
+      email_english_only:
       feed: Abonner på feed
     type:
       adhoc_advisory_group: Ad hoc-rådgivende gruppe

--- a/config/locales/de/organisations.yml
+++ b/config/locales/de/organisations.yml
@@ -90,6 +90,7 @@ de:
     services_and_information: Alle %{acronym} Dienstleistungen und Informationen
     subscription:
       email: Emails erhalten
+      email_english_only:
       feed: Feed abonnieren
     type:
       adhoc_advisory_group: Ad-hoc-Beratungsgruppe

--- a/config/locales/dr/organisations.yml
+++ b/config/locales/dr/organisations.yml
@@ -93,6 +93,7 @@ dr:
     services_and_information: تمام{acronym}%خدمات و اطلاعات
     subscription:
       email: ایمل ها دریافت نمایید
+      email_english_only:
       feed: برای حمایت سبسکرایب نمایید
     type:
       adhoc_advisory_group: گروه مشاورهء موقت

--- a/config/locales/el/organisations.yml
+++ b/config/locales/el/organisations.yml
@@ -90,6 +90,7 @@ el:
     services_and_information: Όλες οι υπηρεσίες και οι πληροφορίες %{acronym}
     subscription:
       email: Λάβετε email
+      email_english_only:
       feed: Εγγραφείτε στη ροή
     type:
       adhoc_advisory_group: Ad-hoc συμβουλευτική ομάδα

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -90,6 +90,7 @@ en:
     services_and_information: All %{acronym} services and information
     subscription:
       email: Get emails
+      email_english_only: Get emails (English only)
       feed: Subscribe to feed
     type:
       adhoc_advisory_group: Ad-hoc advisory group

--- a/config/locales/es-419/organisations.yml
+++ b/config/locales/es-419/organisations.yml
@@ -90,6 +90,7 @@ es-419:
     services_and_information: Todos %{acronym} los servicios e información
     subscription:
       email: Recibir emails
+      email_english_only:
       feed: Suscríbase a la fuente
     type:
       adhoc_advisory_group: Grupo consultivo ad hoc

--- a/config/locales/es/organisations.yml
+++ b/config/locales/es/organisations.yml
@@ -88,6 +88,7 @@ es:
     services_and_information: Todos los servicios e información de %{acrónimo}
     subscription:
       email: Reciba correos electrónicos
+      email_english_only:
       feed: Suscríbase a la fuente
     type:
       adhoc_advisory_group: Grupo consultivo ad hoc

--- a/config/locales/et/organisations.yml
+++ b/config/locales/et/organisations.yml
@@ -90,6 +90,7 @@ et:
     services_and_information: Kõik %{acronym} teenused ja teave
     subscription:
       email: Hangi e-kirju
+      email_english_only:
       feed: Telli voog
     type:
       adhoc_advisory_group: Ajutine nõuanderühm

--- a/config/locales/fa/organisations.yml
+++ b/config/locales/fa/organisations.yml
@@ -90,6 +90,7 @@ fa:
     services_and_information: تمام خدمات و اطلاعات %{acronym}
     subscription:
       email: دریافت ایمیل‌ها
+      email_english_only:
       feed: اشتراک در فید
     type:
       adhoc_advisory_group: گروه مشاوره اختصاصی

--- a/config/locales/fi/organisations.yml
+++ b/config/locales/fi/organisations.yml
@@ -90,6 +90,7 @@ fi:
     services_and_information: Kaikki %{acronym} palvelut ja tiedot
     subscription:
       email: Hanki sähköpostit
+      email_english_only:
       feed: Tilaa syöte
     type:
       adhoc_advisory_group: Ad-hoc-neuvoa-antava ryhmä

--- a/config/locales/fr/organisations.yml
+++ b/config/locales/fr/organisations.yml
@@ -88,6 +88,7 @@ fr:
     services_and_information: Tous les %{acronym} services et informations
     subscription:
       email: Obtenir des courriels
+      email_english_only:
       feed: S'abonner au flux
     type:
       adhoc_advisory_group: Groupe de consultation ad hoc

--- a/config/locales/gd/organisations.yml
+++ b/config/locales/gd/organisations.yml
@@ -90,6 +90,7 @@ gd:
     services_and_information: Gach faisnéis agus seirbhís ó %{acronym}
     subscription:
       email: Faigh r-phost
+      email_english_only:
       feed: Liostáil le fotha
     type:
       adhoc_advisory_group: Grúpa oibre ad hoc

--- a/config/locales/gu/organisations.yml
+++ b/config/locales/gu/organisations.yml
@@ -88,6 +88,7 @@ gu:
     services_and_information: તમામ %{acronym} સેવાઓ અને માહિતી
     subscription:
       email: ઈમેલ્સ મેળવો
+      email_english_only:
       feed: ફીડ માટે સબ્સ્ક્રાઈબ કરો
     type:
       adhoc_advisory_group: એડ-હોક સલાહકાર જૂથ

--- a/config/locales/he/organisations.yml
+++ b/config/locales/he/organisations.yml
@@ -90,6 +90,7 @@ he:
     services_and_information: כל השירותים והמידע של %{acronym}
     subscription:
       email: קבל הודעות דואר אלקטרוני
+      email_english_only:
       feed: הירשם להזנה
     type:
       adhoc_advisory_group: קבוצת ייעוץ אד-הוק

--- a/config/locales/hi/organisations.yml
+++ b/config/locales/hi/organisations.yml
@@ -88,6 +88,7 @@ hi:
     services_and_information: सभी %{acronym} सेवाएं और जानकारी
     subscription:
       email: ईमेल प्राप्त करें
+      email_english_only:
       feed: फीड के लिए सब्स्क्राइब करें
     type:
       adhoc_advisory_group: विशेष सलाहकार समूह

--- a/config/locales/hr/organisations.yml
+++ b/config/locales/hr/organisations.yml
@@ -88,6 +88,7 @@ hr:
     services_and_information: Sve %{acronym} usluge i informacije
     subscription:
       email: Dobijte e -poštu
+      email_english_only:
       feed: Pretplatite se na feed
     type:
       adhoc_advisory_group: Ad-hoc savjetodavna skupina

--- a/config/locales/hu/organisations.yml
+++ b/config/locales/hu/organisations.yml
@@ -90,6 +90,7 @@ hu:
     services_and_information: Minden %{acronym} szolgálatás és információ
     subscription:
       email: E-mailek fogadása
+      email_english_only:
       feed: Feliratkozás a hírcsatornára
     type:
       adhoc_advisory_group: Ad-hoc tanácsadói csoport

--- a/config/locales/hy/organisations.yml
+++ b/config/locales/hy/organisations.yml
@@ -90,6 +90,7 @@ hy:
     services_and_information: Բոլոր %{acronym} ծառայություններն ու տեղեկությունները
     subscription:
       email: Ստանալ էլ․ հաղորդագրություններ
+      email_english_only:
       feed: Բաժանորդագրվել նորություւններին
     type:
       adhoc_advisory_group: Հատուկ խորհրդատվական խումբ

--- a/config/locales/id/organisations.yml
+++ b/config/locales/id/organisations.yml
@@ -90,6 +90,7 @@ id:
     services_and_information: Semua %{acronym} layanan dan informasi
     subscription:
       email: Dapatkan email
+      email_english_only:
       feed: Berlangganan feed
     type:
       adhoc_advisory_group: Grup penasihat ad-hoc

--- a/config/locales/is/organisations.yml
+++ b/config/locales/is/organisations.yml
@@ -90,6 +90,7 @@ is:
     services_and_information: Öll %{acronym} þjónusta og upplýsingar
     subscription:
       email: Fá tölvupósta
+      email_english_only:
       feed: Gerast áskrifandi að straumi
     type:
       adhoc_advisory_group: Sérstakir ráðgjafahópar

--- a/config/locales/it/organisations.yml
+++ b/config/locales/it/organisations.yml
@@ -90,6 +90,7 @@ it:
     services_and_information: Tutti %{acronym} i servizi e le informazioni
     subscription:
       email: Ricevi e-mail
+      email_english_only:
       feed: Iscriviti al feed
     type:
       adhoc_advisory_group: Gruppo di consulenza ad-hoc

--- a/config/locales/ja/organisations.yml
+++ b/config/locales/ja/organisations.yml
@@ -90,6 +90,7 @@ ja:
     services_and_information: すべての%{acronym}サービスと情報
     subscription:
       email: メールを受け取る
+      email_english_only:
       feed: フィードを購読する
     type:
       adhoc_advisory_group: 特別顧問団

--- a/config/locales/ka/organisations.yml
+++ b/config/locales/ka/organisations.yml
@@ -88,6 +88,7 @@ ka:
     services_and_information: ყველა %{acronym} სერვისი და ინფორმაცია
     subscription:
       email: მიიღეთ წერილები
+      email_english_only:
       feed: გამოიწერეთ
     type:
       adhoc_advisory_group: დროებითი საკონსულტაციო ჯგუფი

--- a/config/locales/kk/organisations.yml
+++ b/config/locales/kk/organisations.yml
@@ -90,6 +90,7 @@ kk:
     services_and_information: Барлық %{acronym} қызметтер мен ақпарат
     subscription:
       email: Электрондық хаттарды алу
+      email_english_only:
       feed: Арнаға жазылу
     type:
       adhoc_advisory_group: Арнайы кеңес тобы

--- a/config/locales/ko/organisations.yml
+++ b/config/locales/ko/organisations.yml
@@ -90,6 +90,7 @@ ko:
     services_and_information: 모든 %{acronym} 서비스 및 정보
     subscription:
       email: 이메일 받기
+      email_english_only:
       feed: 피드로 구독하기
     type:
       adhoc_advisory_group: 임시 자문단

--- a/config/locales/lt/organisations.yml
+++ b/config/locales/lt/organisations.yml
@@ -90,6 +90,7 @@ lt:
     services_and_information: Visos %{acronym} paslaugos ir informacija
     subscription:
       email: Gauti el. laiškus
+      email_english_only:
       feed: Prenumeruoti srautą
     type:
       adhoc_advisory_group: Ad-hoc konsultacinė grupė

--- a/config/locales/lv/organisations.yml
+++ b/config/locales/lv/organisations.yml
@@ -90,6 +90,7 @@ lv:
     services_and_information: Visi %{acronym} pakalpojumi un informācija
     subscription:
       email: Saņemt e-pasta ziņojumus
+      email_english_only:
       feed: Abonēt plūsmu
     type:
       adhoc_advisory_group: Ad hoc padomdevēju grupa

--- a/config/locales/ms/organisations.yml
+++ b/config/locales/ms/organisations.yml
@@ -90,6 +90,7 @@ ms:
     services_and_information: Semua %{acronym} perkhidmatan dan maklumat
     subscription:
       email: Dapatkan e-mel
+      email_english_only:
       feed: Langgani siaran maklumat
     type:
       adhoc_advisory_group: Kumpulan penasihat ad hoc

--- a/config/locales/mt/organisations.yml
+++ b/config/locales/mt/organisations.yml
@@ -88,6 +88,7 @@ mt:
     services_and_information: Is-servizzi u l-informazzjoni %{acronym} kollha
     subscription:
       email: Irċievi l-imejls
+      email_english_only:
       feed: Abbona għall-feed
     type:
       adhoc_advisory_group: Grupp konsultattiv ad-hoc

--- a/config/locales/ne/organisations.yml
+++ b/config/locales/ne/organisations.yml
@@ -88,6 +88,7 @@ ne:
     services_and_information:
     subscription:
       email:
+      email_english_only:
       feed:
     type:
       adhoc_advisory_group:

--- a/config/locales/nl/organisations.yml
+++ b/config/locales/nl/organisations.yml
@@ -90,6 +90,7 @@ nl:
     services_and_information: Alle %{acronym} diensten en informatie
     subscription:
       email: Ontvang e-mails
+      email_english_only:
       feed: Abonneren op feed
     type:
       adhoc_advisory_group: Ad hoc adviesgroep

--- a/config/locales/no/organisations.yml
+++ b/config/locales/no/organisations.yml
@@ -90,6 +90,7 @@
     services_and_information: Alle %{akronym}-tjenester og informasjon
     subscription:
       email: Få e-post
+      email_english_only:
       feed: Abonner på feed
     type:
       adhoc_advisory_group: Ad-hoc rådgivende gruppe

--- a/config/locales/pa-pk/organisations.yml
+++ b/config/locales/pa-pk/organisations.yml
@@ -92,6 +92,7 @@ pa-pk:
     services_and_information: ساریاں {acronym}% خدمات تے معلومات
     subscription:
       email: ای میل حاصل کرو
+      email_english_only:
       feed: جواب لین لئی سبسکرائب کرو
     type:
       adhoc_advisory_group: ایڈہاک ایڈوائزری گروپ

--- a/config/locales/pa/organisations.yml
+++ b/config/locales/pa/organisations.yml
@@ -90,6 +90,7 @@ pa:
     services_and_information: ਸਾਰੀਆਂ %{acronym} ਸੇਵਾਵਾਂ ਅਤੇ ਜਾਣਕਾਰੀ
     subscription:
       email: ਈਮੇਲਾਂ ਪ੍ਰਾਪਤ ਕਰੋ
+      email_english_only:
       feed: ਫੀਡ ਦੇ ਗਾਹਕ ਬਣੋ
     type:
       adhoc_advisory_group: ਐਡਹਾਕ ਸਲਾਹਕਾਰ ਸਮੂਹ

--- a/config/locales/pl/organisations.yml
+++ b/config/locales/pl/organisations.yml
@@ -90,6 +90,7 @@ pl:
     services_and_information: Wszystkie usługi i informacje %{acronym}
     subscription:
       email: Otrzymuj wiadomości e-mail
+      email_english_only:
       feed: Subskrybuj kanał
     type:
       adhoc_advisory_group: Doraźna grupa doradcza

--- a/config/locales/ps/organisations.yml
+++ b/config/locales/ps/organisations.yml
@@ -90,6 +90,7 @@ ps:
     services_and_information: ټول %{acronym} خدمتونه او معلومات
     subscription:
       email: بریښنالیکونه ترلاسه کړئ
+      email_english_only:
       feed: فیډ کې ګډون وکړئ
     type:
       adhoc_advisory_group: د عادلانه مشورتي ګروپ

--- a/config/locales/pt/organisations.yml
+++ b/config/locales/pt/organisations.yml
@@ -90,6 +90,7 @@ pt:
     services_and_information: Todos os serviços e informações de %{acronym}
     subscription:
       email: Obter e-mails
+      email_english_only:
       feed: Subscrever o feed
     type:
       adhoc_advisory_group: Grupo consultivo ad-hoc

--- a/config/locales/ro/organisations.yml
+++ b/config/locales/ro/organisations.yml
@@ -90,6 +90,7 @@ ro:
     services_and_information: Toate serviciile și informațiile de la %{acronym}
     subscription:
       email: Primiți e-mailuri
+      email_english_only:
       feed: Abonați-vă la flux
     type:
       adhoc_advisory_group: Grup consultativ ad-hoc

--- a/config/locales/ru/organisations.yml
+++ b/config/locales/ru/organisations.yml
@@ -88,6 +88,7 @@ ru:
     services_and_information: Все услуги и информация
     subscription:
       email: Получите электронные адреса
+      email_english_only:
       feed: Подписывайте на веб-канал
     type:
       adhoc_advisory_group: Специальная консультативная группа

--- a/config/locales/si/organisations.yml
+++ b/config/locales/si/organisations.yml
@@ -90,6 +90,7 @@ si:
     services_and_information: සියලු %{acronym} සේවා සහ තොරතුරු
     subscription:
       email: විද්‍යුත් තැපෑල් ලබා ගන්න
+      email_english_only:
       feed: පෝෂණය කිරීමට දායක වන්න
     type:
       adhoc_advisory_group: තත්කාර්ය උපදේශක කණ්ඩායම

--- a/config/locales/sk/organisations.yml
+++ b/config/locales/sk/organisations.yml
@@ -90,6 +90,7 @@ sk:
     services_and_information: Všetky %{acronym} služby a informácie
     subscription:
       email: Dostávať e-maily
+      email_english_only:
       feed: Prihlásiť sa k odberu
     type:
       adhoc_advisory_group: Ad hoc poradná skupina

--- a/config/locales/sl/organisations.yml
+++ b/config/locales/sl/organisations.yml
@@ -90,6 +90,7 @@ sl:
     services_and_information: Vse %{acronym} storitve in informacije
     subscription:
       email: Prejemajte e-sporočila
+      email_english_only:
       feed: Naročite se na novice
     type:
       adhoc_advisory_group: Ad-hoc svetovalna skupina

--- a/config/locales/so/organisations.yml
+++ b/config/locales/so/organisations.yml
@@ -90,6 +90,7 @@ so:
     services_and_information: Dhamaan %{acronym} adeegyada iyo macluumaadka
     subscription:
       email: Hel iimaylada
+      email_english_only:
       feed: Ku xidhnow warka
     type:
       adhoc_advisory_group: Kooxda latalinta kadiska ah

--- a/config/locales/sq/organisations.yml
+++ b/config/locales/sq/organisations.yml
@@ -88,6 +88,7 @@ sq:
     services_and_information: Të gjitha %{acronym} shërbimet dhe informacionin
     subscription:
       email: Merr emaile
+      email_english_only:
       feed: Abonohu për njoftime
     type:
       adhoc_advisory_group: Grupi këshillues ad-hoc

--- a/config/locales/sr/organisations.yml
+++ b/config/locales/sr/organisations.yml
@@ -90,6 +90,7 @@ sr:
     services_and_information: Sve %{acronym} usluge i informacije
     subscription:
       email: Želim da dobijam e-poruke
+      email_english_only:
       feed: Pretplatite se na fid
     type:
       adhoc_advisory_group: Namenske grupe za savetovanje

--- a/config/locales/sv/organisations.yml
+++ b/config/locales/sv/organisations.yml
@@ -90,6 +90,7 @@ sv:
     services_and_information: Alla %{acronym} tjänster och information
     subscription:
       email: Få e-post
+      email_english_only:
       feed: Prenumerera på flöde
     type:
       adhoc_advisory_group: Rådgivande ad hoc-grupp

--- a/config/locales/sw/organisations.yml
+++ b/config/locales/sw/organisations.yml
@@ -90,6 +90,7 @@ sw:
     services_and_information: Huduma na habari zote za %{acronym}
     subscription:
       email: Pata barua pepe
+      email_english_only:
       feed: Jisajili ili upokee mipasho
     type:
       adhoc_advisory_group: Kikundi cha ushauri kisicho rasmi

--- a/config/locales/ta/organisations.yml
+++ b/config/locales/ta/organisations.yml
@@ -90,6 +90,7 @@ ta:
     services_and_information: அனைத்து %{acronym} சேவைகள் மற்றும் தகவல்கள்
     subscription:
       email: மின்னஞ்சல்களைப் பெறுக
+      email_english_only:
       feed: செய்தியூட்டத்தில் இணைக
     type:
       adhoc_advisory_group: தற்காலிக ஆலோசனைக் குழு

--- a/config/locales/th/organisations.yml
+++ b/config/locales/th/organisations.yml
@@ -90,6 +90,7 @@ th:
     services_and_information: บริการและข้อมูลของ %{acronym} ทั้งหมด
     subscription:
       email: รับอีเมล
+      email_english_only:
       feed: สมัครรับข้อมูลฟีดข่าว
     type:
       adhoc_advisory_group: กลุ่มที่ปรึกษาเฉพาะกิจ

--- a/config/locales/tk/organisations.yml
+++ b/config/locales/tk/organisations.yml
@@ -90,6 +90,7 @@ tk:
     services_and_information: Ähli %{acronym} hyzmatlar we maglumatlar
     subscription:
       email: E-poçtalary alyň
+      email_english_only:
       feed: Goldamak üçin agza boluň
     type:
       adhoc_advisory_group: Aýratyn maslahat beriji topar

--- a/config/locales/tr/organisations.yml
+++ b/config/locales/tr/organisations.yml
@@ -90,6 +90,7 @@ tr:
     services_and_information: Tüm %{acronym} hizmetleri ve bilgisi
     subscription:
       email: E-postalar al
+      email_english_only:
       feed: Yayına abone ol
     type:
       adhoc_advisory_group: Geçici danışma grubu

--- a/config/locales/uk/organisations.yml
+++ b/config/locales/uk/organisations.yml
@@ -90,6 +90,7 @@ uk:
     services_and_information: Усі послуги та інформація %{acronym}
     subscription:
       email: Отримувати електронні листи
+      email_english_only:
       feed: Підпишіться на канал
     type:
       adhoc_advisory_group: Спеціальна консультативна група

--- a/config/locales/ur/organisations.yml
+++ b/config/locales/ur/organisations.yml
@@ -90,6 +90,7 @@ ur:
     services_and_information: "%{acronym} کی تمام سروسز اور معلومات"
     subscription:
       email: ای میلز حاصل کریں
+      email_english_only:
       feed: فیڈ پر سبسکرائب کریں
     type:
       adhoc_advisory_group: ایڈہاک مشاورتی گروپ

--- a/config/locales/uz/organisations.yml
+++ b/config/locales/uz/organisations.yml
@@ -90,6 +90,7 @@ uz:
     services_and_information: Барча %{acronym} хизматлар ва маълумотлар
     subscription:
       email: Электрон манзилларни олиш
+      email_english_only:
       feed: Лентага обуна бўлиш
     type:
       adhoc_advisory_group: Махсус маслаҳат гуруҳи

--- a/config/locales/vi/organisations.yml
+++ b/config/locales/vi/organisations.yml
@@ -90,6 +90,7 @@ vi:
     services_and_information: Tất cả các dịch vụ %{acronym} và thông tin
     subscription:
       email: Nhận email
+      email_english_only:
       feed: Đăng ký nguồn cấp dữ liệu
     type:
       adhoc_advisory_group: Nhóm cố vấn đặc biệt

--- a/config/locales/yi/organisations.yml
+++ b/config/locales/yi/organisations.yml
@@ -88,6 +88,7 @@ yi:
     services_and_information:
     subscription:
       email:
+      email_english_only:
       feed:
     type:
       adhoc_advisory_group:

--- a/config/locales/zh-hk/organisations.yml
+++ b/config/locales/zh-hk/organisations.yml
@@ -88,6 +88,7 @@ zh-hk:
     services_and_information: "%{acronym} 之全部服務及資訊"
     subscription:
       email: 獲取電郵地址
+      email_english_only:
       feed: 訂閱內容
     type:
       adhoc_advisory_group: 特設諮詢小組

--- a/config/locales/zh-tw/organisations.yml
+++ b/config/locales/zh-tw/organisations.yml
@@ -90,6 +90,7 @@ zh-tw:
     services_and_information: 所有 %{acronym} 服務和資訊
     subscription:
       email: 取得電子郵件
+      email_english_only:
       feed: 訂閱提要
     type:
       adhoc_advisory_group: 特設諮詢小組

--- a/config/locales/zh/organisations.yml
+++ b/config/locales/zh/organisations.yml
@@ -88,6 +88,7 @@ zh:
     services_and_information: 全部 %{acronym} 服务和信息
     subscription:
       email: 获取电子邮件
+      email_english_only:
       feed: 订阅推送
     type:
       adhoc_advisory_group: 特别咨询小组


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

# What

Update wording for 'Get emails' button for Welsh content to reflect English only email subscription on the [OSSW page](https://www.gov.uk/government/organisations/office-of-the-secretary-of-state-for-wales "‌"), and also consider whether this would be feasible on other department pages, where Welsh translation is being used.


# Why

To avoid confusion, we want to make sure Welsh users are clear that they won’t receive email subscriptions in Welsh, but English only if subscribed.

[Trello ticket](https://trello.com/c/y7oEYiOp/2305-update-get-emails-button-text-on-welsh-content-to-reflect-english-only-email-subscription-s)
