### PR TITLE
Remove HMRC services and info page

### DIFF
--- a/app/presenters/organisations/header_presenter.rb
+++ b/app/presenters/organisations/header_presenter.rb
@@ -36,13 +36,6 @@ module Organisations
       if org.ordered_featured_links
         links = []
 
-        if has_services_and_information_link?
-          see_more_link = {
-            text: I18n.t("organisations.services_and_information", acronym: org.acronym),
-            path: "/government/organisations/#{org.slug}/services-information",
-          }
-        end
-
         org.ordered_featured_links.each do |link|
           links << {
             text: link["title"],
@@ -54,7 +47,6 @@ module Organisations
           small: org.is_news_organisation?,
           brand: org.brand,
           items: links,
-          see_more_link:,
         }
       end
     end
@@ -107,13 +99,6 @@ module Organisations
           url: "/government/organisations",
         }
       end
-    end
-
-    def has_services_and_information_link?
-      orgs_with_services_and_information_link = %w[
-        hm-revenue-customs
-      ]
-      true if orgs_with_services_and_information_link.include?(org.slug)
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/glTY32Db/2354-archive-and-redirect-the-hmrc-services-and-info-page-s)

This PR removes the HMRC services and info page as part of retiring topic specialist pages. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
