### PR TITLE
Ensure organisation contact sections use 19px font size

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -25,7 +25,7 @@
   }
 
   .organisation__secondary-corporate-information {
-    @include govuk-font(16);
+    @include govuk-font(19);
 
     a:focus {
       @include govuk-focused-text;
@@ -38,6 +38,7 @@
 
   .organisation__address {
     font-style: normal;
+    @include govuk-font(19);
   }
 
   .organisation__contact-number {
@@ -45,8 +46,12 @@
   }
 }
 
+.organisation__paragraph {
+  @include govuk-font(19);
+}
+
 .organisation__parent-organisations {
-  @include govuk-font(16);
+  @include govuk-font(19);
   margin-top: govuk-spacing(3);
 }
 

--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -112,7 +112,7 @@ module Organisations
     end
 
     def contact_description(description)
-      tag.p(description.gsub("\r\n", "<br/>").html_safe) if description.present?
+      tag.p(description.gsub("\r\n", "<br/>").html_safe, class: "organisation__paragraph") if description.present?
     end
   end
 end

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -27,13 +27,14 @@
           <% if contact[:email_addresses].any? %>
             <div class="organisation__margin-bottom">
               <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>
-                <p><%= t('organisations.contact.email') %></p>
+                <p class="organisation__paragraph"><%= t('organisations.contact.email') %></p>
               <% else %>
-                <p lang="en"><%= t('organisations.contact.email') %></p>
+                <p class="organisation__paragraph" lang="en"><%= t('organisations.contact.email') %></p>
               <% end %>
 
               <% contact[:email_addresses].each do |email| %>
                 <p
+                  class="organisation__paragraph"
                   data-module="ga4-link-tracker"
                   data-ga4-track-links-only
                   data-ga4-do-not-redact
@@ -47,7 +48,7 @@
           <% if contact[:links].any? %>
             <div class="organisation__margin-bottom">
               <% contact[:links].each do |link| %>
-                <p><%= link.html_safe %></p>
+                <p class="organisation__paragraph"><%= link.html_safe %></p>
               <% end %>
             </div>
           <% end %>
@@ -55,8 +56,8 @@
           <% if contact[:phone_numbers] %>
             <div class="organisation__margin-bottom">
               <% contact[:phone_numbers].each do |phone| %>
-                <p><%= phone[:title] %></p>
-                <p class="organisation__contact-number"><%= phone[:number] %></p>
+                <p class="organisation__paragraph"><%= phone[:title] %></p>
+                <p class="organisation__contact-number organisation__paragraph"><%= phone[:number] %></p>
               <% end %>
             </div>
           <% end %>

--- a/spec/presenters/organisations/contacts_presenter_spec.rb
+++ b/spec/presenters/organisations/contacts_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/to/some/foi/stuff\">Click me</a>",
           ],
-          description: "<p>FOI requests<br/><br/>are possible</p>",
+          description: "<p class=\"organisation__paragraph\">FOI requests<br/><br/>are possible</p>",
         },
         {
           locale: "en",
@@ -37,7 +37,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/foi/stuff\">FOI contact form</a>",
           ],
-          description: "<p>Something here<br/><br/>Something there</p>",
+          description: "<p class=\"organisation__paragraph\">Something here<br/><br/>Something there</p>",
         },
         {
           locale: "en",


### PR DESCRIPTION
## What
- Ensure organisation contact sections have our 19px font size
- I did not use `govuk-body` as that adds margin and there was already margin added to the elements, so I didn't want to affect that. Therefore I used a new `organisation__paragraph` class where necessary.

## Why
- https://trello.com/c/UHOaQNIl/129-contact-description-text-on-organisation-pages-is-too-small-m

## Visual Changes

### Before

<img width="694" alt="image" src="https://github.com/alphagov/collections/assets/8880610/18b4f23b-e4ee-425c-8a25-809803b369ce">


### After

<img width="694" alt="image" src="https://github.com/alphagov/collections/assets/8880610/5a23132a-2739-40db-9216-141c5fa6e45d">
