### PR TITLE
Use equal item spacing on gem document-list used by taxon-list

### DIFF
--- a/app/views/world_wide_taxons/_tagged_content_list.html.erb
+++ b/app/views/world_wide_taxons/_tagged_content_list.html.erb
@@ -4,6 +4,7 @@
       <%= render "govuk_publishing_components/components/document_list", {
         remove_top_border: true,
         disable_ga4: true,
+        equal_item_spacing: true,
         items: taxon_list_params(presented_taxon)
       } %>
     </div>

--- a/app/views/world_wide_taxons/accordion.html.erb
+++ b/app/views/world_wide_taxons/accordion.html.erb
@@ -20,6 +20,7 @@
             <%= render "govuk_publishing_components/components/document_list", {
               remove_top_border: true,
               disable_ga4: true,
+              equal_item_spacing: true,
               items: taxon_list_params(taxon)
             } %>
           <% end %>


### PR DESCRIPTION
This is following a design review of the spacing of the lists on /contact. Get a preview up first to allow our designer to review the visual changes.

[Trello](https://trello.com/c/F3iYypdh/3053-settle-on-an-approach-and-spacing-for-rendering-a-list-of-links-with-paragraph-tags-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
