### PR TITLE
Update incorrect base_path for 'Past Chancellors of the Exchequer'

### DIFF
--- a/config/past_chancellors/content_item.yml
+++ b/config/past_chancellors/content_item.yml
@@ -1,5 +1,5 @@
 ---
-base_path: /government/history/past-foreign-secretaries
+base_path: /government/history/past-chancellors
 title: Past Chancellors of the Exchequer
 body:
   centuries:


### PR DESCRIPTION
This doesn't appear to be used, and is for documentation / ease only.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
