### PR TITLE
Enable form data UTF-8 sanitisation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -130,7 +130,6 @@ module Collections
     config.middleware.insert_before(
       0,
       Rack::UTF8Sanitizer,
-      sanitizable_content_types: [],
       only: %w[QUERY_STRING],
       strategy: Sanitiser::Strategy,
     )

--- a/lib/sanitiser/strategy.rb
+++ b/lib/sanitiser/strategy.rb
@@ -11,7 +11,7 @@ module Sanitiser
           raise NullByteInString
         end
       rescue StandardError
-        raise SanitisingError, "Non-UTF-8 (or null) character in the query or in the cookie"
+        raise SanitisingError, "Non-UTF-8 (or null) character in the query, cookie or form data"
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What 

After developing the solution presented in [this PR](https://github.com/alphagov/collections/pull/3820), @hannako decided that it would be good to also sanitise and ignore exceptions raised from form data UTF-8 encoding issues. This PR introduces that change.

Collections currently do not have any POST/PATCH/PUT routes, but this change is being added for consistency with other repositories and in case any routes related to uploading form data are added in the future.

## Why

As a follow up to the PR resolving [this Trello ticket](https://trello.com/c/FeOwxE2x/2938-silently-handle-invalid-byte-sequence-in-utf-8-errors-l)