### PR TITLE
Add A/B testing for GraphQL on world index page

### DIFF
--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,8 +1,16 @@
 class WorldController < ApplicationController
   def index
+    ab_test = GovukAbTesting::AbTest.new(
+      "GraphQLWorldIndex",
+      allowed_variants: %w[A B Z],
+      control_variant: "Z",
+    )
+    @requested_variant = ab_test.requested_variant(request.headers)
+    @requested_variant.configure_response(response)
+
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true"
+                        elsif params[:graphql] == "true" || @requested_variant.variant?("B")
                           load_from_graphql
                         else
                           load_from_content_store


### PR DESCRIPTION
This will allow us to serve a defined amount of traffic from GraphQL, to measure response times in a real environment.

It was missed when other A/B tests were added in https://github.com/alphagov/collections/pull/4038.

[Trello card](https://trello.com/c/stxnESVI)