### PR TITLE
Fix Sass warnings

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -81,9 +81,9 @@ $c19-landing-page-header-background: govuk-colour("blue");
 }
 
 .covid__list {
-  @include govuk-font(19);
   margin-bottom: govuk-spacing(3);
   list-style-type: none;
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(4);
@@ -91,8 +91,8 @@ $c19-landing-page-header-background: govuk-colour("blue");
 }
 
 .covid__list-item-description {
-  @include govuk-font(19);
   padding-left: govuk-spacing(6);
+  @include govuk-font(19);
 }
 
 .covid__list-item {

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -51,8 +51,8 @@
 }
 
 .organisation__parent-organisations {
-  @include govuk-font(19);
   margin-top: govuk-spacing(3);
+  @include govuk-font(19);
 }
 
 .organisation__contact-section--border-top {
@@ -69,12 +69,12 @@
 }
 
 .organisation__no10-banner {
-  @include govuk-font(19);
   padding-top: 140px;
   background-image: url("prime-ministers-office-header.jpg");
   background-repeat: no-repeat;
   background-position: 50% 0;
   text-align: center;
+  @include govuk-font(19);
 }
 
 .organisation__no10-yt-link {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -26,8 +26,8 @@
 }
 
 .taxon-page__section-description {
-  @include govuk-font(19);
   margin-top: govuk-spacing(2);
+  @include govuk-font(19);
 }
 
 .taxon-page__section-group {
@@ -43,8 +43,8 @@
 }
 
 .taxon-page__featured-item {
-  @include govuk-clearfix;
   margin-top: govuk-spacing(4);
+  @include govuk-clearfix;
 
   &--single {
     min-width: 330px;
@@ -95,8 +95,8 @@
 }
 
 .taxon-page__link-list-item {
-  @include govuk-font(19);
   margin-bottom: govuk-spacing(2);
+  @include govuk-font(19);
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: 5px;

--- a/app/assets/stylesheets/views/_world_index.scss
+++ b/app/assets/stylesheets/views/_world_index.scss
@@ -19,10 +19,9 @@
   }
 
   .world-locations-group__letter {
-    @include govuk-font(80);
-    font-weight: bold;
     text-indent: -4px;
     margin: 0;
+    @include govuk-font(80, $weight: bold);
   }
 
   .world_locations-group__item {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix Sass compilation warnings in the console.  Declarations starting with e.g. `@include` must follow other declarations, not precede them.

## Why
The linting rules for this changed a while back when we upgraded to the latest version of the sass compiler.

## Visual changes
None.
