### PR TITLE
Remove GraphQL feature flag

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -4,7 +4,7 @@ class MinistersController < ApplicationController
   def index
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true" || Features.graphql_feature_enabled?
+                        elsif params[:graphql] == "true"
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -4,7 +4,7 @@ class RolesController < ApplicationController
   def show
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true" || Features.graphql_feature_enabled?
+                        elsif params[:graphql] == "true"
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -2,7 +2,7 @@ class WorldController < ApplicationController
   def index
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true" || Features.graphql_feature_enabled?
+                        elsif params[:graphql] == "true"
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/lib/features.rb
+++ b/app/lib/features.rb
@@ -1,5 +1,0 @@
-class Features
-  def self.graphql_feature_enabled?
-    ENV["GRAPHQL_FEATURE_FLAG"]
-  end
-end

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -123,124 +123,60 @@ RSpec.feature "Ministers index page" do
     end
   end
 
-  context "without the GraphQL feature flag" do
-    let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
+  let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
 
+  before do
+    stub_content_store_has_item("/government/ministers", document)
+  end
+
+  context "when the GraphQL parameter is not set" do
     before do
-      stub_content_store_has_item("/government/ministers", document)
+      visit "/government/ministers"
     end
 
-    context "when the GraphQL parameter is not set" do
-      before do
-        visit "/government/ministers"
-      end
+    it_behaves_like "ministers index page"
 
-      it_behaves_like "ministers index page"
-
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
-
-      context "during a reshuffle" do
-        let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
-
-        it_behaves_like "ministers index page during a reshuffle"
-      end
-
-      context "during a reshuffle preview" do
-        let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
-
-        it_behaves_like "ministers index page during a reshuffle preview"
-      end
+    it "does not get the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
     end
 
-    context "when the GraphQL parameter is true" do
-      before do
-        stub_publishing_api_graphql_query(
-          Graphql::MinistersIndexQuery.new("/government/ministers").query,
-          document,
-        )
+    context "during a reshuffle" do
+      let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }
 
-        visit "/government/ministers?graphql=true"
-      end
-
-      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
+      it_behaves_like "ministers index page during a reshuffle"
     end
 
-    context "when the GraphQL parameter is false" do
-      before do
-        visit "/government/ministers?graphql=false"
-      end
+    context "during a reshuffle preview" do
+      let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on-preview") }
 
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+      it_behaves_like "ministers index page during a reshuffle preview"
     end
   end
 
-  context "with the GraphQL feature flag" do
-    let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
-
+  context "when the GraphQL parameter is true" do
     before do
-      enable_graphql_feature_flag
-
       stub_publishing_api_graphql_query(
         Graphql::MinistersIndexQuery.new("/government/ministers").query,
         document,
       )
+
+      visit "/government/ministers?graphql=true"
     end
 
-    context "when the GraphQL parameter is not set" do
-      before do
-        visit "/government/ministers"
-      end
+    let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
 
-      it_behaves_like "ministers index page"
+    it "gets the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
+    end
+  end
 
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-
-      context "during a reshuffle" do
-        let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on") }
-
-        it_behaves_like "ministers index page during a reshuffle"
-      end
-
-      context "during a reshuffle preview" do
-        let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on-preview") }
-
-        it_behaves_like "ministers index page during a reshuffle preview"
-      end
+  context "when the GraphQL parameter is false" do
+    before do
+      visit "/government/ministers?graphql=false"
     end
 
-    context "when the GraphQL parameter is true" do
-      before do
-        visit "/government/ministers?graphql=true"
-      end
-
-      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-off") }
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is false" do
-      let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off") }
-
-      before do
-        stub_content_store_has_item("/government/ministers", document)
-        visit "/government/ministers?graphql=false"
-      end
-
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+    it "does not get the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
     end
   end
 end

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -3,249 +3,120 @@ require "integration_spec_helper"
 RSpec.feature "Role page" do
   include SearchApiHelpers
 
-  context "with the GraphQL feature flag" do
+  before do
+    stub_content_store_has_item(
+      "/government/ministers/prime-minister",
+      role_content_item_data,
+    )
+    stub_search(body: { results: [] })
+
+    visit "/government/ministers/prime-minister"
+  end
+
+  let(:role_content_item_data) do
+    GovukSchemas::Example.find("role", example_name: "prime_minister")
+  end
+
+  context "when there is no GraphQL parameter" do
+    it "renders the page successfully" do
+      expect(page).to have_selector("h1", text: "Prime Minister")
+    end
+
+    it "does not get data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
+    end
+
+    context "when there's a current role holder" do
+      let(:role_content_item_data) do
+        GovukSchemas::Example.find("role", example_name: "prime_minister")
+          .tap do |example|
+            any_current = example["links"]["role_appointments"]
+              .any? { |ra| ra["details"]["current"] == true }
+
+            unless any_current
+              example["links"]["role_appointments"][0]["details"]["current"] = true
+            end
+          end
+      end
+
+      it "renders the page successfully" do
+        expect(page.status_code).to eq(200)
+      end
+    end
+
+    context "when there isn't a current role holder" do
+      let(:role_content_item_data) do
+        GovukSchemas::Example.find("role", example_name: "prime_minister")
+          .tap do |example|
+            current = example["links"]["role_appointments"]
+              .find { |ra| ra["details"]["current"] == true }
+
+            if current
+              current["details"]["current"] = false
+              current["details"]["ended_on"] = Time.zone.now
+            end
+          end
+      end
+
+      it "renders the page successfully" do
+        expect(page.status_code).to eq(200)
+      end
+    end
+
+    context "when the role 'supports historical accounts'" do
+      let(:role_content_item_data) do
+        GovukSchemas::Example.find("role", example_name: "prime_minister")
+          .tap do |example|
+            example["details"]["supports_historical_accounts"] = true
+          end
+      end
+
+      it "renders the page successfully" do
+        expect(page.status_code).to eq(200)
+      end
+    end
+
+    context "when the role doesn't 'support historical accounts'" do
+      let(:role_content_item_data) do
+        GovukSchemas::Example.find("role", example_name: "prime_minister")
+          .tap do |example|
+            example["details"]["supports_historical_accounts"] = false
+          end
+      end
+
+      it "renders the page successfully" do
+        expect(page.status_code).to eq(200)
+      end
+    end
+  end
+
+  context "when the GraphQL parameter is true" do
     before do
-      enable_graphql_feature_flag
       stub_publishing_api_graphql_query(
         Graphql::RoleQuery.new("/government/ministers/prime-minister").query,
         role_edition_data,
       )
       stub_search(body: { results: [] })
+
+      visit "/government/ministers/prime-minister?graphql=true"
     end
 
     let(:role_edition_data) do
       fetch_graphql_fixture("prime_minister")
     end
 
-    context "when there is no GraphQL parameter" do
-      before do
-        visit "/government/ministers/prime-minister"
-      end
-
-      it "renders the page successfully" do
-        expect(page).to have_selector("h1", text: "Prime Minister")
-      end
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-
-      context "when there's a current role holder" do
-        let(:role_edition_data) do
-          fetch_graphql_fixture("prime_minister")
-            .tap do |fixture|
-              any_current = fixture["data"]["edition"]["links"]["role_appointments"]
-                .any? { |ra| ra["details"]["current"] == true }
-
-              unless any_current
-                links = fixture["data"]["edition"]["links"]
-                links["role_appointments"][0]["details"]["current"] = true
-              end
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when there isn't a current role holder" do
-        let(:role_edition_data) do
-          fetch_graphql_fixture("prime_minister")
-            .tap do |fixture|
-              current = fixture["data"]["edition"]["links"]["role_appointments"]
-                .find { |ra| ra["details"]["current"] == true }
-
-              if current
-                current["details"]["current"] = false
-                current["details"]["ended_on"] = Time.zone.now
-              end
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when the role 'supports historical accounts'" do
-        let(:role_edition_data) do
-          fetch_graphql_fixture("prime_minister")
-            .tap do |fixture|
-              fixture["data"]["edition"]["details"]["supports_historical_accounts"] = true
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when the role doesn't 'support historical accounts'" do
-        let(:role_edition_data) do
-          fetch_graphql_fixture("prime_minister")
-            .tap do |fixture|
-              fixture["data"]["edition"]["details"]["supports_historical_accounts"] = false
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-    end
-
-    context "when the GraphQL parameter is true" do
-      before do
-        visit "/government/ministers/prime-minister?graphql=true"
-      end
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is false" do
-      before do
-        stub_content_store_has_item(
-          "/government/ministers/prime-minister",
-          role_content_item_data,
-        )
-        stub_search(body: { results: [] })
-
-        visit "/government/ministers/prime-minister?graphql=false"
-      end
-
-      let(:role_content_item_data) do
-        GovukSchemas::Example.find("role", example_name: "prime_minister")
-      end
-
-      it "does not get data from GraphQL" do
-        puts Plek.find("content-store")
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+    it "gets the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
     end
   end
 
-  context "without the GraphQL feature flag" do
+  context "when the GraphQL parameter is false" do
     before do
-      stub_content_store_has_item(
-        "/government/ministers/prime-minister",
-        role_content_item_data,
-      )
-      stub_search(body: { results: [] })
-
-      visit "/government/ministers/prime-minister"
+      visit "/government/ministers/prime-minister?graphql=false"
     end
 
-    let(:role_content_item_data) do
-      GovukSchemas::Example.find("role", example_name: "prime_minister")
-    end
-
-    context "when there is no GraphQL parameter" do
-      it "renders the page successfully" do
-        expect(page).to have_selector("h1", text: "Prime Minister")
-      end
-
-      it "does not get data from GraphQL" do
-        puts Plek.find("content-store")
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
-
-      context "when there's a current role holder" do
-        let(:role_content_item_data) do
-          GovukSchemas::Example.find("role", example_name: "prime_minister")
-            .tap do |example|
-              any_current = example["links"]["role_appointments"]
-                .any? { |ra| ra["details"]["current"] == true }
-
-              unless any_current
-                example["links"]["role_appointments"][0]["details"]["current"] = true
-              end
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when there isn't a current role holder" do
-        let(:role_content_item_data) do
-          GovukSchemas::Example.find("role", example_name: "prime_minister")
-            .tap do |example|
-              current = example["links"]["role_appointments"]
-                .find { |ra| ra["details"]["current"] == true }
-
-              if current
-                current["details"]["current"] = false
-                current["details"]["ended_on"] = Time.zone.now
-              end
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when the role 'supports historical accounts'" do
-        let(:role_content_item_data) do
-          GovukSchemas::Example.find("role", example_name: "prime_minister")
-            .tap do |example|
-              example["details"]["supports_historical_accounts"] = true
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-
-      context "when the role doesn't 'support historical accounts'" do
-        let(:role_content_item_data) do
-          GovukSchemas::Example.find("role", example_name: "prime_minister")
-            .tap do |example|
-              example["details"]["supports_historical_accounts"] = false
-            end
-        end
-
-        it "renders the page successfully" do
-          expect(page.status_code).to eq(200)
-        end
-      end
-    end
-
-    context "when the GraphQL parameter is true" do
-      before do
-        enable_graphql_feature_flag
-        stub_publishing_api_graphql_query(
-          Graphql::RoleQuery.new("/government/ministers/prime-minister").query,
-          role_edition_data,
-        )
-        stub_search(body: { results: [] })
-
-        visit "/government/ministers/prime-minister?graphql=true"
-      end
-
-      let(:role_edition_data) do
-        fetch_graphql_fixture("prime_minister")
-      end
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is false" do
-      before do
-        visit "/government/ministers/prime-minister?graphql=false"
-      end
-
-      it "does not get data from GraphQL" do
-        puts Plek.find("content-store")
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+    it "does not get data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
     end
   end
 end

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -71,90 +71,44 @@ RSpec.feature "World index page" do
     end
   end
 
-  context "without the GraphQL feature flag" do
+  before do
+    stub_content_store_has_item("/world", GovukSchemas::Example.find("world_index", example_name: "world_index"))
+  end
+
+  context "when the GraphQL parameter is not set" do
     before do
-      stub_content_store_has_item("/world", GovukSchemas::Example.find("world_index", example_name: "world_index"))
+      visit "/world"
     end
 
-    context "when the GraphQL parameter is not set" do
-      before do
-        visit "/world"
-      end
+    it_behaves_like "world index page"
 
-      it_behaves_like "world index page"
-
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is true" do
-      before do
-        stub_publishing_api_graphql_query(
-          Graphql::WorldIndexQuery.new("/world").query,
-          fetch_graphql_fixture("world_index"),
-        )
-
-        visit "/world?graphql=true"
-      end
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is false" do
-      before do
-        visit "/world?graphql=false"
-      end
-
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+    it "does not get the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
     end
   end
 
-  context "with the GraphQL feature flag" do
+  context "when the GraphQL parameter is true" do
     before do
-      enable_graphql_feature_flag
-
       stub_publishing_api_graphql_query(
         Graphql::WorldIndexQuery.new("/world").query,
         fetch_graphql_fixture("world_index"),
       )
+
+      visit "/world?graphql=true"
     end
 
-    context "when the GraphQL parameter is not set" do
-      before do
-        visit "/world"
-      end
+    it "gets the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
+    end
+  end
 
-      it_behaves_like "world index page"
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
+  context "when the GraphQL parameter is false" do
+    before do
+      visit "/world?graphql=false"
     end
 
-    context "when the GraphQL parameter is true" do
-      before do
-        visit "/world?graphql=true"
-      end
-
-      it "gets the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
-      end
-    end
-
-    context "when the GraphQL parameter is false" do
-      before do
-        stub_content_store_has_item("/world", GovukSchemas::Example.find("world_index", example_name: "world_index"))
-        visit "/world?graphql=false"
-      end
-
-      it "does not get the data from GraphQL" do
-        expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-      end
+    it "does not get the data from GraphQL" do
+      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,7 +82,3 @@ def search_api_response(titles_and_links_hash)
   end
   { 'results': results_array }
 end
-
-def enable_graphql_feature_flag
-  allow(Features).to receive(:graphql_feature_enabled?).and_return(true)
-end


### PR DESCRIPTION
This is not being used for anything at the moment, since we are manually selecting GraphQL by adding a query parameter to requests.

Removing in preparation for setting up an A/B test that switches between GraphQL and Content Store.  Having a feature flag in addition to this will cause complication.

[Trello card](https://trello.com/c/stxnESVI)