### PR TITLE
Temporarily switch off GraphQL for Ministers page

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -2,7 +2,7 @@ class MinistersController < ApplicationController
   around_action :switch_locale
 
   def index
-    if Features.graphql_feature_enabled? || params.include?(:graphql)
+    if params.include?(:graphql)
       ministers_index = Graphql::MinistersIndex.find!(request.path)
       content_item_data = ministers_index.content_item
     else

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -146,16 +146,15 @@ RSpec.feature "Ministers index page" do
     end
   end
 
-  context "with the GraphQL feature flag" do
+  context "with the GraphQL query param set" do
     let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
 
     before do
-      enable_graphql_feature_flag
       stub_publishing_api_graphql_query(
         Graphql::MinistersIndexQuery.new("/government/ministers").query,
         document,
       )
-      visit "/government/ministers"
+      visit "/government/ministers?graphql=true"
     end
 
     it_behaves_like "ministers index page"


### PR DESCRIPTION
We've switched the GraphQL feature flag on in integration, resulting in Collections rendering the World Index page, the Ministers Index page and all Role pages in that environment using data from Publishing API's GraphQL endpoint.

Publishing API's responses for the Ministers Index data are taking longer than we allow (GDS API Adapters times-out the connection at 4 seconds), so that page is failing to render correctly on the frontend... and that means that Collections's end-to-end tests are failing and so its deployments are backed-up in integration. (It took us a few days to spot this because the deploy alerts channel itself has been broken, and our own deployments for Publishing API have also been broken 😵 Sorry about that.)

This update changes the default data source for the Ministers Index page back to Content Store. Collections can still be forced to use the Publishing API endpoint if the `graphql` query param is set when requesting the page.

https://trello.com/c/PlR5Ken4/1452-querywinkle-the-ministers-index-page