### PR TITLE
Update coronavirus_landing_page_presenter.rb

### DIFF
--- a/app/presenters/coronavirus_landing_page_presenter.rb
+++ b/app/presenters/coronavirus_landing_page_presenter.rb
@@ -74,7 +74,7 @@ class CoronavirusLandingPagePresenter
       },
       {
         label: "Summary of COVID-19 testing, cases and vaccinations data",
-        url: "hhttps://ukhsa-dashboard.data.gov.uk/respiratory-viruses/covid-19",
+        url: "https://ukhsa-dashboard.data.gov.uk/respiratory-viruses/covid-19",
       },
       {
         label: "COVID-19 legislation on legislation.gov.uk",


### PR DESCRIPTION
fix typo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
