### PR TITLE
Conditionally style browse/covid page borders when global bar exists

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -26,6 +26,17 @@ $browse-header-background-colour: #263135;
   overflow: auto;
 }
 
+.browse__breadcrumb-border {
+  background: govuk-colour("blue");
+  height: 10px;
+}
+
+.global-bar-present {
+  .browse__breadcrumb-border {
+    height: 0;
+  }
+}
+
 // The header spacings are a work in progress.
 .browse__header-wrapper {
   padding-bottom: govuk-spacing(7);

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -13,21 +13,28 @@ $c19-landing-page-header-background: govuk-colour("blue");
   }
 }
 
-@include govuk-media-query($from: desktop) {
-  .covid__page-header {
-    border-top: solid govuk-spacing(2) $c19-landing-page-header-background;
+.global-bar-present {
+  @include govuk-media-query($from: desktop) {
+    .covid__page-header {
+      border-top: solid govuk-spacing(2) $c19-landing-page-header-background;
+    }
   }
-}
 
-@include govuk-media-query($until: desktop) {
-  .covid__page-header {
-    margin-top: govuk-spacing(-3);
+  @include govuk-media-query($until: desktop) {
+    .covid__page-header {
+      margin-top: govuk-spacing(-3);
+    }
+  }
+
+  .covid_page_header {
+    border-top: none;
   }
 }
 
 .covid__page-header {
   margin-bottom: govuk-spacing(8);
   background-color: $c19-landing-page-header-background;
+  border-top: solid govuk-spacing(2) $covid-yellow;
   color: govuk-colour("white");
 }
 

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,6 +7,7 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
+    <div class="browse__breadcrumb-border"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
## What/Why
- The `/coronavirus` and `/browse` pages have custom border styles
- These borders clash with the globar bar when it is rendered
- Therefore, a `global-bar-present` class was added to the `<body>` whenever the global bar is rendered: https://github.com/alphagov/govuk_publishing_components/pull/4047
- We use that class in this app to conditionally style the borders on  `/coronavirus` and `/browse`

## Testing
- You can test this by:
    - Navigating to http://127.0.0.1:3070/browse and http://127.0.0.1:3070/coronavirus
    - Seeing that the border styles look correct with the global bar
    - Deleting the global bar from the DOM, and the `global-bar-present` class from the `<body>`, and seeing the border styles on these pages come back

## With global bar
### Coronavirus page
<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/d33ebd9f-5aae-465c-a195-4c02813db228">

### Browse page
<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/781dbf93-f6a8-4b05-b867-00b7188fdbb2">

## Without global bar 
### Coronavirus page
<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/d3e01cce-5bf5-4480-a1df-f21529575866">

### Browse page
<img width="1229" alt="image" src="https://github.com/alphagov/collections/assets/8880610/d60cec6b-4e0f-41a1-8d6b-f928c52a5c08">

