### PR TITLE
Include taxonomy meta tags for GraphQL roles

### DIFF
--- a/app/queries/graphql/role_query.rb
+++ b/app/queries/graphql/role_query.rb
@@ -59,9 +59,41 @@ class Graphql::RoleQuery
               organisations {
                 analytics_identifier
               }
+
+              taxons {
+                ...Taxon
+                links {
+                  parent_taxons {
+                    ...Taxon
+                    links {
+                      parent_taxons {
+                        ...Taxon
+                        links {
+                          parent_taxons {
+                            ...Taxon
+                            links {
+                              parent_taxons {
+                                ...Taxon
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }
+      }
+
+      fragment Taxon on Edition {
+        base_path
+        content_id
+        document_type
+        phase
+        title
       }
     QUERY
   end

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -153,6 +153,10 @@ RSpec.feature "Role page" do
       govuk:publishing-app
       govuk:rendering-app
       govuk:schema-name
+      govuk:taxon-id
+      govuk:taxon-ids
+      govuk:taxon-slug
+      govuk:taxon-slugs
       govuk:updated-at
     ].each do |meta_tag_name|
       it "renders the #{meta_tag_name} meta tag" do

--- a/spec/fixtures/graphql/prime_minister.json
+++ b/spec/fixtures/graphql/prime_minister.json
@@ -73,7 +73,46 @@
           {
             "analytics_identifier": "OT532"
           }
-        ]
+        ],
+        "taxons": [
+          {
+            "api_path": "/api/content/corporate-information",
+            "api_url": "https://www.gov.uk/api/content/corporate-information",
+            "base_path": "/corporate-information",
+            "content_id": "a544d48b-1e9e-47fb-b427-7a987c658c14",
+            "details": {
+              "internal_name": "Corporate information",
+              "notes_for_editors": "",
+              "visible_to_departmental_editors": true
+            },
+            "document_type": "taxon",
+            "links": {
+            "root_taxon": [
+              {
+                "api_path": "/api/content/",
+                "api_url": "https://www.gov.uk/api/content/",
+                "base_path": "/",
+                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                "document_type": "homepage",
+                "links": {},
+                "locale": "en",
+                "public_updated_at": "2023-06-28T09:32:34Z",
+                "schema_name": "homepage",
+                "title": "GOV.UK homepage",
+                "web_url": "https://www.gov.uk/",
+                "withdrawn": false
+              }
+            ]
+          },
+          "locale": "en",
+          "phase": "live",
+          "public_updated_at": "2018-08-22T12:57:58Z",
+          "schema_name": "taxon",
+          "title": "Corporate information",
+          "web_url": "https://www.gov.uk/corporate-information",
+          "withdrawn": false
+        }
+      ]
       },
       "public_updated_at": "2024-07-05T12:32:36+01:00",
       "publishing_app": "whitehall",


### PR DESCRIPTION
Some role pages include meta tags representing the taxonomy that the role belongs to.

We therefore need to request the `taxons` links as part of the GraphQL query to retrieve the content for these meta tags.

Adding five levels of taxonomy, [as was done in Frontend](https://github.com/alphagov/frontend/pull/4741/commits/68b98ece36c05258f06fddef7c23e14ce97089f3), since this is the largest level of taxonomy we currently have.

[Trello card](https://trello.com/c/5ggdXNEB)