### PR TITLE
Use heading component on browse pages

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -54,11 +54,6 @@ $browse-header-background-colour: #263135;
   }
 }
 
-.browse__heading {
-  color: govuk-colour("white");
-  margin-bottom: govuk-spacing(6);
-}
-
 .browse__section {
   margin-bottom: govuk-spacing(9);
 

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -17,9 +17,12 @@
 <% end %>
 
 <%= render "shared/browse_header", { margin_bottom: 9 } do %>
-  <h1 class="browse__heading govuk-heading-xl">
-    <%= t("browse.title") %>
-  </h1>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("browse.title"),
+    inverse: true,
+    font_size: "xl",
+    margin_bottom: 6,
+  } %>
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: t("browse.description"),
     margin_bottom: 2,

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -21,9 +21,12 @@
 <% end %>
 
 <%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
-  <h1 class="browse__heading govuk-heading-xl">
-    <%= page.title %>
-  </h1>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: page.title,
+    inverse: true,
+    font_size: "xl",
+    margin_bottom: 6,
+  } %>
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: page.description,
     margin_bottom: 2,


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace hard coded headings in the browse pages with our heading component. Specifically on:

- https://www.gov.uk/browse
- https://www.gov.uk/browse/benefits

e.g.

![Screenshot 2024-08-05 at 11 05 37](https://github.com/user-attachments/assets/924e2270-2bd9-4bb8-baa3-e74d7c186f9b)


## Why
There's no obvious reason why this shouldn't be a component - and using the component allows us to remove a few lines of CSS.

## Visual changes
None.