### PR TITLE
NewBrowse AB test list view 

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/individual_component_support";
+@import "govuk_publishing_components/components/mixins/prefixed-transform";
 
 // This dark grey is the background colour for the browse pages.
 //
@@ -85,5 +86,77 @@ $browse-header-background-colour: #263135;
 
   @include govuk-media-query($from: "tablet") {
     margin-bottom: govuk-spacing(6);
+  }
+}
+
+// chevron-card added from `frontend` for A/B testing
+.browse__chevron-cards {
+  list-style: none;
+  padding: 0;
+  margin-top: 0;
+}
+
+.chevron-card {
+  border-top: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(1) 0 govuk-spacing(4);
+
+  &:last-child {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+}
+
+.chevron-card__wrapper {
+  padding: 19px 0 4px;
+  position: relative;
+
+  .govuk-heading-s,
+  .chevron-card__description {
+    margin: 0 govuk-spacing(6) 0 0;
+
+    // Ensure card content width is constrained to two thirds on desktop
+    @include govuk-media-query($from: "desktop") {
+      max-width: 66.6667%;
+    }
+  }
+}
+
+.chevron-card__link {
+  &::after {
+    bottom: 0;
+    content: "";
+    display: block;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &::before {
+    $dimension: 7px;
+    $width: 3px;
+
+    border-right: $width solid $govuk-brand-colour;
+    border-top: $width solid $govuk-brand-colour;
+    content: "";
+    display: block;
+    height: $dimension;
+    position: absolute;
+    right: govuk-spacing(1);
+    top: 50%;
+    margin-top: 5px;
+    @include prefixed-transform($rotate: 45deg);
+    width: $dimension;
+  }
+
+  &:hover {
+    &::before {
+      border-color: $govuk-link-hover-colour;
+    }
+  }
+
+  &:focus {
+    &::before {
+      border-color: $govuk-focus-text-colour;
+    }
   }
 }

--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -1,4 +1,5 @@
 class BrowseController < ApplicationController
+  include NewBrowseAbTestable
   slimmer_template "gem_layout_full_width"
 
   def index
@@ -19,6 +20,8 @@ class BrowseController < ApplicationController
   end
 
 private
+
+  helper_method :new_browse_variant_b?
 
   def show_html(page)
     template = :show

--- a/app/controllers/new_browse_ab_testable.rb
+++ b/app/controllers/new_browse_ab_testable.rb
@@ -22,7 +22,7 @@ module NewBrowseAbTestable
   end
 
   def new_browse_variant_b?
-    page_under_test? && new_browse_variant.variant?("B")
+    new_browse_page_under_test? && new_browse_variant.variant?("B")
   end
 
   def new_browse_page_under_test?

--- a/app/views/browse/_browse_grid.html.erb
+++ b/app/views/browse/_browse_grid.html.erb
@@ -1,0 +1,30 @@
+<% total_links = page.second_level_browse_pages.count.to_s %>
+<%= render "govuk_publishing_components/components/cards", {
+  items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
+    {
+      link: {
+        text: second_level_browse_page.title,
+        path: second_level_browse_page.base_path,
+        data_attributes: {
+          track_category: "browseClicked",
+          track_action: "topicsLink",
+          track_label: second_level_browse_page.base_path,
+          track_dimension: second_level_browse_page.title,
+          track_options: {
+            dimension28: total_links,
+            dimension29: second_level_browse_page.title,
+            dimension114: index + 1,
+          },
+          ga4_link: {
+            event_name: "navigation",
+            type: "browse card",
+            index_link: index + 1,
+            index_total: total_links,
+          },
+        },
+      },
+      description: second_level_browse_page.description,
+    }
+  end,
+  sub_heading_level: display_action_links_for_slug?(page.slug) ? 3 : 2,
+} %>

--- a/app/views/browse/_browse_list.html.erb
+++ b/app/views/browse/_browse_list.html.erb
@@ -1,0 +1,28 @@
+<% total_links = page.second_level_browse_pages.count.to_s %>
+<ul class="browse__chevron-cards">
+  <% page.second_level_browse_pages.map.with_index do |second_level_browse_page, index| %>
+    <%= render partial: "browse/chevron_card", locals: {
+      title: second_level_browse_page.title,
+      link: second_level_browse_page.base_path,
+      description: second_level_browse_page.description,
+      sub_heading_level: display_action_links_for_slug?(page.slug) ? 3 : 2,
+      data_attributes: {
+        track_category: "browseClicked",
+        track_action: "topicsLink",
+        track_label: second_level_browse_page.base_path,
+        track_dimension: second_level_browse_page.title,
+        track_options: {
+          dimension28: total_links,
+          dimension29: second_level_browse_page.title,
+          dimension114: index + 1,
+        },
+        ga4_link: {
+          event_name: "navigation",
+          type: "browse card",
+          index_link: index + 1,
+          index_total: total_links,
+        },
+      },
+    } %>
+  <% end %>
+</ul>

--- a/app/views/browse/_chevron_card.html.erb
+++ b/app/views/browse/_chevron_card.html.erb
@@ -1,0 +1,22 @@
+<%
+  element ||= :li
+
+  link = capture do
+    link_to(raw(title), link, {
+      class: "govuk-link chevron-card__link",
+      data: data_attributes,
+    })
+  end
+%>
+
+<%= content_tag(element, class: "chevron-card") do %>
+  <div class="chevron-card__wrapper">
+    <%= render("govuk_publishing_components/components/heading", {
+      text: link,
+      font_size: "s",
+      heading_level: sub_heading_level,
+      margin_bottom: 2,
+    }) %>
+    <p class="govuk-body chevron-card__description"><%= raw(description) %></p>
+  </div>
+<% end %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -60,35 +60,6 @@
   </div>
 <% end %>
 
-<% total_links = page.second_level_browse_pages.count.to_s %>
 <%= render "shared/browse_cards_container" do %>
-  <%= render "govuk_publishing_components/components/cards", {
-    items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
-      {
-        link: {
-          text: second_level_browse_page.title,
-          path: second_level_browse_page.base_path,
-          data_attributes: {
-            track_category: "browseClicked",
-            track_action: "topicsLink",
-            track_label: second_level_browse_page.base_path,
-            track_dimension: second_level_browse_page.title,
-            track_options: {
-              dimension28: total_links,
-              dimension29: second_level_browse_page.title,
-              dimension114: index + 1,
-            },
-            ga4_link: {
-              event_name: "navigation",
-              type: "browse card",
-              index_link: index + 1,
-              index_total: total_links,
-            },
-          },
-        },
-        description: second_level_browse_page.description,
-      }
-    end,
-    sub_heading_level: display_action_links_for_slug?(page.slug) ? 3 : 2,
-  } %>
+  <%= render partial: "browse/browse_grid", locals: { page: page } %>
 <% end %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -61,5 +61,9 @@
 <% end %>
 
 <%= render "shared/browse_cards_container" do %>
-  <%= render partial: "browse/browse_grid", locals: { page: page } %>
+  <% if new_browse_variant_b? %>
+    <%= render partial: "browse/browse_list", locals: { page: page } %>
+  <% else %>
+    <%= render partial: "browse/browse_grid", locals: { page: page } %>
+  <% end %>
 <% end %>

--- a/spec/controllers/browse_controller_spec.rb
+++ b/spec/controllers/browse_controller_spec.rb
@@ -50,11 +50,21 @@ RSpec.describe BrowseController do
       context "NewBrowse AB test" do
         subject { get :show, params: { top_level_slug: "benefits" } }
 
-        %w[A B Z].each do |variant|
-          it "with variant #{variant}" do
-            with_variant NewBrowse: variant do
-              expect(subject).to render_template(:show)
-            end
+        it "with variant A" do
+          with_variant NewBrowse: "A" do
+            expect(subject).to render_template(partial: "_browse_grid")
+          end
+        end
+
+        it "with variant B" do
+          with_variant NewBrowse: "B" do
+            expect(subject).to render_template(partial: "_browse_list")
+          end
+        end
+
+        it "with variant Z" do
+          with_variant NewBrowse: "Z" do
+            expect(subject).to render_template(partial: "_browse_grid")
           end
         end
       end


### PR DESCRIPTION
## What

Adds a new partial for users allocated a variant B cookie.

Related PR in govuk-fastly https://github.com/alphagov/govuk-fastly/pull/76#pullrequestreview-2053127468

|Variant A or Z | Variant B|
|--|--|
|<img width="832" alt="Screenshot 2024-05-13 at 17 02 46" src="https://github.com/alphagov/collections/assets/17908089/5ac6d7d0-2c96-4d80-b52d-fdd3792b9b4a">|<img width="821" alt="Screenshot 2024-05-13 at 17 03 42" src="https://github.com/alphagov/collections/assets/17908089/a19f68a3-f3aa-486a-a849-c05ba4e611fe">|

## How to view the B variant before we turn the AB test on

To toggle between the variants install [modheader](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) and then add a new Request Header by clicking the +. Enter a Name of govuk-abtest-newbrowse and a Value of B

Trello: https://trello.com/c/VUPBYG8Y/2594-ramp-up-newbrowse-ab-test-5-to-b-for-10-days