### PR TITLE
Refactor _topic-list component to _document-navigation-list

### DIFF
--- a/app/assets/stylesheets/components/_document-navigation-list.scss
+++ b/app/assets/stylesheets/components/_document-navigation-list.scss
@@ -1,20 +1,20 @@
 @import "govuk_publishing_components/individual_component_support";
 
-.app-c-topic-list__item {
+.app-c-document-navigation-list__item {
   @include govuk-font(19, $weight: bold);
 }
 
-.app-c-topic-list > li {
+.app-c-document-navigation-list > li {
   // Needed to override `.govuk-list > li`
   margin-bottom: govuk-spacing(2);
 }
 
-.app-c-topic-list--small {
-  .app-c-topic-list__item {
+.app-c-document-navigation-list--small {
+  .app-c-document-navigation-list__item {
     margin-bottom: govuk-spacing(1);
   }
 
-  .app-c-topic-list__link {
+  .app-c-document-navigation-list__link {
     @include govuk-font(16, $weight: bold);
   }
 }

--- a/app/helpers/document_navigation_list_helper.rb
+++ b/app/helpers/document_navigation_list_helper.rb
@@ -1,5 +1,5 @@
-module TopicListHelper
-  def topic_list_item_tracking_attributes(tracking_attributes, title, path, index)
+module DocumentNavigationListHelper
+  def document_navigation_list_item_tracking_attributes(tracking_attributes, title, path, index)
     tracking_attributes.deep_dup.tap do |t|
       t[:track_label] = path
       t[:track_options][:dimension29] = title
@@ -7,7 +7,7 @@ module TopicListHelper
     end
   end
 
-  def topic_list_tracking_attributes(list_count, list_index, category)
+  def document_navigation_list_tracking_attributes(list_count, list_index, category)
     {
       track_category: category,
       track_action: list_index ? "#{list_index + 1}." : "",
@@ -17,27 +17,27 @@ module TopicListHelper
     }
   end
 
-  def topic_list_params(list, tracking_attributes: nil, list_index: nil, category: nil, list_count: nil, list_title: nil)
-    tracking_attributes ||= topic_list_tracking_attributes(list.count, list_index, category)
+  def document_navigation_list_params(list, tracking_attributes: nil, list_index: nil, category: nil, list_count: nil, list_title: nil)
+    tracking_attributes ||= document_navigation_list_tracking_attributes(list.count, list_index, category)
     ga4_data = {}
     ga4_data[:index_section] = list_index + 1 if list_index
     ga4_data[:index_section_count] = list_count if list_count
     ga4_data[:section] = list_title if list_title
 
     {
-      items: topic_list_items(list, tracking_attributes),
+      items: document_navigation_list_items(list, tracking_attributes),
       ga4_data:,
     }
   end
 
 private
 
-  def topic_list_items(list, tracking_attributes)
+  def document_navigation_list_items(list, tracking_attributes)
     list.each_with_index.map do |list_item, list_item_index|
       {
         text: list_item.title,
         path: list_item.base_path,
-        data_attributes: topic_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_item_index),
+        data_attributes: document_navigation_list_item_tracking_attributes(tracking_attributes, list_item.title, list_item.base_path, list_item_index),
       }
     end
   end

--- a/app/views/components/_document_navigation_list.html.erb
+++ b/app/views/components/_document_navigation_list.html.erb
@@ -1,4 +1,4 @@
-<% add_app_component_stylesheet("topic-list") %>
+<% add_app_component_stylesheet("document-navigation-list") %>
 <%
   items ||= []
   see_more_link ||= false
@@ -11,15 +11,15 @@
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)
 
-  ul_classes = %w[govuk-list app-c-topic-list]
-  ul_classes << "app-c-topic-list--small" if small
+  ul_classes = %w[govuk-list app-c-document-navigation-list]
+  ul_classes << "app-c-document-navigation-list--small" if small
   ul_classes << "govuk-!-margin-bottom-6" if margin_bottom
   ul_classes << brand_helper.brand_class if brand
 %>
 <% if items.any? %>
   <%= tag.ul(class: ul_classes, lang: "en", data: ul_data_attributes) do %>
     <% items.each_with_index do |item, index| %>
-      <li class="app-c-topic-list__item">
+      <li class="app-c-document-navigation-list__item">
         <%
           ga4_link_data = ga4_data.empty? ? {} : {
             ga4_link: {
@@ -40,13 +40,13 @@
             item[:path],
             data: {**item[:data_attributes] || {}}.merge(ga4_link_data),
             "aria-label": item[:aria_label],
-            class: "govuk-link govuk-link--no-underline app-c-topic-list__link #{brand_helper.color_class}"
+            class: "govuk-link govuk-link--no-underline app-c-document-navigation-list__link #{brand_helper.color_class}"
           )
         %>
       </li>
     <% end %>
     <% if see_more_link %>
-      <li class="app-c-topic-list__item">
+      <li class="app-c-document-navigation-list__item">
         <%
           ga4_link_data = ga4_data.empty? ? {} : {
             ga4_link: {
@@ -64,7 +64,7 @@
             see_more_link[:text],
             see_more_link[:path],
             data: {**see_more_link[:data_attributes] || {}}.merge(ga4_link_data),
-            class: "govuk-link app-c-topic-list__link #{brand_helper.color_class}"
+            class: "govuk-link app-c-document-navigation-list__link #{brand_helper.color_class}"
           )
         %>
       </li>

--- a/app/views/components/docs/document_navigation_list.yml
+++ b/app/views/components/docs/document_navigation_list.yml
@@ -1,5 +1,5 @@
-name: Topic list
-description: A list of topics
+name: Document Navigation List
+description: A list of documents used in navigation links
 shared_accessibility_criteria:
   - link
 examples:

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -10,7 +10,7 @@
     <% end %>
   <% if @show.corporate_information[:corporate_information_links][:items].any? && !@organisation.is_no_10? %>
     <div class="<%= "organisation__section-border-top" if @organisation.is_promotional_org? %>">
-      <%= render "components/topic_list", @show.corporate_information[:corporate_information_links].merge({ ga4_data: { section: t('organisations.corporate_information', locale: :en) } })  %>
+      <%= render "components/document_navigation_list", @show.corporate_information[:corporate_information_links].merge({ ga4_data: { section: t('organisations.corporate_information', locale: :en) } })  %>
     </div>
   <% end %>
   <% if @show.corporate_information[:job_links][:items].any? && !@organisation.is_no_10? %>
@@ -21,7 +21,7 @@
       font_size: 24,
       lang: t_fallback('organisations.jobs_contracts')
     } %>
-    <%= render "components/topic_list", @show.corporate_information[:job_links].merge({ ga4_data: { section: t('organisations.jobs_contracts', locale: :en) } }) %>
+    <%= render "components/document_navigation_list", @show.corporate_information[:job_links].merge({ ga4_data: { section: t('organisations.jobs_contracts', locale: :en) } }) %>
   <% end %>
 
   <% if @organisation.secondary_corporate_information && !@organisation.is_no_10? %>

--- a/app/views/organisations/_courts_header.html.erb
+++ b/app/views/organisations/_courts_header.html.erb
@@ -12,6 +12,6 @@
 
   <div class="govuk-grid-column-one-third">
     <%= render "govuk_publishing_components/components/translation_nav", @header.translation_links %>
-    <%= render "components/topic_list", @header.ordered_featured_links.merge({ ga4_data: { section: @header.org.title } }) %>
+    <%= render "components/document_navigation_list", @header.ordered_featured_links.merge({ ga4_data: { section: @header.org.title } }) %>
   </div>
 </div>

--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -20,7 +20,7 @@
     <% if @organisation.is_live? %>
       <div class="<%= @header.link_wrapper_class %> organisation__margin-bottom">
         <%= render "govuk_publishing_components/components/translation_nav", @header.translation_links %>
-        <%= render "components/topic_list", @header.ordered_featured_links.merge({ ga4_data: { section: @header.org.title } }) %>
+        <%= render "components/document_navigation_list", @header.ordered_featured_links.merge({ ga4_data: { section: @header.org.title } }) %>
       </div>
     <% end %>
   </div>

--- a/app/views/organisations/_standard_org_foi_profiles.html.erb
+++ b/app/views/organisations/_standard_org_foi_profiles.html.erb
@@ -8,6 +8,6 @@
         padding: true,
         margin_bottom: 3
     } %>
-    <%= render "components/topic_list", @show.high_profile_groups.merge({ ga4_data: { section: @show.high_profile_groups[:title] } }) %>
+    <%= render "components/document_navigation_list", @show.high_profile_groups.merge({ ga4_data: { section: @show.high_profile_groups[:title] } }) %>
     </section>
 <% end %>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -21,7 +21,7 @@
       } %>
     <% end %>
 
-    <%= render "components/topic_list", {
+    <%= render "components/document_navigation_list", {
         items: @world_location_news.ordered_featured_links,
     } %>
   </div>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,6 +1,6 @@
 APP_STYLESHEETS = {
   "components/_taxon-list.scss" => "components/_taxon-list.css",
-  "components/_topic-list.scss" => "components/_topic-list.css",
+  "components/_document-navigation-list.scss" => "components/_document-navigation-list.css",
   "views/_browse.scss" => "views/_browse.css",
   "views/_bunting.scss" => "views/_bunting.css",
   "views/_covid.scss" => "views/_covid.css",

--- a/spec/components/document_navigation_list_spec.rb
+++ b/spec/components/document_navigation_list_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe "topic_list component", type: :view do
+RSpec.describe "document_navigation_list component", type: :view do
   include ComponentTestHelper
 
   def component_name
-    "topic_list"
+    "document_navigation_list"
   end
 
   let(:simple_item) do
@@ -27,14 +27,14 @@ RSpec.describe "topic_list component", type: :view do
 
   it "renders a list of links" do
     render_component(items: [simple_item])
-    expect(rendered).to have_selector(%(.app-c-topic-list__link[href="#{simple_item[:path]}"]), text: simple_item[:text])
+    expect(rendered).to have_selector(%(.app-c-document-navigation-list__link[href="#{simple_item[:path]}"]), text: simple_item[:text])
   end
 
   it "renders links with data attributes" do
     simple_item[:data_attributes] = { test: "test" }
     render_component(items: [simple_item])
 
-    expect(rendered).to have_selector(".app-c-topic-list__link[data-test='test']")
+    expect(rendered).to have_selector(".app-c-document-navigation-list__link[data-test='test']")
   end
 
   it "sets GA4 data attributes correctly" do
@@ -111,19 +111,19 @@ RSpec.describe "topic_list component", type: :view do
 
   it "renders a see more link" do
     render_component(items: [simple_item], see_more_link:)
-    expect(rendered).to have_selector(".app-c-topic-list__item a[href='/more'][data-test='test']", text: "More")
+    expect(rendered).to have_selector(".app-c-document-navigation-list__item a[href='/more'][data-test='test']", text: "More")
   end
 
   it "adds branding correctly" do
     render_component(items: [simple_item], see_more_link:, brand: "attorney-generals-office")
-    expect(rendered).to have_selector(".app-c-topic-list.brand--attorney-generals-office")
-    expect(rendered).to have_selector(".app-c-topic-list .app-c-topic-list__link.brand__color")
+    expect(rendered).to have_selector(".app-c-document-navigation-list.brand--attorney-generals-office")
+    expect(rendered).to have_selector(".app-c-document-navigation-list .app-c-document-navigation-list__link.brand__color")
     expect(rendered).to have_selector(".brand__color", text: "More")
   end
 
   it "renders small version" do
     render_component(items: [simple_item], small: true)
-    expect(rendered).to have_selector(".app-c-topic-list.app-c-topic-list--small")
+    expect(rendered).to have_selector(".app-c-document-navigation-list.app-c-document-navigation-list--small")
   end
 
   it "renders without margin-bottom by default" do

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -136,18 +136,18 @@ RSpec.describe "Organisation pages" do
     it "does not display them if they are absent from content item" do
       visit "/government/organisations/prime-ministers-office-10-downing-street"
       expect(page).not_to have_css("section#featured-documents")
-      expect(page).not_to have_css(".app-c-topic-list.app-c-topic-list--small")
+      expect(page).not_to have_css(".app-c-document-navigation-list.app-c-document-navigation-list--small")
     end
 
     it "displays them if they are present" do
       visit "/government/organisations/attorney-generals-office"
       expect(page).to have_css("section#featured-documents")
-      expect(page).to have_css(".app-c-topic-list.app-c-topic-list--small .app-c-topic-list__link", text: "Attorney General's guidance to the legal profession")
+      expect(page).to have_css(".app-c-document-navigation-list.app-c-document-navigation-list--small .app-c-document-navigation-list__link", text: "Attorney General's guidance to the legal profession")
 
       visit "/government/organisations/charity-commission"
       expect(page).to have_css("section#featured-documents")
-      expect(page).to have_css(".app-c-topic-list .app-c-topic-list__link", text: "Find a charity")
-      expect(page).not_to have_css(".app-c-topic-list.app-c-topic-list--small")
+      expect(page).to have_css(".app-c-document-navigation-list .app-c-document-navigation-list__link", text: "Find a charity")
+      expect(page).not_to have_css(".app-c-document-navigation-list.app-c-document-navigation-list--small")
     end
   end
 
@@ -340,8 +340,8 @@ RSpec.describe "Organisation pages" do
       visit "/government/organisations/attorney-generals-office"
       expect(page).to have_css("section#high-profile-groups")
       expect(page).to have_css(".gem-c-heading", text: "High profile groups within AGO")
-      expect(page).to have_css(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-1']", text: "High Profile Group 1")
-      expect(page).to have_css(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office-2']", text: "High Profile Group 2")
+      expect(page).to have_css(".app-c-document-navigation-list__link[href='/government/organisations/attorney-generals-office-1']", text: "High Profile Group 1")
+      expect(page).to have_css(".app-c-document-navigation-list__link[href='/government/organisations/attorney-generals-office-2']", text: "High Profile Group 2")
     end
 
     it "does not show section for organisations without high profile groups" do
@@ -370,9 +370,9 @@ RSpec.describe "Organisation pages" do
       visit "/government/organisations/attorney-generals-office"
       expect(page).to have_css("div#corporate-info")
       expect(page).to have_css(".gem-c-heading", text: "Corporate information")
-      expect(page).to have_css(".app-c-topic-list__link[href='/government/organisations/attorney-generals-office/about/complaints-procedure']", text: "Complaints procedure")
+      expect(page).to have_css(".app-c-document-navigation-list__link[href='/government/organisations/attorney-generals-office/about/complaints-procedure']", text: "Complaints procedure")
       expect(page).to have_css(".gem-c-heading", text: "Jobs and contracts")
-      expect(page).to have_css(".app-c-topic-list__link[href='https://www.civilservicejobs.service.gov.uk/csr']", text: "Jobs")
+      expect(page).to have_css(".app-c-document-navigation-list__link[href='https://www.civilservicejobs.service.gov.uk/csr']", text: "Jobs")
     end
 
     it "does not show corporate info pages if data is unavailable" do

--- a/spec/support/courts_pages_helper.rb
+++ b/spec/support/courts_pages_helper.rb
@@ -43,7 +43,7 @@ module CourtPagesHelper
   end
 
   def and_featured_links
-    expect(page).to have_selector(".app-c-topic-list")
+    expect(page).to have_selector(".app-c-document-navigation-list")
   end
 
   def and_the_what_we_do_section


### PR DESCRIPTION
`_topic-list` is a remnant from when we supported specialist topics. However it was used in various other locations to create lists of hyperlinks, so we couldn't outright remove the component. So this refactor renames it for now until it is replaced with a component from govuk-publishing-components in the future.

https://trello.com/c/ws9ZGJtZ/2419-refactor-name-of-topiclist-in-collections-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
