### PR TITLE
Request a base_path for the GraphQL World Index

### DIFF
--- a/app/queries/graphql/world_index_query.rb
+++ b/app/queries/graphql/world_index_query.rb
@@ -14,6 +14,7 @@ class Graphql::WorldIndexQuery
       {
         edition(base_path: "#{@base_path}") {
           ... on WorldIndex {
+            base_path
             title
 
             details {


### PR DESCRIPTION
A recent change to the layout template expects all pages' "content item" data have a base_path.