### PR TITLE
Upgrade govuk_publishing_components to v49.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (48.0.0)
+    govuk_publishing_components (49.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -11,7 +11,7 @@
         <p class="govuk-visually-hidden"><%= t('organisations.count_prefix') %> <span class="js-accessible-item-count"><%= organisations.count %></span> <%= organisation_type.to_s.humanize %></p>
         <%= render "govuk_publishing_components/components/big_number", {
           number: organisations.count,
-          data_attributes: {
+          nested_data_attributes: {
             item_count: "true",
           },
           aria: {

--- a/app/views/world/index.html.erb
+++ b/app/views/world/index.html.erb
@@ -49,7 +49,7 @@
             aria: {
               hidden: true,
             },
-            data_attributes: {
+            nested_data_attributes: {
               item_count: "true",
             },
           } %>
@@ -90,7 +90,7 @@
             aria: {
               hidden: true,
             },
-            data_attributes: {
+            nested_data_attributes: {
               item_count: "true",
             },
           } %>


### PR DESCRIPTION
## What / Why
- Upgrades `govuk_publishing_components` to `v49.0.0`
- Changes `data_attributes` to `nested_data_attributes` due to https://github.com/alphagov/govuk_publishing_components/pull/4550
- Affects http://127.0.0.1:3070/world and http://127.0.0.1:3070/government/organisations