### PR TITLE
Enable ARM support for Collections

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
@@ -13,7 +13,7 @@ RUN rails assets:precompile && rm -fr log
 RUN bootsnap precompile --gemfile .
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 
 ENV GOVUK_APP_NAME=collections
 


### PR DESCRIPTION
## What?
This switches the Workflow to the multi-arch build so we start getting ARM builds for Collections.