### PR TITLE
Update COVID-19 landing page 'More COVID-19 information' links

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -54,27 +54,27 @@ class CoronavirusLandingPagePresenter
     { links: [
       {
         label: "Guidance and regulation about COVID-19",
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=guidance_and_regulation&order=updated-newest",
+        url: "/search/all?order=updated-newest&level_one_taxon=8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8&level_two_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=guidance_and_regulation",
       },
       {
         label: "News and communications about COVID-19",
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications&order=updated-newest",
+        url: "/search/all?order=updated-newest&level_one_taxon=8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8&level_two_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=news_and_communications",
       },
       {
         label: "Research and statistics about COVID-19",
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=research_and_statistics&order=updated-newest",
+        url: "/search/all?order=updated-newest&level_one_taxon=8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8&level_two_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=research_and_statistics",
       },
       {
         label: "Policy papers and consultations about COVID-19",
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=policy_and_engagement&order=updated-newest",
+        url: "/search/all?order=updated-newest&level_one_taxon=8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8&level_two_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=policy_and_engagement",
       },
       {
         label: "Transparency and freedom of information releases about COVID-19",
-        url: "/search/all?level_one_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=transparency&order=updated-newest",
+        url: "/search/all?order=updated-newest&level_one_taxon=8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8&level_two_taxon=5b7b9532-a775-4bd2-a3aa-6ce380184b6c&content_purpose_supergroup%5B%5D=transparency",
       },
       {
         label: "Summary of COVID-19 testing, cases and vaccinations data",
-        url: "https://coronavirus.data.gov.uk/",
+        url: "hhttps://ukhsa-dashboard.data.gov.uk/respiratory-viruses/covid-19",
       },
       {
         label: "COVID-19 legislation on legislation.gov.uk",

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -71,7 +71,7 @@
     } do
     render 'govuk_publishing_components/components/signup_link', {
       link_text:  "Sign up to get emails when we change any COVID-19 information on the GOV.UK website",
-      link_href: "/email-signup?topic=/coronavirus-taxon",
+      link_href: "/email-signup?topic=/health-and-social-care/covid-19",
       heading: "Stay up to date with GOV.UK",
       background: true
     }


### PR DESCRIPTION
This pull request updates:

- all content supergroup finder links to direct users to the correct search filtering for the COVID-19 sub topic
- the 'Summary of COVID-19 testing, cases and vaccinations data' link to the UKHSA data dashboard
- the 'Sign up to get emails' link to the correct taxon URL

This is because the location of the COVID-19 topic ('taxon') and all of child taxons has moved under the "Health and social care" topic.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
