### PR TITLE
Update GraphQL queries to use generic edition type

### DIFF
--- a/app/queries/graphql/role_query.rb
+++ b/app/queries/graphql/role_query.rb
@@ -7,7 +7,7 @@ class Graphql::RoleQuery
     <<-QUERY
       {
         edition(base_path: "#{@base_path}") {
-          ... on Role {
+          ... on Edition {
             base_path
             locale
             title

--- a/app/queries/graphql/world_index_query.rb
+++ b/app/queries/graphql/world_index_query.rb
@@ -5,7 +5,7 @@ class Graphql::WorldIndexQuery
 
   def query
     <<-QUERY
-      fragment worldLocationInfo on WorldLocation {
+      fragment worldLocationInfo on Edition {
         active
         name
         slug
@@ -13,7 +13,7 @@ class Graphql::WorldIndexQuery
 
       {
         edition(base_path: "#{@base_path}") {
-          ... on WorldIndex {
+          ... on Edition {
             title
 
             details {


### PR DESCRIPTION
Publishing API was updated in https://github.com/alphagov/publishing-api/pull/3063 to have a single edition type for most content, instead of a specific type for roles and the world index page.

Updating the query used by this application in making such requests to Publishing API.

The ministers index page retains a specific edition type, as optimisations exist for determining one of the links in that page.

[Trello card](https://trello.com/c/MSjuzc9M)