### PR TITLE
More efficient ministers index

### DIFF
--- a/app/helpers/ministers_index_helper.rb
+++ b/app/helpers/ministers_index_helper.rb
@@ -3,8 +3,13 @@ module MinistersIndexHelper
     link_to role.title, role.url, class: "govuk-link"
   end
 
-  def cabinet_minister_description(minister)
-    list_of_roles = joined_list(minister.roles.map { |role| role_link(role) }).html_safe
+  def cabinet_minister_description(minister, department: nil)
+    roles = if department.nil?
+              minister.roles
+            else
+              minister.roles_for_department(department)
+            end
+    list_of_roles = joined_list(roles.map { |role| role_link(role) }).html_safe
     footnotes = tag.span(minister.role_payment_info.join(". "), class: "footnotes")
 
     if minister.role_payment_info.any?

--- a/app/presenters/ministers_index_presenter.rb
+++ b/app/presenters/ministers_index_presenter.rb
@@ -33,6 +33,7 @@ class MinistersIndexPresenter
     ordered_ministerial_departments = @content_item_data.dig("links", "ordered_ministerial_departments") || []
     ordered_ministerial_departments.map do |department_data|
       Department.new(
+        content_id: department_data.fetch("content_id"),
         url: department_data.fetch("web_url"),
         title: department_data.fetch("title"),
         crest: department_data.dig("details", "logo", "crest"),
@@ -46,7 +47,7 @@ class MinistersIndexPresenter
     end
   end
 
-  Department = Struct.new(:url, :title, :crest, :formatted_title, :brand, :roles, :ministers, keyword_init: true)
+  Department = Struct.new(:content_id, :url, :title, :crest, :formatted_title, :brand, :roles, :ministers, keyword_init: true)
 
   def whips
     ordered_whip_organisations.each do |whip_org|
@@ -85,13 +86,15 @@ class MinistersIndexPresenter
 
     def roles
       roles = current_role_appointments.map { |role_app|
+        role_data = role_app.dig("links", "role").first
         Role.new(
-          id: role_app.dig("links", "role").first.fetch("content_id"),
-          title: role_app.dig("links", "role").first.fetch("title"),
-          url: role_app.dig("links", "role").first["web_url"],
-          seniority: role_app.dig("links", "role").first.fetch("details").fetch("seniority", 1000),
-          payment_info: role_app.dig("links", "role").first.dig("details", "role_payment_type"),
-          whip: role_app.dig("links", "role").first.dig("details", "whip_organisation", "label").present?,
+          id: role_data.fetch("content_id"),
+          title: role_data.fetch("title"),
+          url: role_data["web_url"],
+          seniority: role_data.fetch("details").fetch("seniority", 1000),
+          payment_info: role_data.dig("details", "role_payment_type"),
+          whip: role_data.dig("details", "whip_organisation", "label").present?,
+          org_ids: (role_data.dig("links", "organisations") || []).map { |org| org["content_id"] },
         )
       }.sort_by(&:seniority)
 
@@ -103,7 +106,7 @@ class MinistersIndexPresenter
       org_role_ids = department.roles.map { |role| role["content_id"] }
 
       roles.select do |role|
-        org_role_ids.include?(role.id)
+        org_role_ids.include?(role.id) || role.org_ids.include?(department.content_id)
       end
     end
 
@@ -111,7 +114,7 @@ class MinistersIndexPresenter
       roles.map(&:payment_info).compact.uniq
     end
 
-    Role = Struct.new(:id, :title, :url, :seniority, :payment_info, :whip, keyword_init: true)
+    Role = Struct.new(:id, :title, :url, :seniority, :payment_info, :whip, :org_ids, keyword_init: true)
 
   private
 

--- a/app/queries/graphql/ministers_index_query.rb
+++ b/app/queries/graphql/ministers_index_query.rb
@@ -56,6 +56,7 @@ class Graphql::MinistersIndexQuery
               ordered_ministerial_departments {
                 title
                 web_url
+                content_id
 
                 details {
                   brand
@@ -69,10 +70,6 @@ class Graphql::MinistersIndexQuery
                 links {
                   ordered_ministers {
                     ...basePersonInfo
-                  }
-
-                  ordered_roles {
-                    content_id
                   }
                 }
               }
@@ -113,6 +110,11 @@ class Graphql::MinistersIndexQuery
                   whip_organisation {
                     label
                     sort_order
+                  }
+                }
+                links {
+                  organisations {
+                    content_id
                   }
                 }
               }

--- a/app/views/ministers/_ministers_by_organisation.html.erb
+++ b/app/views/ministers/_ministers_by_organisation.html.erb
@@ -21,7 +21,7 @@
               heading_text: minister.name,
               heading_level: 3,
               context: { text: minister.honorific },
-              description: cabinet_minister_description(minister),
+              description: cabinet_minister_description(minister, department: organisation),
             } %>
           </div>
         </li>

--- a/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
+++ b/spec/fixtures/graphql/ministers_index-reshuffle-mode-off.json
@@ -671,7 +671,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "Prime Minister",
-                              "web_url": "https://www.gov.uk/government/ministers/prime-minister"
+                              "web_url": "https://www.gov.uk/government/ministers/prime-minister",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -690,7 +697,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "First Lord of the Treasury",
-                              "web_url": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+                              "web_url": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -709,7 +723,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "Minister for the Union",
-                              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-union"
+                              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-union",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -728,7 +749,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "Minister for the Civil Service",
-                              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+                              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-civil-service",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -827,23 +855,10 @@
                   "title": "Nusrat Ghani MP",
                   "web_url": "https://www.gov.uk/government/people/nusrat-ghani"
                 }
-              ],
-              "ordered_roles": [
-                {
-                  "content_id": "845e5811-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "846a7351-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "846a754c-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2"
-                }
               ]
             },
             "title": "Cabinet Office",
+            "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48",
             "web_url": "https://www.gov.uk/government/organisations/cabinet-office"
           },
           {
@@ -881,7 +896,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "Secretary of State for Business and Trade",
-                              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -900,7 +922,17 @@
                                 "whip_organisation": {}
                               },
                               "title": "President of the Board of Trade",
-                              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+                                  },
+                                  {
+                                    "content_id": "c4e41647-ad69-4e96-843b-05fa7867bbc0"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -983,17 +1015,10 @@
                   "title": "Nusrat Ghani MP",
                   "web_url": "https://www.gov.uk/government/people/nusrat-ghani"
                 }
-              ],
-              "ordered_roles": [
-                {
-                  "content_id": "5cb74a2c-7e9f-444a-8347-d944cc05b606"
-                },
-                {
-                  "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9"
-                }
               ]
             },
             "title": "Department for Business and Trade",
+            "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48",
             "web_url": "https://www.gov.uk/government/organisations/department-for-business-and-trade"
           },
           {
@@ -1031,7 +1056,14 @@
                                 "whip_organisation": {}
                               },
                               "title": "Secretary of State for Business and Trade",
-                              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -1050,7 +1082,17 @@
                                 "whip_organisation": {}
                               },
                               "title": "President of the Board of Trade",
-                              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade",
+                              "links": {
+                                "organisations": [
+                                  {
+                                    "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48"
+                                  },
+                                  {
+                                    "content_id": "c4e41647-ad69-4e96-843b-05fa7867bbc0"
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }
@@ -1079,23 +1121,10 @@
                   "title": "The Rt Hon Kemi Badenoch MP",
                   "web_url": "https://www.gov.uk/government/people/kemi-badenoch"
                 }
-              ],
-              "ordered_roles": [
-                {
-                  "content_id": "845e61e9-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "846a61ea-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "30371bc0-0c68-4146-b5a1-2ba89b15516c"
-                },
-                {
-                  "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9"
-                }
               ]
             },
             "title": "UK Export Finance",
+            "content_id": "c4e41647-ad69-4e96-843b-05fa7867bbc0",
             "web_url": "https://www.gov.uk/government/organisations/uk-export-finance"
           },
           {
@@ -1107,19 +1136,9 @@
               }
             },
             "links": {
-              "ordered_roles": [
-                {
-                  "content_id": "845e8426-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "8461c3df-c0f1-11e4-8223-005056011aef"
-                },
-                {
-                  "content_id": "8461ca79-c0f1-11e4-8223-005056011aef"
-                }
-              ]
             },
             "title": "Office of the Advocate General for Scotland",
+            "content_id": "93f52ac4-7eb5-47bf-acfe-c11d1c8e8d76",
             "web_url": "https://www.gov.uk/government/organisations/office-of-the-advocate-general-for-scotland"
           }
         ]

--- a/spec/presenters/ministers_index_presenter_spec.rb
+++ b/spec/presenters/ministers_index_presenter_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe MinistersIndexPresenter do
               {
                 "web_url" => "foo",
                 "title" => "foo",
+                "content_id" => "foo",
                 "details" => {
                   "brand" => "foo",
                   "logo" => {
@@ -180,6 +181,7 @@ RSpec.describe MinistersIndexPresenter do
           title: "Whip role",
           url: "https://www.integration.publishing.service.gov.uk/government/ministers/whip-role",
           whip: true,
+          org_ids: [],
         ),
       ]
     end


### PR DESCRIPTION
This depends on https://github.com/alphagov/publishing-api/pull/3362, which adds the ability to query the organsiations for a particular role.

Once we can query that, we can stop fetching every role in every organisation (including things like board members which don't appear on the page), massively reducing the amount of content we request from graphql.

I'm starting this PR in draft while I gather some local performance data to give an idea of how much of a saving this is in practice.