### PR TITLE
Set up AB test logic for NewBrowse 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,10 @@
 class ApplicationController < ActionController::Base
   include Slimmer::Template
+  include NewBrowseAbTestable
 
-  helper_method :level_two_browse_variant
+  helper_method :new_browse_variant
   helper_method :content_item_h
+  helper_method :new_browse_page_under_test?
 
   protect_from_forgery with: :exception
 

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -10,6 +10,8 @@ class BrowseController < ApplicationController
   end
 
   def show
+    set_new_browse_response_header if new_browse_page_under_test?
+
     page = MainstreamBrowsePage.find("/browse/#{params[:top_level_slug]}")
     setup_content_item_and_navigation_helpers(page)
 

--- a/app/controllers/new_browse_ab_testable.rb
+++ b/app/controllers/new_browse_ab_testable.rb
@@ -1,0 +1,31 @@
+module NewBrowseAbTestable
+  # placeholder custom dimension
+  CUSTOM_DIMENSION = 67
+
+  ALLOWED_VARIANTS = %w[A B Z].freeze
+
+  def new_browse_test
+    @new_browse_test ||= GovukAbTesting::AbTest.new(
+      "NewBrowse",
+      dimension: CUSTOM_DIMENSION,
+      allowed_variants: ALLOWED_VARIANTS,
+      control_variant: "Z",
+    )
+  end
+
+  def new_browse_variant
+    new_browse_test.requested_variant(request.headers)
+  end
+
+  def set_new_browse_response_header
+    new_browse_variant.configure_response(response)
+  end
+
+  def new_browse_variant_b?
+    page_under_test? && new_browse_variant.variant?("B")
+  end
+
+  def new_browse_page_under_test?
+    request.path.starts_with?("/browse")
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
+  <%= new_browse_variant.analytics_meta_tag.html_safe if new_browse_page_under_test? %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
   <%=
     render_component_stylesheets

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe BrowseController do
 
       expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
     end
+
+    it "is not included in the newbrowse AB test" do
+      assert_response_not_modified_for_ab_test("NewBrowse")
+    end
   end
 
   describe "GET top_level_browse_page" do
@@ -41,6 +45,18 @@ RSpec.describe BrowseController do
         get :show, params: { top_level_slug: "benefits" }
         expect(response.content_type).to eq "text/html; charset=utf-8"
         expect(response).to render_template(partial: "_cards")
+      end
+
+      context "NewBrowse AB test" do
+        subject { get :show, params: { top_level_slug: "benefits" } }
+
+        %w[A B Z].each do |variant|
+          it "with variant #{variant}" do
+            with_variant NewBrowse: variant do
+              expect(subject).to render_template(:show)
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Add the AB test logic needed for the upcoming Browse AB test

- Related [PR in govuk-fastly](https://github.com/alphagov/govuk-fastly/pull/75)
- [Trello](https://trello.com/c/l9wMWXrt/2582-setup-newbrowse-ab-test-100-to-z-for-24-hours) card
- Review app