### PR TITLE
Reorder number 10 org page

### DIFF
--- a/app/views/organisations/_featured_news_no10.html.erb
+++ b/app/views/organisations/_featured_news_no10.html.erb
@@ -17,8 +17,17 @@
       } %>
     </div>
   </div>
-
-  <% @documents.remaining_featured_news.first(6).in_groups_of(3, false) do |news| %>
+  <%
+    first_document = @documents.remaining_featured_news.first
+    first_document[:context][:text] = "Featured"
+    documents_without_first = @documents.remaining_featured_news.drop(1).first(6)
+  %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+      <%= render "govuk_publishing_components/components/image_card", first_document.merge({ large: true }) %>
+    </div>
+  </div>
+  <% documents_without_first.in_groups_of(3, false) do |news| %>
     <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
       <% news.each do |news_item| %>
         <% classes = %w[] %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -13,8 +13,8 @@
            content_item: @organisation.content_item.content_item_data %>
 
 <% if @organisation.is_no_10? %>
+  <%= render partial: 'featured_news_no10' %>
   <%= render partial: 'latest_news' %>
-  <%= render partial: 'featured_news_small' %>
   <%= render partial: 'videos' if @documents.has_promotional_video_feature? %>
   <%= render partial: 'promotional_features_side_by_side' %>
 <% else %>


### PR DESCRIPTION
## What / Why
- Moves the "Featured" section above "Latest News" for the No. 10 org page
- Adds a new large featured image card to this "Featured" section
- I've overwritten the `context` for the image card to say "Featured" as per the designs.
- Trello card: https://trello.com/c/ey4KM89d/59-make-changes-to-no10-organisation-page
- Some work has been done to ensure the small cards below the large one will still have 6 items: https://github.com/alphagov/whitehall/pull/9530
- Using `first_featured_news` means the thumbnail is rendered at a higher resolution.

## Screenshots
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/b58eec28-f81f-43da-93a4-f9b09ae5941d">

