### PR TITLE
Allow `ordered_parent_organisations` links to be an empty array

### DIFF
--- a/app/views/roles/_organisations.html.erb
+++ b/app/views/roles/_organisations.html.erb
@@ -1,4 +1,4 @@
-<% if role.organisations %>
+<% if role.organisations.present? %>
   <div class="organisations-list <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <span lang="en"><%= t('roles.organisations') %></span>:
     <%= to_sentence(role.organisations.map { |organisation| link_to(organisation['title'], organisation['base_path'], class: "govuk-link") }) %>

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -18,6 +18,36 @@ RSpec.feature "Role page" do
     GovukSchemas::Example.find("role", example_name: "prime_minister")
   end
 
+  context "when the ordered_parent_organisations links are nil" do
+    let(:role_content_item_data) do
+      GovukSchemas::Example.find("role", example_name: "prime_minister").tap do |content_item|
+        content_item["links"]["ordered_parent_organisations"] = nil
+      end
+    end
+
+    it "does not include the organisations list" do
+      expect(page).to_not have_selector("div.organisations-list")
+    end
+  end
+
+  context "when the ordered_parent_organisations links are an empty array" do
+    let(:role_content_item_data) do
+      GovukSchemas::Example.find("role", example_name: "prime_minister").tap do |content_item|
+        content_item["links"]["ordered_parent_organisations"] = []
+      end
+    end
+
+    it "does not include the organisations list" do
+      expect(page).to_not have_selector("div.organisations-list")
+    end
+  end
+
+  context "when the ordered_parent_organisations links are present" do
+    it "includes the organisations list" do
+      expect(page).to have_selector("div.organisations-list")
+    end
+  end
+
   context "when there is no GraphQL parameter" do
     it "renders the page successfully" do
       expect(page).to have_selector("h1", text: "Prime Minister")


### PR DESCRIPTION
The code is currently assuming the `ordered_parent_organisations` links will be nil if there are no parent organisations.

This assumption is not correct, as the link could theoretically be present but with an empty array.  This would lead to the organisations section appearing, but without any organisations listed.

Therefore updating to support both cases, so we only display the organisations section when they are any.

This is important for GraphQL, since we will always be including an empty array, even if there are no links.

[Trello card](https://trello.com/c/5ggdXNEB)