### PR TITLE
Add GA4 section parameter to topic cards

### DIFF
--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -76,6 +76,7 @@
               type: "browse card",
               index_link: index + 1,
               index_total: total_links,
+              section: page.popular_list ? t("browse.topics", lang: :en) : nil
             },
           },
         },


### PR DESCRIPTION
## What / Why
- Adds section parameter to the cards on pages like https://www.gov.uk/browse/driving
- Trello card: https://trello.com/c/o6wvtsJf/861-add-section-parameters-for-clicks-on-browse-card-links

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
