### PR TITLE
Do not show department organisation section if there are no minister …

### DIFF
--- a/app/views/ministers/_ministers_by_organisation.html.erb
+++ b/app/views/ministers/_ministers_by_organisation.html.erb
@@ -1,0 +1,31 @@
+<%= content_tag :section, id: organisation.title.parameterize do %>
+  <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
+    <%= render "govuk_publishing_components/components/organisation_logo", {
+      organisation: {
+        name: organisation.formatted_title.html_safe,
+        url: organisation.url,
+        brand: organisation.brand,
+        crest: organisation.crest,
+      },
+      heading_level: 3,
+    } %>
+  </div>
+  <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
+    <ul class="govuk-list govuk-grid-row">
+      <% organisation.ministers.each.with_index do |minister, i| %>
+        <% extra_class = (i % 3 == 0) ? " clear-column" : "" %>
+        <li class="govuk-grid-column-one-quarter govuk-grid-column-one-third<%= extra_class %>">
+          <div>
+            <%= render "govuk_publishing_components/components/image_card", {
+              href: minister.person_url,
+              heading_text: minister.name,
+              heading_level: 3,
+              context: { text: minister.honorific },
+              description: cabinet_minister_description(minister),
+            } %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -95,37 +95,7 @@
   </div>
 
   <% @presented_ministers.by_organisation.each do |organisation| %>
-    <%= content_tag :section, id: organisation.title.parameterize do %>
-      <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
-        <%= render "govuk_publishing_components/components/organisation_logo", {
-          organisation: {
-            name: organisation.formatted_title.html_safe,
-            url: organisation.url,
-            brand: organisation.brand,
-            crest: organisation.crest,
-          },
-          heading_level: 3,
-        } %>
-      </div>
-      <div class="govuk-grid-column-three-quarters govuk-!-padding-bottom-7">
-        <ul class="govuk-list govuk-grid-row">
-          <% organisation.ministers.each.with_index do |minister, i| %>
-            <% extra_class = (i % 3 == 0) ? " clear-column" : "" %>
-            <li class="govuk-grid-column-one-quarter govuk-grid-column-one-third<%= extra_class %>">
-              <div>
-                <%= render "govuk_publishing_components/components/image_card", {
-                  href: minister.person_url,
-                  heading_text: minister.name,
-                  heading_level: 3,
-                  context: { text: minister.honorific },
-                  description: cabinet_minister_description(minister),
-                } %>
-              </div>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+    <%= render partial: 'ministers_by_organisation', locals: { organisation: } if organisation.ministers.any? %>
   <% end %>
 </section>
 

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -98,6 +98,11 @@ RSpec.feature "Ministers index page" do
     expect(kemi_badenoch_uef).to_not have_text("Secretary of State for Business and Trade")
   end
 
+  scenario "the ministers by department section does not show departments without ministers appointed" do
+    expect(page).not_to have_selector("#office-of-the-advocate-general-for-scotland")
+    expect(page).not_to have_text("Office of the Advocate General for Scotland")
+  end
+
   context "during a reshuffle" do
     let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 


### PR DESCRIPTION
…roles appointed.

This is currently breaking the layout. Have also pulled the section out as a partial for readability.

Depends on https://github.com/alphagov/publishing-api/pull/2805 for the tests to be correctly testing the negative scenario

https://trello.com/c/PhXHTAq0/2739-fix-or-exclude-department-from-ministers-page-if-it-has-no-ministers-associated-with-it

Before:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/1fbd7163-f14a-4580-928d-396f4dafcf1b">

After:
<img width="836" alt="image" src="https://github.com/user-attachments/assets/0a359e1e-bfc5-4a17-bd12-2d5c96c542d3">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
