### PR TITLE
Move breadcrumbs out of the `<main>` landmark on taxons to fix a WCAG fail

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -8,6 +8,15 @@
   }
 }
 
+.taxon-page__breadcrumbs-wrapper {
+  background-color: govuk-colour("blue");
+  padding: govuk-spacing(3) 0 govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: govuk-spacing(8);
+  }
+}
+
 .taxon-page__email-link-wrapper {
   background-color: govuk-colour("light-grey");
   margin-top: -(govuk-spacing(6));

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -1,4 +1,3 @@
-<% content_for :is_full_width_header, true %>
 <% content_for :title, presented_taxon.title %>
 <% content_for :meta_tags do %>
   <meta name="robots" content="noindex">

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -9,6 +9,17 @@
   } %>
 <% end %>
 
+<% content_for :breadcrumbs do %>
+  <div class="taxon-page__breadcrumbs-wrapper">
+    <div class="govuk-width-container">
+      <%= render 'govuk_publishing_components/components/breadcrumbs', {
+        breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
+        collapse_on_mobile: true,
+        inverse: true
+      } %>
+    </div>
+  </div>
+<% end %>
 <%= render partial: 'page_header', locals: { presented_taxon: presented_taxon } %>
 
 <% if taxon_is_live?(presented_taxon) %>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,10 +1,5 @@
 <%= render "govuk_publishing_components/components/inverse_header", { full_width: true } do %>
   <div class="govuk-width-container">
-    <%= render 'govuk_publishing_components/components/breadcrumbs', {
-      breadcrumbs: GovukPublishingComponents::AppHelpers::TaxonBreadcrumbs.new(@content_item).breadcrumbs,
-      collapse_on_mobile: true,
-      inverse: true
-    } %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,12 +1,15 @@
-<%= render "govuk_publishing_components/components/inverse_header", { full_width: true } do %>
+<%= render "govuk_publishing_components/components/inverse_header", { 
+  full_width: true,         
+  padding_top: false
+ } do %>
   <div class="govuk-width-container">
-
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/title", {
           title: presented_taxon.title,
           average_title_length: 'long',
-          inverse: true
+          inverse: true,
+          margin_top: 0
         } %>
 
         <%= render 'govuk_publishing_components/components/lead_paragraph', {


### PR DESCRIPTION
## What
Move breadcrumbs out of the `<main>` landmark on taxon pages, retaining the existing visual design of the full width element header element enclosing them. This change fixes a WCAG fail and skips the breadcrumbs when the 'skip to main content' link is activated (which it should do as the breadcrumbs are navigational content). 

This PR:
- Removes setting the `is_full_width_header` variable for taxons. It was being used to suppress the standard method of rendering breadcrumbs within the app via this check:  https://github.com/alphagov/collections/blob/ef25eb5670f7d2fca897cbb7a6e0cdbff9a26718/app/views/layouts/application.html.erb#L15 Instead, taxons would pass their breadcrumbs to the inverse header component to render them within that component. However, this would place the breadcrumbs within the `<main>` container which was causing the WCAG fail so we want to revert that behaviour.
- Uses the `breadcrumbs` block  within the main layout to render the breadcrumbs (and correspondingly stop passing them to the inverse header to render them there).
- Adjusts the spacing of the breadcrumbs and the inverted header. We essentially want to stop from setting the padding and margin at the top of the inverted header (where it would now come between the breadcrumbs and the inverted header since the breadcrumbs no longer sit inside the inverted header) and set it at the at the top of the breadcrumbs instead.

## Why
The breadcrumbs were within the `<main>` landmark which is also the target of the ‘skip to main content' link. There was no mechanism to allow users to bypass the breadcrumb links. Typically users should be able to use the ‘skip to main content’ link to bypass repeated blocks of content, like navigation links and breadcrumbs, that are repeated on multiple pages, and navigate directly to the main content of the page.

The breadcrumbs should not be in the main landmark and the 'skip to content' link should skip over them. This would also comply with [Design System guidance](https://design-system.service.gov.uk/components/breadcrumbs/#how-it-works).

WCAG reference: 2.4.1 Bypass Blocks (Level A)

## Further information
This PR fixes the issue on the taxon pages. We have a separate card to investigate whether there are other locations being impacted by the same issue. We also want to remove [the breadcrumbs option from the inverse header doc](https://components.publishing.service.gov.uk/component-guide/inverse_header/with_breadcrumbs_and_paragraph)s because it is not possible to include the breadcrumbs in the header without getting this WCAG fail, but doing so will be part of the investigation of understanding if there are other locations with the same issue.

## How the change was tested

The change was confirmed to allow the 'skip to main content' link to skip over the breadcrumbs. There were no visual changes to the page.

### Page types
I've reviewed the change on taxon pages such as `/welfare/entitlement` (with short breadcrumbs) and `/further-education-financial-management-and-data-collection`(with long breadcrumbs that wrap on smaller resolutions). (We also used to have taxons under `/coronavirus-taxon/[taxon]` but those all now redirect to `/coronavirus/` which uses a different template).

### Devices, browsers and assistive technology 

#### Windows 11	
✅  	Edge  (latest versions)
✅ 	Google Chrome  (latest versions)
✅	Mozilla Firefox (latest versions)

#### macOS 14.5	
✅    Safari 17
✅  	Google Chrome (latest versions)
✅	Mozilla Firefox (latest versions)

#### iOS	
✅  Chrome on iPhone 14
✅  Safari on iPhone XS
✅  Safari on iPad 10th 

#### Android	
✅  Chrome on Samsung Galaxy S23
✅  Samsung browser on Samsung Galaxy S8 
✅  Chrome on Google Pixel Pro

### Screen readers
✅ JAWS 2023 with Chrome 
✅ NVDA 2024 with Firefox

### Other 
✅ Mozilla Firefox (latest versions) when user sets their own colours
✅  Windows High Contrast mode

### Issue seen in Chrome mobile simulator
For reference, I was seeing an issue on Chrome's mobile simulator (under dev tools, with Chrome 125 on Mac) where on certain zoom levels (48%), with the zoom auto-adjusted and with the breadcrumbs wrapping, there would sometimes appear to be a 1px gap between the blocks of background colour. It would disappear on page load or switching between different zoom levels. 

<img width="504" alt="Chrome mobile simulator at times rendering a thin border when zoom is auto-adjusted" src="https://github.com/alphagov/collections/assets/5007934/28d50820-25e1-4d38-a5eb-05e2fe56108a"> 

I've not been able to replicate it when testing on any real devices nor understand what might be causing it even when stripping the design back to its simplest components so I think it's a glitch in the tool trying to simulate the background colour. 

## Visual Changes

### Before (iPhone 14, Chrome)
<img width="330" alt="iphone-14-chrome-before" src="https://github.com/alphagov/collections/assets/5007934/1b19667b-193a-41d3-930d-2b67cdb65b97">

### After (iPhone 14, Chrome)
<img width="324" alt="iphone-14-chrome-after" src="https://github.com/alphagov/collections/assets/5007934/04e13b40-9ca7-439a-b68c-c8204e6c6a86">

### Before (iPad 10th, Safari)

<img width="468" alt="ipad-10th-safari-before" src="https://github.com/alphagov/collections/assets/5007934/4d980dff-29c3-4c3c-a3ed-5913b8866681">


### After (iPad 10th, Safari)

<img width="466" alt="ipad-10th-safari-after" src="https://github.com/alphagov/collections/assets/5007934/80e911cf-945d-4c6a-943a-0d3825c3a248">

### Before (Samsung Galaxy S23, Chrome)

<img width="318" alt="samsung-galaxy-s23-chrome-before" src="https://github.com/alphagov/collections/assets/5007934/c3034a2a-60f6-4799-8309-9987a3760a76">


### After (Samsung Galaxy S23, Chrome)

<img width="321" alt="Screenshot 2024-06-11 at 10 09 28" src="https://github.com/alphagov/collections/assets/5007934/65a842ea-a62b-4c2b-b408-4519beb61fc5">

Fixes [Trello card](https://trello.com/c/ACEA8DIq/2507-misplaced-breadcrumbs-on-taxon-pages-l)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
