### PR TITLE
Upgrade to govuk frontend 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,7 +216,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link application.js
+//= link es6-components.js
 //= link test-dependencies.js
 
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-//= require govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind
+//= require govuk_publishing_components/vendor/polyfills-govuk-frontend-v4/Function/prototype/bind
 
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/details

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require govuk-frontend/govuk/vendor/polyfills/Function/prototype/bind
 
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,10 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/accordion

--- a/app/assets/stylesheets/views/_bunting.scss
+++ b/app/assets/stylesheets/views/_bunting.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("mid-grey", $legacy: "grey-2");
+  border-top: 1px solid govuk-colour("mid-grey");
   @extend %responsive-bunting-height;
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,6 +37,7 @@
   <title><%= yield :title %> - <%= t('application.title.suffix')%></title>
   <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
   <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag 'es6-components', type: "module" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>


### PR DESCRIPTION
## What

- Move components that rely on govuk-frontend modules to separate `es6-components.js` file
- Remove Sass variables
- Update polyfill file paths

## Why

### Move components that rely on govuk-frontend modules to seperate `es6-components.js` file

In the event that a browser below the target for `govuk-frontend` loads a page with JS on it, attempting to parse the JS from `govuk-frontend` will cause an error. To avoid this from happening, JS that contains `govuk-frontend` JS has been moved to seperate file which will be loaded in a script tag with `type="module"`. This will prevent the JS from being parsed and so prevent the error

### Remove Sass variables

- The `$legacy` attribute in `govuk-colour` has been deprecated and using it will have no effect (other than generating warnings on pre-compilation)

### Update polyfill file paths
Browser polyfills are no longer included in v5 of govuk-frontend, any Polyfills provided in v4 of govuk-frontend will be included in the new version of the govuk-publishing-components gem.

The intention is for this PR to include the bump to the govuk-frontend v5 version of the govuk-publishing-components gem, this will also fix the failing tests relating to the missing polyfill.

[Trello](https://trello.com/c/QtJuwSIH/2337-upgrade-collections-to-run-on-v51-of-govuk-frontend)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.