### PR TITLE
Render meta tags and <main> `lang` attribute on GraphQL version of World Index page

### DIFF
--- a/app/queries/graphql/world_index_query.rb
+++ b/app/queries/graphql/world_index_query.rb
@@ -14,8 +14,16 @@ class Graphql::WorldIndexQuery
       {
         edition(base_path: "#{@base_path}") {
           ... on Edition {
+            content_id
+            document_type
+            first_published_at
             locale
+            public_updated_at
+            publishing_app
+            rendering_app
+            schema_name
             title
+            updated_at
 
             details {
               world_locations {

--- a/app/queries/graphql/world_index_query.rb
+++ b/app/queries/graphql/world_index_query.rb
@@ -14,6 +14,7 @@ class Graphql::WorldIndexQuery
       {
         edition(base_path: "#{@base_path}") {
           ... on Edition {
+            locale
             title
 
             details {

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -71,6 +71,10 @@ RSpec.feature "World index page" do
       expect(ga4_focus_loss_data["action"]).to eq "filter"
       expect(ga4_focus_loss_data["section"]).to eq "Help and services around the world"
     end
+
+    scenario "renders the locale in <main> element" do
+      expect(page).to have_css("main[lang='en']")
+    end
   end
 
   before do

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -75,6 +75,22 @@ RSpec.feature "World index page" do
     scenario "renders the locale in <main> element" do
       expect(page).to have_css("main[lang='en']")
     end
+
+    %w[
+      govuk:public-updated-at
+      govuk:updated-at
+      govuk:first-published-at
+      govuk:content-id
+      govuk:schema-name
+      govuk:rendering-app
+      govuk:publishing-app
+      govuk:format
+    ].each do |meta_tag_name|
+      scenario "renders the #{meta_tag_name} meta tag" do
+        meta_tag = page.first("meta[name='#{meta_tag_name}']", visible: false)
+        expect(meta_tag["content"]).to be_present
+      end
+    end
   end
 
   before do

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -99,6 +99,8 @@ RSpec.feature "World index page" do
       visit "/world?graphql=true"
     end
 
+    it_behaves_like "world index page"
+
     it "gets the data from GraphQL" do
       expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).to have_been_made
     end

--- a/spec/fixtures/graphql/world_index.json
+++ b/spec/fixtures/graphql/world_index.json
@@ -1,6 +1,7 @@
 {
   "data": {
     "edition": {
+      "locale": "en",
       "title": "Help and services around the world",
       "details": {
         "world_locations": [

--- a/spec/fixtures/graphql/world_index.json
+++ b/spec/fixtures/graphql/world_index.json
@@ -1,8 +1,16 @@
 {
   "data": {
     "edition": {
+      "content_id": "07ebb35d-1c0d-414d-9dfa-ec09a2163dfa",
+      "document_type": "world_index",
+      "first_published_at": "2023-03-29T14:18:21+01:00",
       "locale": "en",
+      "public_updated_at": "2025-03-14T09:49:07+00:00",
+      "publishing_app": "whitehall",
+      "rendering_app": "collections",
+      "schema_name": "world_index",
       "title": "Help and services around the world",
+      "updated_at": "2025-03-14T09:49:07+00:00",
       "details": {
         "world_locations": [
           {


### PR DESCRIPTION
https://trello.com/c/ezCkqbaq/1665-make-graphql-version-of-world-index-the-same-as-the-regular-version

Request some additional fields from GraphQL when serving the World Index page so that `<main>`'s `lang` attribute and a bunch of meta tags are included in the rendered page.

We're doing this to improve consistency between the GraphQL and the regular versions of this page.