### PR TITLE
Add additional guard clause when we fetch popular tasks from SearchAPI

### DIFF
--- a/app/models/popular_list_set.rb
+++ b/app/models/popular_list_set.rb
@@ -30,6 +30,8 @@ private
       fields: SearchApiFields::POPULAR_BROWSE_SEARCH_FIELDS,
     }
     Services.cached_search(params)
+  rescue GdsApi::HTTPServerError
+    {}
   end
 
   def second_level_browse_content_ids

--- a/spec/models/popular_list_spec.rb
+++ b/spec/models/popular_list_spec.rb
@@ -39,5 +39,12 @@ RSpec.describe PopularListSet do
       stub_search(params:, body: search_response)
       expect(popular_list.formatted_results).to eq expected_results
     end
+
+    context "SearchAPI is unavailable" do
+      it "returns nil" do
+        stub_search_api_isnt_available
+        expect(popular_list.formatted_results).to eq nil
+      end
+    end
   end
 end

--- a/spec/support/search_api_helpers.rb
+++ b/spec/support/search_api_helpers.rb
@@ -1,6 +1,10 @@
 module SearchApiHelpers
   include SearchApiFields
 
+  def stub_search_api_isnt_available
+    stub_request(:any, /#{Plek.find('search-api')}\/.*/).to_return(status: 503)
+  end
+
   def stub_search(body:, params: nil)
     if params
       stub_any_search


### PR DESCRIPTION
Missing from https://github.com/alphagov/collections/pull/3829

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
