### PR TITLE
Fix whip logic for GraphQL rendered Ministers Index page

### DIFF
--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -91,7 +91,7 @@ class MinistersIndexPresenter
           url: role_app.dig("links", "role").first["web_url"],
           seniority: role_app.dig("links", "role").first.fetch("details").fetch("seniority", 1000),
           payment_info: role_app.dig("links", "role").first.dig("details", "role_payment_type"),
-          whip: role_app.dig("links", "role").first.dig("details", "whip_organisation").present?,
+          whip: role_app.dig("links", "role").first.dig("details", "whip_organisation", "label").present?,
         )
       }.sort_by(&:seniority)
 

--- a/spec/presenters/ministers_index_presenter_spec.rb
+++ b/spec/presenters/ministers_index_presenter_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe MinistersIndexPresenter do
                           "web_url" => "https://www.integration.publishing.service.gov.uk/government/ministers/role",
                           "details" => {
                             "seniority" => 100,
-                            "whip_organisation" => {},
+                            "whip_organisation" => non_whip_role_organisation,
                           },
                         },
                       ],
@@ -171,22 +171,44 @@ RSpec.describe MinistersIndexPresenter do
       }
     end
 
-    it "returns people with only their whip roles" do
-      presenter = MinistersIndexPresenter.new(content_item_data)
-      expect(
-        presenter.whips.find { |whip_types| whip_types.item_key == "ordered_junior_lords_of_the_treasury_whips" }.ministers.first.roles,
-      ).to eq(
-        [
-          MinistersIndexPresenter::Minister::Role.new(
-            id: "01d57ccd-ef0d-4a28-b638-eab2cc06ffe9",
-            payment_info: nil,
-            seniority: 109,
-            title: "Whip role",
-            url: "https://www.integration.publishing.service.gov.uk/government/ministers/whip-role",
-            whip: true,
-          ),
-        ],
-      )
+    let(:expected_roles) do
+      [
+        MinistersIndexPresenter::Minister::Role.new(
+          id: "01d57ccd-ef0d-4a28-b638-eab2cc06ffe9",
+          payment_info: nil,
+          seniority: 109,
+          title: "Whip role",
+          url: "https://www.integration.publishing.service.gov.uk/government/ministers/whip-role",
+          whip: true,
+        ),
+      ]
+    end
+
+    context "when the response is from Content Store" do
+      let(:non_whip_role_organisation) { {} }
+
+      it "returns people with only their whip roles" do
+        presenter = MinistersIndexPresenter.new(content_item_data)
+        expect(
+          presenter.whips.find { |whip_types| whip_types.item_key == "ordered_junior_lords_of_the_treasury_whips" }.ministers.first.roles,
+        ).to eq(expected_roles)
+      end
+    end
+
+    context "when the response is from GraphQL" do
+      let(:non_whip_role_organisation) do
+        {
+          "label" => nil,
+          "sort_order" => nil,
+        }
+      end
+
+      it "returns people with only their whip roles" do
+        presenter = MinistersIndexPresenter.new(content_item_data)
+        expect(
+          presenter.whips.find { |whip_types| whip_types.item_key == "ordered_junior_lords_of_the_treasury_whips" }.ministers.first.roles,
+        ).to eq(expected_roles)
+      end
     end
   end
 

--- a/spec/presenters/ministers_index_presenter_spec.rb
+++ b/spec/presenters/ministers_index_presenter_spec.rb
@@ -115,5 +115,80 @@ RSpec.describe MinistersIndexPresenter do
     end
   end
 
+  describe "#whips" do
+    let(:content_item_data) do
+      {
+        "links" => {
+          "ordered_junior_lords_of_the_treasury_whips" => [
+            {
+              "name" => "Person 1",
+              "links" => {
+                "role_appointments" => [
+                  {
+                    "details" => {
+                      "current" => true,
+                    },
+                    "links" => {
+                      "role" => [
+                        {
+                          "content_id" => "01d57ccd-ef0d-4a28-b638-eab2cc06ffe9",
+                          "title" => "Whip role",
+                          "web_url" => "https://www.integration.publishing.service.gov.uk/government/ministers/whip-role",
+                          "details" => {
+                            "seniority" => 109,
+                            "whip_organisation" => {
+                              "label" => "Junior Lords of the Treasury",
+                              "sort_order" => 2,
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  {
+                    "details" => {
+                      "current" => true,
+                    },
+                    "links" => {
+                      "role" => [
+                        {
+                          "content_id" => "d301319d-5957-4fec-acbc-1dfef3f79267",
+                          "title" => "Another role",
+                          "web_url" => "https://www.integration.publishing.service.gov.uk/government/ministers/role",
+                          "details" => {
+                            "seniority" => 100,
+                            "whip_organisation" => {},
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+    end
+
+    it "returns people with only their whip roles" do
+      presenter = MinistersIndexPresenter.new(content_item_data)
+      expect(
+        presenter.whips.find { |whip_types| whip_types.item_key == "ordered_junior_lords_of_the_treasury_whips" }.ministers.first.roles,
+      ).to eq(
+        [
+          MinistersIndexPresenter::Minister::Role.new(
+            id: "01d57ccd-ef0d-4a28-b638-eab2cc06ffe9",
+            payment_info: nil,
+            seniority: 109,
+            title: "Whip role",
+            url: "https://www.integration.publishing.service.gov.uk/government/ministers/whip-role",
+            whip: true,
+          ),
+        ],
+      )
+    end
+  end
+
   # TODO: add tests for MinistersIndexPresenter::Minister class
 end


### PR DESCRIPTION
For GraphQL responses, we are currently incorrectly showing non-whip roles for people in the whips section of the ministers index page.
    
This is because GraphQL provides a hash for the `whip_organisation`, with each value being `nil`. We cannot change this, as that is a fundamental GraphQL concept.
    
Therefore updating the logic to check for a label, instead of just the presence of an organisation hash.

[Trello card](https://trello.com/c/HcOHeixw)