### PR TITLE
Add GA4 focus loss tracker to /world and /government/organisations

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -20,7 +20,16 @@
           },
           name: "search-box",
           id: "filter-organisations-list",
-          controls: "search_results"
+          controls: "search_results",
+          data: {
+            module: "ga4-focus-loss-tracker",
+            ga4_focus_loss: {
+              event_name: "filter",
+              type: "filter",
+              action: "filter",
+              section: t("organisations.index_title", title: @presented_organisations.title, lang: :en)
+            }
+          }
         } %>
       </form>
     </div>

--- a/app/views/world/index.html.erb
+++ b/app/views/world/index.html.erb
@@ -18,7 +18,16 @@
           },
           name: "search-box",
           id: "filter-list",
-          controls: "search_results"
+          controls: "search_results",
+          data: {
+            module: "ga4-focus-loss-tracker",
+            ga4_focus_loss: {
+              event_name: "filter",
+              type: "filter",
+              action: "filter",
+              section: @presented_index.title
+            }
+          }
         } %>
       </form>
     </div>

--- a/spec/features/content_store_organisations_spec.rb
+++ b/spec/features/content_store_organisations_spec.rb
@@ -81,6 +81,17 @@ RSpec.feature "Content store organisations" do
     expect(ga4_link_data["type"]).to eq "filter"
   end
 
+  scenario "renders the filter input box with GA4 tracking" do
+    ga4_module = ".filter-list__form input[data-module=ga4-focus-loss-tracker]"
+    expect(page).to have_css(ga4_module)
+
+    ga4_focus_loss_data = JSON.parse(page.first(ga4_module)["data-ga4-focus-loss"])
+    expect(ga4_focus_loss_data["event_name"]).to eq "filter"
+    expect(ga4_focus_loss_data["type"]).to eq "filter"
+    expect(ga4_focus_loss_data["action"]).to eq "filter"
+    expect(ga4_focus_loss_data["section"]).to eq "Departments, agencies and public bodies"
+  end
+
 private
 
   def organisations_content_hash

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -62,4 +62,15 @@ RSpec.feature "World index page" do
     expect(ga4_link_data["event_name"]).to eq "navigation"
     expect(ga4_link_data["type"]).to eq "filter"
   end
+
+  scenario "renders the filter input box with GA4 tracking" do
+    ga4_module = ".filter-list__form input[data-module=ga4-focus-loss-tracker]"
+    expect(page).to have_css(ga4_module)
+
+    ga4_focus_loss_data = JSON.parse(page.first(ga4_module)["data-ga4-focus-loss"])
+    expect(ga4_focus_loss_data["event_name"]).to eq "filter"
+    expect(ga4_focus_loss_data["type"]).to eq "filter"
+    expect(ga4_focus_loss_data["action"]).to eq "filter"
+    expect(ga4_focus_loss_data["section"]).to eq "Help and services around the world"
+  end
 end


### PR DESCRIPTION
## What
- Adds the `ga4-focus-loss-tracker` to `/world` and `/government/organisations` filter inputs

## Why
- https://trello.com/c/EXuAg9qR/801-add-tracking-filter-search-input