### PR TITLE
Remove coronavirus taxon redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,6 @@ Rails.application.routes.draw do
     GovukHealthcheck::RailsCache,
   )
 
-  ["/coronavirus-taxon", "/coronavirus-taxon/*slug"].each do |path|
-    get path => redirect("/coronavirus", status: 307)
-  end
-
   get "/coronavirus", to: "coronavirus_landing_page#show", as: :coronavirus_landing_page
 
   unless Rails.env.production?

--- a/spec/support/coronavirus_content_item_helper.rb
+++ b/spec/support/coronavirus_content_item_helper.rb
@@ -1,6 +1,4 @@
 module CoronavirusContentItemHelper
-  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxons".freeze
-
   def coronavirus_landing_page_content_item
     load_content_item("coronavirus_landing_page.json")
   end

--- a/spec/support/coronavirus_landing_page_steps.rb
+++ b/spec/support/coronavirus_landing_page_steps.rb
@@ -7,7 +7,7 @@ module CoronavirusLandingPageSteps
   include SearchApiHelpers
 
   CORONAVIRUS_PATH = "/coronavirus".freeze
-  CORONAVIRUS_TAXON_PATH = "/coronavirus-taxon".freeze
+  CORONAVIRUS_TAXON_PATH = "/health-and-social-care/covid-19".freeze
   OTHER_SUBTAXON_PATH = "#{CORONAVIRUS_TAXON_PATH}/no-hub-page".freeze
 
   def given_there_is_a_content_item


### PR DESCRIPTION
Once we move the COVID 19 taxon from being a level one taxon to sitting under the health and social care taxon we can handle the rerouting of the taxon homepage by setting an email override in content tagger. This means we can remove the code which reroutes the COVID 19 landing page.

Trello card: https://trello.com/c/QTwBBhTN/3272-prepare-the-removal-of-the-code-for-rerouting-covid-19-taxon

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
