### PR TITLE
Move UR banner below header on browse page

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -19,8 +19,6 @@
   } %>
 <% end %>
 
-<%= render partial: 'shared/intervention_banner' %>
-
 <%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
   <h1 class="browse__heading govuk-heading-xl">
     <%= page.title %>
@@ -31,6 +29,8 @@
     inverse: true
   } %>
 <% end %>
+
+<%= render partial: 'shared/intervention_banner' %>
 
 <% if display_action_links_for_slug?(page.slug) %>
   <div class="govuk-width-container">


### PR DESCRIPTION
## What

Move UR banner below the header

| Before | After |
|-|-|
|<img width="902" alt="Screenshot 2024-03-20 at 15 14 36" src="https://github.com/alphagov/collections/assets/17908089/d8075a7a-9973-4edb-b5b8-312bd6ac3b44">|<img width="1032" alt="Screenshot 2024-03-20 at 15 14 13" src="https://github.com/alphagov/collections/assets/17908089/634c7eaf-2336-439b-bba3-807e05614853">|


- missed from https://github.com/alphagov/collections/pull/3566

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
