### PR TITLE
Remove Joining organisations from the "works with" sublists on the organisations page

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,6 +1,0 @@
-# this is for an organisations_homepage content item, so will not work with an organisation content item
-module OrganisationsHelper
-  def child_organisations_count(organisation)
-    organisation["works_with"].values.flatten.count
-  end
-end

--- a/app/lib/organisations_support.rb
+++ b/app/lib/organisations_support.rb
@@ -1,0 +1,41 @@
+# this is for an organisations_homepage content item, so will not work with an organisation content item
+module OrganisationsSupport
+  def joining?(organisation)
+    return false if organisation.nil?
+
+    organisation["govuk_status"] == "joining"
+  end
+
+  def reject_joining_organisations(organisations)
+    organisations.reject { |organisation| joining?(organisation) }
+  end
+
+  def works_with_categorised_links(organisation)
+    organisation.fetch("works_with", {})
+  end
+
+  def reject_empty_link_categories(categorised_links)
+    categorised_links.reject { |_category, links| links.empty? }
+  end
+
+  def reject_joining_links(links, organisation_map)
+    links.reject do |link|
+      joining?(organisation_map[link["href"]])
+    end
+  end
+
+  def reject_joining_categorised_links(categorised_links, organisation_map)
+    non_joining_categorised_links = categorised_links.transform_values do |links|
+      reject_joining_links(links, organisation_map)
+    end
+    reject_empty_link_categories(non_joining_categorised_links)
+  end
+
+  def non_joining_works_with_categorised_links(organisation, organisation_map)
+    reject_joining_categorised_links(works_with_categorised_links(organisation), organisation_map)
+  end
+
+  def non_joining_works_with_links_count(organisation, organisation_map)
+    non_joining_works_with_categorised_links(organisation, organisation_map).values.flatten.count
+  end
+end

--- a/app/models/content_store_organisations.rb
+++ b/app/models/content_store_organisations.rb
@@ -50,6 +50,24 @@ class ContentStoreOrganisations
     details["ordered_devolved_administrations"]
   end
 
+  def all
+    @all ||= [
+      *number_10,
+      *ministerial_departments,
+      *non_ministerial_departments,
+      *agencies_and_other_public_bodies,
+      *high_profile_groups,
+      *public_corporations,
+      *devolved_administrations,
+    ]
+  end
+
+  def by_href
+    @by_href ||= all.index_by do |organisation|
+      organisation["href"]
+    end
+  end
+
   def count_by_type(organisation_type)
     details[organisation_type].count
   end

--- a/spec/lib/organisations_support_spec.rb
+++ b/spec/lib/organisations_support_spec.rb
@@ -1,0 +1,170 @@
+RSpec.describe OrganisationsSupport do
+  include OrganisationsHelpers
+
+  subject { Class.new { include OrganisationsSupport }.new }
+
+  describe "#joining?" do
+    let(:organisation) do
+      {
+        "govuk_status" => status,
+      }
+    end
+
+    context "when organisation is joining" do
+      let(:status) { "joining" }
+
+      it "returns true" do
+        expect(subject.joining?(organisation)).to be(true)
+      end
+    end
+
+    context "when organisation is not live" do
+      let(:status) { "live" }
+
+      it "returns false" do
+        expect(subject.joining?(organisation)).to be(false)
+      end
+    end
+
+    context "when organisation is nil" do
+      it "returns false" do
+        expect(subject.joining?(nil)).to be(false)
+      end
+    end
+  end
+
+  describe "#reject_joining_organisations" do
+    let(:organisations) do
+      [
+        {
+          "title" => "Organisation A",
+          "govuk_status" => "joining",
+        },
+        {
+          "title" => "Organisation B",
+          "govuk_status" => "live",
+        },
+      ]
+    end
+
+    it "rejects joining organisations" do
+      expected = [
+        {
+          "title" => "Organisation B",
+          "govuk_status" => "live",
+        },
+      ]
+
+      expect(subject.reject_joining_organisations(organisations)).to eq(expected)
+    end
+  end
+
+  describe "#works_with_categorised_links" do
+    let(:organisation) do
+      department_with_joining_organisation_hash.dig("details", "ordered_ministerial_departments", 0)
+    end
+
+    it "returns links to organisations this organisation works with" do
+      expected = {
+        executive_ndpb: [
+          {
+            title: "Coal Authority",
+            href: "/government/organisations/the-coal-authority",
+          },
+          {
+            title: "Mining Remediation Authority",
+            href: "/government/organisations/mining-remediation-authority",
+          },
+        ],
+      }.with_indifferent_access
+
+      expect(subject.works_with_categorised_links(organisation)).to eq(expected)
+    end
+  end
+
+  describe "#reject_empty_link_categories" do
+    it "does not return empty categories" do
+      categorised_links = {
+        category_a: [
+          {
+            title: "link A",
+          },
+        ],
+        category_b: [],
+      }
+
+      expected = {
+        category_a: [
+          {
+            title: "link A",
+          },
+        ],
+      }
+
+      expect(subject.reject_empty_link_categories(categorised_links)).to eq(expected)
+    end
+  end
+
+  describe "#reject_joining_links" do
+    it "does not return joining links" do
+      links = [
+        {
+          "title" => "link A",
+          "href" => "/test/a",
+        },
+        {
+          "title" => "link B",
+          "href" => "/test/b",
+        },
+      ]
+
+      organisation_map = {
+        "/test/a" => { "govuk_status" => "joining" },
+        "/test/b" => { "govuk_status" => "live" },
+      }
+
+      expected = [
+        {
+          "title" => "link B",
+          "href" => "/test/b",
+        },
+      ]
+
+      expect(subject.reject_joining_links(links, organisation_map)).to eq(expected)
+    end
+  end
+
+  describe "#reject_joining_categorised_links" do
+    it "does not return joining links or empty categories" do
+      categorised_links = {
+        "category_a" => [
+          {
+            "title" => "link A",
+            "href" => "/test/a",
+          },
+          {
+            "title" => "link B",
+            "href" => "/test/b",
+          },
+        ],
+        "category_b" => {},
+      }
+
+      organisation_map = {
+        "/test/a" => { "govuk_status" => "joining" },
+        "/test/b" => { "govuk_status" => "live" },
+      }
+
+      expected = {
+        "category_a" => [
+          {
+            "title" => "link B",
+            "href" => "/test/b",
+          },
+        ],
+      }
+
+      expect(subject.reject_joining_categorised_links(categorised_links, organisation_map)).to eq(expected)
+    end
+  end
+end

--- a/spec/models/content_store_organisations_spec.rb
+++ b/spec/models/content_store_organisations_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe ContentStoreOrganisations do
+  include OrganisationsHelpers
+
+  subject { described_class.new(ContentItem.new(non_ministerial_departments_hash)) }
+
+  describe "#all" do
+    it "returns all organisations" do
+      all_organisations = [
+        {
+          title: "The Charity Commission",
+          href: "/government/organisations/charity-commission",
+          brand: "department-for-business-innovation-skills",
+          separate_website: true,
+        }.with_indifferent_access,
+        {
+          title: "Academy for Social Justice Commissioning",
+          href: "/government/organisations/academy-for-social-justice-commissioning",
+          brand: "ministry-of-justice",
+        }.with_indifferent_access,
+        {
+          title: "Bona Vacantia",
+          href: "/government/organisations/bona-vacantia",
+          brand: "attorney-generals-office",
+        }.with_indifferent_access,
+        {
+          title: "BBC",
+          href: "/government/organisations/bbc",
+          brand: "department-for-culture-media-sport",
+        }.with_indifferent_access,
+        {
+          title: "Northern Ireland Executive ",
+          href: "/government/organisations/northern-ireland-executive",
+          brand: nil,
+        }.with_indifferent_access,
+      ]
+      expect(subject.all).to eq(all_organisations)
+    end
+  end
+
+  describe "#by_href" do
+    it "returns all organisations mapped by their href values" do
+      all_organisations_map = {
+        "/government/organisations/charity-commission" => {
+          title: "The Charity Commission",
+          href: "/government/organisations/charity-commission",
+          brand: "department-for-business-innovation-skills",
+          separate_website: true,
+        },
+        "/government/organisations/academy-for-social-justice-commissioning" => {
+          title: "Academy for Social Justice Commissioning",
+          href: "/government/organisations/academy-for-social-justice-commissioning",
+          brand: "ministry-of-justice",
+        },
+        "/government/organisations/bona-vacantia" => {
+          title: "Bona Vacantia",
+          href: "/government/organisations/bona-vacantia",
+          brand: "attorney-generals-office",
+        },
+        "/government/organisations/bbc" => {
+          title: "BBC",
+          href: "/government/organisations/bbc",
+          brand: "department-for-culture-media-sport",
+        },
+        "/government/organisations/northern-ireland-executive" => {
+          title: "Northern Ireland Executive ",
+          href: "/government/organisations/northern-ireland-executive",
+          brand: nil,
+        },
+      }.with_indifferent_access
+      expect(subject.by_href).to eq(all_organisations_map)
+    end
+  end
+end

--- a/spec/presenters/organisations_presenter_spec.rb
+++ b/spec/presenters/organisations_presenter_spec.rb
@@ -129,6 +129,17 @@ RSpec.describe Organisations::IndexPresenter do
 
       expect(organisations_presenter.works_with_statement(test_org)).to eq("Works with 2 agencies and public bodies")
     end
+
+    context "when joining organisation present" do
+      let(:organisations_presenter) { presenter_from_hash(department_with_joining_organisation_hash) }
+      let(:department) do
+        department_with_joining_organisation_hash.dig("details", "ordered_ministerial_departments", 0)
+      end
+
+      it "does not include joining organisation in returned string" do
+        expect(organisations_presenter.works_with_statement(department)).to eq("Works with 1 public body")
+      end
+    end
   end
 
   describe "#ordered_works_with" do
@@ -178,6 +189,29 @@ RSpec.describe Organisations::IndexPresenter do
       ]
 
       expect(organisations_presenter.ordered_works_with(test_org)).to eq(expected)
+    end
+
+    context "when joining organisation present" do
+      let(:organisations_presenter) { presenter_from_hash(department_with_joining_organisation_hash) }
+      let(:department) do
+        department_with_joining_organisation_hash.dig("details", "ordered_ministerial_departments", 0)
+      end
+
+      it "does not include joining organisation in returned value" do
+        expected = [
+          [
+            "executive_ndpb",
+            [
+              {
+                "title" => "Coal Authority",
+                "href" => "/government/organisations/the-coal-authority",
+              },
+            ],
+          ],
+        ]
+
+        expect(organisations_presenter.ordered_works_with(department)).to eq(expected)
+      end
     end
   end
 

--- a/spec/support/organisations_helpers.rb
+++ b/spec/support/organisations_helpers.rb
@@ -89,4 +89,46 @@ module OrganisationsHelpers
       },
     }.with_indifferent_access
   end
+
+  def department_with_joining_organisation_hash
+    {
+      "title": "Departments, agencies and public bodies",
+      details: {
+        ordered_agencies_and_other_public_bodies: [
+          {
+            title: "Coal Authority",
+            href: "/government/organisations/the-coal-authority",
+            brand: nil,
+            govuk_status: "live",
+          },
+          {
+            title: "Mining Remediation Authority",
+            href: "/government/organisations/mining-remediation-authority",
+            brand: nil,
+            govuk_status: "joining",
+          },
+        ],
+        ordered_ministerial_departments: [
+          {
+            title: "Department for Energy Security and Net Zero",
+            href: "/government/organisation…y-security-and-net-zero",
+            brand: "department-for-business-innovation-skills",
+            govuk_status: "live",
+            works_with: {
+              executive_ndpb: [
+                {
+                  title: "Coal Authority",
+                  href: "/government/organisations/the-coal-authority",
+                },
+                {
+                  title: "Mining Remediation Authority",
+                  href: "/government/organisations/mining-remediation-authority",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }.with_indifferent_access
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

On the organisations page: [https://www.gov.uk/government/organisations](https://www.gov.uk/government/organisations "smartCard-inline")  if you search for energy, then click on the “Works with 17 agencies…” link beneath the DESNZ link, it includes the Mining Remediation Authority - but that’s a new name for the Coal Authority that isn’t supposed to take effect until 28th November. It’s got a status of Joining, and Joining organisations were removed from the main list ( this [change was made in 2020](https://github.com/alphagov/collections/pull/1859/files "‌")) - we need them also not to appear in the sublist.

## Why

[Trello card](https://trello.com/c/huNdfRHv/3029-remove-joining-organisations-from-the-works-with-sublists-on-the-organisations-page)