### PR TITLE
Add guards to fix preview of Ministers page during a reshuffle

### DIFF
--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -16,19 +16,22 @@ class MinistersIndexPresenter
   end
 
   def cabinet_ministers
-    @ministers_index.content_item_data.dig("links", "ordered_cabinet_ministers").map do |minister_data|
+    ordered_cabinet_ministers = @ministers_index.content_item_data.dig("links", "ordered_cabinet_ministers") || []
+    ordered_cabinet_ministers.map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def also_attends_cabinet
-    @ministers_index.content_item_data.dig("links", "ordered_also_attends_cabinet").map do |minister_data|
+    ordered_also_attends_cabinet = @ministers_index.content_item_data.dig("links", "ordered_also_attends_cabinet") || []
+    ordered_also_attends_cabinet.map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def by_organisation
-    @ministers_index.content_item_data.dig("links", "ordered_ministerial_departments").map do |department_data|
+    ordered_ministerial_departments = @ministers_index.content_item_data.dig("links", "ordered_ministerial_departments") || []
+    ordered_ministerial_departments.map do |department_data|
       Department.new(
         url: department_data.fetch("web_url"),
         title: department_data.fetch("title"),
@@ -46,7 +49,8 @@ class MinistersIndexPresenter
 
   def whips
     ordered_whip_organisations.each do |whip_org|
-      whip_org.ministers = @ministers_index.content_item_data.dig("links", whip_org.item_key).map do |minister_data|
+      ordered_whip_organisation = @ministers_index.content_item_data.dig("links", whip_org.item_key) || []
+      whip_org.ministers = ordered_whip_organisation.map do |minister_data|
         Minister.new(minister_data, whip_only: true)
       end
     end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -113,4 +113,17 @@ RSpec.feature "Ministers index page" do
       expect(page).not_to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
     end
   end
+
+  context "during a reshuffle preview" do
+    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
+
+    scenario "renders the sections and contents even with empty roles sets" do
+      expect(page.status_code).to eq(200)
+      expect(page).to have_selector(".gem-c-lead-paragraph")
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
+    end
+  end
 end


### PR DESCRIPTION
Currently, the rendering view assumes there's only 2 views of the page - a fully assigned ministers index, or a banner that is displayed in case of a reshuffle. In reshuffle mode preview, however, means that the if statement in the view assumes wrongly about the data, since the reshuffle flag / message is not passed for the preview. We should cater for these cases during reshuffle where there could be empty lists of ministers.

PR required for tests to pass: https://github.com/alphagov/publishing-api/pull/2789

https://trello.com/c/iSsdS462/2697-fix-frontend-issues-preventing-preview-of-ministers-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
