### PR TITLE
Add the GA4 link tracker to /world and /government/organisations links

### DIFF
--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -22,7 +22,10 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
-      <ol>
+      <ol
+        data-module="ga4-link-tracker"
+        data-ga4-track-links-only
+        data-ga4-link="<%= { event_name: "navigation", type: "filter" }.to_json %>">
         <% organisations.each do |organisation| %>
           <%= content_tag :li, {
             class: "organisations-list__item",

--- a/app/views/world/index.html.erb
+++ b/app/views/world/index.html.erb
@@ -45,7 +45,11 @@
       </div>
 
       <div class="govuk-grid-column-two-thirds">
-        <ol class="world-locations-groups">
+        <ol
+          class="world-locations-groups"
+          data-module="ga4-link-tracker"
+          data-ga4-track-links-only
+          data-ga4-link="<%= { event_name: "navigation", type: "filter" }.to_json %>">
           <% @presented_index.grouped_world_locations.each do |letter, locations| %>
             <div class="world-locations-group" data-filter="inner-block">
               <h3 class="world-locations-group__letter"><%= letter %></h3>

--- a/spec/features/content_store_organisations_spec.rb
+++ b/spec/features/content_store_organisations_spec.rb
@@ -71,6 +71,16 @@ RSpec.feature "Content store organisations" do
     expect(page.has_css?("#toggle_attorney-general-s-office a[href='/government/organisations/hm-crown-prosecution-service-inspectorate']", text: "HM Crown Prosecution Service Inspectorate", visible: false)).to be(true)
   end
 
+  scenario "renders links with GA4 tracking" do
+    ga4_module = "ol[data-module=ga4-link-tracker]"
+    expect(page).to have_css(ga4_module)
+    expect(page).to have_css("ol[data-ga4-track-links-only]")
+
+    ga4_link_data = JSON.parse(page.first(ga4_module)["data-ga4-link"])
+    expect(ga4_link_data["event_name"]).to eq "navigation"
+    expect(ga4_link_data["type"]).to eq "filter"
+  end
+
 private
 
   def organisations_content_hash

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -52,4 +52,14 @@ RSpec.feature "World index page" do
       expect(page).to have_link("The UK Permanent Delegation to the OECD (Organisation for Economic Co-operation and Development)", href: "/world/the-uk-permanent-delegation-to-the-oecd-organisation-for-economic-co-operation-and-development")
     end
   end
+
+  scenario "renders links with GA4 tracking" do
+    ga4_module = "ol[data-module=ga4-link-tracker]"
+    expect(page).to have_css(ga4_module)
+    expect(page).to have_css("ol[data-ga4-track-links-only]")
+
+    ga4_link_data = JSON.parse(page.first(ga4_module)["data-ga4-link"])
+    expect(ga4_link_data["event_name"]).to eq "navigation"
+    expect(ga4_link_data["type"]).to eq "filter"
+  end
 end


### PR DESCRIPTION
## What
Adds the GA4 link tracker to `/government/organisations` and `/world` result links

## Why
https://trello.com/c/NgIag6go/802-add-tracking-filter-search-link-clicks

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
