### PR TITLE
Fix GA4 event data on taxon pages

### DIFF
--- a/app/views/taxons/sections/_guidance_and_regulation.html.erb
+++ b/app/views/taxons/sections/_guidance_and_regulation.html.erb
@@ -1,4 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
+  disable_ga4: true,
   items: section[:documents],
   margin_bottom: 7
 %>

--- a/app/views/taxons/sections/_news_and_communications.html.erb
+++ b/app/views/taxons/sections/_news_and_communications.html.erb
@@ -19,6 +19,7 @@
 
 <% if section[:documents].any? %>
   <%= render 'govuk_publishing_components/components/document_list',
+    disable_ga4: true,
     items: section[:documents_with_promoted],
     margin_bottom: 7
   %>

--- a/app/views/taxons/sections/_policy_and_engagement.html.erb
+++ b/app/views/taxons/sections/_policy_and_engagement.html.erb
@@ -1,4 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
+  disable_ga4: true,
   items: section[:documents],
   margin_bottom: 7
 %>

--- a/app/views/taxons/sections/_research_and_statistics.html.erb
+++ b/app/views/taxons/sections/_research_and_statistics.html.erb
@@ -1,4 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
+  disable_ga4: true,
   items: section[:documents],
   margin_bottom: 7
 %>

--- a/app/views/taxons/sections/_services.html.erb
+++ b/app/views/taxons/sections/_services.html.erb
@@ -1,4 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
+  disable_ga4: true,
   items: section[:documents],
   margin_bottom: 7
 %>

--- a/app/views/taxons/sections/_transparency.html.erb
+++ b/app/views/taxons/sections/_transparency.html.erb
@@ -1,4 +1,5 @@
 <%= render 'govuk_publishing_components/components/document_list',
+  disable_ga4: true,
   items: section[:documents],
   margin_bottom: 7
 %>


### PR DESCRIPTION
## What

Set `disable_ga4` to true for the document-list component used to render each section on a taxon page.

## Why

This fixes an issue on taxon pages (/education for example), where link clicks would fire 2 events instead of 1, both of which were missing some data.

## Event data changes

The data below is sent to GA after clicking the "Student finance for undergraduates" link on this page - https://www.gov.uk/education/funding-and-finance-for-students#/education/student-grants-bursaries-scholarships

### Before

```json
{
 "event": "event_data",
 "event_data": {
  "event_name": "navigation",
  "external": "false",
  "index": {
   "index_link": "2"
  },
  "link_domain": "https://www.gov.uk",
  "method": "command/win click",
  "text": "Student finance for undergraduates",
  "type": "document list",
  "url": "/student-finance"
 },
 "govuk_gem_version": "46.2.0",
 "timestamp": "1733824170576"
}

{
 "event": "event_data",
 "event_data": {
  "event_name": "navigation",
  "external": "false",
  "index": {
   "index_link": "2"
  },
  "link_domain": "https://www.gov.uk",
  "method": "command/win click",
  "text": "Student finance for undergraduates",
  "type": "document list",
  "url": "/student-finance"
 },
 "govuk_gem_version": "46.2.0",
 "timestamp": "1733824170581"
}
```

### After

Only 1 event is fired and information for "index_section", "index_section_count" and "section" is now included.

```json
{
 "event": "event_data",
 "event_data": {
  "event_name": "navigation",
  "external": "false",
  "index": {
   "index_link": "2",
   "index_section": "1",
   "index_section_count": "8"
  },
  "index_total": "6",
  "link_domain": "https://www.gov.uk",
  "method": "command/win click",
  "section": "Services",
  "text": "Student finance for undergraduates",
  "type": "document list",
  "url": "/student-finance"
 },
 "govuk_gem_version": "46.2.0",
 "timestamp": "1733824112924"
}
```