### PR TITLE
[DO NOT MERGE] Remove `browse__breadcrumb-border`

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -26,17 +26,6 @@ $browse-header-background-colour: #263135;
   overflow: auto;
 }
 
-.browse__breadcrumb-border {
-  background: govuk-colour("blue");
-  height: 10px;
-}
-
-.global-bar-present {
-  .browse__breadcrumb-border {
-    height: 0;
-  }
-}
-
 // The header spacings are a work in progress.
 .browse__header-wrapper {
   padding-bottom: govuk-spacing(7);

--- a/app/views/shared/_browse_breadcrumbs.html.erb
+++ b/app/views/shared/_browse_breadcrumbs.html.erb
@@ -7,7 +7,6 @@
 
 <div class="browse__breadcrumb-wrapper">
   <div class="govuk-width-container">
-    <div class="browse__breadcrumb-border"></div>
     <div class="govuk-grid-row">
       <div class="<%= column_classes.join(' ') %>">
         <%= render "application/breadcrumbs", {


### PR DESCRIPTION
## What
Remove `browse__breadcrumb-border` (from Browse pages)

https://trello.com/c/3EkNY2Bs/3254-prepare-a-pr-to-turn-off-the-blue-border-at-the-bottom-of-the-header?filter=label:Frontend%20devs

## Why
The blue bar beneath the current black header on [GOV.UK](http://gov.uk/) pages is applied by https://github.com/alphagov/govuk_publishing_components. We want to remove this, and will need to update the gem accordingly. However the blue bar code is very old and complicated and we’re not sure how best to do it.

## Visual Changes

### Before

### After

## Anything else
https://github.com/alphagov/govuk_publishing_components/pull/4616
https://github.com/alphagov/frontend/pull/4627
https://github.com/alphagov/static/pull/3578