### PR TITLE
Set up DWP user research banner

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,5 +1,6 @@
 class BrowseController < ApplicationController
   slimmer_template "gem_layout_full_width"
+  include RecruitmentBannerHelper
 
   def index
     page = MainstreamBrowsePage.find("/browse")

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,5 +1,6 @@
 class OrganisationsController < ApplicationController
   skip_before_action :set_expiry
+  include RecruitmentBannerHelper
   before_action do
     set_expiry content_item.max_age, public_cache: content_item.public_cache
   end

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -1,5 +1,4 @@
 <% add_view_stylesheet("browse") %>
-
 <% content_for :title, page.title %>
 
 <%= render 'shared/tag_meta', tag: page %>
@@ -19,6 +18,8 @@
     column_two_thirds: true
   } %>
 <% end %>
+
+<%= render partial: 'shared/intervention_banner' %>
 
 <%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
   <h1 class="browse__heading govuk-heading-xl">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,6 +2,7 @@
 
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
+<%= render partial: 'shared/intervention_banner' %>
 <%= render partial: 'header' %>
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',
            schema: :organisation,

--- a/lib/data/recruitment_banners.yml
+++ b/lib/data/recruitment_banners.yml
@@ -9,3 +9,10 @@
   #     - /foreign-travel-advice
 
 banners:
+- name: DWP user research banner
+  suggestion_text: Help improve GOV.UK
+  suggestion_link_text: Take part in user research (opens in a new tab)
+  survey_url: https://forms.office.com/e/CkfCRwdLQj
+  page_paths:
+    - /government/organisations/department-for-work-pensions
+    - /browse/benefits

--- a/spec/features/recruitment_banner_spec.rb
+++ b/spec/features/recruitment_banner_spec.rb
@@ -1,0 +1,43 @@
+require "integration_spec_helper"
+
+RSpec.feature "Research panel banner" do
+  include SearchApiHelpers
+  include OrganisationHelpers
+  include RecruitmentBannerHelper
+
+  scenario "browse pages where we want to display Brand User Research banner" do
+    base_path = "/browse/benefits"
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    schema["base_path"] = base_path
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [base_path], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_selector(".gem-c-intervention")
+  end
+
+  scenario "organisation pages where we want to display Brand User Research banner" do
+    base_path = "/government/organisations/department-for-work-pensions"
+    schema = GovukSchemas::Example.find("organisation", example_name: "tribunal")
+    schema["base_path"] = base_path
+    stub_content_and_search(schema)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to have_selector(".gem-c-intervention")
+  end
+
+  scenario "pages where we don't want to display Brand User Research banner" do
+    schema = GovukSchemas::Example.find("mainstream_browse_page", example_name: "level_2_page")
+    stub_content_store_has_item(schema["base_path"], schema)
+    search_api_has_documents_for_browse_page(schema["content_id"], [schema["base_path"]], page_size: SearchApiSearch::PAGE_SIZE_TO_GET_EVERYTHING)
+
+    visit schema["base_path"]
+
+    expect(page.status_code).to eq(200)
+    expect(page).to_not have_selector(".gem-c-intervention")
+  end
+end


### PR DESCRIPTION
The banner will be added on the following pages:
- [/government/organisations/department-for-work-pensions](https://www.gov.uk/government/organisations/department-for-work-pensions)
![image](https://github.com/alphagov/collections/assets/17481621/7c89cd6a-f19c-4da6-90ce-9950c65a2eb7)

- [/browse/benefits](https://www.gov.uk/browse/benefits)
![image](https://github.com/alphagov/collections/assets/17481621/6e6c44b9-74d1-4b70-8fd2-5203328b0245)

Trello card: https://trello.com/c/zfgadIUN