### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "rails_translation_manager"
 gem "rinku", require: "rails_rinku"
 gem "slimmer"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :test do
   gem "cucumber-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     expgen (0.1.1)
       parslet
     faraday (2.9.0)
@@ -736,6 +736,8 @@ GEM
       tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timecop (0.9.8)
     timeout (0.4.1)
@@ -743,8 +745,6 @@ GEM
       sync
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     unparser (0.6.13)
       diff-lcs (~> 1.3)
@@ -801,8 +801,8 @@ DEPENDENCIES
   simplecov-rcov
   slimmer
   sprockets-rails
+  terser
   timecop
-  uglifier
   unparser
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScript.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
govuk_publishing_components has govuk-frontend as a dependency.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
