### PR TITLE
Check ruby test coverage before merging PRs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
-if ENV["USE_SIMPLECOV"]
-  require "simplecov"
-  require "simplecov-rcov"
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start
+require "simplecov"
+require "simplecov-rcov"
+SimpleCov.start do
+  formatter SimpleCov::Formatter::RcovFormatter
+  enable_coverage :branch
+  minimum_coverage 95
 end
 
 if ENV["USE_I18N_COVERAGE"]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Set up automated checking of ruby test coverage by simplecov as a requirement before a PR can be merged. This can be done in two ways. Either a test can be added, which checks simplecov coverage or an additional step can be added to GitHub CI. Investigate which of those two approaches is easier to implement and implement it.

## Why

We need to keep ruby code test coverage at 95% as indicated by simplecov in order to maintain the requirement of dependabot automerger.

[Trello card](https://trello.com/c/c3Cvewr6/2665-check-ruby-test-coverage-before-merging-prs)