### PR TITLE
Temporarily remove border styles due to global bar

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -13,9 +13,20 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 }
 
+@include govuk-media-query($from: desktop) {
+  .covid__page-header {
+    border-top: solid govuk-spacing(2) $c19-landing-page-header-background;
+  }
+}
+
+@include govuk-media-query($until: desktop) {
+  .covid__page-header {
+    margin-top: govuk-spacing(-3);
+  }
+}
+
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
-  border-top: solid govuk-spacing(2) $covid-yellow;
   background-color: $c19-landing-page-header-background;
   color: govuk-colour("white");
 }

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,7 +7,6 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
-    <div class="gem-c-layout-for-public__blue-bar"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
# What / Why

This contains the same changes as https://github.com/alphagov/collections/pull/3226 to remove borders now that the global bar is deployed

<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/065a65f0-0e96-4df5-8874-a287a4af0c13">

<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/58f358f4-408b-4855-b3f5-ac5ba6d519b8">
