### PR TITLE
Remove world and world news atom feeds

### DIFF
--- a/app/controllers/world_location_news_controller.rb
+++ b/app/controllers/world_location_news_controller.rb
@@ -1,22 +1,9 @@
 class WorldLocationNewsController < ApplicationController
   around_action :switch_locale
-  enable_request_formats show: :atom
 
   def show
-    path = request.path.gsub(".atom", "")
-    @world_location_news = WorldLocationNews.find!(path)
+    @world_location_news = WorldLocationNews.find!(request.path)
 
-    respond_to do |format|
-      format.html do
-        setup_content_item_and_navigation_helpers(@world_location_news)
-      end
-
-      format.atom do
-        results = FeedContent.new(filter_world_locations: params[:name]).results(10)
-        items = results.map { |result| FeedEntryPresenter.new(result) }
-
-        render "feeds/feed", locals: { items:, root_url: Plek.new.website_root + path, title: "#{@world_location_news.title} - Activity on GOV.UK" }
-      end
-    end
+    setup_content_item_and_navigation_helpers(@world_location_news)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,17 +94,9 @@ Rails.application.routes.draw do
       to: "embassies#index",
       as: :embassies
 
-  get "/world/:name/news(.:locale).atom",
-      to: "world_location_news#show",
-      as: :world_location_news_feed
-
   get "/world/:name/news(.:locale)",
       to: "world_location_news#show",
       as: :world_location_news
-
-  get "/world/:name(.:locale).atom",
-      to: "world_location_news#show",
-      as: :international_delegation_news_feed
 
   get "/world/*taxon_base_path", to: "world_wide_taxons#show"
 

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -244,31 +244,6 @@ RSpec.feature "World Location News pages" do
     end
   end
 
-  context "when requesting the atom feed" do
-    let(:related_documents) { { "An announcement on World Locations" => "/foo/announcement_one", "Another announcement" => "/foo/announcement_two" } }
-
-    before do
-      stub_search(body: search_api_response(related_documents))
-    end
-
-    it "sets the page title" do
-      visit "#{base_path}.atom"
-      expect(page).to have_title("#{content_item['title']} - Activity on GOV.UK")
-    end
-
-    it "should include the correct entries" do
-      visit "#{base_path}.atom"
-
-      entries = Hash.from_xml(page.html).dig("feed", "entry")
-
-      expect(entries.first).to include("title" => "some_display_type: An announcement on World Locations")
-      expect(entries.first["link"]).to include("href" => "http://www.test.gov.uk/foo/announcement_one")
-
-      expect(entries.second).to include("title" => "some_display_type: Another announcement")
-      expect(entries.second["link"]).to include("href" => "http://www.test.gov.uk/foo/announcement_two")
-    end
-  end
-
   context "for an International Delegation page" do
     let(:base_path) { "/world/mock-country" }
 
@@ -282,11 +257,6 @@ RSpec.feature "World Location News pages" do
       visit base_path
       expect(page).to have_title("UK and Mock Country - GOV.UK")
       expect(page).to have_text("International delegation")
-    end
-
-    it "renders the atom feed" do
-      visit "#{base_path}.atom"
-      expect(page).to have_title("#{content_item['title']} - Activity on GOV.UK")
     end
   end
 

--- a/spec/features/world_location_taxon_spec.rb
+++ b/spec/features/world_location_taxon_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "World location taxon page" do
   let(:taxon) { WorldWideTaxon.find(base_path) }
   let(:child_taxon_base_path) { "/world/news-and-events-usa" }
   let(:child_taxon) { WorldWideTaxon.find(child_taxon_base_path) }
-  let(:feed_url) { "#{Plek.new.website_root}/world/usa.atom" }
   let(:email_url) { Plek.new.website_root + "/email-signup?link=#{base_path}" }
 
   scenario "contains email signup url if we are browsing a world location" do
@@ -24,19 +23,6 @@ RSpec.feature "World location taxon page" do
     visit base_path
 
     expect(page).to have_selector("a[href='#{email_url}']", text: "Get emails for this topic")
-  end
-
-  scenario "does not contain the feed selector if we are browsing a world location leaf page" do
-    world_usa = world_usa_taxon(base_path:, phase: "live")
-    world_usa.delete("links")
-
-    stub_content_store_has_item(base_path, world_usa)
-    stub_content_for_taxon(taxon.content_id, search_results)
-
-    visit base_path
-
-    expect(page).not_to have_selector("button", text: "Subscribe to feed")
-    expect(page).not_to have_selector(".gem-c-subscription-links input[value='#{feed_url}']")
   end
 
 private


### PR DESCRIPTION
We no longer support atom feeds for this content. The link to atom feeds were removed in this [PR](https://github.com/alphagov/collections/pull/3238).

Another issue has meant that these routes have been inaccessible and returning 404 anyway.