### PR TITLE
Improve print styles for right-to-left (RTL) content

### DIFF
--- a/app/views/application/_breadcrumbs.html.erb
+++ b/app/views/application/_breadcrumbs.html.erb
@@ -3,5 +3,6 @@
 <%= render 'govuk_publishing_components/components/breadcrumbs', {
   breadcrumbs: Breadcrumbs.new(@content_item).breadcrumbs,
   collapse_on_mobile: true,
-  inverse: inverse
+  inverse: inverse,
+  dir: page_text_direction
 } %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -8,6 +8,7 @@
       heading_level: 1,
       margin_bottom: 8,
       font_size: "xl",
+      dir: page_text_direction
     } %>
   </div>
 

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -6,7 +6,7 @@
   <%= tag("meta", name: "description", content: @world_location_news.description) if @world_location_news.description %>
 <% end %>
 
-<div class="govuk-grid-row" <%= dir_attribute %> <%= lang_attribute %>>
+<div class="govuk-grid-row gem-print-columns-none" <%= dir_attribute %> <%= lang_attribute %>>
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
       context: I18n.t("world_location_news.types.#{@world_location_news.type}"),
@@ -30,7 +30,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row gem-print-columns-none">
   <div class="govuk-grid-column-full"  <%= dir_attribute %> <%= lang_attribute %>>
     <% if @world_location_news.ordered_featured_documents&.any? %>
       <section id="featured">
@@ -57,7 +57,7 @@
 </div>
 
 <% if I18n.locale == :en %>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row gem-print-columns-none">
     <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
       <section id="latest">
         <%= render "govuk_publishing_components/components/heading", {
@@ -89,7 +89,7 @@
 <% end %>
 
 <% if @world_location_news.mission_statement.present? %>
-  <div class="govuk-grid-row"  <%= dir_attribute %> <%= lang_attribute %>>
+  <div class="govuk-grid-row gem-print-columns-none"  <%= dir_attribute %> <%= lang_attribute %>>
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("world_location_news.headings.mission"),
@@ -105,7 +105,7 @@
 <% end %>
 
 <% if I18n.locale == :en && (@world_location_news.announcements.any? || @world_location_news.publications.any? || @world_location_news.statistics.any?) %>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row gem-print-columns-none">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("world_location_news.headings.documents"),
@@ -123,7 +123,7 @@
 <% end %>
 
 <% if @world_location_news.organisations&.any? %>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row gem-print-columns-none">
     <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
       <section id="organisations">
         <%= render "govuk_publishing_components/components/heading", {
@@ -157,7 +157,7 @@
 <% end %>
 
 <% if @world_location_news.worldwide_organisations&.any? %>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row gem-print-columns-none">
     <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-7">
       <% @world_location_news.worldwide_organisations.each do |organisation| %>
         <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
## What
Improve print styles for right-to-left (RTL) content:
- Force `world_location_news` layout to print full width.
- Enable RTL rendering for breadcrumbs and header

_Note: While the heading has now been flipped to read right-to-left in RTL mode, the layout remains the same: the heading is on the left of the screen with the language switch on the right. This follows the pattern set out on other pages, where the columns remain in their original direction._

This is part of the work to improve print styles more generally. [Trello](https://trello.com/c/6E5UoTiK/335-rtl-print-styles-have-been-considered-and-implemented-where-required)

_Note: This is a dependency of https://github.com/alphagov/government-frontend/pull/3404_

## Why
The components should render in the intended direction for RTL languages.

## Visual Changes
### Full width layouts
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/08f4781b-1456-4ffb-973b-4e4f06c6467b)  |![image](https://github.com/user-attachments/assets/57e9500b-7e94-4c55-8397-3b311e92416f) |

### Breadcrumbs & Header
| Before    | After |
| -------- | ------- |
| <img width="1015" alt="image" src="https://github.com/user-attachments/assets/eb9fc4d8-b389-4c74-8886-016dce1d1434" />  | <img width="1015" alt="image" src="https://github.com/user-attachments/assets/94ac707a-7b3c-43b7-9a6c-834894d26533" /> |