### PR TITLE
Add missing content to GraphQL version of ministers index page

### DIFF
--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -12,6 +12,7 @@ class Graphql::MinistersIndexQuery
             content_id
             document_type
             first_published_at
+            locale
             public_updated_at
             publishing_app
             rendering_app

--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -9,6 +9,14 @@ class Graphql::MinistersIndexQuery
         edition(base_path: "#{@base_path}") {
           ... on MinistersIndex {
             base_path
+            content_id
+            document_type
+            first_published_at
+            public_updated_at
+            publishing_app
+            rendering_app
+            schema_name
+            updated_at
 
             links {
               ordered_cabinet_ministers {

--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -19,6 +19,10 @@ class Graphql::MinistersIndexQuery
             schema_name
             updated_at
 
+            details {
+              body
+            }
+
             links {
               ordered_cabinet_ministers {
                 ...basePersonInfo

--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -21,6 +21,7 @@ class Graphql::MinistersIndexQuery
 
             details {
               body
+              reshuffle
             }
 
             links {

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -16,6 +16,22 @@ RSpec.feature "Ministers index page" do
       expect(page).to have_selector(".gem-c-heading__text", text: I18n.t("ministers.title"))
     end
 
+    %w[
+      govuk:content-id
+      govuk:first-published-at
+      govuk:format
+      govuk:public-updated-at
+      govuk:publishing-app
+      govuk:rendering-app
+      govuk:schema-name
+      govuk:updated-at
+    ].each do |meta_tag_name|
+      it "renders the #{meta_tag_name} meta tag" do
+        meta_tag = page.first("meta[name='#{meta_tag_name}']", visible: false)
+        expect(meta_tag["content"]).to be_present
+      end
+    end
+
     scenario "renders section headers" do
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -154,6 +154,18 @@ RSpec.feature "Ministers index page" do
     end
 
     it_behaves_like "ministers index page"
+
+    context "during a reshuffle" do
+      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on") }
+
+      it_behaves_like "ministers index page during a reshuffle"
+    end
+
+    context "during a reshuffle preview" do
+      let(:document) { fetch_graphql_fixture("ministers_index-reshuffle-mode-on-preview") }
+
+      it_behaves_like "ministers index page during a reshuffle preview"
+    end
   end
 
   shared_examples "ministers index page during a reshuffle" do

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -36,6 +36,13 @@ RSpec.feature "Ministers index page" do
       expect(page).to have_css("main[lang='en']")
     end
 
+    scenario "renders the lead paragraph with anchor links" do
+      expect(page).to have_selector(".gem-c-lead-paragraph")
+      within(".gem-c-lead-paragraph") do
+        expect(page).to have_link("Cabinet ministers", href: "#cabinet-ministers", class: "govuk-link")
+      end
+    end
+
     scenario "renders section headers" do
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))
@@ -121,13 +128,6 @@ RSpec.feature "Ministers index page" do
     end
 
     it_behaves_like "ministers index page"
-
-    scenario "renders the lead paragraph with anchor links" do
-      expect(page).to have_selector(".gem-c-lead-paragraph")
-      within(".gem-c-lead-paragraph") do
-        expect(page).to have_link("Cabinet ministers", href: "#cabinet-ministers", class: "govuk-link")
-      end
-    end
 
     context "during a reshuffle" do
       let(:document) { GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-on") }

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -32,6 +32,10 @@ RSpec.feature "Ministers index page" do
       end
     end
 
+    it "renders the locale in <main> element" do
+      expect(page).to have_css("main[lang='en']")
+    end
+
     scenario "renders section headers" do
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.cabinet"))
       expect(page).to have_selector(".gem-c-heading", text: I18n.t("ministers.also_attends"))

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
@@ -2,9 +2,12 @@
   "data": {
     "edition": {
       "base_path": "/government/ministers",
+      "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
       "details": {
         "body": "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business."
       },
+      "document_type": "ministers_index",
+      "first_published_at": "2016-11-14T16:28:54+00:00",
       "links": {
         "ordered_also_attends_cabinet": [
           {
@@ -1120,7 +1123,12 @@
             "web_url": "https://www.gov.uk/government/organisations/office-of-the-advocate-general-for-scotland"
           }
         ]
-      }
+      },
+      "public_updated_at": "2025-02-25T14:53:56+00:00",
+      "publishing_app": "whitehall",
+      "rendering_app": "collections",
+      "schema_name": "ministers_index",
+      "updated_at": "2025-04-13T16:56:58+01:00"
     }
   }
 }

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
@@ -1124,6 +1124,7 @@
           }
         ]
       },
+      "locale": "en",
       "public_updated_at": "2025-02-25T14:53:56+00:00",
       "publishing_app": "whitehall",
       "rendering_app": "collections",

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
@@ -9,6 +9,7 @@
       "document_type": "ministers_index",
       "first_published_at": "2016-11-14T16:28:54+00:00",
       "links": {},
+      "locale": "en",
       "public_updated_at": "2025-02-25T14:53:56+00:00",
       "publishing_app": "whitehall",
       "rendering_app": "collections",

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on-preview.json
@@ -2,10 +2,18 @@
   "data": {
     "edition": {
       "base_path": "/government/ministers",
+      "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
       "details": {
         "body": "Read biographies and responsibilities"
       },
-      "links": {}
+      "document_type": "ministers_index",
+      "first_published_at": "2016-11-14T16:28:54+00:00",
+      "links": {},
+      "public_updated_at": "2025-02-25T14:53:56+00:00",
+      "publishing_app": "whitehall",
+      "rendering_app": "collections",
+      "schema_name": "ministers_index",
+      "updated_at": "2025-04-13T16:56:58+01:00"
     }
   }
 }

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
@@ -2,12 +2,20 @@
   "data": {
     "edition": {
       "base_path": "/government/ministers",
-      "links": {},
+      "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
       "details": {
         "reshuffle": {
           "message": "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n"
         }
-      }
+      },
+      "document_type": "ministers_index",
+      "first_published_at": "2016-11-14T16:28:54+00:00",
+      "links": {},
+      "public_updated_at": "2025-02-25T14:53:56+00:00",
+      "publishing_app": "whitehall",
+      "rendering_app": "collections",
+      "schema_name": "ministers_index",
+      "updated_at": "2025-04-13T16:56:58+01:00"
     }
   }
 }

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-on.json
@@ -11,6 +11,7 @@
       "document_type": "ministers_index",
       "first_published_at": "2016-11-14T16:28:54+00:00",
       "links": {},
+      "locale": "en",
       "public_updated_at": "2025-02-25T14:53:56+00:00",
       "publishing_app": "whitehall",
       "rendering_app": "collections",


### PR DESCRIPTION
This adds missing content to the ministers index page when rendered using the response from GraphQL.

See each commit for details of what has been added.

Depends on https://github.com/alphagov/publishing-api/pull/3289.

[Trello card](https://trello.com/c/HcOHeixw)