### PR TITLE
FIx ActionView::Template::Error

### DIFF
--- a/app/models/world_location_news.rb
+++ b/app/models/world_location_news.rb
@@ -67,7 +67,10 @@ class WorldLocationNews
   end
 
   def latest
-    @latest ||= @documents_service.fetch_related_documents_with_format
+    @latest ||= [*announcements, *publications, *statistics]
+        .select { |entry| entry.dig(:metadata, :public_updated_at).present? }
+        .sort { |entry1, entry2| - (entry1.dig(:metadata, :public_updated_at) <=> entry2.dig(:metadata, :public_updated_at)) }
+        .first(SearchDocuments::DEFAULT_COUNT)
   end
 
   def announcements

--- a/app/services/search_documents.rb
+++ b/app/services/search_documents.rb
@@ -1,5 +1,6 @@
 class SearchDocuments
   include SearchApiFields
+  DEFAULT_COUNT = 3
 
   def initialize(slug, filter_field)
     @slug = slug
@@ -15,7 +16,7 @@ private
 
   def default_search_options
     { @filter_field.to_sym => [@slug],
-      count: 3,
+      count: DEFAULT_COUNT,
       order: "-public_timestamp",
       fields: TOPICAL_EVENTS_SEARCH_FIELDS }
   end

--- a/spec/models/world_location_news_spec.rb
+++ b/spec/models/world_location_news_spec.rb
@@ -116,6 +116,90 @@ RSpec.describe WorldLocationNews do
 
       world_location_news.statistics
     end
+
+    it "should correctly combine announcements, publications and statistics into latest" do
+      announcements = [
+        {
+          link: {
+            text: "Changes to Birth and Death Registrations Overseas",
+            path: "/government/news/changes-to-birth-and-death-registrations-overseas--2",
+          },
+          metadata: {
+            public_updated_at: 5.days.ago,
+            document_type: "News story",
+          },
+        },
+        {
+          link: {
+            text: "Foreign Secretary statement on the death of Nelson Mandela",
+            path: "/government/news/foreign-secretary-statement-on-the-death-of-nelson-mandela",
+          },
+          metadata:
+          {
+            public_updated_at: 1.day.ago,
+            document_type: "Press release",
+          },
+        },
+      ]
+      publications = [
+        {
+          link: {
+            text: "Overseas business risk for Zimbabwe",
+            path: "/government/publications/overseas-business-risk-zimbabwe",
+          },
+          metadata: {
+            public_updated_at: 3.days.ago,
+            document_type: "Guidance",
+          },
+        },
+        {
+          link: {
+            text: "UK-Zimbabwe development partnership summary",
+            path: "/government/publications/uk-zimbabwe-development-partnership-summary",
+          },
+          metadata: {
+            public_updated_at: 4.days.ago,
+            document_type: "Policy paper",
+          },
+        },
+      ]
+      statistics = [
+        {
+          link: {
+            text: "German Wages Statistics",
+            path: "/government/publications/german-wages-statistics",
+          },
+          metadata: {
+            public_updated_at: 8.days.ago,
+            document_type: "Statistics",
+          },
+        },
+        {
+          link: {
+            text: "French Migration Statistics",
+            path: "/government/publications/french-migration-statistics",
+          },
+          metadata: {
+            public_updated_at: 2.days.ago,
+            document_type: "Statistics",
+          },
+        },
+      ]
+      expect(world_location_news)
+        .to receive(:announcements)
+        .with(no_args)
+        .and_return(announcements)
+      expect(world_location_news)
+        .to receive(:publications)
+        .with(no_args)
+        .and_return(publications)
+      expect(world_location_news)
+        .to receive(:statistics)
+        .with(no_args)
+        .and_return(statistics)
+      expect(world_location_news.latest)
+        .to eq([announcements[1], statistics[1], publications[0]])
+    end
   end
 
   it "should include the type" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Implement a fix for the following sentry error:

https://govuk.sentry.io/issues/4338933238/?environment=production-eks&environment=production&environment=producton&project=-1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=15

## Why

[Trello ticket](https://trello.com/c/KJiKDHNp/2647-sentry-errors-fix-collections-actionviewtemplateerror)

## How

Modify the method [`latest`](https://github.com/alphagov/collections/blob/318dc698f28b5b5573749898043f268e8e94d7ef/app/models/world_location_news.rb#L69) to use the combined results from methods `announcements`, `publications` and `statistics` (from the same file). Return 3 latest entries (sorted by `public_timestamp`).