### PR TITLE
Replace use of tint mixins with hex variables

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -5,7 +5,7 @@
 // be run as an A/B test, we need to use a different class name for each view.
 .browse__breadcrumb-wrapper,
 .browse__header-wrapper {
-  background-color: govuk-tint(govuk-colour("blue"), 80%);
+  background-color: $govuk-blue-tint-80;
 }
 
 .browse__breadcrumb-wrapper {


### PR DESCRIPTION
## What

Replace use of tint mixins with hex variables

## Why

Dart Sass 1.79.0 introduced support for CSS Color Level 4 color spaces. Consequently, the `govuk-tint` mixin now outputs rgb values with floating-point precision, leading to unsupported property value warnings in some browsers, such as Safari 11.1.1. To maintain compatibility, we're defining equivalent hex colour values as variables instead.

<img width="1343" alt="Screenshot 2025-05-14 at 14 08 19" src="https://github.com/user-attachments/assets/7d076edf-81e5-4338-bdcc-65a97685f611" />