### PR TITLE
Remove hack that prevents the emergency banner appearing on HM Queen Elizabeth II's page.

### DIFF
--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -5,8 +5,6 @@ class TopicalEventsController < ApplicationController
     path = topical_event_path(params[:name])
     @topical_event = TopicalEvent.find!(path)
 
-    slimmer_template "gem_layout_no_emergency_banner" if @topical_event.slug == "her-majesty-queen-elizabeth-ii"
-
     respond_to do |format|
       format.html do
         setup_content_item_and_navigation_helpers(@topical_event)


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
