### PR TITLE
Improve headings on Roles pages

### DIFF
--- a/app/views/roles/_current_role_holder_with_biography.html.erb
+++ b/app/views/roles/_current_role_holder_with_biography.html.erb
@@ -3,10 +3,13 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("roles.headings.current_holder"),
       lang: t_fallback("roles.headings.current_holder"),
+      margin_bottom: 2,
     } %>
 
     <%= render "govuk_publishing_components/components/heading", {
       text: role.current_holder["title"],
+      heading_level: 3,
+      font_size: "m",
       margin_bottom: 2,
     } %>
 

--- a/app/views/roles/_past_role_holders.html.erb
+++ b/app/views/roles/_past_role_holders.html.erb
@@ -2,6 +2,7 @@
   <section id="past-role-holders" class="govuk-!-padding-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("roles.previous_holders"),
+      margin_bottom: 2,
     } %>
     <p class="govuk-body" lang="en">
       <%= t("roles.find_out_more_html", link: link_to(t("roles.past") + " #{role.title.pluralize}", role.past_holders_url, class: "govuk-link")) %>
@@ -11,6 +12,7 @@
   <section id="past-role-holders" class="govuk-!-padding-bottom-9">
     <%= render "govuk_publishing_components/components/heading", {
       text: t("roles.previous_holders"),
+      margin_bottom: 2,
     } %>
     <%= render "components/taxon_list", {
       heading_level: 3,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix some spacing issues to do with the headings on the roles pages, e.g. https://www.gov.uk/government/ministers/attorney-general

See individual commits for details.

## Why
I stumbled across it and it bothered me.

## Visual changes
Generally improving spacing beneath headings, also replacing the second H2 in 'Current role holder' with a H3, and reducing the font size accordingly.

Before | After
------ | -----
![Screenshot 2024-07-12 at 09 27 57](https://github.com/user-attachments/assets/b4e35c92-e4fa-4fcc-8443-f5e6bcd7de00) | ![Screenshot 2024-07-12 at 09 28 02](https://github.com/user-attachments/assets/f46bb2a0-d806-4f6b-961a-d927038abe7c)
![Screenshot 2024-07-12 at 09 27 47](https://github.com/user-attachments/assets/4ac46cd8-007e-4135-898f-9d158d178ec7) | ![Screenshot 2024-07-12 at 09 27 52](https://github.com/user-attachments/assets/f6ac24b5-15c5-47cb-a204-70d81596d6d8)
