### PR TITLE
Add additional fields to role GraphQL query

### DIFF
--- a/app/queries/graphql/role_query.rb
+++ b/app/queries/graphql/role_query.rb
@@ -9,8 +9,16 @@ class Graphql::RoleQuery
         edition(base_path: "#{@base_path}") {
           ... on Edition {
             base_path
+            content_id
+            document_type
+            first_published_at
             locale
+            public_updated_at
+            publishing_app
+            rendering_app
+            schema_name
             title
+            updated_at
 
             details {
               body
@@ -43,8 +51,13 @@ class Graphql::RoleQuery
               }
 
               ordered_parent_organisations {
+                analytics_identifier
                 base_path
                 title
+              }
+
+              organisations {
+                analytics_identifier
               }
             }
           }

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -109,6 +109,27 @@ RSpec.feature "Role page" do
     it "gets the data from GraphQL" do
       expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
     end
+
+    it "renders the locale in <main> element" do
+      expect(page).to have_css("main[lang='en']")
+    end
+
+    %w[
+      govuk:content-id
+      govuk:first-published-at
+      govuk:format
+      govuk:organisations
+      govuk:public-updated-at
+      govuk:publishing-app
+      govuk:rendering-app
+      govuk:schema-name
+      govuk:updated-at
+    ].each do |meta_tag_name|
+      it "renders the #{meta_tag_name} meta tag" do
+        meta_tag = page.first("meta[name='#{meta_tag_name}']", visible: false)
+        expect(meta_tag["content"]).to be_present
+      end
+    end
   end
 
   context "when the GraphQL parameter is false" do

--- a/spec/fixtures/graphql/prime_minister.json
+++ b/spec/fixtures/graphql/prime_minister.json
@@ -2,6 +2,9 @@
   "data": {
     "edition": {
       "base_path": "/government/ministers/prime-minister",
+      "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
+      "document_type": "ministerial_role",
+      "first_published_at": "2011-10-11T17:11:44+01:00",
       "title": "Prime Minister",
       "details": {
         "body": "\u003cp\u003eThe Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government. \u003c/p\u003e\n\n\u003cp\u003eAs leader of the UK government the Prime Minister also: \u003c/p\u003e\n\n\u003cul\u003e\n  \u003cli\u003eoversees the \u003ca href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\"\u003eoperation of the Civil Service\u003c/a\u003e and government agencies \u003c/li\u003e\n  \u003cli\u003echooses members of the government \u003c/li\u003e\n  \u003cli\u003eis the principal government figure in the House of Commons \u003c/li\u003e\n\u003c/ul\u003e\n",
@@ -53,15 +56,30 @@
         ],
         "ordered_parent_organisations": [
           {
+            "analytics_identifier": "D2",
             "base_path": "/government/organisations/cabinet-office",
             "title": "Cabinet Office"
           },
           {
+            "analytics_identifier": "OT532",
             "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
             "title": "Prime Minister's Office, 10 Downing Street"
           }
+        ],
+        "organisations": [
+          {
+            "analytics_identifier": "D2"
+          },
+          {
+            "analytics_identifier": "OT532"
+          }
         ]
-      }
+      },
+      "public_updated_at": "2024-07-05T12:32:36+01:00",
+      "publishing_app": "whitehall",
+      "rendering_app": "collections",
+      "schema_name": "role",
+      "updated_at": "2025-04-01T10:16:23+01:00"
     }
   }
 }


### PR DESCRIPTION
We need additional fields included in the GraphQL query in order to render meta tags on the page.

These tags are extracted from the response by [`govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/blob/b2b64934c89db058bfb1d765ecfcbd6b6b90c683/lib/govuk_publishing_components/presenters/meta_tags.rb).

[Trello card](https://trello.com/c/ZOEv2NXr)