### PR TITLE
Replace title components with headings

### DIFF
--- a/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
+++ b/app/views/coronavirus_landing_page/components/landing_page/_page_header.html.erb
@@ -8,11 +8,13 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: raw(title),
-          inverse: true,
-          margin_top: 0
-        } %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: raw(title),
+            heading_level: 1,
+            font_size: "xl",
+            inverse: true,
+            margin_bottom: 8
+          } %>
       </div>
     </div>
   </div>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -7,8 +7,13 @@
 </head>
 <body>
 <div id="wrapper">
-  <main class="govspeak">
-    <%= render "govuk_publishing_components/components/title", title: "collections" %>
+  <main class="govspeak govuk-!-margin-top-8">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "collections",
+      heading_level: 1,
+      font_size: "xl",
+      margin_bottom: 8
+    } %>
     <% html = capture do %>
       <p><%= t('development.header') %>.</p>
       <table>

--- a/app/views/taxons/_page_header.html.erb
+++ b/app/views/taxons/_page_header.html.erb
@@ -5,13 +5,13 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: presented_taxon.title,
-          average_title_length: 'long',
+        <%= render "govuk_publishing_components/components/heading", {
+          text: presented_taxon.title,
+          heading_level: 1,
+          font_size: "l",
           inverse: true,
-          margin_top: 0
+          margin_bottom: 8
         } %>
-
         <%= render 'govuk_publishing_components/components/lead_paragraph', {
             text: presented_taxon.description,
             inverse: true


### PR DESCRIPTION
## What
Replace title components with headings.

## Why
We are attempting to retire the page title component in favour of the heading component. [Trello](https://trello.com/c/Z8t7nZrM/441-replace-title-with-heading-in-collections)

## Visual Changes
None. Components look the same.
