### PR TITLE
Fix empty link in phase banner on worldwide taxon pages

### DIFF
--- a/app/views/world_wide_taxons/_common.html.erb
+++ b/app/views/world_wide_taxons/_common.html.erb
@@ -24,7 +24,7 @@
       rel="noopener noreferrer"
       target="_blank"
     >
-      <%- t("world_wide_taxons.take_the_survey") %>
+      <%= t("world_wide_taxons.take_the_survey") %>
     </a>
   <% end %>
   <%= render "govuk_publishing_components/components/phase_banner", {


### PR DESCRIPTION
This corrects the survey link in the phase banner on worldwide taxon pages. The link doesn't currently render the link text and therefore the link itself is not being rendered. This was picked up in a recent accessibility audit of GOV.UK pages. 

The syntax was originally included [here](https://github.com/alphagov/collections/pull/2406/files#diff-aa447976054d5484b466a903217011826b49fd9ee03f478a36a1d77efb4b8d2aR24) and appears to be an oversight rather than there being some other intended purpose for it.

[Preview of the relevant page](https://collections-pr-3537.herokuapp.com/world/india)

[Trello ticket](https://trello.com/c/kw7gLWE2/852-investigate-empty-link-in-phase-banner-s-m
)


--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
