### PR TITLE
Update share links branding and update govuk_publishing_components to v45.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (44.11.0)
+    govuk_publishing_components (45.0.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -42,7 +42,7 @@
         lang: t_fallback('organisations.follow_us')
       } %>
       <div lang="en">
-        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links.merge({ ga4_extra_data: { section: t('organisations.follow_us', locale: :en, brand: @organisation.brand ) }}) %>
+        <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links.merge({black_icons: true, black_links: true, ga4_extra_data: { section: t('organisations.follow_us', locale: :en, brand: @organisation.brand ) }}) %>
       </div>
   <% end %>
 </div>

--- a/app/views/organisations/_what_we_do.html.erb
+++ b/app/views/organisations/_what_we_do.html.erb
@@ -37,7 +37,7 @@
           lang: t_fallback('organisations.follow_us')
         } %>
         <div lang="en">
-          <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links.merge({ ga4_extra_data: { section: t('organisations.what_we_do', locale: :en) }}) %>
+          <%= render "govuk_publishing_components/components/share_links", @what_we_do.share_links.merge({ black_icons: true, ga4_extra_data: { section: t('organisations.what_we_do', locale: :en) }}) %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## What / Why
- Uses the new `black_links` and `black_icons` options for the `share_links` components
- Because the component has changed in `govuk_publishing_components` `v45.0.0` to remove brand colours. So we are using `black_icons` and `black_links` for the number 10 page. And only using `black_icons` for other organisation pages.