### PR TITLE
Change devolved administrations to devolved governments

### DIFF
--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -52,7 +52,7 @@ module Organisations
         ),
         high_profile_groups: @organisations.high_profile_groups,
         public_corporations: @organisations.public_corporations,
-        devolved_administrations: @organisations.devolved_administrations,
+        devolved_governments: @organisations.devolved_administrations,
       }
     end
 

--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -100,7 +100,7 @@ en:
       advisory_ndpb: Advisory non-departmental public body
       civil_service: Civil service
       court: Court
-      devolved_administration: Devolved administration
+      devolved_administration: Devolved government
       executive_agency: Executive agency
       executive_ndpb: Executive non-departmental public body
       executive_office: Executive office

--- a/spec/presenters/organisations_presenter_spec.rb
+++ b/spec/presenters/organisations_presenter_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe Organisations::IndexPresenter do
       expect(organisations_presenter.all_organisations[:public_corporations]).to eq(expected)
     end
 
-    it "returns devolved_administrations departments as part of all_organisations hash" do
+    it "returns devolved_governments departments as part of all_organisations hash" do
       expected = [{
         "title": "Northern Ireland Executive ",
         "href": "/government/organisations/northern-ireland-executive",
         "brand": nil,
       }.with_indifferent_access]
 
-      expect(organisations_presenter.all_organisations[:devolved_administrations]).to eq(expected)
+      expect(organisations_presenter.all_organisations[:devolved_governments]).to eq(expected)
     end
   end
 


### PR DESCRIPTION
Update the devolved administrations organisation type on the organisations index page. It should now say devolved governments

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2dc577fc-ffc1-4809-af08-828b7918cdc9) | ![image](https://github.com/user-attachments/assets/845d5ddf-439a-47df-9b51-124f2fc63585) | 

Trello card: https://trello.com/c/Jzfz7JvW/3288-change-devolved-administrations-to-devolved-governments