### PR TITLE
Update usage of the title component

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -8,10 +8,12 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: raw(title),
+        <%= render "govuk_publishing_components/components/heading", {
+          text: title,
+          heading_level: 1,
+          margin_bottom: 8,
           inverse: true,
-          margin_top: 0
+          font_size: "xl",
         } %>
       </div>
     </div>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -8,7 +8,13 @@
 <body>
 <div id="wrapper">
   <main class="govspeak">
-    <%= render "govuk_publishing_components/components/title", title: "collections" %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "collections",
+      heading_level: 1,
+      margin_bottom: 4,
+      font_size: "xl",
+      padding: true,
+    } %>
     <% html = capture do %>
       <p><%= t('development.header') %>.</p>
       <table>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -1,17 +1,17 @@
-<%= render "govuk_publishing_components/components/inverse_header", { 
-  full_width: true,         
+<%= render "govuk_publishing_components/components/inverse_header", {
+  full_width: true,
   padding_top: false
  } do %>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: presented_taxon.title,
-          average_title_length: 'long',
+        <%= render "govuk_publishing_components/components/heading", {
+          text: presented_taxon.title,
+          heading_level: 1,
+          margin_bottom: 8,
           inverse: true,
-          margin_top: 0
+          font_size: "l",
         } %>
-
         <%= render 'govuk_publishing_components/components/lead_paragraph', {
             text: presented_taxon.description,
             inverse: true

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -8,7 +8,6 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/title", {
       title: @world_location_news.title,
-      margin_top: 0,
       context: I18n.t("world_location_news.types.#{@world_location_news.type}"),
     } %>
   </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

- moving towards a world where the title component has no margin_top option: https://github.com/alphagov/govuk_publishing_components/pull/4508
- this removes instances of the use of the margin_top option for the title component
- in some cases it was possible to replace the title component with the heading component for no visual change (where the margin_top: 0 option was applied)
- in other cases there is a visual change, but this will be minimal

## Why
We're updating the component spacing model to make it more consistent and having a margin_top option isn't part of the intended outcome.

## Visual changes
For the [coronavirus landing page](https://www.gov.uk/coronavirus) the title component used the `margin_top: 0` option, so we replace the component with the heading component, which means no visual change (app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb).

For the development index page we replace the title component with the heading component. This results in a small visual change, but this is a non-public facing page so isn't a concern (app/views/development/index.html.erb).

For the [taxon pages](https://www.gov.uk/transport/driving-and-motorcycle-tests) the title component used the `margin_top: 0` option, so we replace the component with the heading component, which means no visual change (app/views/taxons/_page_header.html.erb).

For the [world location news pages](https://www.gov.uk/world/ukraine/news) the title component used the `margin_top: 0` option, but requires the 'context' feature of the title component (not available in the heading component) so we keep it as it is, but remove the option (app/views/world_location_news/show.html.erb). This currently will not produce a visual difference until we merge https://github.com/alphagov/govuk_publishing_components/pull/4508 at which point it will change as shown below (only on desktop and tablet, mobile remains unchanged). I think this change is acceptable, as the title seems quite squashed against the breadcrumb in this instance.

Before | After
------ | -----
![Screenshot 2024-12-19 at 16 20 19](https://github.com/user-attachments/assets/b52dfc93-917a-4726-b0c6-4c85e70e2c0e) | ![Screenshot 2024-12-19 at 16 20 26](https://github.com/user-attachments/assets/829afd95-ec72-4848-8703-838a420389f1)
