### PR TITLE
Fix organisation logo layout on topical event pages

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -172,21 +172,16 @@
           padding: true,
           border_top: 2,
         } %>
-        <% @topical_event.emphasised_organisations.flatten.in_groups_of(4, false) do |row| %>
-          <div class="govuk-grid-row">
-            <% row.each do |organisation|%>
-              <div class="govuk-grid-column-one-quarter govuk-!-padding-bottom-7">
-                <%= render "govuk_publishing_components/components/organisation_logo", {
-                  organisation: {
-                    name: organisation["title"],
-                    url: organisation["base_path"],
-                    crest: organisation.dig("details", "logo", "crest"),
-                    brand: organisation.dig("details", "brand"),
-                  }
-                } %>
-              </div>
-            <% end %>
-          </div>
+        <% @topical_event.emphasised_organisations.flatten.each do |organisation| %>
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: organisation["title"],
+              url: organisation["base_path"],
+              crest: organisation.dig("details", "logo", "crest"),
+              brand: organisation.dig("details", "brand"),
+            },
+            margin_bottom: 6,
+          } %>
         <% end %>
 
         <% if @topical_event.slug == 'first-world-war-centenary' %>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -164,35 +164,32 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% if @topical_event.emphasised_organisations && @topical_event.emphasised_organisations.any? %>
-      <div class="organisations">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: t("topical_events.organisations"),
-          font_size: "l",
-          margin_bottom: 4,
-          padding: true,
-          border_top: 2,
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("topical_events.organisations"),
+        font_size: "l",
+        margin_bottom: 4,
+        padding: true,
+        border_top: 2,
+      } %>
+      <% @topical_event.emphasised_organisations.flatten.each do |organisation| %>
+        <%= render "govuk_publishing_components/components/organisation_logo", {
+          organisation: {
+            name: organisation["title"],
+            url: organisation["base_path"],
+            crest: organisation.dig("details", "logo", "crest"),
+            brand: organisation.dig("details", "brand"),
+          },
+          margin_bottom: 6,
         } %>
-        <% @topical_event.emphasised_organisations.flatten.each do |organisation| %>
-          <%= render "govuk_publishing_components/components/organisation_logo", {
-            organisation: {
-              name: organisation["title"],
-              url: organisation["base_path"],
-              crest: organisation.dig("details", "logo", "crest"),
-              brand: organisation.dig("details", "brand"),
-            },
-            margin_bottom: 6,
-          } %>
-        <% end %>
+      <% end %>
 
-        <% if @topical_event.slug == 'first-world-war-centenary' %>
-          <%= render "first_world_war_centenary"%>
-        <% end %>
+      <% if @topical_event.slug == 'first-world-war-centenary' %>
+        <%= render "first_world_war_centenary"%>
+      <% end %>
 
-        <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-unboxed' %>
-          <%= render "platinum_jubilee_unboxed" %>
-        <% end %>
-
-      </div>
+      <% if @topical_event.slug == '2022-events-platinum-jubilee-commonwealth-games-unboxed' %>
+        <%= render "platinum_jubilee_unboxed" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -1,4 +1,7 @@
-<% ga4_link_attributes = {
+<%
+  add_view_stylesheet("topical_events")
+
+  ga4_link_attributes = {
     event_name: "navigation",
     type: "subscribe",
     index_link: 1,
@@ -7,8 +10,6 @@
   }.to_json
 %>
 
-<% add_view_stylesheet("topical_events") %>
-
 <% content_for :title, @topical_event.title %>
 <% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing topical-events-show" %>
 
@@ -16,7 +17,7 @@
   <%= tag("meta", name: "description", content: @topical_event.description) if @topical_event.description %>
 <% end %>
 
-  <% if @topical_event.slug == "her-majesty-queen-elizabeth-ii" %>
+<% if @topical_event.slug == "her-majesty-queen-elizabeth-ii" %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/heading", {
@@ -27,10 +28,10 @@
       } %>
     </div>
   </div>
-  <% else %>
-    <% if @topical_event.slug == 'coronation' %>
-      <%= render "bunting"%>
-    <% end %>
+<% else %>
+  <% if @topical_event.slug == 'coronation' %>
+    <%= render "bunting"%>
+  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/heading", {
@@ -42,8 +43,9 @@
       } %>
     </div>
   </div>
-  <% end %>
-  <div class="govuk-grid-row">
+<% end %>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/lead_paragraph", {
       text: @topical_event.description,
@@ -93,9 +95,11 @@
       </section>
     <% end %>
   </div>
+</div>
 
-  <div class="govuk-grid-column-full">
-    <% if @topical_event.ordered_featured_documents&.any? %>
+<% if @topical_event.ordered_featured_documents&.any? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
       <section id="featured">
         <%= render "govuk_publishing_components/components/heading", {
           text: I18n.t("shared.featured"),
@@ -115,11 +119,13 @@
           </div>
         <% end %>
       </section>
-    <% end %>
+    </div>
   </div>
+<% end %>
 
-  <div class="govuk-grid-column-two-thirds topical-events__section-break">
-    <section id="latest">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section id="latest" class="topical-events__section-break">
       <%= render "govuk_publishing_components/components/heading", {
         text: I18n.t("topical_events.headings.latest"),
         padding: true,
@@ -144,25 +150,23 @@
         } %>
       </div>
     </section>
-  </div>
 
-  <section id="documents" class="govuk-grid-column-two-thirds">
-    <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.guidance_and_regulation.any? %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: I18n.t("topical_events.headings.documents"),
-        padding: true,
-        font_size: "l",
-        border_top: 2,
-        margin_bottom: 3,
-      } %>
-    <% end %>
+    <section id="documents">
+      <% if @topical_event.publications.any? || @topical_event.consultations.any? || @topical_event.announcements.any? || @topical_event.guidance_and_regulation.any? %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: I18n.t("topical_events.headings.documents"),
+          padding: true,
+          font_size: "l",
+          border_top: 2,
+          margin_bottom: 3,
+        } %>
+      <% end %>
 
-    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:topical_event, :consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
-    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:topical_event, :announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
-    <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.guidance_and_regulation, heading: I18n.t("topical_events.headings.guidance_and_regulation"), link_to: search_url(:topical_event, :guidance_and_regulation, @topical_event.slug) }) if @topical_event.guidance_and_regulation.any? %>
-  </section>
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.consultations, heading: I18n.t("topical_events.headings.consultations"), link_to: search_url(:topical_event, :consultation, @topical_event.slug) }) if @topical_event.consultations.any? %>
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.announcements, heading: I18n.t("topical_events.headings.announcements"), link_to: search_url(:topical_event, :announcement, @topical_event.slug) }) if @topical_event.announcements.any? %>
+      <%= render(partial: 'shared/document_list_from_search_api', locals: { documents: @topical_event.guidance_and_regulation, heading: I18n.t("topical_events.headings.guidance_and_regulation"), link_to: search_url(:topical_event, :guidance_and_regulation, @topical_event.slug) }) if @topical_event.guidance_and_regulation.any? %>
+    </section>
 
-  <div class="govuk-grid-column-two-thirds">
     <% if @topical_event.emphasised_organisations && @topical_event.emphasised_organisations.any? %>
       <%= render "govuk_publishing_components/components/heading", {
         text: t("topical_events.organisations"),

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -175,17 +175,21 @@
         padding: true,
         border_top: 2,
       } %>
+      <ul class="govuk-list">
       <% @topical_event.emphasised_organisations.flatten.each do |organisation| %>
-        <%= render "govuk_publishing_components/components/organisation_logo", {
-          organisation: {
-            name: organisation["title"],
-            url: organisation["base_path"],
-            crest: organisation.dig("details", "logo", "crest"),
-            brand: organisation.dig("details", "brand"),
-          },
-          margin_bottom: 6,
-        } %>
+        <li>
+          <%= render "govuk_publishing_components/components/organisation_logo", {
+            organisation: {
+              name: organisation["title"],
+              url: organisation["base_path"],
+              crest: organisation.dig("details", "logo", "crest"),
+              brand: organisation.dig("details", "brand"),
+            },
+            margin_bottom: 6,
+          } %>
+        </li>
       <% end %>
+      </ul>
 
       <% if @topical_event.slug == 'first-world-war-centenary' %>
         <%= render "first_world_war_centenary"%>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes an issue where organisation logo text overlapped at a small desktop size if there were four items. We looked at various layout options but the simplest and cleanest is to just stack them, as on mobile.

Also wraps the logos in a list, to improve navigation for users of assistive tech.

Also cleans up the general markup of this page. There were multiple `govuk-grid-column-two-thirds` elements stacked in the same `govuk-grid-row` unnecessarily. This changes that to wrap most of the page content in one grid column in one grid row (but we maintain the separate full grid column for the Featured section).

Example URLs for testing:

- https://www.gov.uk/government/topical-events/russian-invasion-of-ukraine-uk-government-response (original problem)
- https://www.gov.uk/government/topical-events/her-majesty-queen-elizabeth-ii
- https://www.gov.uk/government/topical-events/spring-statement-2025
- https://www.gov.uk/government/topical-events/plan-for-jobs

## Why
Issue noticed during testing.

## Visual changes

Before | After
------ | ------
![Screenshot 2025-04-24 at 09 53 32](https://github.com/user-attachments/assets/7fa24edd-4874-41fe-889a-fde025ee7c27) | ![Screenshot 2025-04-24 at 09 53 47](https://github.com/user-attachments/assets/95dd3758-0149-47e7-9f26-99b31c0aefd8)

The spacing underneath the org logos (comparing on mobile) is very slightly different. Originally there was a govuk-spacing of 7, but that looked a little big, so I've reduced it to 6. However the list also adds a little bit of spacing beneath each list item, so the spacing is pretty close to what it was, if not exactly as before.


Trello card: https://trello.com/c/RG7ViYbD/563-organisation-logos-on-topical-event-pages-and-other-pages-are-looking-squished-m-l
