### PR TITLE
Fix markup for world-locations section

### DIFF
--- a/app/assets/stylesheets/views/_world_index.scss
+++ b/app/assets/stylesheets/views/_world_index.scss
@@ -6,6 +6,7 @@
   }
 
   .world-locations-groups {
+    list-style-type: none;
     padding: govuk-spacing(5) 0 0;
   }
 

--- a/app/views/world/index.html.erb
+++ b/app/views/world/index.html.erb
@@ -60,7 +60,7 @@
           data-ga4-track-links-only
           data-ga4-link="<%= { event_name: "navigation", type: "filter" }.to_json %>">
           <% @presented_index.grouped_world_locations.each do |letter, locations| %>
-            <div class="world-locations-group" data-filter="inner-block">
+            <li class="world-locations-group" data-filter="inner-block">
               <h3 class="world-locations-group__letter"><%= letter %></h3>
               <ol class="world-locations-group__list">
                 <% locations.each do |location| %>
@@ -69,7 +69,7 @@
                   </li>
                 <% end %>
               </ol>
-            </div>
+            </li>
           <% end %>
         </ol>
       </div>
@@ -96,7 +96,7 @@
 
       <div class="govuk-grid-column-two-thirds">
         <ol class="world-locations-groups">
-          <div class="world-locations-group">
+          <li class="world-locations-group">
             <ol class="world-locations-group__list">
               <% @presented_index.international_delegations.each do |delegation| %>
                 <li class="world_locations-group__item" data-filter="item" data-filter-terms="<%= @presented_index.filter_terms(delegation) %>">
@@ -104,7 +104,7 @@
                 </li>
               <% end %>
             </ol>
-          </div>
+          </li>
         </ol>
       </div>
     </section>


### PR DESCRIPTION
## What
[Trello card](https://trello.com/c/HsaHBtP3/2952-invalid-html-in-list-of-services-around-the-world)

The [Help and Services around the world](https://www.gov.uk/world) page has invalid HTML as the `<ol>` around the results has child elements that are not `<li>` elements.

When I ran the results page in W3 Validator, it states that`Element [div] not allowed as child of element [ol]: <div class="world-locations-group" data-filter="inner-block">`

## Why
As it's invalid HTML, it should be fixed. 

## Page Preview
https://collections-pr-3807.herokuapp.com/world