### PR TITLE
Make org logos inline on topical event pages

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -186,6 +186,7 @@
               brand: organisation.dig("details", "brand"),
             },
             margin_bottom: 6,
+            inline: true,
           } %>
         </li>
       <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Sets the 'inline' option on organisation logo components on the topical event pages (like this one https://www.gov.uk/government/topical-events/russian-invasion-of-ukraine-uk-government-response), to reduce the clickable area to a sensible size.

## Why
Because I forgot to do it in https://github.com/alphagov/collections/pull/4060

## Visual changes
Before | After
------ | ------
![Screenshot 2025-04-28 at 14 20 01](https://github.com/user-attachments/assets/d812f9b3-4208-4da0-ae40-fa42b0138db0) | ![Screenshot 2025-04-28 at 14 20 14](https://github.com/user-attachments/assets/521ab4c1-ed94-4bd0-af78-6f9dffa21803)


Trello card: https://trello.com/c/RG7ViYbD/563-organisation-logos-on-topical-event-pages-and-other-pages-are-looking-squished-m-l