### PR TITLE
Remove unused classes

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -49,21 +49,6 @@
   &--single {
     min-width: 330px;
   }
-
-  .taxon-page__featured-image {
-    box-sizing: border-box;
-    width: (1 / 3) * 100%;
-    float: left;
-    margin-bottom: govuk-spacing(2);
-    padding-right: govuk-spacing(3);
-
-    @include govuk-media-query($from: tablet) {
-      float: none;
-      margin-bottom: govuk-spacing(2);
-      padding-right: 0;
-      width: 100%;
-    }
-  }
 }
 
 .taxon-page__featured-see-more {
@@ -79,54 +64,6 @@
   .js-enabled & {
     display: block;
     margin-bottom: govuk-spacing(4);
-  }
-}
-
-.taxon-page__grid {
-  background-color: govuk-colour("light-grey");
-  padding-top: govuk-spacing(6);
-  margin-top: 60px;
-
-  .taxon-page__grid-heading {
-    @include govuk-font(19, $weight: bold);
-    margin-bottom: govuk-spacing(3);
-
-    @include govuk-media-query($from: tablet) {
-      padding-bottom: govuk-spacing(2);
-    }
-  }
-
-  .taxon-page__grid-wrapper {
-    list-style-type: none;
-    padding-bottom: govuk-spacing(3);
-    font-size: 0; // Set so li elements don't wrap unnecessarily due to white space
-  }
-
-  .taxon-page__grid-wrapper .taxon-page__grid-item {
-    padding-bottom: govuk-spacing(6);
-
-    @include govuk-media-query($from: tablet) {
-      box-sizing: border-box;
-      display: inline-block;
-      width: 50%;
-      min-height: 150px;
-      vertical-align: top;
-      padding: 0 15px 45px 0;
-    }
-
-    @include govuk-media-query($from: desktop) {
-      width: (1 / 3) * 100%;
-    }
-  }
-
-  .taxon-page__grid-item-description {
-    @include govuk-font(19);
-    margin-top: govuk-spacing(1);
-    margin-bottom: govuk-spacing(4);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
   }
 }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- attempting to fix Sass compilation warnings, discovered that classes do not appear to be in use, so removing
- e.g. `taxon-page__featured-image` contained a width calculation that was causing a Sass compilation error: `Using / for division outside of calc() is deprecated`

## Visual changes
None, hopefully. Couldn't find any instance of the classes I've removed outside of the Sass files.

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings