### PR TITLE
Add Google's 'no image preview' meta tag to organisation index pages

### DIFF
--- a/app/views/organisations/_meta.html.erb
+++ b/app/views/organisations/_meta.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :meta_tags do %>
   <%= tag("meta", name: "description", content: organisation.description) if organisation.description %>
+  <%= tag("meta", name: "robots", content: "max-image-preview:none") %>
   <%= auto_discovery_link_tag(:json, api_organisation_url(organisation.slug), title: organisation.title) %>
   <%= auto_discovery_link_tag(:atom, feed_organisation_url(organisation.slug, format: :atom), title: organisation.title) %>
 <% end %>

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Organisation pages" do
     expect(page).to have_css(".content")
   end
 
-  it "includes description and autodiscovery meta tags" do
+  it "includes description, autodiscovery, and google no image preview meta tags" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
     padded_string =
       "10 Downing Street is the official residence and the office of the British Prime Minister.\
@@ -66,6 +66,7 @@ RSpec.describe "Organisation pages" do
       and to communicate the government’s policies to Parliament, the public and international audiences."
     string = padded_string.gsub("      ", " ")
     expect(page).to have_selector("meta[name='description'][content='#{string}']", visible: :hidden)
+    expect(page).to have_selector("meta[name='robots'][content='max-image-preview:none']", visible: :hidden)
     expect(page).to have_css("link[rel='alternate'][type='application/json'][href$='/api/organisations/prime-ministers-office-10-downing-street']", visible: :hidden)
     expect(page).to have_css("link[rel='alternate'][type='application/atom+xml'][href$='/government/organisations/prime-ministers-office-10-downing-street.atom']", visible: :hidden)
   end


### PR DESCRIPTION
## What
- Adds Google's [max-image-snippet](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#:~:text=max%2Dimage%2Dpreview%3A%20%5Bsetting%5D,-Set%20the%20maximum) meta tag to each organisation's index page. The meta tag's value is set to the value `none`, which should prevent a featured image showing up next to organisation pages on Google Search results.

## Why
- Google seems to be showing some of our organisation pages as ["Rich snippets"](https://www.semrush.com/blog/rich-snippets/). In other words, it's adding an image from the organisation page next to the search result.
- From looking online, it seems that Google decide themselves what image from the page they think is best to feature next to a search result.
- This may be a problem for us due to some examples we've been alerted to. It seems that for some organisations they are taking a photo of someone in the "Related people" section, and using them as the featured image on Google. This may cause concern due to interpretations that can be made by having a person as the featured image for a whole organisation. As well as this, sometimes it grabs one of the Featured images, which could also be an issue depending on what the featured image is.
- You can stop Google from showing an image preview on a search result with the `max-image-snippet` meta tag. Therefore I've added it in this PR.

## Affected search results
- https://www.google.com/search?q=Prime+Minister%27s+Office%2C+10+Downing+Street
- https://www.google.com/search?q=Attorney%20General%27s%20Office
- https://www.google.com/search?q=Cabinet+Office
- https://www.google.com/search?q=Department+for+Culture%2C+Media+%26+Sport
- https://www.google.com/search?q=department+for+environment+food+%26+rural+affairs
- https://www.google.com/search?q=Department+for+Science%2C+Innovation+%26+Technology
- https://www.google.com/search?q=Department+for+Transport
- https://www.google.com/search?q=FCDO
- https://www.google.com/search?q=Foreign%2C+Commonwealth+%26+Development+Office
- https://www.google.com/search?q=HM+Treasury
- https://www.google.com/search?q=Ministry%20of%20Defence
- https://www.google.com/search?q=Office%20of%20the%20Advocate%20General%20for%20Scotland
- https://www.google.com/search?q=Office%20of%20the%20Secretary%20of%20State%20for%20Scotland
- https://www.google.com/search?q=Office%20of%20the%20Secretary%20of%20State%20for%20Wales
- https://www.google.com/search?q=Forestry%20Commission
