### PR TITLE
Do not force analytics labels for popular links to be in English and refactor browse helper

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -1,28 +1,27 @@
 module BrowseHelper
-  ACTION_LINK_DATA = {
-    benefits: [
-      { lang: "browse.check_benefits_and_financial_support", href: "/check-benefits-financial-support" },
-    ],
-    business: [
-      { lang: "browse.hmrc_online_services", href: "/log-in-register-hmrc-online-services" },
-      { lang: "browse.self_assessment_tax_returns", href: "/self-assessment-tax-returns" },
-      { lang: "browse.pay_employers_paye", href: "/pay-paye-tax" },
-    ],
-  }.freeze
-
-  def display_action_links_for_slug?(slug)
-    ACTION_LINK_DATA.key?(slug.to_sym)
+  def display_popular_links_for_slug?(slug)
+    I18n.exists?(slug.to_s, scope: "browse.popular_links")
   end
 
-  def action_link_data(slug)
-    links = ACTION_LINK_DATA[slug.to_sym]
-    return [] unless links
-
-    links.each_with_index do |link, index|
-      link[:text] = I18n.t(link[:lang])
-      link[:ga4_text] = I18n.t(link[:lang], locale: :en)
-      link[:index_link] = index + 1
-      link[:index_total] = links.length
+  def popular_links_for_slug(slug)
+    links = I18n.t(slug.to_s, scope: "browse.popular_links")
+    count = links.length
+    links.map.with_index(1) do |link, index|
+      {
+        text: link[:title],
+        href: link[:url],
+        data_attributes: {
+          module: "ga4-link-tracker",
+          ga4_track_links_only: "",
+          ga4_link: {
+            event_name: "navigation",
+            type: "action",
+            index_link: index,
+            index_total: count,
+            text: link[:title],
+          },
+        },
+      }
     end
   end
 end

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -34,7 +34,7 @@
   } %>
 <% end %>
 
-<% if display_action_links_for_slug?(page.slug) %>
+<% if display_popular_links_for_slug?(page.slug) %>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
@@ -45,9 +45,9 @@
             font_size: "m"
           } %>
           <ul class="govuk-list govuk-!-margin-bottom-7">
-            <% action_link_data(page.slug).each do |link| %>
+            <% popular_links_for_slug(page.slug).each do |link| %>
               <li>
-                <%= render "shared/browse_action_link", locals: link %>
+                <%= render partial: "shared/browse_action_link", locals: {link:} %>
               </li>
             <% end %>
           </ul>
@@ -60,7 +60,7 @@
 <% total_links = page.second_level_browse_pages.count.to_s %>
 <%= render "shared/browse_cards_container" do %>
   <%= render "govuk_publishing_components/components/cards", {
-    heading: display_action_links_for_slug?(page.slug) ? t("browse.topics") : nil,
+    heading: display_popular_links_for_slug?(page.slug) ? t("browse.topics") : nil,
     items: page.second_level_browse_pages.map.with_index do |second_level_browse_page, index|
       {
         link: {
@@ -78,6 +78,6 @@
         description: second_level_browse_page.description,
       }
     end,
-    sub_heading_level: display_action_links_for_slug?(page.slug) ? 3 : 2,
+    sub_heading_level: display_popular_links_for_slug?(page.slug) ? 3 : 2,
   } %>
 <% end %>

--- a/app/views/shared/_browse_action_link.erb
+++ b/app/views/shared/_browse_action_link.erb
@@ -1,17 +1,5 @@
 <%= render "govuk_publishing_components/components/action_link", {
-  text: locals[:text],
-  href: locals[:href],
   dark_large_icon: true,
   margin_bottom: 3,
-  data_attributes: {
-    module: "ga4-link-tracker",
-    ga4_track_links_only: "",
-    ga4_link: {
-      event_name: "navigation",
-      type: "action",
-      index_link: locals[:index_link],
-      index_total: locals[:index_total],
-      text: locals[:ga4_text]
-    }
-  }
+  **link,
 } %>

--- a/config/locales/ar/browse.yml
+++ b/config/locales/ar/browse.yml
@@ -1,12 +1,19 @@
 ---
 ar:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: جميع الفئات
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/az/browse.yml
+++ b/config/locales/az/browse.yml
@@ -1,12 +1,19 @@
 ---
 az:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Bütün kateqoriyalar
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/be/browse.yml
+++ b/config/locales/be/browse.yml
@@ -1,12 +1,19 @@
 ---
 be:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Усе катэгорыі
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/bg/browse.yml
+++ b/config/locales/bg/browse.yml
@@ -1,12 +1,19 @@
 ---
 bg:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Всички категории
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/bn/browse.yml
+++ b/config/locales/bn/browse.yml
@@ -1,12 +1,19 @@
 ---
 bn:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: সকল শ্রেণিবিভাগ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/cs/browse.yml
+++ b/config/locales/cs/browse.yml
@@ -1,12 +1,19 @@
 ---
 cs:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Všechny kategorie
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/cy/browse.yml
+++ b/config/locales/cy/browse.yml
@@ -1,12 +1,19 @@
 ---
 cy:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Pob categori
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/da/browse.yml
+++ b/config/locales/da/browse.yml
@@ -1,12 +1,19 @@
 ---
 da:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Alle kategorier
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/de/browse.yml
+++ b/config/locales/de/browse.yml
@@ -1,12 +1,19 @@
 ---
 de:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Alle Kategorien
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/dr/browse.yml
+++ b/config/locales/dr/browse.yml
@@ -1,12 +1,19 @@
 ---
 dr:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: تمام کتگوری ها
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/el/browse.yml
+++ b/config/locales/el/browse.yml
@@ -1,12 +1,19 @@
 ---
 el:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Όλες οι κατηγορίες
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/en/browse.yml
+++ b/config/locales/en/browse.yml
@@ -4,9 +4,16 @@ en:
     all_categories: All categories
     popular_tasks: Popular tasks
     topics: Topics
-    check_benefits_and_financial_support: Check benefits and financial support you can get
-    hmrc_online_services: "HMRC online services: sign in or set up an account"
-    self_assessment_tax_returns: Self Assessment tax returns
-    pay_employers_paye: "Pay employers' PAYE"
     description: Find the government services, forms and accounts you need to use
     title: Services and information
+    popular_links:
+      benefits:
+        - title: Check benefits and financial support you can get
+          url: /check-benefits-financial-support
+      business:
+        - title: "HMRC online services: sign in or set up an account"
+          url: /log-in-register-hmrc-online-services
+        - title: Self Assessment tax returns
+          url: /self-assessment-tax-returns
+        - title: "Pay employers' PAYE"
+          url: /pay-paye-tax

--- a/config/locales/es-419/browse.yml
+++ b/config/locales/es-419/browse.yml
@@ -1,12 +1,19 @@
 ---
 es-419:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Todas las categorías
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/es/browse.yml
+++ b/config/locales/es/browse.yml
@@ -1,12 +1,19 @@
 ---
 es:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Todas las categorías
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/et/browse.yml
+++ b/config/locales/et/browse.yml
@@ -1,12 +1,19 @@
 ---
 et:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Kõik kategooriad
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fa/browse.yml
+++ b/config/locales/fa/browse.yml
@@ -1,12 +1,19 @@
 ---
 fa:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: تمام دسته‌بندی‌ها
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fi/browse.yml
+++ b/config/locales/fi/browse.yml
@@ -1,12 +1,19 @@
 ---
 fi:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Kaikki kategoriat
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/fr/browse.yml
+++ b/config/locales/fr/browse.yml
@@ -1,12 +1,19 @@
 ---
 fr:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Toutes catégories
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/gd/browse.yml
+++ b/config/locales/gd/browse.yml
@@ -1,12 +1,19 @@
 ---
 gd:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Gach cineál táirgí
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/gu/browse.yml
+++ b/config/locales/gu/browse.yml
@@ -1,12 +1,19 @@
 ---
 gu:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: તમામ શ્રેણીઓ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/he/browse.yml
+++ b/config/locales/he/browse.yml
@@ -1,12 +1,19 @@
 ---
 he:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: כל הקטגוריות
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hi/browse.yml
+++ b/config/locales/hi/browse.yml
@@ -1,12 +1,19 @@
 ---
 hi:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: सभी वर्ग
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hr/browse.yml
+++ b/config/locales/hr/browse.yml
@@ -1,12 +1,19 @@
 ---
 hr:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Sve kategorije
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hu/browse.yml
+++ b/config/locales/hu/browse.yml
@@ -1,12 +1,19 @@
 ---
 hu:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Minden kategória
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/hy/browse.yml
+++ b/config/locales/hy/browse.yml
@@ -1,12 +1,19 @@
 ---
 hy:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Բոլոր կատեգորիաները
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/id/browse.yml
+++ b/config/locales/id/browse.yml
@@ -1,12 +1,19 @@
 ---
 id:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Semua kategori
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/is/browse.yml
+++ b/config/locales/is/browse.yml
@@ -1,12 +1,19 @@
 ---
 is:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Allir flokkar
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/it/browse.yml
+++ b/config/locales/it/browse.yml
@@ -1,12 +1,19 @@
 ---
 it:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Tutte le categorie
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ja/browse.yml
+++ b/config/locales/ja/browse.yml
@@ -1,12 +1,19 @@
 ---
 ja:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: すべてのカテゴリ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ka/browse.yml
+++ b/config/locales/ka/browse.yml
@@ -1,12 +1,19 @@
 ---
 ka:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: ყველა კატეგორია
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/kk/browse.yml
+++ b/config/locales/kk/browse.yml
@@ -1,12 +1,19 @@
 ---
 kk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Барлық санаттар
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ko/browse.yml
+++ b/config/locales/ko/browse.yml
@@ -1,12 +1,19 @@
 ---
 ko:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: 모든 범주
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/lt/browse.yml
+++ b/config/locales/lt/browse.yml
@@ -1,12 +1,19 @@
 ---
 lt:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Visos kategorijos
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/lv/browse.yml
+++ b/config/locales/lv/browse.yml
@@ -1,12 +1,19 @@
 ---
 lv:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Visas kategorijas
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ms/browse.yml
+++ b/config/locales/ms/browse.yml
@@ -1,12 +1,19 @@
 ---
 ms:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Semua kategori
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/mt/browse.yml
+++ b/config/locales/mt/browse.yml
@@ -1,12 +1,19 @@
 ---
 mt:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Kategoriji kollha
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ne/browse.yml
+++ b/config/locales/ne/browse.yml
@@ -1,12 +1,19 @@
 ---
 ne:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories:
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/nl/browse.yml
+++ b/config/locales/nl/browse.yml
@@ -1,12 +1,19 @@
 ---
 nl:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Alle categorieën
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/no/browse.yml
+++ b/config/locales/no/browse.yml
@@ -1,12 +1,19 @@
 ---
 'no':
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Alle kategorier
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pa-pk/browse.yml
+++ b/config/locales/pa-pk/browse.yml
@@ -1,12 +1,19 @@
 ---
 pa-pk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: سارے گروہ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pa/browse.yml
+++ b/config/locales/pa/browse.yml
@@ -1,12 +1,19 @@
 ---
 pa:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: ਸਾਰੀਆਂ ਸ਼੍ਰੇਣੀਆਂ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pl/browse.yml
+++ b/config/locales/pl/browse.yml
@@ -1,12 +1,19 @@
 ---
 pl:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Wszystkie kategorie
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ps/browse.yml
+++ b/config/locales/ps/browse.yml
@@ -1,12 +1,19 @@
 ---
 ps:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: ټولې کټګورۍ
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/pt/browse.yml
+++ b/config/locales/pt/browse.yml
@@ -1,12 +1,19 @@
 ---
 pt:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Todas as categorias
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ro/browse.yml
+++ b/config/locales/ro/browse.yml
@@ -1,12 +1,19 @@
 ---
 ro:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Toate categoriile
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ru/browse.yml
+++ b/config/locales/ru/browse.yml
@@ -1,12 +1,19 @@
 ---
 ru:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Все категории
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/si/browse.yml
+++ b/config/locales/si/browse.yml
@@ -1,12 +1,19 @@
 ---
 si:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: සියලු ප්රවර්ග
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sk/browse.yml
+++ b/config/locales/sk/browse.yml
@@ -1,12 +1,19 @@
 ---
 sk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Všetky kategórie
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sl/browse.yml
+++ b/config/locales/sl/browse.yml
@@ -1,12 +1,19 @@
 ---
 sl:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Vse kategorije
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/so/browse.yml
+++ b/config/locales/so/browse.yml
@@ -1,12 +1,19 @@
 ---
 so:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Dhamaan qeybaha
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sq/browse.yml
+++ b/config/locales/sq/browse.yml
@@ -1,12 +1,19 @@
 ---
 sq:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Të gjitha kategoritë
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sr/browse.yml
+++ b/config/locales/sr/browse.yml
@@ -1,12 +1,19 @@
 ---
 sr:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Sve kategorije
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sv/browse.yml
+++ b/config/locales/sv/browse.yml
@@ -1,12 +1,19 @@
 ---
 sv:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Alla kategorier
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/sw/browse.yml
+++ b/config/locales/sw/browse.yml
@@ -1,12 +1,19 @@
 ---
 sw:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Aina zote
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ta/browse.yml
+++ b/config/locales/ta/browse.yml
@@ -1,12 +1,19 @@
 ---
 ta:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: அனைத்து வகையினங்கள்
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/th/browse.yml
+++ b/config/locales/th/browse.yml
@@ -1,12 +1,19 @@
 ---
 th:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: ทุกหมวดหมู่
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/tk/browse.yml
+++ b/config/locales/tk/browse.yml
@@ -1,12 +1,19 @@
 ---
 tk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Ähli toparlar
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/tr/browse.yml
+++ b/config/locales/tr/browse.yml
@@ -1,12 +1,19 @@
 ---
 tr:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Tüm kategoriler
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/uk/browse.yml
+++ b/config/locales/uk/browse.yml
@@ -1,12 +1,19 @@
 ---
 uk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Всі категорії
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/ur/browse.yml
+++ b/config/locales/ur/browse.yml
@@ -1,12 +1,19 @@
 ---
 ur:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: تمام زمرہ جات
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/uz/browse.yml
+++ b/config/locales/uz/browse.yml
@@ -1,12 +1,19 @@
 ---
 uz:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Барча тоифалар
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/vi/browse.yml
+++ b/config/locales/vi/browse.yml
@@ -1,12 +1,19 @@
 ---
 vi:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: Tất cả danh mục
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/yi/browse.yml
+++ b/config/locales/yi/browse.yml
@@ -1,12 +1,19 @@
 ---
 yi:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories:
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh-hk/browse.yml
+++ b/config/locales/zh-hk/browse.yml
@@ -1,12 +1,19 @@
 ---
 zh-hk:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: 所有種類
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh-tw/browse.yml
+++ b/config/locales/zh-tw/browse.yml
@@ -1,12 +1,19 @@
 ---
 zh-tw:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: 所有類別
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/config/locales/zh/browse.yml
+++ b/config/locales/zh/browse.yml
@@ -1,12 +1,19 @@
 ---
 zh:
   browse:
+    popular_links:
+      benefits:
+        - title:
+          url:
+      business:
+        - title:
+          url:
+        - title:
+          url:
+        - title:
+          url:
     all_categories: 全部分类
-    check_benefits_and_financial_support:
     description:
-    hmrc_online_services:
-    pay_employers_paye:
     popular_tasks:
-    self_assessment_tax_returns:
     title:
     topics:

--- a/spec/helpers/browse_helper_spec.rb
+++ b/spec/helpers/browse_helper_spec.rb
@@ -1,16 +1,64 @@
 RSpec.describe BrowseHelper do
-  describe "action links on browse pages" do
-    it "returns expected data for a browse page with action links" do
-      expected = [
-        { text: t("browse.hmrc_online_services"), ga4_text: t("browse.hmrc_online_services", locale: :en), lang: "browse.hmrc_online_services", href: "/log-in-register-hmrc-online-services", index_link: 1, index_total: 3 },
-        { text: t("browse.self_assessment_tax_returns"), ga4_text: t("browse.self_assessment_tax_returns", locale: :en), lang: "browse.self_assessment_tax_returns", href: "/self-assessment-tax-returns", index_link: 2, index_total: 3 },
-        { text: t("browse.pay_employers_paye"), ga4_text: t("browse.pay_employers_paye", locale: :en), lang: "browse.pay_employers_paye", href: "/pay-paye-tax", index_link: 3, index_total: 3 },
-      ]
-      expect(helper.action_link_data("business")).to eq(expected)
+  describe "#display_popular_links_for_slug?" do
+    it "returns true for existing slug" do
+      expect(helper.display_popular_links_for_slug?("business")).to be(true)
     end
 
-    it "returns nothing where there are no action links" do
-      expect(helper.action_link_data("not-a-page")).to eq([])
+    it "returns false for nonexisting slug" do
+      expect(helper.display_popular_links_for_slug?("random12345")).to be(false)
+    end
+  end
+
+  describe "#popular_links_for_slug" do
+    it "returns popular links data" do
+      expected_links = [
+        {
+          text: "HMRC online services: sign in or set up an account",
+          href: "/log-in-register-hmrc-online-services",
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_track_links_only: "",
+            ga4_link: {
+              event_name: "navigation",
+              type: "action",
+              index_link: 1,
+              index_total: 3,
+              text: "HMRC online services: sign in or set up an account",
+            },
+          },
+        },
+        {
+          text: "Self Assessment tax returns",
+          href: "/self-assessment-tax-returns",
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_track_links_only: "",
+            ga4_link: {
+              event_name: "navigation",
+              type: "action",
+              index_link: 2,
+              index_total: 3,
+              text: "Self Assessment tax returns",
+            },
+          },
+        },
+        {
+          text: "Pay employers' PAYE",
+          href: "/pay-paye-tax",
+          data_attributes: {
+            module: "ga4-link-tracker",
+            ga4_track_links_only: "",
+            ga4_link: {
+              event_name: "navigation",
+              type: "action",
+              index_link: 3,
+              index_total: 3,
+              text: "Pay employers' PAYE",
+            },
+          },
+        },
+      ]
+      expect(helper.popular_links_for_slug("business")).to eq(expected_links)
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

In preparation for adding the AB test configuration to collections, we can refactor the way the code is currently organised.

In addition to that, do not force the analytics labels of popular links to always be in English.

## Why

[Trello card](https://trello.com/c/SQT21D91/2761-refactor-browsehelper-in-preparation-for-ab-test-m)