### PR TITLE
Prevent organisation latest documents from including the org page

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -46,9 +46,16 @@ module Organisations
     end
 
     def latest_documents
-      @latest_documents ||= Services.cached_search(
+      @latest_documents ||= latest_documents_excluding_org_page
+      search_results_to_documents(@latest_documents, @org)
+    end
+
+  private
+
+    def latest_documents_excluding_org_page
+      documents = Services.cached_search(
         {
-          count: 3,
+          count: 4,
           order: "-public_timestamp",
           filter_organisations: @org.slug,
           fields: %w[title link content_store_document_type public_timestamp],
@@ -56,10 +63,8 @@ module Organisations
         metric_key: "organisations.search.request_time",
       )["results"]
 
-      search_results_to_documents(@latest_documents, @org)
+      documents.reject { |doc| doc["link"] == @org.base_path }.take(3)
     end
-
-  private
 
     def items_for_a_promotional_feature(feature)
       number_of_items = feature["items"].length

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe Organisations::DocumentsPresenter do
       expect(documents_presenter.latest_documents).to eq(expected)
     end
 
+    context "The returned latest documents include the organisation page" do
+      before do
+        stub_search_api_latest_documents_request_includes_org_page(documents_presenter.org.slug)
+      end
+
+      it "doesn't return the organisation page in the latest documents" do
+        expect(documents_presenter.latest_documents[:items].count).to eq(1)
+        expect(documents_presenter.latest_documents[:items].first["link"]).not_to eq("/government/organisations/#{documents_presenter.org.slug}")
+      end
+    end
+
     it "formats document types with acronyms correctly" do
       # This only applies to types containing "FOI" and "DFID"
       stub_search_api_latest_content_with_acronym("attorney-generals-office")

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -53,20 +53,25 @@ module OrganisationHelpers
 
     url = build_search_api_query_url(
       filter_organisations: organisation_slug,
-      count: 3,
+      count: 4,
     )
 
     stub_request(:get, url).to_return(body: build_result_body("other", true).to_json)
   end
 
   def stub_search_api_latest_documents_request(organisation_slug)
-    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=4&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
   end
 
   def stub_search_api_latest_content_with_acronym(organisation_slug)
-    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=3&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=4&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
       .to_return(body: { results: [search_response] }.to_json)
+  end
+
+  def stub_search_api_latest_documents_request_includes_org_page(organisation_slug)
+    stub_request(:get, Plek.new.find("search-api") + "/search.json?count=4&fields%5B%5D=content_store_document_type&fields%5B%5D=link&fields%5B%5D=public_timestamp&fields%5B%5D=title&filter_organisations=#{organisation_slug}&order=-public_timestamp")
+      .to_return(body: { results: [search_response, org_page_search_response(organisation_slug)] }.to_json)
   end
 
   def search_response
@@ -74,6 +79,15 @@ module OrganisationHelpers
       title: "Attorney General launches recruitment campaign for new Chief Inspector",
       link: "/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector",
       content_store_document_type: "press release",
+      public_timestamp: "2020-07-26T23:15:09.000+00:00",
+    }
+  end
+
+  def org_page_search_response(organisation_slug)
+    {
+      title: "Org page for this organisation",
+      link: "/government/organisations/#{organisation_slug}",
+      content_store_document_type: "organisation",
       public_timestamp: "2020-07-26T23:15:09.000+00:00",
     }
   end


### PR DESCRIPTION
- Organisations with very few documents tend to end up with their own organisation page in their latest documents, which obviously just leads to circular links. Solve this by always asking for 4 latest documents, rejecting documents where the link matches the document base path, then taking the first three.

Fixes report in Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5652462

##Before
<img width="990" alt="Screenshot 2024-03-28 at 11 35 29" src="https://github.com/alphagov/collections/assets/4225737/08bea50a-c893-4ac3-8b2c-8a973f398ea3">

##After
<img width="968" alt="Screenshot 2024-03-28 at 12 03 13" src="https://github.com/alphagov/collections/assets/4225737/6317efa3-fb1c-4616-b6a2-3b0568e3c8d7">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
