### PR TITLE
Add locale strings for call for evidence document type

### DIFF
--- a/config/locales/en/shared.yml
+++ b/config/locales/en/shared.yml
@@ -43,6 +43,12 @@ en:
       business_finance_support_scheme:
         one: Business finance support scheme
         other: Business finance support schemes
+      call_for_evidence:
+        one: Call for evidence
+        other: Calls for evidence
+      call_for_evidence_outcome:
+        one: Call for evidence outcome
+        other: Call for evidence outcomes
       campaign:
         one: Campaign
         other: Campaigns
@@ -52,6 +58,9 @@ en:
       case_study:
         one: Case study
         other: Case studies
+      closed_call_for_evidence:
+        one: Closed call for evidence
+        other: Closed calls for evidence
       closed_consultation:
         one: Closed consultation
         other: Closed consultations
@@ -208,6 +217,9 @@ en:
       official_statistics_announcement:
         one: Official statistics announcement
         other: Official statistics announcements
+      open_call_for_evidence:
+        one: Open call for evidence
+        other: Open calls for evidence
       open_consultation:
         one: Open consultation
         other: Open consultations


### PR DESCRIPTION
This was missed during the original call for evidence implementation, and picked up by a user in this Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5601467

Trello: https://trello.com/c/rmcAajUm
