### PR TITLE
Fix ministers preview when departments missing ordered_ministers

### DIFF
--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -38,7 +38,7 @@ class MinistersIndexPresenter
         crest: department_data.dig("details", "logo", "crest"),
         formatted_title: department_data.dig("details", "logo", "formatted_title"),
         brand: department_data.dig("details", "brand"),
-        ministers: department_data.dig("links", "ordered_ministers").map do |minister_data|
+        ministers: (department_data.dig("links", "ordered_ministers") || []).map do |minister_data|
           Minister.new(minister_data, org_role_ids: role_ids_for_organisation(department_data))
         end,
       )

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -109,7 +109,7 @@ class MinistersIndexPresenter
   private
 
     def current_role_appointments
-      @data.dig("links", "role_appointments").select do |role_app|
+      (@data.dig("links", "role_appointments") || []).select do |role_app|
         role_app.dig("details", "current") && role_app.dig("links", "role").first["web_url"].present?
       end
     end
@@ -145,6 +145,6 @@ private
   WhipOrganisation = Struct.new(:item_key, :name_key, :ministers, keyword_init: true)
 
   def role_ids_for_organisation(org_data)
-    org_data.dig("links", "ordered_roles").map { |role| role["content_id"] }
+    (org_data.dig("links", "ordered_roles") || []).map { |role| role["content_id"] }
   end
 end

--- a/spec/presenters/ministers_index_presenter_spec.rb
+++ b/spec/presenters/ministers_index_presenter_spec.rb
@@ -1,0 +1,129 @@
+RSpec.describe MinistersIndexPresenter do
+  let(:ministers_index) do
+    content_item = double("content item", details:, content_item_data:)
+    double("ministers_index", content_item:)
+  end
+  let(:details) do
+    {
+      "body" => "Foo",
+      "reshuffle" => nil,
+    }
+  end
+  let(:content_item_data) { { "links" => {} } }
+
+  describe "#cabinet_ministers" do
+    it "defaults to empty array if no ordered_cabinet_ministers provided" do
+      presenter = MinistersIndexPresenter.new(ministers_index)
+      expect(presenter.cabinet_ministers).to eq([])
+    end
+
+    context "ordered_cabinet_ministers is provided" do
+      let(:content_item_data) do
+        {
+          "links" => {
+            "ordered_cabinet_ministers" => [{ "foo" => "bar" }],
+          },
+        }
+      end
+
+      it "returns array of ministers" do
+        stubbed_minister = double("MinistersIndexPresenter::Minister")
+        allow(MinistersIndexPresenter::Minister).to receive(:new).and_return(stubbed_minister)
+
+        presenter = MinistersIndexPresenter.new(ministers_index)
+        expect(presenter.cabinet_ministers).to eq([stubbed_minister])
+      end
+    end
+  end
+
+  describe "#also_attends_cabinet" do
+    it "defaults to empty array if no ordered_also_attends_cabinet provided" do
+      presenter = MinistersIndexPresenter.new(ministers_index)
+      expect(presenter.also_attends_cabinet).to eq([])
+    end
+
+    context "ordered_also_attends_cabinet is provided" do
+      let(:content_item_data) do
+        {
+          "links" => {
+            "ordered_also_attends_cabinet" => [{ "foo" => "bar" }],
+          },
+        }
+      end
+
+      it "returns array of ministers" do
+        stubbed_minister = double("MinistersIndexPresenter::Minister")
+        allow(MinistersIndexPresenter::Minister).to receive(:new).and_return(stubbed_minister)
+
+        presenter = MinistersIndexPresenter.new(ministers_index)
+        expect(presenter.also_attends_cabinet).to eq([stubbed_minister])
+      end
+    end
+  end
+
+  describe "#by_organisation" do
+    it "defaults to empty array if no ordered_ministerial_departments provided" do
+      presenter = MinistersIndexPresenter.new(ministers_index)
+      expect(presenter.by_organisation).to eq([])
+    end
+
+    context "ordered_ministerial_departments is provided" do
+      let(:content_item_data) do
+        {
+          "links" => {
+            "ordered_ministerial_departments" => [
+              {
+                "web_url" => "foo",
+                "title" => "foo",
+                "details" => {
+                  "brand" => "foo",
+                  "logo" => {
+                    "crest" => "foo",
+                    "formatted_title" => "foo",
+                  },
+                },
+                "links" => ordered_ministerial_departments_links,
+              },
+            ],
+          },
+        }
+      end
+      let(:ordered_ministerial_departments_links) do
+        {
+          "ordered_ministers" => [{ "foo" => "bar" }],
+        }
+      end
+
+      it "returns array of departments" do
+        stubbed_department = double("MinistersIndexPresenter::Department")
+        allow(MinistersIndexPresenter::Department).to receive(:new).and_return(stubbed_department)
+
+        presenter = MinistersIndexPresenter.new(ministers_index)
+        expect(presenter.by_organisation).to eq([stubbed_department])
+      end
+
+      it "returns ministers associated with departments" do
+        stubbed_minister = double("MinistersIndexPresenter::Minister")
+        allow(MinistersIndexPresenter::Minister).to receive(:new).and_return(stubbed_minister)
+        stubbed_department = double("MinistersIndexPresenter::Department", ministers: [stubbed_minister])
+        allow(MinistersIndexPresenter::Department).to receive(:new).and_return(stubbed_department)
+
+        presenter = MinistersIndexPresenter.new(ministers_index)
+        expect(presenter.by_organisation.first.ministers).to eq([stubbed_minister])
+      end
+
+      context "no ministers specified for the department" do
+        let(:ordered_ministerial_departments_links) { {} }
+
+        it "has departments' ministers defaulting to empty array" do
+          allow_any_instance_of(MinistersIndexPresenter::Department).to receive(:ministers).and_call_original
+
+          presenter = MinistersIndexPresenter.new(ministers_index)
+          expect(presenter.by_organisation.first.ministers).to eq([])
+        end
+      end
+    end
+  end
+
+  # TODO: add tests for MinistersIndexPresenter::Minister class
+end


### PR DESCRIPTION
A number of preview issues were fixed in #3673 but it looks like this was missed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
