### PR TITLE
Add A/B test for GraphQL

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -2,9 +2,17 @@ class MinistersController < ApplicationController
   around_action :switch_locale
 
   def index
+    ab_test = GovukAbTesting::AbTest.new(
+      "GraphQLMinistersIndex",
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true"
+                        elsif params[:graphql] == "true" || @requested_variant.variant?("B")
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -2,9 +2,17 @@ class RolesController < ApplicationController
   around_action :switch_locale
 
   def show
+    ab_test = GovukAbTesting::AbTest.new(
+      "GraphQLRoles",
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true"
+                        elsif params[:graphql] == "true" || @requested_variant.variant?("B")
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
   <%=
     render_component_stylesheets
   %>
+  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant %>
 </head>
 <body>
   <div class="wrapper" id="wrapper">

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ Capybara.automatic_label_click = true
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 GovukAbTesting.configure do |config|
-  config.acceptance_test_framework = :active_support
+  config.acceptance_test_framework = :capybara
 end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
Sets up a A/B test to divide traffic between GraphQL and Content Store for role pages and the ministers index page.

Each document type has been given a different test name, so we can enable/disable the tests for each document type separately.

[Trello card](https://trello.com/c/stxnESVI)