### PR TITLE
Use type=module for application.js

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,3 @@
-//= require govuk_publishing_components/vendor/polyfills-govuk-frontend-v4/Function/prototype/bind
-
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card

--- a/app/assets/javascripts/modules/coronavirus-landing-page.js
+++ b/app/assets/javascripts/modules/coronavirus-landing-page.js
@@ -1,5 +1,3 @@
-//= require govuk_publishing_components/vendor/polyfills/closest
-
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 

--- a/app/assets/javascripts/modules/list-filter.js
+++ b/app/assets/javascripts/modules/list-filter.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-var */
-//= require govuk_publishing_components/vendor/polyfills/closest
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -81,7 +81,7 @@
   display: none;
 }
 
-.js-enabled {
+.govuk-frontend-supported {
   .organisation__no10-yt-link {
     display: block;
   }

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -61,7 +61,7 @@
 .taxon-page__show-more-toggle {
   display: none;
 
-  .js-enabled & {
+  .govuk-frontend-supported & {
     display: block;
     margin-bottom: govuk-spacing(4);
   }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 <head>
   <title><%= yield :title %> - <%= t('application.title.suffix')%></title>
   <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
-  <%= javascript_include_tag "application" %>
+  <%= javascript_include_tag "application", type: "module" %>
   <%= javascript_include_tag 'es6-components', type: "module" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
 <html>
 <head>
   <title><%= yield :title %> - <%= t('application.title.suffix')%></title>
-  <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
+  <%= javascript_include_tag "test-dependencies", type: "module" if Rails.env.test? %>
   <%= javascript_include_tag "application", type: "module" %>
   <%= javascript_include_tag 'es6-components', type: "module" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- To accurately test this you will need to use local static that is using a local version the `govuk_publishing_components` branch linked above. If you test without, this app's `application.js` seems to crash.
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers