### PR TITLE
Adjust chat entry component

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -102,6 +102,6 @@ $browse-header-background-colour: #263135;
 
 .browse__govuk-chat-promo--second-level {
   @include govuk-media-query($until: "tablet") {
-    border-top-width: 2px;
+    padding-top: 0;
   }
 }

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -96,7 +96,6 @@ $browse-header-background-colour: #263135;
 
 .browse__govuk-chat-promo {
   @include govuk-media-query($until: "tablet") {
-    border-top: 4px solid govuk-colour("blue");
     padding-top: govuk-spacing(4);
   }
 }

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -23,7 +23,7 @@
 
   <% if show_govuk_chat_promo?(step_by_step.base_path) %>
     <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
-      <%= render "govuk_publishing_components/components/chat_entry", { border_top: true } %>
+      <%= render "govuk_publishing_components/components/chat_entry", { margin_top_until_tablet: true } %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## What
This PR introduces the following changes to the chat entry component:

- On L1/L2 browse pages (<= tablet only) and step by step pages - remove the blue border top
- On L2 browse pages (<= tablet only) - ensure no padding-top is applied
- On step by step pages (<= tablet only) - adds a margin top

N.B. there are no changes to the L1 or L2 browse page designs on desktop.

Relies on [PR #4417](https://github.com/alphagov/govuk_publishing_components/pull/4417) in the components gem.

## Why
Design requirements - [trello card](https://trello.com/c/iOuUw0vs/2157-entry-banner-tweaks).

## Visual changes
### Before (L1 browse page - mobile)
![image](https://github.com/user-attachments/assets/d86fb946-542a-4de1-9918-730572f3a5bd)

### After (L1 browse page - mobile)
![image](https://github.com/user-attachments/assets/477d5fca-7e77-4b85-a43a-09e2c0b39c3f)

### Before (L2 browse page - mobile)
![image](https://github.com/user-attachments/assets/6391df36-c836-4b0e-aa67-ac820a4de782)

### After (L2 browse page - mobile)
![image](https://github.com/user-attachments/assets/a087b80a-b0d0-4fda-99c0-a836c6bd1188)

### Before (Step by step page - desktop)
![image](https://github.com/user-attachments/assets/d4c57ff1-95e4-4635-bdf7-e74b2b248e2f)

### After (Step by step page - desktop)
![image](https://github.com/user-attachments/assets/40f0cdc7-cb48-4125-9581-bf6d18d96a26)

### Before (Step by step page - mobile)
![image](https://github.com/user-attachments/assets/897f36b1-3ead-4a8e-b1d3-02b08fa082c3)

### After (Step by step page - mobile)
![image](https://github.com/user-attachments/assets/e799d6bb-8b2d-4dd4-af7f-e2c73a9faa9a)
