### PR TITLE
Update test for step nav chat promo

### DIFF
--- a/spec/features/step_nav_page_spec.rb
+++ b/spec/features/step_nav_page_spec.rb
@@ -37,16 +37,15 @@ RSpec.feature "Step by step nav pages" do
   end
 
   it "renders the GOV.UK Chat promo" do
-    schema = GovukSchemas::Schema.find(frontend_schema: "step_by_step_nav")
-    content_item = GovukSchemas::RandomExample.new(schema:).payload.tap do |item|
-      item["base_path"] = GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first
-    end
+    content_item = GovukSchemas::RandomExample.for_schema(frontend_schema: "step_by_step_nav")
+    ["/set-up-limited-company", "/set-up-as-sole-trader"].each do |path|
+      content_item["base_path"] = path
+      stub_content_store_has_item(content_item["base_path"], content_item)
 
-    stub_content_store_has_item(content_item["base_path"], content_item)
-
-    ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
-      visit content_item["base_path"]
-      expect(page).to have_selector(".gem-c-chat-entry")
+      ClimateControl.modify GOVUK_CHAT_PROMO_ENABLED: "true" do
+        visit content_item["base_path"]
+        expect(page).to have_selector(".gem-c-chat-entry")
+      end
     end
   end
 


### PR DESCRIPTION
This test step nav feature test was using the first base_path from `GOVUK_CHAT_PROMO_BASE_PATHS` [array](https://github.com/alphagov/collections/blob/76e3fd466172ffea86678b73a708199e1808c34e/app/helpers/govuk_chat_promo_helper.rb#L3), which was in fact a browse page base_path. This has caused some unexpected test failures when attempting to add a feature to browse pages in separate work.
