### PR TITLE
GOV.UK Chat promo: show on more pages

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -1,11 +1,25 @@
 module GovukChatPromoHelper
   GOVUK_CHAT_PROMO_BASE_PATHS = %w[
+    /browse/benefits/looking-for-work
     /browse/business
     /browse/business/business-tax
+    /browse/business/limited-company
     /browse/business/setting-up
+    /browse/employing-people
+    /browse/employing-people/payroll
+    /browse/employing-people/recruiting-hiring
+    /browse/tax
+    /browse/tax/capital-gains
+    /browse/tax/dealing-with-hmrc
     /browse/tax/self-assessment
-    /set-up-limited-company
+    /browse/tax/vat
+    /browse/working
+    /browse/working/finding-job
+    /browse/working/state-pension
+    /browse/working/time-off
+    /browse/working/workplace-personal-pensions
     /set-up-as-sole-trader
+    /set-up-limited-company
   ].freeze
 
   def show_govuk_chat_promo?(base_path)

--- a/app/views/second_level_browse_page/show_a_to_z.html.erb
+++ b/app/views/second_level_browse_page/show_a_to_z.html.erb
@@ -36,7 +36,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <div class="govuk-grid-row">    
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2" data-module="ga4-link-tracker">
       <%
         index_section_count = page.lists.count
@@ -49,5 +49,13 @@
         </div>
       <% end %>
     </div>
+
+    <% if show_govuk_chat_promo?(page.base_path) %>
+      <div class="govuk-grid-column-one-third-from-desktop">
+        <div class="browse__govuk-chat-promo">
+          <%= render "govuk_publishing_components/components/chat_entry" %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/features/mainstream_browsing_spec.rb
+++ b/spec/features/mainstream_browsing_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature "Mainstream browsing" do
 
   it "renders the GOV.UK Chat promo" do
     content_item = GovukSchemas::Example.find("mainstream_browse_page", example_name: "top_level_page").tap do |item|
-      item["base_path"] = GovukChatPromoHelper::GOVUK_CHAT_PROMO_BASE_PATHS.first
+      item["base_path"] = "/browse/business"
     end
 
     stub_content_store_has_item(content_item["base_path"], content_item)


### PR DESCRIPTION
Displays the promo on a few more pages.

Some of the new URLs use the `show_a_to_z` view, so the logic to render
the promo needed adding there too.

Also updates a test which relies on the content item base path being a
mainstream browse page to use a hard-coded URL.