### PR TITLE
Add previous roles to people pages

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -26,6 +26,24 @@ class Person
     current_roles.map { |role| role["title"] }.to_sentence(locale: content_item.locale)
   end
 
+    def previous_roles_items
+    previous_roles.map do |role|
+      {
+        link: {
+          text: role["title"],
+          path: role["base_path"],
+        },
+        metadata: {
+          appointment_duration: "#{role['start_year']} to #{role['end_year']}",
+        },
+      }
+    end
+  end
+
+  def has_previous_roles?
+    previous_roles.present?
+  end
+
   def image_url
     details.dig("image", "url")
   end
@@ -81,6 +99,19 @@ private
 
   def previous_role_appointments
     @previous_role_appointments ||= role_appointments(current: false)
+  end
+
+
+  def previous_roles
+    previous_role_appointments
+      .sort_by { |role_appointment| role_appointment["details"]["started_on"] }
+      .reverse
+      .map do |role_appointment|
+        role_appointment["links"]["role"].first.tap do |role|
+          role["start_year"] = Time.zone.parse(role_appointment["details"]["started_on"]).strftime("%Y")
+          role["end_year"] = Time.zone.parse(role_appointment["details"]["ended_on"]).strftime("%Y")
+        end
+      end
   end
 
   def links

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -26,7 +26,7 @@ class Person
     current_roles.map { |role| role["title"] }.to_sentence(locale: content_item.locale)
   end
 
-    def previous_roles_items
+  def previous_roles_items
     previous_roles.map do |role|
       {
         link: {
@@ -86,21 +86,27 @@ private
     base_path.split("/").last
   end
 
-  def role_appointments(current:)
-    links
-      .fetch("role_appointments", [])
-      .filter { |role_appointment| role_appointment.dig("details", "current") == current }
-      .sort_by { |role_appointment| role_appointment.dig("details", "person_appointment_order") }
+  def role_appointments
+    @role_appointments ||= links.fetch("role_appointments", [])
+  end
+
+  def sort_by_appointment_order(appointments)
+    appointments.sort_by { |role_appointment| role_appointment.dig("details", "person_appointment_order") }
+  end
+
+  def role_appointment(current:)
+    sort_by_appointment_order(
+      role_appointments.filter { |role_appointment| role_appointment.dig("details", "current") == current },
+    )
   end
 
   def current_role_appointments
-    @current_role_appointments ||= role_appointments(current: true)
+    @current_role_appointments ||= role_appointment(current: true)
   end
 
   def previous_role_appointments
-    @previous_role_appointments ||= role_appointments(current: false)
+    @previous_role_appointments ||= role_appointment(current: false)
   end
-
 
   def previous_roles
     previous_role_appointments
@@ -128,5 +134,9 @@ private
 
   def available_translations
     links["available_translations"]&.map(&:symbolize_keys) || []
+  end
+
+  def role_from_appointment(appointment)
+    appointment.dig("links", "role", 0)
   end
 end

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -11,6 +11,11 @@
         href: "#current-roles"
       } : nil,
 
+      person.has_previous_roles? ? {
+        text: t("people.previous_roles"),
+        href: "#previous-roles"
+      } : nil,
+
       person.announcements.items.present? ? {
         text: t("shared.schema_name.announcement.other"),
         href: "#announcements"

--- a/app/views/people/_contents.html.erb
+++ b/app/views/people/_contents.html.erb
@@ -11,7 +11,7 @@
         href: "#current-roles"
       } : nil,
 
-      person.has_previous_roles? ? {
+      person.has_previous_non_ministerial_roles? ? {
         text: t("people.previous_roles"),
         href: "#previous-roles"
       } : nil,

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,0 +1,19 @@
+<% if person.has_previous_roles? %>
+  <div 
+    class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>"
+    <%= dir_attribute %>
+    <%= lang_attribute %>
+  >
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("people.previous_roles_in_government"),
+      lang: t_fallback("people.previous_roles_in_government"),
+      id: "previous-roles",
+      margin_bottom: 2
+      } 
+    %>
+
+    <%= render "govuk_publishing_components/components/document_list", {
+      items: person.previous_roles_items
+    } %>
+  </div>
+<% end %>

--- a/app/views/people/_previous_roles.html.erb
+++ b/app/views/people/_previous_roles.html.erb
@@ -1,4 +1,4 @@
-<% if person.has_previous_roles? %>
+<% if person.has_previous_non_ministerial_roles? %>
   <div 
     class="previous-roles govuk-!-padding-bottom-9 <%= direction_rtl_class %>"
     <%= dir_attribute %>
@@ -13,7 +13,7 @@
     %>
 
     <%= render "govuk_publishing_components/components/document_list", {
-      items: person.previous_roles_items
+      items: person.previous_non_ministerial_roles_items
     } %>
   </div>
 <% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -15,6 +15,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: "biography", locals: { person: person } %>
     <%= render partial: "current_roles", locals: { person: person } %>
+    <%= render partial: "previous_roles", locals: { person: person } %>
     <%= render partial: "shared/announcements", locals: { announcements: person.announcements, locale: I18n.locale } %>
   </div>
 </div>

--- a/config/locales/ar/people.yml
+++ b/config/locales/ar/people.yml
@@ -2,4 +2,6 @@
 ar:
   people:
     biography: سيرة ذاتية
+    previous_roles: الأدوار السابقة
+    previous_roles_in_government: الأدوار السابقة بالحكومة
     read_more: المزيد عن هذه الشخصية

--- a/config/locales/az/people.yml
+++ b/config/locales/az/people.yml
@@ -2,4 +2,6 @@
 az:
   people:
     biography: Bioqrafiya
+    previous_roles: Əvvəlki vəzifələri
+    previous_roles_in_government: Hökumət orqanında əvvəlki vəzifələri
     read_more: Bu şəxs haqqında ətraflı

--- a/config/locales/be/people.yml
+++ b/config/locales/be/people.yml
@@ -2,4 +2,6 @@
 be:
   people:
     biography: Бiяграфiя
+    previous_roles: Папярэднія пасады
+    previous_roles_in_government: Папярэднія дзяржаўныя пасады
     read_more: Больш аб гэтай персоне

--- a/config/locales/bg/people.yml
+++ b/config/locales/bg/people.yml
@@ -2,4 +2,6 @@
 bg:
   people:
     biography: Биография
+    previous_roles: Предишни длъжности
+    previous_roles_in_government: Предишни длъжности в правителството
     read_more: Повече за това лице

--- a/config/locales/bn/people.yml
+++ b/config/locales/bn/people.yml
@@ -2,4 +2,6 @@
 bn:
   people:
     biography: জীবনী
+    previous_roles: পূর্ববর্তী ভূমিকা
+    previous_roles_in_government: সরকারে পূর্ববর্তী ভূমিকা
     read_more: এই ব্যক্তি সম্পর্কে আরও

--- a/config/locales/cs/people.yml
+++ b/config/locales/cs/people.yml
@@ -2,4 +2,6 @@
 cs:
   people:
     biography: Životopis
+    previous_roles: Předchozí funkce
+    previous_roles_in_government: Předchozí funkce ve státní správě
     read_more: Více o této osobě

--- a/config/locales/cy/people.yml
+++ b/config/locales/cy/people.yml
@@ -2,4 +2,6 @@
 cy:
   people:
     biography: Bywgraffiad
+    previous_roles: Rolau blaenorol
+    previous_roles_in_government: Rolau blaenorol yn y llywodraeth
     read_more: Mwy am y person hwn

--- a/config/locales/da/people.yml
+++ b/config/locales/da/people.yml
@@ -2,4 +2,6 @@
 da:
   people:
     biography: Biografi
+    previous_roles: Tidligere roller
+    previous_roles_in_government: Tidligere roller i regeringen
     read_more: Mere om denne person

--- a/config/locales/de/people.yml
+++ b/config/locales/de/people.yml
@@ -2,4 +2,6 @@
 de:
   people:
     biography: Biografie
+    previous_roles: Frühere Funktionen
+    previous_roles_in_government: Frühere Funktionen in der Regierung
     read_more: Mehr über diese Person

--- a/config/locales/dr/people.yml
+++ b/config/locales/dr/people.yml
@@ -2,4 +2,6 @@
 dr:
   people:
     biography: بیوگرافی
+    previous_roles: وظیفه هایی قبلی
+    previous_roles_in_government: وظیفه هایی قبلی در دولت
     read_more: اطلاعات بیشتر در بارهء این شخص

--- a/config/locales/el/people.yml
+++ b/config/locales/el/people.yml
@@ -2,4 +2,6 @@
 el:
   people:
     biography: Βιογραφία
+    previous_roles: Προηγούμενοι ρόλοι
+    previous_roles_in_government: Προηγούμενοι ρόλοι στην κυβέρνηση
     read_more: Περισσότερα για αυτό το άτομο

--- a/config/locales/en/people.yml
+++ b/config/locales/en/people.yml
@@ -2,4 +2,6 @@
 en:
   people:
     biography: Biography
+    previous_roles: Previous roles
+    previous_roles_in_government: Previous roles in government
     read_more: More about this person

--- a/config/locales/es-419/people.yml
+++ b/config/locales/es-419/people.yml
@@ -2,4 +2,6 @@
 es-419:
   people:
     biography: Biografía
+    previous_roles: Funciones anteriores
+    previous_roles_in_government: Funciones anteriores en el gobierno
     read_more: Más información sobre esta persona

--- a/config/locales/es/people.yml
+++ b/config/locales/es/people.yml
@@ -2,4 +2,6 @@
 es:
   people:
     biography: Biografía
+    previous_roles: Funciones anteriores
+    previous_roles_in_government: Funciones anteriores en el gobierno
     read_more: Más sobre esta persona

--- a/config/locales/et/people.yml
+++ b/config/locales/et/people.yml
@@ -2,4 +2,6 @@
 et:
   people:
     biography: Biograafia
+    previous_roles: Varasemad rollid
+    previous_roles_in_government: Varasemad rollid valitsuses
     read_more: Rohkem selle isiku kohta

--- a/config/locales/fa/people.yml
+++ b/config/locales/fa/people.yml
@@ -2,4 +2,6 @@
 fa:
   people:
     biography: زندگی‌نامه
+    previous_roles: نقش‌های قبلی
+    previous_roles_in_government: نقش‌های قبلی در دولت
     read_more: اطلاعات بیشتر درباره این فرد

--- a/config/locales/fi/people.yml
+++ b/config/locales/fi/people.yml
@@ -2,4 +2,6 @@
 fi:
   people:
     biography: Elämäkerta
+    previous_roles: Aiemmat roolit
+    previous_roles_in_government: Aiemmat tehtävät julkishallinnossa
     read_more: Lisää tästä henkilöstä

--- a/config/locales/fr/people.yml
+++ b/config/locales/fr/people.yml
@@ -2,4 +2,6 @@
 fr:
   people:
     biography: Biographie
+    previous_roles: Rôles précédents
+    previous_roles_in_government: Rôles précédents au gouvernement
     read_more: Plus d'informations sur cette personne

--- a/config/locales/gd/people.yml
+++ b/config/locales/gd/people.yml
@@ -2,4 +2,6 @@
 gd:
   people:
     biography: Beathaisnéis
+    previous_roles: Feidhmeanna roimhe seo
+    previous_roles_in_government: Róil a bhí ar siúl roimhe seo ag Aireacht an Taobh istigh
     read_more: Níos mó a fhoghlaim faoin duine seo

--- a/config/locales/gu/people.yml
+++ b/config/locales/gu/people.yml
@@ -2,4 +2,6 @@
 gu:
   people:
     biography: જીવનચરિત્ર
+    previous_roles: અગાઉની ભૂમિકાઓ
+    previous_roles_in_government: સરકારમાં અગાઉની ભૂમિકાઓ
     read_more: આ વ્યક્તિ વિશે વધુ

--- a/config/locales/he/people.yml
+++ b/config/locales/he/people.yml
@@ -2,4 +2,6 @@
 he:
   people:
     biography: ביוגרפיה
+    previous_roles: תפקידים קודמים
+    previous_roles_in_government: תפקידים קודמים בממשלה
     read_more: עוד על האדם הזה

--- a/config/locales/hi/people.yml
+++ b/config/locales/hi/people.yml
@@ -2,4 +2,6 @@
 hi:
   people:
     biography: जीवनी
+    previous_roles: पिछली भूमिकाएं
+    previous_roles_in_government: सरकार में पिछली भूमिकाएं
     read_more: इस व्यक्ति के बारे में और बातें

--- a/config/locales/hr/people.yml
+++ b/config/locales/hr/people.yml
@@ -2,4 +2,6 @@
 hr:
   people:
     biography: Biografija
+    previous_roles: Prethodne uloge
+    previous_roles_in_government: Ranije uloge u vladi
     read_more: Više o ovoj osobi

--- a/config/locales/hu/people.yml
+++ b/config/locales/hu/people.yml
@@ -2,4 +2,6 @@
 hu:
   people:
     biography: Életrajz
+    previous_roles: Korábbi beosztások
+    previous_roles_in_government: Korábbi állami beosztások
     read_more: Több erről a személyről

--- a/config/locales/hy/people.yml
+++ b/config/locales/hy/people.yml
@@ -2,4 +2,6 @@
 hy:
   people:
     biography: Կենսագրություն
+    previous_roles: Նախկին պաշտոններ
+    previous_roles_in_government: Նախկին պաշտոններ կառավարությունում
     read_more: Ավելի շատ տեղեկություն այս անձի մասին

--- a/config/locales/id/people.yml
+++ b/config/locales/id/people.yml
@@ -2,4 +2,6 @@
 id:
   people:
     biography: Biografi
+    previous_roles: Peran sebelumnya
+    previous_roles_in_government: Peran sebelumnya dalam pemerintahan
     read_more: Selengkapnya tentang orang ini

--- a/config/locales/is/people.yml
+++ b/config/locales/is/people.yml
@@ -2,4 +2,6 @@
 is:
   people:
     biography: Ævisaga
+    previous_roles: Fyrri hlutverki
+    previous_roles_in_government: Fyrri hlutverk hjá ríkinu
     read_more: Meira um þessa manneskju

--- a/config/locales/it/people.yml
+++ b/config/locales/it/people.yml
@@ -2,4 +2,6 @@
 it:
   people:
     biography: Biografia
+    previous_roles: Ruoli precedenti
+    previous_roles_in_government: Ruoli precedenti nel governo
     read_more: Maggiori informazioni su questa persona

--- a/config/locales/ja/people.yml
+++ b/config/locales/ja/people.yml
@@ -2,4 +2,6 @@
 ja:
   people:
     biography: 経歴
+    previous_roles: 以前の役割
+    previous_roles_in_government: 政府における以前の役割
     read_more: この人についての詳細

--- a/config/locales/ka/people.yml
+++ b/config/locales/ka/people.yml
@@ -2,4 +2,6 @@
 ka:
   people:
     biography: ბიოგრაფია
+    previous_roles: წინა როლები
+    previous_roles_in_government: წინა რომელი სახელმწიფოში
     read_more: მეტი ამ ადამიანის შესახებ

--- a/config/locales/kk/people.yml
+++ b/config/locales/kk/people.yml
@@ -2,4 +2,6 @@
 kk:
   people:
     biography: Биография
+    previous_roles: Алдыңғы рөлдер
+    previous_roles_in_government: Мемлекеттегі алдыңғы рөлдер
     read_more: Осы адам туралы қосымша ақпарат

--- a/config/locales/ko/people.yml
+++ b/config/locales/ko/people.yml
@@ -2,4 +2,6 @@
 ko:
   people:
     biography: 약력
+    previous_roles: 이전 역할
+    previous_roles_in_government: 정부 내 이전 역할
     read_more: 이 사람에 대해 자세히 살펴보기

--- a/config/locales/lt/people.yml
+++ b/config/locales/lt/people.yml
@@ -2,4 +2,6 @@
 lt:
   people:
     biography: Biografija
+    previous_roles: Ankstesnė funkcija
+    previous_roles_in_government: Ankstesnė funkcija vyriausybėje
     read_more: Daugiau informacijos apie šį asmenį

--- a/config/locales/lv/people.yml
+++ b/config/locales/lv/people.yml
@@ -2,4 +2,6 @@
 lv:
   people:
     biography: Biogrāfija
+    previous_roles: Iepriekšējie amati
+    previous_roles_in_government: Iepriekšējie amati valdībā
     read_more: Vairāk par šo personu

--- a/config/locales/ms/people.yml
+++ b/config/locales/ms/people.yml
@@ -2,4 +2,6 @@
 ms:
   people:
     biography: Biografi
+    previous_roles: Peranan sebelum ini
+    previous_roles_in_government: Peranan sebelum ini dalam kerajaan
     read_more: Lebih lanjut tentang individu ini

--- a/config/locales/mt/people.yml
+++ b/config/locales/mt/people.yml
@@ -2,4 +2,6 @@
 mt:
   people:
     biography: Bijografija
+    previous_roles: Rwolijiet preċedenti
+    previous_roles_in_government: Rwolijiet preċedenti fil-gvern
     read_more: Iktar dwar din il-persuna

--- a/config/locales/ne/people.yml
+++ b/config/locales/ne/people.yml
@@ -2,4 +2,6 @@
 ne:
   people:
     biography:
+    previous_roles:
+    previous_roles_in_government:
     read_more:

--- a/config/locales/nl/people.yml
+++ b/config/locales/nl/people.yml
@@ -2,4 +2,6 @@
 nl:
   people:
     biography: Biografie
+    previous_roles: Vorige functies
+    previous_roles_in_government: Eerdere functies bij de overheid
     read_more: Meer over deze persoon

--- a/config/locales/no/people.yml
+++ b/config/locales/no/people.yml
@@ -2,4 +2,6 @@
 'no':
   people:
     biography: Biografi
+    previous_roles: Tidligere roller
+    previous_roles_in_government: Tidligere roller i regjeringen
     read_more: Mer om denne personen

--- a/config/locales/pa-pk/people.yml
+++ b/config/locales/pa-pk/people.yml
@@ -2,4 +2,6 @@
 pa-pk:
   people:
     biography: سوانح حیات
+    previous_roles: پچھلے کردار
+    previous_roles_in_government: حکومت دے وچ پچھلا کردار
     read_more: ایس بندے بارے کُج ہور

--- a/config/locales/pa/people.yml
+++ b/config/locales/pa/people.yml
@@ -2,4 +2,6 @@
 pa:
   people:
     biography: ਜੀਵਨੀ
+    previous_roles: ਪਿਛਲੀਆਂ ਭੂਮਿਕਾਵਾਂ
+    previous_roles_in_government: ਸਰਕਾਰ ਵਿੱਚ ਪਿਛਲੀਆਂ ਭੂਮਿਕਾਵਾਂ
     read_more: ਇਸ ਵਿਅਕਤੀ ਬਾਰੇ ਹੋਰ

--- a/config/locales/pl/people.yml
+++ b/config/locales/pl/people.yml
@@ -2,4 +2,6 @@
 pl:
   people:
     biography: Biografia
+    previous_roles: Poprzednie funkcje
+    previous_roles_in_government: Poprzednie funkcje w rządzie
     read_more: Więcej o tej osobie

--- a/config/locales/ps/people.yml
+++ b/config/locales/ps/people.yml
@@ -2,4 +2,6 @@
 ps:
   people:
     biography: ژوندلیک
+    previous_roles: پخواني رولونه
+    previous_roles_in_government: په حکومت کې پخوانی رول
     read_more: د دې کس په اړه نور

--- a/config/locales/pt/people.yml
+++ b/config/locales/pt/people.yml
@@ -2,4 +2,6 @@
 pt:
   people:
     biography: Biografia
+    previous_roles: Cargos anteriores
+    previous_roles_in_government: Cargos anteriores no governo
     read_more: Mais sobre esta pessoa

--- a/config/locales/ro/people.yml
+++ b/config/locales/ro/people.yml
@@ -2,4 +2,6 @@
 ro:
   people:
     biography: Biografie
+    previous_roles: Roluri anterioare
+    previous_roles_in_government: Roluri anterioare în guvern
     read_more: Mai multe despre această persoană

--- a/config/locales/ru/people.yml
+++ b/config/locales/ru/people.yml
@@ -2,4 +2,6 @@
 ru:
   people:
     biography: Биография
+    previous_roles: Предыдущие должности
+    previous_roles_in_government: Предыдущие должности в правительстве
     read_more: Больше о человеке

--- a/config/locales/si/people.yml
+++ b/config/locales/si/people.yml
@@ -2,4 +2,6 @@
 si:
   people:
     biography: චරිතාපදානය
+    previous_roles: පෙර භූමිකාවන්
+    previous_roles_in_government: රජයේ පෙර භූමිකාවන්
     read_more: මෙම පුද්ගලයා ගැන වැඩි විස්තර

--- a/config/locales/sk/people.yml
+++ b/config/locales/sk/people.yml
@@ -2,4 +2,6 @@
 sk:
   people:
     biography: Biografia
+    previous_roles: Predchádzajúce funkcie
+    previous_roles_in_government: Predchádzajúce funkcie v štátnej správe
     read_more: Viac o tejto osobe

--- a/config/locales/sl/people.yml
+++ b/config/locales/sl/people.yml
@@ -2,4 +2,6 @@
 sl:
   people:
     biography: Biografija
+    previous_roles: Prejšnje vloge
+    previous_roles_in_government: Prejšnje vloge v vladi
     read_more: Več o tej osebi

--- a/config/locales/so/people.yml
+++ b/config/locales/so/people.yml
@@ -2,4 +2,6 @@
 so:
   people:
     biography: Qoraalka
+    previous_roles: Doorarka hore
+    previous_roles_in_government: Doorarka hore ee dawlada
     read_more: Waxbadan oo khuseeya qofkan

--- a/config/locales/sq/people.yml
+++ b/config/locales/sq/people.yml
@@ -2,4 +2,6 @@
 sq:
   people:
     biography: Biografia
+    previous_roles: Rolet e mëparshme
+    previous_roles_in_government: Rolet e mëparshme në qeveri
     read_more: Më shumë për këtë person

--- a/config/locales/sr/people.yml
+++ b/config/locales/sr/people.yml
@@ -2,4 +2,6 @@
 sr:
   people:
     biography: Biografija
+    previous_roles: Prethodne funkcije
+    previous_roles_in_government: Prethodne funkcije u Parlamentu
     read_more: Više o ovoj osobi

--- a/config/locales/sv/people.yml
+++ b/config/locales/sv/people.yml
@@ -2,4 +2,6 @@
 sv:
   people:
     biography: Biografi
+    previous_roles: Tidigare roller
+    previous_roles_in_government: Tidigare roller inom den offentliga sektorn
     read_more: Mer om den här personen

--- a/config/locales/sw/people.yml
+++ b/config/locales/sw/people.yml
@@ -2,4 +2,6 @@
 sw:
   people:
     biography: Wasifu
+    previous_roles: Nafasi za awali
+    previous_roles_in_government: Nafasi za awali katika serikali
     read_more: Maelezo zaidi kuhusu mtu huyu

--- a/config/locales/ta/people.yml
+++ b/config/locales/ta/people.yml
@@ -2,4 +2,6 @@
 ta:
   people:
     biography: வாழ்வுரை
+    previous_roles: முந்தைய பங்களிப்புகள்
+    previous_roles_in_government: அரசாங்கத்தில் முந்தைய பங்களிப்புகள்
     read_more: இந்த நபர் பற்றி மேலும் தகவல்கள்

--- a/config/locales/th/people.yml
+++ b/config/locales/th/people.yml
@@ -2,4 +2,6 @@
 th:
   people:
     biography: ชีวประวัติ
+    previous_roles: บทบาทหน้าที่ก่อนหน้านี้
+    previous_roles_in_government: บทบาทหน้าที่ก่อนหน้านี้ในรัฐบาล
     read_more: ข้อมูลเพิ่มเติมเกี่ยวกับบุคคลนี้

--- a/config/locales/tk/people.yml
+++ b/config/locales/tk/people.yml
@@ -2,4 +2,6 @@
 tk:
   people:
     biography: Terjimehaly
+    previous_roles: Öňki wezipeleri
+    previous_roles_in_government: Hökümetdäki öňki wezipeleri
     read_more: Bu adam hakda has giňişleýin

--- a/config/locales/tr/people.yml
+++ b/config/locales/tr/people.yml
@@ -2,4 +2,6 @@
 tr:
   people:
     biography: Biyografi
+    previous_roles: Önceki makamlar
+    previous_roles_in_government: Devlette önceki makamları
     read_more: Bu kişi hakkında daha fazla

--- a/config/locales/uk/people.yml
+++ b/config/locales/uk/people.yml
@@ -2,4 +2,6 @@
 uk:
   people:
     biography: Біографія
+    previous_roles: Попередні функції
+    previous_roles_in_government: Попередні функції в уряді
     read_more: Детальніше про цю особу

--- a/config/locales/ur/people.yml
+++ b/config/locales/ur/people.yml
@@ -2,4 +2,6 @@
 ur:
   people:
     biography: سوانح عمری
+    previous_roles: گزشتہ کردار
+    previous_roles_in_government: حکومت میں گزشتہ کردار
     read_more: اس شخص کے بارے میں مزید

--- a/config/locales/uz/people.yml
+++ b/config/locales/uz/people.yml
@@ -2,4 +2,6 @@
 uz:
   people:
     biography: Биография
+    previous_roles: Олдинги рольлар
+    previous_roles_in_government: Ҳукуматдаги олдинги рольлар
     read_more: Ушбу шахс ҳақида кўпроқ маълумотлар

--- a/config/locales/vi/people.yml
+++ b/config/locales/vi/people.yml
@@ -2,4 +2,6 @@
 vi:
   people:
     biography: Tiểu sử
+    previous_roles: Các vai trò trước đây
+    previous_roles_in_government: Các vai trò trước đây trong chính phủ
     read_more: Thông tin thêm về người này

--- a/config/locales/yi/people.yml
+++ b/config/locales/yi/people.yml
@@ -2,4 +2,6 @@
 yi:
   people:
     biography:
+    previous_roles:
+    previous_roles_in_government:
     read_more:

--- a/config/locales/zh-hk/people.yml
+++ b/config/locales/zh-hk/people.yml
@@ -2,4 +2,6 @@
 zh-hk:
   people:
     biography: 人員簡介
+    previous_roles: 上一職位
+    previous_roles_in_government: 上一政府職位
     read_more: 該人士之詳情

--- a/config/locales/zh-tw/people.yml
+++ b/config/locales/zh-tw/people.yml
@@ -2,4 +2,6 @@
 zh-tw:
   people:
     biography: 自我簡介
+    previous_roles: 先前角色
+    previous_roles_in_government: 在政府中的先前角色
     read_more: 關於更多這個人

--- a/config/locales/zh/people.yml
+++ b/config/locales/zh/people.yml
@@ -2,4 +2,6 @@
 zh:
   people:
     biography: 自我介绍
+    previous_roles: 以前的职位
+    previous_roles_in_government: 以前的政府职位
     read_more: 更多关于这个人的信息

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe Person do
     end
   end
 
+  describe "ordered previous appointments" do
+    it "should have previous appointment text" do
+      text = person.previous_roles_items.first[:link][:text]
+
+      expect(text).to eq("Secretary of State for Foreign and Commonwealth Affairs")
+    end
+
+    it "should have previous appointment duration text" do
+      duration = person.previous_roles_items.first[:metadata][:appointment_duration]
+      expect(duration).to eq("2016 to 2018")
+    end
+  end
+
   describe "announcements" do
     before do
       results = [

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -76,15 +76,15 @@ RSpec.describe Person do
     end
   end
 
-  describe "ordered previous appointments" do
-    it "should have previous appointment text" do
-      text = person.previous_roles_items.first[:link][:text]
+  describe "previous non ministerial roles items" do
+    it "should have previous non ministerial roles items text" do
+      text = person.previous_non_ministerial_roles_items.first[:link][:text]
 
       expect(text).to eq("Secretary of State for Foreign and Commonwealth Affairs")
     end
 
     it "should have previous appointment duration text" do
-      duration = person.previous_roles_items.first[:metadata][:appointment_duration]
+      duration = person.previous_non_ministerial_roles_items.first[:metadata][:appointment_duration]
       expect(duration).to eq("2016 to 2018")
     end
   end


### PR DESCRIPTION
Adding previous roles to people pages where there are previous roles that are non ministerial.

This is to give more context as to why a person has a page on GOV.UK.

Also refactored the old code for getting role appointments to make it easier to follow and less repetitious

Trello card: https://trello.com/c/awkhfo7v/1867-people-pages-change-to-show-previous-roles-in-government

## Screenshots
|Person type | Before | After |
|--------|--------|--------|
| Person with ministerial and non ministerial roles | <img width="543" alt="image" src="https://github.com/user-attachments/assets/e939187e-cb6c-4299-b246-8e9467946fbb" /> | <img width="692" alt="image" src="https://github.com/user-attachments/assets/826fc2e9-7b5e-4ad2-b60f-77c2086b0dfe" /> | 
| Board member | <img width="1030" alt="image" src="https://github.com/user-attachments/assets/a1137a5c-7071-4dad-998c-f4467861b638" /> | <img width="1065" alt="image" src="https://github.com/user-attachments/assets/e341a194-a4c9-48b5-9e2f-53cda9bcab75" /> | 
| Military | <img width="717" alt="image" src="https://github.com/user-attachments/assets/99341dd2-ad80-4b10-9384-1b32f5f18afb" /> | <img width="896" alt="image" src="https://github.com/user-attachments/assets/294fb628-4a72-44c3-8a90-7a8bf1a64dc3" /> | 
| Ministerial | <img width="695" alt="image" src="https://github.com/user-attachments/assets/9af9d74e-fa3f-447c-a86a-09b93878db07" /> | <img width="725" alt="image" src="https://github.com/user-attachments/assets/ef134002-a043-409c-81cd-49f88efb4694" /> |
