### PR TITLE
Enable toggling of GraphQL with query string

### DIFF
--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,6 +1,6 @@
 class WorldController < ApplicationController
   def index
-    if Features.graphql_feature_enabled?
+    if Features.graphql_feature_enabled? || params.include?(:graphql)
       index = WorldIndexGraphql.find!("/world")
       @presented_index = WorldIndexGraphqlPresenter.new(index)
     else

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -92,4 +92,16 @@ RSpec.feature "World index page" do
 
     it_behaves_like "world index page"
   end
+
+  context "with the GraphQL query string" do
+    before do
+      stub_publishing_api_graphql_query(
+        Graphql::WorldIndexQuery.new("/world").query,
+        fetch_graphql_fixture("world_index"),
+      )
+      visit "/world?graphql=true"
+    end
+
+    it_behaves_like "world index page"
+  end
 end


### PR DESCRIPTION
This will be used during load testing to allow us to make GraphQL queries without needing to update the environment variable.

[Trello card](https://trello.com/c/P7cdLbnK)