### PR TITLE
Prepare custom banners for specific open and closed organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,6 +7,10 @@ class Organisation
 
   HMCTS_CONTENT_ID = "6f757605-ab8f-4b62-84e4-99f79cf085c2".freeze
 
+  CUSTOM_BANNERS_DATA = {
+    "org-slug-tbc" => "This organisation is changing. Read the <a href=\"#\">latest updates on government departments</a>. (Placeholder message)",
+  }.freeze
+
   def initialize(content_item)
     @content_item = content_item
   end
@@ -14,6 +18,10 @@ class Organisation
   def self.find!(base_path)
     content_item = ContentItem.find!(base_path)
     new(content_item)
+  end
+
+  def custom_banner
+    CUSTOM_BANNERS_DATA[slug] || false
   end
 
   def title

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,7 +8,8 @@ class Organisation
   HMCTS_CONTENT_ID = "6f757605-ab8f-4b62-84e4-99f79cf085c2".freeze
 
   CUSTOM_BANNERS_DATA = {
-    "org-slug-tbc" => "This organisation is changing. Read the <a href=\"#\">latest updates on government departments</a>. (Placeholder message)",
+    "department-for-levelling-up-housing-and-communities" => "This organisation is changing. It’s now called the <a href=\"/government/organisations/ministry-of-housing-communities-local-government\">Ministry of Housing, Communities and Local Government</a>.",
+    "ministry-of-housing-communities-local-government" => "This is a new organisation. It was previously called the <a href=\"/government/organisations/department-for-levelling-up-housing-and-communities\">Department for Levelling Up, Housing and Communities</a>.",
   }.freeze
 
   def initialize(content_item)

--- a/app/views/organisations/separate_website.html.erb
+++ b/app/views/organisations/separate_website.html.erb
@@ -9,7 +9,7 @@
   content_item: organisation.content_item.content_item_data %>
 
 <%= render "govuk_publishing_components/components/notice", {
-  title: @not_live.non_live_organisation_notice
+  title: sanitize(@organisation.custom_banner ? @organisation.custom_banner : @not_live.non_live_organisation_notice)
 } %>
 
 <div class="govuk-grid-row organisation__margin-bottom">

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -3,6 +3,11 @@
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
 <%= render partial: 'header' %>
+<% if @organisation.custom_banner %>
+  <%= render "govuk_publishing_components/components/notice", {
+    title: sanitize(@organisation.custom_banner)
+  } %>
+<% end %>
 <%= render 'govuk_publishing_components/components/machine_readable_metadata',
            schema: :organisation,
            content_item: @organisation.content_item.content_item_data %>


### PR DESCRIPTION
There may be a requirement to add banners on a per-organisation basis. This commit gets the groundwork in place for that, taking inspiration from the last time we did this (in #3172). Unlike last time, we may also need to have custom banners on _closed_ organisations, which already have their own banner logic.

Trello: https://trello.com/c/M1R5xg3w/2725-prepare-banners-for-new-and-closing-organisations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
