### PR TITLE
Use GraphQL for rendering Ministers Index page

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -2,8 +2,15 @@ class MinistersController < ApplicationController
   around_action :switch_locale
 
   def index
-    ministers_index = MinistersIndex.find!(request.path)
-    @presented_ministers = MinistersIndexPresenter.new(ministers_index.content_item.content_item_data)
+    if Features.graphql_feature_enabled? || params.include?(:graphql)
+      ministers_index = Graphql::MinistersIndex.find!(request.path)
+      content_item_data = ministers_index.content_item
+    else
+      ministers_index = MinistersIndex.find!(request.path)
+      content_item_data = ministers_index.content_item.content_item_data
+    end
+
+    @presented_ministers = MinistersIndexPresenter.new(content_item_data)
     setup_content_item_and_navigation_helpers(ministers_index)
   end
 end

--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -3,7 +3,7 @@ class MinistersController < ApplicationController
 
   def index
     ministers_index = MinistersIndex.find!(request.path)
-    @presented_ministers = MinistersIndexPresenter.new(ministers_index)
+    @presented_ministers = MinistersIndexPresenter.new(ministers_index.content_item.content_item_data)
     setup_content_item_and_navigation_helpers(ministers_index)
   end
 end

--- a/app/models/graphql/ministers_index.rb
+++ b/app/models/graphql/ministers_index.rb
@@ -1,0 +1,17 @@
+class Graphql::MinistersIndex
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def self.find!(base_path)
+    query = Graphql::MinistersIndexQuery.new(base_path).query
+
+    edition = Services.publishing_api.graphql_query(query)
+      .dig("data", "edition")
+      .deep_transform_keys(&:underscore)
+
+    new(edition)
+  end
+end

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -1,36 +1,36 @@
 class MinistersIndexPresenter
-  def initialize(ministers_index)
-    @ministers_index = ministers_index.content_item
+  def initialize(content_item_data)
+    @content_item_data = content_item_data
   end
 
   def lead_paragraph
-    @ministers_index.details.fetch("body", nil)
+    @content_item_data.fetch("details", {})["body"]
   end
 
   def is_during_reshuffle?
-    @ministers_index.details.fetch("reshuffle", nil)
+    @content_item_data.fetch("details", {})["reshuffle"]
   end
 
   def reshuffle_messaging
-    @ministers_index.details.dig("reshuffle", "message")
+    @content_item_data.dig("details", "reshuffle", "message")
   end
 
   def cabinet_ministers
-    ordered_cabinet_ministers = @ministers_index.content_item_data.dig("links", "ordered_cabinet_ministers") || []
+    ordered_cabinet_ministers = @content_item_data.dig("links", "ordered_cabinet_ministers") || []
     ordered_cabinet_ministers.map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def also_attends_cabinet
-    ordered_also_attends_cabinet = @ministers_index.content_item_data.dig("links", "ordered_also_attends_cabinet") || []
+    ordered_also_attends_cabinet = @content_item_data.dig("links", "ordered_also_attends_cabinet") || []
     ordered_also_attends_cabinet.map do |minister_data|
       Minister.new(minister_data)
     end
   end
 
   def by_organisation
-    ordered_ministerial_departments = @ministers_index.content_item_data.dig("links", "ordered_ministerial_departments") || []
+    ordered_ministerial_departments = @content_item_data.dig("links", "ordered_ministerial_departments") || []
     ordered_ministerial_departments.map do |department_data|
       Department.new(
         url: department_data.fetch("web_url"),
@@ -49,7 +49,7 @@ class MinistersIndexPresenter
 
   def whips
     ordered_whip_organisations.each do |whip_org|
-      ordered_whip_organisation = @ministers_index.content_item_data.dig("links", whip_org.item_key) || []
+      ordered_whip_organisation = @content_item_data.dig("links", whip_org.item_key) || []
       whip_org.ministers = ordered_whip_organisation.map do |minister_data|
         Minister.new(minister_data, whip_only: true)
       end

--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -1,0 +1,111 @@
+class Graphql::MinistersIndexQuery
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def query
+    <<-QUERY
+      {
+        edition(basePath: "#{@base_path}") {
+          ... on MinistersIndex {
+            basePath
+
+            links {
+              orderedCabinetMinisters {
+                ...basePersonInfo
+              }
+
+              orderedAlsoAttendsCabinet {
+                ...basePersonInfo
+              }
+
+              orderedAssistantWhips {
+                ...basePersonInfo
+              }
+
+              orderedBaronessesAndLordsInWaitingWhips {
+                ...basePersonInfo
+              }
+
+              orderedHouseLordsWhips {
+                ...basePersonInfo
+              }
+
+              orderedHouseOfCommonsWhips {
+                ...basePersonInfo
+              }
+
+              orderedJuniorLordsOfTheTreasuryWhips {
+                ...basePersonInfo
+              }
+
+              orderedMinisterialDepartments {
+                title
+                webUrl
+
+                details {
+                  brand
+
+                  logo {
+                    crest
+                    formattedTitle
+                  }
+                }
+
+                links {
+                  orderedMinisters {
+                    ...basePersonInfo
+                  }
+
+                  orderedRoles {
+                    contentId
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      fragment basePersonInfo on MinistersIndexPerson {
+        title
+        basePath
+        webUrl
+
+        details {
+          privyCounsellor
+
+          image {
+            url
+            altText
+          }
+        }
+
+        links {
+          roleAppointments {
+            details {
+              current
+            }
+
+            links {
+              role {
+                contentId
+                title
+                webUrl
+
+                details {
+                  rolePaymentType
+                  seniority
+                  whipOrganisation {
+                    label
+                    sortOrder
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    QUERY
+  end
+end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -1,111 +1,104 @@
 require "integration_spec_helper"
 
 RSpec.feature "Ministers index page" do
-  let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
+  shared_examples "ministers index page" do
+    scenario "returns 200 when visiting ministers page" do
+      expect(page.status_code).to eq(200)
+    end
 
-  before do
-    stub_content_store_has_item("/government/ministers", document)
-    visit "/government/ministers"
-  end
+    scenario "renders webpage title" do
+      expect(page).to have_title(I18n.t("ministers.govuk_title"))
+    end
 
-  scenario "returns 200 when visiting ministers page" do
-    expect(page.status_code).to eq(200)
-  end
+    scenario "renders page title" do
+      expect(page).to have_selector(".gem-c-title__text", text: I18n.t("ministers.title"))
+    end
 
-  scenario "renders webpage title" do
-    expect(page).to have_title(I18n.t("ministers.govuk_title"))
-  end
+    scenario "renders the lead paragraph with anchor links" do
+      expect(page).to have_selector(".gem-c-lead-paragraph")
+      within(".gem-c-lead-paragraph") do
+        expect(page).to have_link("Cabinet ministers", href: "#cabinet-ministers", class: "govuk-link")
+      end
+    end
 
-  scenario "renders page title" do
-    expect(page).to have_selector(".gem-c-title__text", text: I18n.t("ministers.title"))
-  end
+    scenario "renders section headers" do
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
+      expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
+    end
 
-  scenario "renders the lead paragraph with anchor links" do
-    expect(page).to have_selector(".gem-c-lead-paragraph")
-    within(".gem-c-lead-paragraph") do
-      expect(page).to have_link("Cabinet ministers", href: "#cabinet-ministers", class: "govuk-link")
+    scenario "renders cabinet ministers in the relevant section" do
+      within("#cabinet li", match: :first) do
+        expect(page).to have_text("The Rt Hon")
+        expect(page).to have_text("Rishi Sunak MP")
+        expect(page).to have_text("Prime Minister, First Lord of the Treasury, Minister for the Civil Service, Minister for the Union")
+      end
+    end
+
+    scenario "cabinet section shows ministers' role payment type info where required" do
+      greg_hands = all("#cabinet li")[1]
+      expect(greg_hands).to have_text("Greg Hands MP")
+      expect(greg_hands).to have_text("Minister without Portfolio")
+      expect(greg_hands).to have_text("Unpaid")
+    end
+
+    scenario "renders ministers who also attend cabinet in the relevant section" do
+      within("#also-attends-cabinet li", match: :first) do
+        expect(page).to have_text("The Rt Hon")
+        expect(page).to have_text("Simon Hart MP")
+        expect(page).to have_text("Parliamentary Secretary to the Treasury (Chief Whip)")
+      end
+    end
+
+    scenario "also attends cabinet section shows ministers' role payment type info where required" do
+      john_glen = all("#also-attends-cabinet li")[1]
+      expect(john_glen).to have_text("John Glen MP")
+      expect(john_glen).to have_text("Chief Secretary to the Treasury")
+      expect(john_glen).to have_text("Unpaid")
+    end
+
+    scenario "renders whips by whip organisation in the relevant section" do
+      within("#whip-house-of-commons") do
+        expect(page).to have_text("House of Commons")
+      end
+    end
+
+    scenario "the whip section shows only ministers' whip roles" do
+      lord_caine = all("#whip-baronesses-and-lords-in-waiting li")[1]
+      expect(lord_caine).to have_text("Lord Caine")
+      expect(lord_caine).to have_text("Lord in Waiting")
+      expect(lord_caine).to_not have_text("Parliamentary Under Secretary of State")
+    end
+
+    scenario "renders ministers by department in the relevant section" do
+      cabinet_office = find("#cabinet-office")
+      expect(cabinet_office).to have_text("Cabinet Office")
+      expect(cabinet_office.find("li", match: :first)).to have_text("Rishi Sunak")
+    end
+
+    scenario "the ministers by department section show only ministers' roles within that department" do
+      dbt = find("#department-for-business-and-trade")
+      expect(dbt).to have_text("Business & Trade")
+      kemi_badenoch_dbt = dbt.find("li", match: :first)
+      expect(kemi_badenoch_dbt).to have_text("Kemi Badenoch")
+      expect(kemi_badenoch_dbt).to have_text("Secretary of State for Business and Trade, President of the Board of Trade")
+
+      uef = find("#uk-export-finance")
+      expect(uef).to have_text("UK Export Finance")
+      kemi_badenoch_uef = uef.find("li", match: :first)
+      expect(kemi_badenoch_uef).to have_text("Kemi Badenoch")
+      expect(kemi_badenoch_uef).to have_text("President of the Board of Trade")
+      expect(kemi_badenoch_uef).to_not have_text("Secretary of State for Business and Trade")
+    end
+
+    scenario "the ministers by department section does not show departments without ministers appointed" do
+      expect(page).not_to have_selector("#office-of-the-advocate-general-for-scotland")
+      expect(page).not_to have_text("Office of the Advocate General for Scotland")
     end
   end
 
-  scenario "renders section headers" do
-    expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
-    expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
-    expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
-    expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
-  end
-
-  scenario "renders cabinet ministers in the relevant section" do
-    within("#cabinet li", match: :first) do
-      expect(page).to have_text("The Rt Hon")
-      expect(page).to have_text("Rishi Sunak MP")
-      expect(page).to have_text("Prime Minister, First Lord of the Treasury, Minister for the Civil Service, Minister for the Union")
-    end
-  end
-
-  scenario "cabinet section shows ministers' role payment type info where required" do
-    greg_hands = all("#cabinet li")[1]
-    expect(greg_hands).to have_text("Greg Hands MP")
-    expect(greg_hands).to have_text("Minister without Portfolio")
-    expect(greg_hands).to have_text("Unpaid")
-  end
-
-  scenario "renders ministers who also attend cabinet in the relevant section" do
-    within("#also-attends-cabinet li", match: :first) do
-      expect(page).to have_text("The Rt Hon")
-      expect(page).to have_text("Simon Hart MP")
-      expect(page).to have_text("Parliamentary Secretary to the Treasury (Chief Whip)")
-    end
-  end
-
-  scenario "also attends cabinet section shows ministers' role payment type info where required" do
-    john_glen = all("#also-attends-cabinet li")[1]
-    expect(john_glen).to have_text("John Glen MP")
-    expect(john_glen).to have_text("Chief Secretary to the Treasury")
-    expect(john_glen).to have_text("Unpaid")
-  end
-
-  scenario "renders whips by whip organisation in the relevant section" do
-    within("#whip-house-of-commons") do
-      expect(page).to have_text("House of Commons")
-    end
-  end
-
-  scenario "the whip section shows only ministers' whip roles" do
-    lord_caine = all("#whip-baronesses-and-lords-in-waiting li")[1]
-    expect(lord_caine).to have_text("Lord Caine")
-    expect(lord_caine).to have_text("Lord in Waiting")
-    expect(lord_caine).to_not have_text("Parliamentary Under Secretary of State")
-  end
-
-  scenario "renders ministers by department in the relevant section" do
-    cabinet_office = find("#cabinet-office")
-    expect(cabinet_office).to have_text("Cabinet Office")
-    expect(cabinet_office.find("li", match: :first)).to have_text("Rishi Sunak")
-  end
-
-  scenario "the ministers by department section show only ministers' roles within that department" do
-    dbt = find("#department-for-business-and-trade")
-    expect(dbt).to have_text("Business & Trade")
-    kemi_badenoch_dbt = dbt.find("li", match: :first)
-    expect(kemi_badenoch_dbt).to have_text("Kemi Badenoch")
-    expect(kemi_badenoch_dbt).to have_text("Secretary of State for Business and Trade, President of the Board of Trade")
-
-    uef = find("#uk-export-finance")
-    expect(uef).to have_text("UK Export Finance")
-    kemi_badenoch_uef = uef.find("li", match: :first)
-    expect(kemi_badenoch_uef).to have_text("Kemi Badenoch")
-    expect(kemi_badenoch_uef).to have_text("President of the Board of Trade")
-    expect(kemi_badenoch_uef).to_not have_text("Secretary of State for Business and Trade")
-  end
-
-  scenario "the ministers by department section does not show departments without ministers appointed" do
-    expect(page).not_to have_selector("#office-of-the-advocate-general-for-scotland")
-    expect(page).not_to have_text("Office of the Advocate General for Scotland")
-  end
-
-  context "during a reshuffle" do
-    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
-
+  shared_examples "ministers index page during a reshuffle" do
     scenario "renders the reshuffle messaging instead of the usual contents" do
       within(".gem-c-notice") do
         expect(page).to have_text("Check latest appointments")
@@ -119,9 +112,7 @@ RSpec.feature "Ministers index page" do
     end
   end
 
-  context "during a reshuffle preview" do
-    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
-
+  shared_examples "ministers index page during a reshuffle preview" do
     scenario "renders the sections and contents even with empty roles sets" do
       expect(page.status_code).to eq(200)
       expect(page).to have_selector(".gem-c-lead-paragraph")
@@ -130,5 +121,26 @@ RSpec.feature "Ministers index page" do
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.by_department"))
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.whips"))
     end
+  end
+
+  let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
+
+  before do
+    stub_content_store_has_item("/government/ministers", document)
+    visit "/government/ministers"
+  end
+
+  it_behaves_like "ministers index page"
+
+  context "during a reshuffle" do
+    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
+
+    it_behaves_like "ministers index page during a reshuffle"
+  end
+
+  context "during a reshuffle preview" do
+    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
+
+    it_behaves_like "ministers index page during a reshuffle preview"
   end
 end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -123,24 +123,53 @@ RSpec.feature "Ministers index page" do
     end
   end
 
-  let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
+  context "without the graphql feature flag" do
+    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
 
-  before do
-    stub_content_store_has_item("/government/ministers", document)
-    visit "/government/ministers"
+    before do
+      stub_content_store_has_item("/government/ministers", document)
+      visit "/government/ministers"
+    end
+
+    it_behaves_like "ministers index page"
+
+    context "during a reshuffle" do
+      let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
+
+      it_behaves_like "ministers index page during a reshuffle"
+    end
+
+    context "during a reshuffle preview" do
+      let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
+
+      it_behaves_like "ministers index page during a reshuffle preview"
+    end
   end
 
-  it_behaves_like "ministers index page"
+  context "with the GraphQL feature flag" do
+    let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
 
-  context "during a reshuffle" do
-    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
+    before do
+      enable_graphql_feature_flag
+      stub_publishing_api_graphql_query(
+        Graphql::MinistersIndexQuery.new("/government/ministers").query,
+        document,
+      )
+      visit "/government/ministers"
+    end
 
-    it_behaves_like "ministers index page during a reshuffle"
-  end
+    it_behaves_like "ministers index page"
 
-  context "during a reshuffle preview" do
-    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
+    context "during a reshuffle" do
+      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on") }
 
-    it_behaves_like "ministers index page during a reshuffle preview"
+      it_behaves_like "ministers index page during a reshuffle"
+    end
+
+    context "during a reshuffle preview" do
+      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on-preview") }
+
+      it_behaves_like "ministers index page during a reshuffle preview"
+    end
   end
 end

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
@@ -1,0 +1,1126 @@
+{
+  "data": {
+    "edition": {
+      "basePath": "/government/ministers",
+      "details": {
+        "body": "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business."
+      },
+      "links": {
+        "orderedAlsoAttendsCabinet": [
+          {
+            "basePath": "/government/people/simon-hart",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Simon Hart MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3188/s465_Simon_Hart_960-640.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "845e6a56-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 0,
+                          "whipOrganisation": {
+                            "label": "House of Commons",
+                            "sortOrder": 1
+                          }
+                        },
+                        "title": "Parliamentary Secretary to the Treasury (Chief Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Simon Hart MP",
+            "webUrl": "https://www.gov.uk/government/people/simon-hart"
+          },
+          {
+            "basePath": "/government/people/john-glen",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon John Glen MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3123/s465_John_Glen_GOVUK.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "845e6667-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": "Unpaid",
+                          "seniority": 1,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Chief Secretary to the Treasury",
+                        "webUrl": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon John Glen MP",
+            "webUrl": "https://www.gov.uk/government/people/john-glen"
+          }
+        ],
+        "orderedAssistantWhips": [
+          {
+            "basePath": "/government/people/ruth-edwards",
+            "details": {
+              "image": {
+                "altText": "Ruth Edwards MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/5345/s465_Ruth_Edwards.jpg"
+              },
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "c4760cc3-8145-4d5f-a0f0-a7b43fe53396",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Assistant Whips",
+                            "sortOrder": 3
+                          }
+                        },
+                        "title": "Assistant Government Whip",
+                        "webUrl": "https://www.gov.uk/government/ministers/assistant-government-whip--27"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Ruth Edwards MP",
+            "webUrl": "https://www.gov.uk/government/people/ruth-edwards"
+          },
+          {
+            "basePath": "/government/people/joy-morrissey",
+            "details": {
+              "image": null,
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "bac019ff-68c6-4ea3-b997-864ec4e01f05",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Assistant Whips",
+                            "sortOrder": 3
+                          }
+                        },
+                        "title": "Assistant Government Whip",
+                        "webUrl": "https://www.gov.uk/government/ministers/assistant-government-whip--31"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Joy Morrissey MP",
+            "webUrl": "https://www.gov.uk/government/people/joy-morrissey"
+          }
+        ],
+        "orderedBaronessesAndLordsInWaitingWhips": [
+          {
+            "basePath": "/government/people/baroness-bloomfield-of-hinton-waldrist",
+            "details": {
+              "image": null,
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "84614ae7-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Baronesses and Lords in Waiting",
+                            "sortOrder": 5
+                          }
+                        },
+                        "title": "Baroness in Waiting (Government Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/baroness-northover"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Baroness Bloomfield of Hinton Waldrist",
+            "webUrl": "https://www.gov.uk/government/people/baroness-bloomfield-of-hinton-waldrist"
+          },
+          {
+            "basePath": "/government/people/lord-caine",
+            "details": {
+              "image": {
+                "altText": "Lord Caine",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4907/s465_Untitled_design__3___1_.png"
+              },
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "5b63ecfc-583e-4193-82ec-ddec3daaae74",
+                        "details": {
+                          "rolePaymentType": "Unpaid",
+                          "seniority": 100,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Parliamentary Under Secretary of State ",
+                        "webUrl": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--154"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "bed8196a-257f-4389-b254-3aee0606477d",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Baronesses and Lords in Waiting",
+                            "sortOrder": 5
+                          }
+                        },
+                        "title": "Lord in Waiting",
+                        "webUrl": "https://www.gov.uk/government/ministers/lord-in-waiting--4"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Lord Caine",
+            "webUrl": "https://www.gov.uk/government/people/lord-caine"
+          }
+        ],
+        "orderedCabinetMinisters": [
+          {
+            "basePath": "/government/people/rishi-sunak",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Rishi Sunak MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3339/s465_Rishi_profile.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "845e5811-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 0,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Prime Minister",
+                        "webUrl": "https://www.gov.uk/government/ministers/prime-minister"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "846a754c-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 1,
+                          "whipOrganisation": {}
+                        },
+                        "title": "First Lord of the Treasury",
+                        "webUrl": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 3,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Minister for the Union",
+                        "webUrl": "https://www.gov.uk/government/ministers/minister-for-the-union"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "846a7351-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 2,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Minister for the Civil Service",
+                        "webUrl": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Rishi Sunak MP",
+            "webUrl": "https://www.gov.uk/government/people/rishi-sunak"
+          },
+          {
+            "basePath": "/government/people/greg-hands",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Greg Hands MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/397/s465_Greg_Hands_May2015_GOVUK.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "d7f7603e-ac5b-40cf-bafe-6765d6ffb53b",
+                        "details": {
+                          "rolePaymentType": "Unpaid",
+                          "seniority": 29,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Minister without Portfolio",
+                        "webUrl": "https://www.gov.uk/government/ministers/minister-without-portfolio--8"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Greg Hands MP",
+            "webUrl": "https://www.gov.uk/government/people/greg-hands"
+          }
+        ],
+        "orderedHouseLordsWhips": [
+          {
+            "basePath": "/government/people/susan-williams-of-trafford",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Baroness Williams of Trafford",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1552/s465_Baroness_Williams_-_Official_-_960_x_640.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "84619671-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "House of Lords",
+                            "sortOrder": 4
+                          }
+                        },
+                        "title": "Captain of the Honourable Corps of Gentlemen at Arms (Lords Chief Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/lords-chief-whip-and-captain-of-the-honourable-corps-of-gentlemen-at-arms"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Baroness Williams of Trafford",
+            "webUrl": "https://www.gov.uk/government/people/susan-williams-of-trafford"
+          },
+          {
+            "basePath": "/government/people/earl-of-courtown",
+            "details": {
+              "image": {
+                "altText": "The Earl of Courtown",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2284/s465_Earl_of_Courtown.jpg"
+              },
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "84619907-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "House of Lords",
+                            "sortOrder": 4
+                          }
+                        },
+                        "title": "Captain of the King's Bodyguard of the Yeomen of the Guard (Lords Deputy Chief Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/government-deputy-chief-whip-and-captain-of-the-kings-bodyguard-of-the-yeomen-of-the-guard"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Earl of Courtown",
+            "webUrl": "https://www.gov.uk/government/people/earl-of-courtown"
+          }
+        ],
+        "orderedHouseOfCommonsWhips": [
+          {
+            "basePath": "/government/people/simon-hart",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Simon Hart MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3188/s465_Simon_Hart_960-640.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "845e6a56-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 0,
+                          "whipOrganisation": {
+                            "label": "House of Commons",
+                            "sortOrder": 1
+                          }
+                        },
+                        "title": "Parliamentary Secretary to the Treasury (Chief Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Simon Hart MP",
+            "webUrl": "https://www.gov.uk/government/people/simon-hart"
+          },
+          {
+            "basePath": "/government/people/marcus-jones",
+            "details": {
+              "image": {
+                "altText": "The Rt Hon Marcus Jones MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2268/s465_Marcus_Jones_-_Official_960x640.jpg"
+              },
+              "privyCounsellor": true
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "84619b8e-c0f1-11e4-8223-005056011aef",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "House of Commons",
+                            "sortOrder": 1
+                          }
+                        },
+                        "title": "Treasurer of HM Household (Deputy Chief Whip)",
+                        "webUrl": "https://www.gov.uk/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "The Rt Hon Marcus Jones MP",
+            "webUrl": "https://www.gov.uk/government/people/marcus-jones"
+          }
+        ],
+        "orderedJuniorLordsOfTheTreasuryWhips": [
+          {
+            "basePath": "/government/people/amanda-solloway",
+            "details": {
+              "image": {
+                "altText": "Amanda Solloway MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4216/s465_amanda-solloway-cc-by-3.jpg"
+              },
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "4d415f0a-1c2e-4c11-9294-4838f756f509",
+                        "details": {
+                          "rolePaymentType": "Paid as a whip",
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Junior Lords of the Treasury",
+                            "sortOrder": 2
+                          }
+                        },
+                        "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                        "webUrl": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--19"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "beb88ec6-58ea-4eec-ab83-4d5e80eabd11",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {}
+                        },
+                        "title": "Parliamentary Under Secretary of State (Minister for Energy Consumers and Affordability)",
+                        "webUrl": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-minister-for-energy-consumers-and-affordability"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Amanda Solloway MP",
+            "webUrl": "https://www.gov.uk/government/people/amanda-solloway"
+          },
+          {
+            "basePath": "/government/people/steve-double",
+            "details": {
+              "image": {
+                "altText": "Steve Double MP",
+                "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4847/s465_steve-double-960x640.jpg"
+              },
+              "privyCounsellor": false
+            },
+            "links": {
+              "roleAppointments": [
+                {
+                  "details": {
+                    "current": true
+                  },
+                  "links": {
+                    "role": [
+                      {
+                        "contentId": "b5775e81-f891-4cef-8431-05e23e6339e4",
+                        "details": {
+                          "rolePaymentType": null,
+                          "seniority": 100,
+                          "whipOrganisation": {
+                            "label": "Junior Lords of the Treasury",
+                            "sortOrder": 2
+                          }
+                        },
+                        "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                        "webUrl": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--17"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "title": "Steve Double MP",
+            "webUrl": "https://www.gov.uk/government/people/steve-double"
+          }
+        ],
+        "orderedMinisterialDepartments": [
+          {
+            "details": {
+              "brand": "cabinet-office",
+              "logo": {
+                "crest": "single-identity",
+                "formattedTitle": "Cabinet Office"
+              }
+            },
+            "links": {
+              "orderedMinisters": [
+                {
+                  "basePath": "/government/people/rishi-sunak",
+                  "details": {
+                    "image": {
+                      "altText": "The Rt Hon Rishi Sunak MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3339/s465_Rishi_profile.jpg"
+                    },
+                    "privyCounsellor": true
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "845e5811-c0f1-11e4-8223-005056011aef",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 0,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Prime Minister",
+                              "webUrl": "https://www.gov.uk/government/ministers/prime-minister"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "846a754c-c0f1-11e4-8223-005056011aef",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 1,
+                                "whipOrganisation": {}
+                              },
+                              "title": "First Lord of the Treasury",
+                              "webUrl": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 3,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister for the Union",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-for-the-union"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "846a7351-c0f1-11e4-8223-005056011aef",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 2,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister for the Civil Service",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "The Rt Hon Rishi Sunak MP",
+                  "webUrl": "https://www.gov.uk/government/people/rishi-sunak"
+                },
+                {
+                  "basePath": "/government/people/greg-hands",
+                  "details": {
+                    "image": {
+                      "altText": "The Rt Hon Greg Hands MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/397/s465_Greg_Hands_May2015_GOVUK.jpg"
+                    },
+                    "privyCounsellor": true
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "d7f7603e-ac5b-40cf-bafe-6765d6ffb53b",
+                              "details": {
+                                "rolePaymentType": "Unpaid",
+                                "seniority": 29,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister without Portfolio",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-without-portfolio--8"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "The Rt Hon Greg Hands MP",
+                  "webUrl": "https://www.gov.uk/government/people/greg-hands"
+                },
+                {
+                  "basePath": "/government/people/nusrat-ghani",
+                  "details": {
+                    "image": {
+                      "altText": "Nusrat Ghani MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3346/s465_nusrat-ghani.jpg"
+                    },
+                    "privyCounsellor": false
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "e901f3a3-b51c-4491-8667-6605155a3fcd",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 100,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister of State at the Department for Business and Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-of-state--155"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "949c0326-a1ca-4fcd-8d0b-8d205ea8cbad",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 100,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister of State for the Investment Security Unit",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-of-state--156"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "Nusrat Ghani MP",
+                  "webUrl": "https://www.gov.uk/government/people/nusrat-ghani"
+                }
+              ],
+              "orderedRoles": [
+                {
+                  "contentId": "845e5811-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "846a7351-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "846a754c-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2"
+                }
+              ]
+            },
+            "title": "Cabinet Office",
+            "webUrl": "https://www.gov.uk/government/organisations/cabinet-office"
+          },
+          {
+            "details": {
+              "brand": "department-for-business-and-trade",
+              "logo": {
+                "crest": "dbt",
+                "formattedTitle": "Department for<br/>Business &amp; Trade"
+              }
+            },
+            "links": {
+              "orderedMinisters": [
+                {
+                  "basePath": "/government/people/kemi-badenoch",
+                  "details": {
+                    "image": {
+                      "altText": "The Rt Hon Kemi Badenoch MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4010/s465_Kemi_gov.uk.png"
+                    },
+                    "privyCounsellor": true
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "5cb74a2c-7e9f-444a-8347-d944cc05b606",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 21,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Secretary of State for Business and Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 22,
+                                "whipOrganisation": {}
+                              },
+                              "title": "President of the Board of Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "84753907-c0f1-11e4-8223-005056011aef",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 23,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister for Women and Equalities",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-for-women-and-equalities--3"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "The Rt Hon Kemi Badenoch MP",
+                  "webUrl": "https://www.gov.uk/government/people/kemi-badenoch"
+                },
+                {
+                  "basePath": "/government/people/nusrat-ghani",
+                  "details": {
+                    "image": {
+                      "altText": "Nusrat Ghani MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3346/s465_nusrat-ghani.jpg"
+                    },
+                    "privyCounsellor": false
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "e901f3a3-b51c-4491-8667-6605155a3fcd",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 100,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister of State at the Department for Business and Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-of-state--155"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "949c0326-a1ca-4fcd-8d0b-8d205ea8cbad",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 100,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister of State for the Investment Security Unit",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-of-state--156"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "Nusrat Ghani MP",
+                  "webUrl": "https://www.gov.uk/government/people/nusrat-ghani"
+                }
+              ],
+              "orderedRoles": [
+                {
+                  "contentId": "5cb74a2c-7e9f-444a-8347-d944cc05b606"
+                },
+                {
+                  "contentId": "de3d5e37-ff1c-4111-b029-fc926da764e9"
+                }
+              ]
+            },
+            "title": "Department for Business and Trade",
+            "webUrl": "https://www.gov.uk/government/organisations/department-for-business-and-trade"
+          },
+          {
+            "details": {
+              "brand": "department-for-business-and-trade",
+              "logo": {
+                "crest": "dbt",
+                "formattedTitle": "UK Export <br/>Finance"
+              }
+            },
+            "links": {
+              "orderedMinisters": [
+                {
+                  "basePath": "/government/people/kemi-badenoch",
+                  "details": {
+                    "image": {
+                      "altText": "The Rt Hon Kemi Badenoch MP",
+                      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4010/s465_Kemi_gov.uk.png"
+                    },
+                    "privyCounsellor": true
+                  },
+                  "links": {
+                    "roleAppointments": [
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "5cb74a2c-7e9f-444a-8347-d944cc05b606",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 21,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Secretary of State for Business and Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 22,
+                                "whipOrganisation": {}
+                              },
+                              "title": "President of the Board of Trade",
+                              "webUrl": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "details": {
+                          "current": true
+                        },
+                        "links": {
+                          "role": [
+                            {
+                              "contentId": "84753907-c0f1-11e4-8223-005056011aef",
+                              "details": {
+                                "rolePaymentType": null,
+                                "seniority": 23,
+                                "whipOrganisation": {}
+                              },
+                              "title": "Minister for Women and Equalities",
+                              "webUrl": "https://www.gov.uk/government/ministers/minister-for-women-and-equalities--3"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "title": "The Rt Hon Kemi Badenoch MP",
+                  "webUrl": "https://www.gov.uk/government/people/kemi-badenoch"
+                }
+              ],
+              "orderedRoles": [
+                {
+                  "contentId": "845e61e9-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "846a61ea-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "30371bc0-0c68-4146-b5a1-2ba89b15516c"
+                },
+                {
+                  "contentId": "de3d5e37-ff1c-4111-b029-fc926da764e9"
+                }
+              ]
+            },
+            "title": "UK Export Finance",
+            "webUrl": "https://www.gov.uk/government/organisations/uk-export-finance"
+          },
+          {
+            "details": {
+              "brand": "office-of-the-advocate-general-for-scotland",
+              "logo": {
+                "crest": "so",
+                "formattedTitle": "Office of the<br/>Advocate General<br/>for Scotland"
+              }
+            },
+            "links": {
+              "orderedRoles": [
+                {
+                  "contentId": "845e8426-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "8461c3df-c0f1-11e4-8223-005056011aef"
+                },
+                {
+                  "contentId": "8461ca79-c0f1-11e4-8223-005056011aef"
+                }
+              ]
+            },
+            "title": "Office of the Advocate General for Scotland",
+            "webUrl": "https://www.gov.uk/government/organisations/office-of-the-advocate-general-for-scotland"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "edition": {
+      "basePath": "/government/ministers",
+      "details": {
+        "body": "Read biographies and responsibilities"
+      },
+      "links": {}
+    }
+  }
+}

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "edition": {
+      "basePath": "/government/ministers",
+      "links": {},
+      "details": {
+        "reshuffle": {
+          "message": "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n"
+        }
+      }
+    }
+  }
+}

--- a/spec/presenters/ministers_index_presenter_spec.rb
+++ b/spec/presenters/ministers_index_presenter_spec.rb
@@ -1,19 +1,9 @@
 RSpec.describe MinistersIndexPresenter do
-  let(:ministers_index) do
-    content_item = double("content item", details:, content_item_data:)
-    double("ministers_index", content_item:)
-  end
-  let(:details) do
-    {
-      "body" => "Foo",
-      "reshuffle" => nil,
-    }
-  end
   let(:content_item_data) { { "links" => {} } }
 
   describe "#cabinet_ministers" do
     it "defaults to empty array if no ordered_cabinet_ministers provided" do
-      presenter = MinistersIndexPresenter.new(ministers_index)
+      presenter = MinistersIndexPresenter.new(content_item_data)
       expect(presenter.cabinet_ministers).to eq([])
     end
 
@@ -30,7 +20,7 @@ RSpec.describe MinistersIndexPresenter do
         stubbed_minister = double("MinistersIndexPresenter::Minister")
         allow(MinistersIndexPresenter::Minister).to receive(:new).and_return(stubbed_minister)
 
-        presenter = MinistersIndexPresenter.new(ministers_index)
+        presenter = MinistersIndexPresenter.new(content_item_data)
         expect(presenter.cabinet_ministers).to eq([stubbed_minister])
       end
     end
@@ -38,7 +28,7 @@ RSpec.describe MinistersIndexPresenter do
 
   describe "#also_attends_cabinet" do
     it "defaults to empty array if no ordered_also_attends_cabinet provided" do
-      presenter = MinistersIndexPresenter.new(ministers_index)
+      presenter = MinistersIndexPresenter.new(content_item_data)
       expect(presenter.also_attends_cabinet).to eq([])
     end
 
@@ -55,7 +45,7 @@ RSpec.describe MinistersIndexPresenter do
         stubbed_minister = double("MinistersIndexPresenter::Minister")
         allow(MinistersIndexPresenter::Minister).to receive(:new).and_return(stubbed_minister)
 
-        presenter = MinistersIndexPresenter.new(ministers_index)
+        presenter = MinistersIndexPresenter.new(content_item_data)
         expect(presenter.also_attends_cabinet).to eq([stubbed_minister])
       end
     end
@@ -63,7 +53,7 @@ RSpec.describe MinistersIndexPresenter do
 
   describe "#by_organisation" do
     it "defaults to empty array if no ordered_ministerial_departments provided" do
-      presenter = MinistersIndexPresenter.new(ministers_index)
+      presenter = MinistersIndexPresenter.new(content_item_data)
       expect(presenter.by_organisation).to eq([])
     end
 
@@ -98,7 +88,7 @@ RSpec.describe MinistersIndexPresenter do
         stubbed_department = double("MinistersIndexPresenter::Department")
         allow(MinistersIndexPresenter::Department).to receive(:new).and_return(stubbed_department)
 
-        presenter = MinistersIndexPresenter.new(ministers_index)
+        presenter = MinistersIndexPresenter.new(content_item_data)
         expect(presenter.by_organisation).to eq([stubbed_department])
       end
 
@@ -108,7 +98,7 @@ RSpec.describe MinistersIndexPresenter do
         stubbed_department = double("MinistersIndexPresenter::Department", ministers: [stubbed_minister])
         allow(MinistersIndexPresenter::Department).to receive(:new).and_return(stubbed_department)
 
-        presenter = MinistersIndexPresenter.new(ministers_index)
+        presenter = MinistersIndexPresenter.new(content_item_data)
         expect(presenter.by_organisation.first.ministers).to eq([stubbed_minister])
       end
 
@@ -118,7 +108,7 @@ RSpec.describe MinistersIndexPresenter do
         it "has departments' ministers defaulting to empty array" do
           allow_any_instance_of(MinistersIndexPresenter::Department).to receive(:ministers).and_call_original
 
-          presenter = MinistersIndexPresenter.new(ministers_index)
+          presenter = MinistersIndexPresenter.new(content_item_data)
           expect(presenter.by_organisation.first.ministers).to eq([])
         end
       end


### PR DESCRIPTION
When the `GRAPHQL_FEATURE_FLAG` environment variable or the `graphql` query param is set, use Publishing API's GraphQL endpoint as the source of the data for serving the Ministers Index page. Otherwise use the standard Content Store data source.

(Corresponding backend changes: https://github.com/alphagov/publishing-api/pull/3009)

https://trello.com/c/PlR5Ken4/1452-querywinkle-the-ministers-index-page