### PR TITLE
Add class attribute to contact_description method

### DIFF
--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -112,7 +112,7 @@ module Organisations
     end
 
     def contact_description(description)
-      tag.p(description.gsub("\r\n", "<br/>").html_safe) if description.present?
+      tag.p(description.gsub("\r\n", "<br/>").html_safe, class: "govuk-body") if description.present?
     end
   end
 end

--- a/spec/presenters/organisations/contacts_presenter_spec.rb
+++ b/spec/presenters/organisations/contacts_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/to/some/foi/stuff\">Click me</a>",
           ],
-          description: "<p>FOI requests<br/><br/>are possible</p>",
+          description: "<p class=\"govuk-body\">FOI requests<br/><br/>are possible</p>",
         },
         {
           locale: "en",
@@ -37,7 +37,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/foi/stuff\">FOI contact form</a>",
           ],
-          description: "<p>Something here<br/><br/>Something there</p>",
+          description: "<p class=\"govuk-body\">Something here<br/><br/>Something there</p>",
         },
         {
           locale: "en",


### PR DESCRIPTION
- Add class attribute to contact_description method, reference rails docs: https://api.rubyonrails.org/v7.1.3.2/classes/ActionView/Helpers/TagHelper.html

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
