### PR TITLE
Add additional URL for chat promo banner

### DIFF
--- a/app/helpers/govuk_chat_promo_helper.rb
+++ b/app/helpers/govuk_chat_promo_helper.rb
@@ -18,6 +18,7 @@ module GovukChatPromoHelper
     /browse/working/state-pension
     /browse/working/time-off
     /browse/working/workplace-personal-pensions
+    /import-goods-into-uk
     /set-up-as-sole-trader
     /set-up-limited-company
   ].freeze


### PR DESCRIPTION
We're adding the promotional banner to some more pages. This is the only one that is rendered by Collections.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
