### PR TITLE
Update Japanese translation of Japanese

### DIFF
--- a/config/locales/ja/shared.yml
+++ b/config/locales/ja/shared.yml
@@ -8,7 +8,7 @@ ja:
     featured: 特徴
     get_emails: このトピックでメールを取得する
     language_direction: ltr
-    language_name: 日本
+    language_name: 日本語
     schema_name:
       aaib_report:
         other: 航空事故調査局報告書


### PR DESCRIPTION
The translation of Japanese (日本語) was mistakenly put in as Japan[日本)

This was requested via [zendesk](https://govuk.zendesk.com/agent/tickets/5644887)
