### PR TITLE
Fix auditing issues

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
-//= require govuk_publishing_components/components/intervention
 //= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/step-by-step-nav
 

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -2,10 +2,6 @@
   h2 {
     border-bottom: 5px solid #005ea5;
   }
-
-  .gem-c-notice p {
-    margin-top: 0;
-  }
 }
 
 .clear-column {

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -1,9 +1,3 @@
-.ministers-index {
-  h2 {
-    border-bottom: 5px solid #005ea5;
-  }
-}
-
 .clear-column {
   clear: both;
 }

--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :title, t("ministers.govuk_title") %>
 
-<% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing ministers-index" %>
+<% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -34,6 +34,8 @@
       id: "cabinet-ministers",
       margin_bottom: 4,
       padding: true,
+      border_top: 5,
+      brand: "cabinet-office"
     } %>
   </div>
 
@@ -64,6 +66,8 @@
       id: "also-attends-cabinet-ministers",
       margin_bottom: 4,
       padding: true,
+      border_top: 5,
+      brand: "cabinet-office"
     } %>
   </div>
 
@@ -94,6 +98,8 @@
       id: "ministers-by-department",
       margin_bottom: 4,
       padding: true,
+      border_top: 5,
+      brand: "cabinet-office"
     } %>
   </div>
 
@@ -109,6 +115,8 @@
       id: "whips",
       margin_bottom: 4,
       padding: true,
+      border_top: 5,
+      brand: "cabinet-office"
     } %>
   </div>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the appearance of headings on the [ministers index page](https://www.gov.uk/government/ministers) to be more consistent with headings across GOV.UK, specifically switch the border bottom for a border top. See individual commit for details.

Also remove some unused component JS.

## Why
Issues raised in our component auditing tools.

## Visual changes
Before | After
------ | ------
![Screenshot 2025-06-05 at 10 26 46](https://github.com/user-attachments/assets/89d79d79-b5fa-48b7-a80d-302f1455dbe3) | ![Screenshot 2025-06-05 at 10 31 46](https://github.com/user-attachments/assets/631df008-1c89-4276-a3fd-d0d1c17bd2bb)
