### PR TITLE
[DO NOT MERGE] Display GOV.UK Chat promo on certain pages

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -93,3 +93,16 @@ $browse-header-background-colour: #263135;
     margin-bottom: govuk-spacing(6);
   }
 }
+
+.browse__govuk-chat-promo {
+  @include govuk-media-query($until: "tablet") {
+    border-top: 4px solid govuk-colour("blue");
+    padding-top: govuk-spacing(5);
+  }
+}
+
+.browse__govuk-chat-promo--second-level {
+  @include govuk-media-query($until: "tablet") {
+    border-top-width: 2px;
+  }
+}

--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,0 +1,14 @@
+module GovukChatPromoHelper
+  GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+    /browse/business
+    /browse/business/business-tax
+    /browse/business/setting-up
+    /browse/tax/self-assessment
+    /set-up-limited-company
+    /set-up-as-sole-trader
+  ].freeze
+
+  def show_govuk_chat_promo?(base_path)
+    ENV["GOVUK_CHAT_PROMO_ENABLED"] == "true" && GOVUK_CHAT_PROMO_BASE_PATHS.include?(base_path)
+  end
+end

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -37,9 +37,9 @@
 
 <% if display_popular_links_for_slug?(page.slug) %>
   <div class="govuk-width-container">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <div class="browse__action-links">
+    <div class="browse__action-links">
+      <div class="govuk-grid-row">
+        <div class="<%= show_govuk_chat_promo?(page.base_path) ? "govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop" : "govuk-grid-column-full" %>">
           <%= render "govuk_publishing_components/components/heading", {
             text: t("browse.popular_tasks"),
             margin_bottom: 6,
@@ -53,6 +53,14 @@
             <% end %>
           </ul>
         </div>
+
+        <% if show_govuk_chat_promo?(page.base_path) %>
+          <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
+            <div class="browse__govuk-chat-promo">
+              <%= render "govuk_publishing_components/components/chat_entry" %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -34,8 +34,16 @@
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" data-module="ga4-link-tracker">
+    <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop" data-module="ga4-link-tracker">
       <%= render partial: curated_partial, locals: { page: page } %>
     </div>
+
+    <% if show_govuk_chat_promo?(page.base_path) %>
+      <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
+        <div class="browse__govuk-chat-promo browse__govuk-chat-promo--second-level">
+          <%= render "govuk_publishing_components/components/chat_entry" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -4,19 +4,27 @@
   <meta name="description" content="<%= step_by_step.description %>">
 <% end %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
     <%= render 'govuk_publishing_components/components/title',
         title: step_by_step.title,
         average_title_length: 'long',
         margin_bottom: 6 %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
     <%= render "govuk_publishing_components/components/govspeak", {
     } do %>
       <%= step_by_step.introduction %>
     <% end %>
-  </div>
-</div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+
     <%= render "govuk_publishing_components/components/step_by_step_nav", step_by_step.payload_for_component %>
   </div>
+
+  <% if show_govuk_chat_promo?(step_by_step.base_path) %>
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
+      <%= render "govuk_publishing_components/components/chat_entry", { border_top: true } %>
+    </div>
+  <% end %>
 </div>

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -141,4 +141,17 @@ RSpec.feature "Mainstream browsing" do
       end
     end
   end
+
+  it "renders the GOV.UK Chat promo" do
+    content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "top_level_page").tap do |item|
+      item["base_path"] = GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first
+    end
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      visit content_item["base_path"]
+      expect(page).to have_selector(".gem-c-chat-entry")
+    end
+  end
 end

--- a/spec/features/step_nav_page_spec.rb
+++ b/spec/features/step_nav_page_spec.rb
@@ -36,6 +36,20 @@ RSpec.feature "Step by step nav pages" do
     expect(page).to have_title("#{content_item['title']} - GOV.UK")
   end
 
+  it "renders the GOV.UK Chat promo" do
+    schema = GovukSchemas::Schema.find(frontend_schema: "step_by_step_nav")
+    content_item = GovukSchemas::RandomExample.new(schema:).payload.tap do |item|
+      item["base_path"] = GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first
+    end
+
+    stub_content_store_has_item(content_item["base_path"], content_item)
+
+    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+      visit content_item["base_path"]
+      expect(page).to have_selector(".gem-c-chat-entry")
+    end
+  end
+
   def step_nav_example
     schema = GovukSchemas::Schema.find(frontend_schema: "step_by_step_nav")
 

--- a/spec/helpers/govuk_chat_promo_helper_spec.rb
+++ b/spec/helpers/govuk_chat_promo_helper_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe GovukChatPromoHelper do
+  describe "#show_govuk_chat_promo?" do
+    it "should return false if the environment variable is not set" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "false" do
+        expect(helper.show_govuk_chat_promo?(described_class::GOVUK_CHAT_PROMO_BASE_PATHS.first)).to be false
+      end
+    end
+
+    it "should return false if the base path is not in the configured list" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+        expect(helper.show_govuk_chat_promo?("/does-not-match")).to be false
+      end
+    end
+
+    it "should return true if the base path is in the configured list" do
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+        expect(helper.show_govuk_chat_promo?(described_class::GOVUK_CHAT_PROMO_BASE_PATHS.first)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to show a promo to the new GOV.UK Chat application on certain pages on GOV.UK. It's a CTA pointing users to the chat app.

The list of URLs we want the promo to appear on is quite short and covers only L1 browse, L2 browse and step_by_step  content types from this codebase.

Following are screenshots of each page type on desktop and mobile, showing the before/after states.


### L1 Browse

| Before  | After |
| ------------- | ------------- |
| <img width="1002" alt="l1_browse_desktop_before" src="https://github.com/user-attachments/assets/5628555e-30d9-45bf-a6c4-0a3e8584adf6"> | <img width="1017" alt="l1_browse_desktop_after" src="https://github.com/user-attachments/assets/414afd05-280e-49e3-b948-382d2487165d"> |
| <img width="415" alt="l1_browse_mobile_before" src="https://github.com/user-attachments/assets/0dc346e9-c32f-46d3-9ac7-f77277a04dd4"> | <img width="417" alt="l1_browse_mobile_after" src="https://github.com/user-attachments/assets/fc4f5d0d-3448-4933-97d2-31f5d70a2ab8"> |

### L2 browse

| Before  | After |
| ------------- | ------------- |
| <img width="997" alt="l2_browse_desktop_before" src="https://github.com/user-attachments/assets/9b6e285d-cd80-41a7-a367-4cb3295d55ab"> | <img width="1008" alt="l2_browse_desktop_after" src="https://github.com/user-attachments/assets/2fcd786a-4f76-4910-bc8b-b8bc14797508"> |
| <img width="416" alt="l2_browse_mobile_before" src="https://github.com/user-attachments/assets/c521f913-7eb3-4360-b7df-44ee125dd0bd"> | <img width="412" alt="l2_browse_mobile_after" src="https://github.com/user-attachments/assets/49d70504-1886-4885-91fa-95fe2f605549"> |

### step_by_step

| Before  | After |
| ------------- | ------------- |
| <img width="1010" alt="sbs_desktop_before" src="https://github.com/user-attachments/assets/cf3ad1bf-98f8-4e6e-97d8-bcf22ec19ba8"> |<img width="1044" alt="sbs_desktop_after" src="https://github.com/user-attachments/assets/2f979ac2-efa1-415a-af95-4b2712767802"> |
| <img width="416" alt="sbs_mobile_before" src="https://github.com/user-attachments/assets/0a3ccc69-61e1-469e-9d61-967a4d9d2a8f"> | <img width="416" alt="sbs_mobile_after" src="https://github.com/user-attachments/assets/d4d5dab8-a5a1-457c-8da1-e31a5ea8d748"> |



