### PR TITLE
Remove call to intervention banner from layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,6 @@
     unless (!content_item_h["locale"])
       lang = content_item_h["locale"]
     end
-    unless content_item_h["base_path"].include? "/browse"
-      call_recruitment_banner_partial = true
-    end
   end
 %>
 
@@ -21,9 +18,6 @@
     <% else %>
       <%= render 'breadcrumbs' %>
     <% end %>
-  <% end %>
-  <% if call_recruitment_banner_partial %>
-    <%= render "govuk_web_banners/recruitment_banner" %>
   <% end %>
   <%=
     content_tag(:main,

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,6 +2,7 @@
 
 <%= render partial: 'meta', locals: { organisation: @organisation } %>
 <%= render partial: 'breadcrumb' %>
+<%= render "govuk_web_banners/recruitment_banner" %>
 <%= render partial: 'header' %>
 <% if @organisation.custom_banner %>
   <%= render "govuk_publishing_components/components/notice", {

--- a/spec/fixtures/graphql/world_index.json
+++ b/spec/fixtures/graphql/world_index.json
@@ -1,7 +1,6 @@
 {
   "data": {
     "edition": {
-      "base_path": "/world",
       "title": "Help and services around the world",
       "details": {
         "world_locations": [


### PR DESCRIPTION
The call to the intervention banner in the application layout has cause problems with [e2e tests](https://argo-workflows.eks.integration.govuk.digital/workflows/apps/post-sync-w5wll?tab=workflow&nodeId=post-sync-w5wll-1049345404&sidePanel=logs:post-sync-w5wll-1049345404:main&uid=5f77b2a8-9e23-49ec-ab6f-dbdcf31b278d), as not all content items served by this application have a base_path.

Removing for the time being, and adding to the organisation template instead, as the only page rendered by this application that has a banner scheduled is https://www.gov.uk/government/organisations/uk-visas-and-immigration

See: https://github.com/alphagov/govuk_web_banners/blob/main/config/govuk_web_banners/recruitment_banners.yml

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
