### PR TITLE
Add use_v1 to world_locations_news search links

### DIFF
--- a/app/helpers/document_list_helper.rb
+++ b/app/helpers/document_list_helper.rb
@@ -44,22 +44,9 @@ private
   end
 
   def world_location_news_query_params(content_type, slug)
-    case content_type
-    when :latest
-      {
-        order: "updated-newest",
-        world_locations: [slug],
-      }
-    when :publication
-      {
-        content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency],
-        order: "updated-newest",
-        world_locations: [slug],
-      }
-    else
-      {
-        world_locations: [slug],
-      }
-    end
+    query_params = { world_locations: [slug] }
+    query_params.merge!(order: "updated-newest") if %i[latest publication].include?(content_type)
+    query_params.merge!(content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency]) if content_type == :publication
+    query_params
   end
 end

--- a/app/helpers/document_list_helper.rb
+++ b/app/helpers/document_list_helper.rb
@@ -44,7 +44,12 @@ private
   end
 
   def world_location_news_query_params(content_type, slug)
-    query_params = { world_locations: [slug] }
+    query_params = {
+      world_locations: [slug],
+      # TODO: remove use_v1 once search-api-v2 handles world location news queries for world_locations like
+      #       https://www.gov.uk/search/all?order=updated-newest&world_locations%5B%5D=uk-delegation-to-council-of-europe
+      use_v1: true,
+    }
     query_params.merge!(order: "updated-newest") if %i[latest publication].include?(content_type)
     query_params.merge!(content_purpose_supergroup: %w[guidance_and_regulation policy_and_engagement transparency]) if content_type == :publication
     query_params

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature "World Location News pages" do
 
       within("#latest") do
         latest_documents.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all", href: "/search/all?order=updated-newest&world_locations%5B%5D=mock-country")
+        expect(page).to have_link("See all", href: "/search/all?order=updated-newest&use_v1=true&world_locations%5B%5D=mock-country")
       end
     end
 
@@ -168,17 +168,17 @@ RSpec.feature "World Location News pages" do
 
       within("#our-announcements") do
         related_announcements.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all our announcements", href: "/search/news-and-communications?world_locations%5B%5D=mock-country")
+        expect(page).to have_link("See all our announcements", href: "/search/news-and-communications?use_v1=true&world_locations%5B%5D=mock-country")
       end
 
       within("#our-publications") do
         related_publications.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all our publications", href: "/search/all?content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=policy_and_engagement&content_purpose_supergroup%5B%5D=transparency&order=updated-newest&world_locations%5B%5D=mock-country")
+        expect(page).to have_link("See all our publications", href: "/search/all?content_purpose_supergroup%5B%5D=guidance_and_regulation&content_purpose_supergroup%5B%5D=policy_and_engagement&content_purpose_supergroup%5B%5D=transparency&order=updated-newest&use_v1=true&world_locations%5B%5D=mock-country")
       end
 
       within("#our-statistics") do
         related_statistics.each { |title, link| expect(page).to have_link(title, href: link) }
-        expect(page).to have_link("See all our statistics", href: "/search/research-and-statistics?world_locations%5B%5D=mock-country")
+        expect(page).to have_link("See all our statistics", href: "/search/research-and-statistics?use_v1=true&world_locations%5B%5D=mock-country")
       end
     end
 

--- a/spec/helpers/document_list_helper_spec.rb
+++ b/spec/helpers/document_list_helper_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DocumentListHelper do
 
   context "on a world location news page" do
     it "correctly constructs search urls for different document types" do
-      expected_latest_url = "/search/all?order=updated-newest&world_locations%5B%5D=somewhere"
+      expected_latest_url = "/search/all?order=updated-newest&use_v1=true&world_locations%5B%5D=somewhere"
 
       expected_results = {
         latest: expected_latest_url,


### PR DESCRIPTION
The v2 search api isn't finding any documents for queries like

https://www.gov.uk/search/all?order=updated-newest&world_locations%5B%5D=uk-delegation-to-council-of-europe

This is presumably because it doesn't have the same logic for indexing world locations as v1 did. We should probably fix that and remove the use_v1 flag, but for the short term this is a quick fix for the immediate issue.

This was raised by FCDO on Zendesk[1]

- [1] https://govuk.zendesk.com/agent/tickets/5664229

