### PR TITLE
Remove browse.json redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   unless Rails.env.production?
     get "/development", to: "development#index"
   end
-  
+
   resources :browse, only: %i[index show], param: :top_level_slug do
     get ":second_level_slug", on: :member, to: "second_level_browse_page#show"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,9 +21,7 @@ Rails.application.routes.draw do
   unless Rails.env.production?
     get "/development", to: "development#index"
   end
-
-  get "/browse.json" => redirect("/api/content/browse")
-
+  
   resources :browse, only: %i[index show], param: :top_level_slug do
     get ":second_level_slug", on: :member, to: "second_level_browse_page#show"
   end


### PR DESCRIPTION
This doesn't path doesn't appear to be used anymore. The logs show only 8 requests to this path over the last 90 days.
