### PR TITLE
Remove "important board members" image constraint

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -139,10 +139,6 @@ class Organisation
     links.fetch("ordered_roles", [])
   end
 
-  def important_board_member_count
-    details["important_board_members"]
-  end
-
   def social_media_links
     details["social_media_links"]
   end

--- a/app/presenters/organisations/people_presenter.rb
+++ b/app/presenters/organisations/people_presenter.rb
@@ -14,7 +14,7 @@ module Organisations
     end
 
     def all_people
-      all_people = @org.all_people.map do |person_type, people|
+      @org.all_people.map do |person_type, people|
         {
           type: person_type,
           title: I18n.t("organisations.people.#{person_type}"),
@@ -23,28 +23,11 @@ module Organisations
           people: people.map { |person| formatted_person_data(person, person_type) },
         }
       end
-
-      images_for_important_board_members(all_people)
     end
 
   private
 
     attr_reader :allowed_role_content_ids
-
-    def images_for_important_board_members(people)
-      people.map do |people_group|
-        if people_group[:type].eql?(:board_members)
-          people_group[:people].map.with_index(1) do |person, i|
-            if @org.important_board_member_count && i > @org.important_board_member_count
-              person.delete(:image_src)
-              person.delete(:image_alt)
-            end
-          end
-        end
-
-        people_group
-      end
-    end
 
     def is_person_ministerial?(type)
       type.eql?(:ministers)

--- a/spec/presenters/organisations/people_presenter_spec.rb
+++ b/spec/presenters/organisations/people_presenter_spec.rb
@@ -180,36 +180,6 @@ RSpec.describe Organisations::PeoplePresenter do
       expect(people_presenter.all_people.third[:people][1][:description]).to eq(expected)
     end
 
-    it "does not show images for non-important board members" do
-      non_important_board_members = presenter_from_organisation_hash(organisation_with_non_important_board_members)
-
-      expected_important = {
-        brand: "attorney-generals-office",
-        href: "/government/people/jeremy-heywood",
-        description: "Cabinet Secretary",
-        metadata: "Unpaid",
-        heading_text: "Sir Jeremy Heywood",
-        lang: "en",
-        heading_level: 0,
-        extra_details_no_indent: true,
-        image_src: "/photo/jeremy-heywood",
-      }
-
-      expected_non_important = {
-        brand: "attorney-generals-office",
-        href: "/government/people/john-manzoni",
-        description: "Chief Executive of the Civil Service",
-        metadata: nil,
-        heading_text: "John Manzoni",
-        lang: "en",
-        heading_level: 0,
-        extra_details_no_indent: true,
-      }
-
-      expect(non_important_board_members.all_people.third[:people][0]).to eq(expected_important)
-      expect(non_important_board_members.all_people.third[:people][1]).to eq(expected_non_important)
-    end
-
     it "fetches image" do
       expect(people_presenter.all_people.third[:people][0][:image_src]).to eq("/photo/jeremy-heywood")
     end

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -350,69 +350,6 @@ module OrganisationHelpers
     }.with_indifferent_access
   end
 
-  def organisation_with_non_important_board_members
-    {
-      title: "Attorney General's Office",
-      base_path: "/government/organisations/attorney-generals-office",
-      details: {
-        brand: "attorney-generals-office",
-        organisation_govuk_status: {
-          status: "live",
-        },
-        important_board_members: 1,
-      },
-      links: {
-        ordered_roles: [
-          { content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339" },
-          { content_id: "61a62a60-df26-4454-81da-0594f0d74d76" },
-        ],
-        ordered_board_members: [
-          {
-            title: "Sir Jeremy Heywood",
-            locale: "en",
-            base_path: "/government/people/jeremy-heywood",
-            details: {
-              image: {
-                url: "/photo/jeremy-heywood",
-                alt_text: "Sir Jeremy Heywood",
-              },
-            },
-            links: {
-              role_appointments: [
-                current_role_appointment(
-                  content_id: "264a1f0e-6e0a-479b-83d4-2660afe36339",
-                  title: "Cabinet Secretary",
-                  document_type: "board_member_role",
-                  payment_type: "Unpaid",
-                ),
-              ],
-            },
-          },
-          {
-            title: "John Manzoni",
-            locale: "en",
-            base_path: "/government/people/john-manzoni",
-            details: {
-              image: {
-                url: "/photo/john-manzoni",
-                alt_text: "John Manzoni",
-              },
-            },
-            links: {
-              role_appointments: [
-                current_role_appointment(
-                  content_id: "61a62a60-df26-4454-81da-0594f0d74d76",
-                  title: "Chief Executive of the Civil Service",
-                  document_type: "board_member_role",
-                ),
-              ],
-            },
-          },
-        ],
-      },
-    }.with_indifferent_access
-  end
-
   def organisation_with_no_documents
     {
       title: "Org with No Docs",


### PR DESCRIPTION
Sister PR: https://github.com/alphagov/whitehall/pull/9765

This feature was added in #754 (counterpart in Whitehall: https://github.com/alphagov/whitehall/pull/4162). Neither PR really explains/justifies the feature: it appears to have been added as a workaround for a specific organisation, where they'd neglected to add an image for one of their board members. Instead of adding an image for them, this feature was added to impose an artificial limit on the number of images to display on the page.

This has since caused numerous support tickets for the publishing team, with publishers struggling to understand why board member photos are missing from the org page. The limit, tucked away in the organisation settings, is not well known and is not intuitive.

We've decided to remove the feature, removing complexity from both Whitehall and Collections. It should result in fewer support tickets for the team, and be a net positive for organisations in terms of an easier-to-understand system. If we find there is a requirement to re-introduce something like this in future, we can approach it more holistically. For now, the simplest thing is to remove the feature, as we suspect it's not widely used.

Trello: https://trello.com/c/mz0WLkIR/3282-remove-display-management-team-images-feature

## Screenshots

Before (manually updated to limit of 5 in Integration):

<img width="997" alt="Screenshot 2024-12-20 at 13 48 22" src="https://github.com/user-attachments/assets/091dd780-1bcf-4512-a93c-d555ab0fa454" />

After (deployed branch to Integration, which now ignores the limit):

<img width="997" alt="Screenshot 2024-12-20 at 13 51 54" src="https://github.com/user-attachments/assets/c2d471f1-dc16-46f6-ba44-6fdfa708763c" />

NB, cabinet-office is the org that was used as an example in PR #754. Interesting to note it no longer uses the image limit, and it has a missing image for a person, which no longer appears to be contentious.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
