### PR TITLE
Add Knowledge graph as thing using the API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,3 +25,4 @@ Please [add your application to this list](https://github.com/alphagov/collectio
 - [Signon](https://github.com/alphagov/signon/blob/53302a17ccfedca9914d15937a040d6b586dbebd/lib/organisations_fetcher.rb#L24)
 - [Support API](https://github.com/alphagov/support-api/blob/e6f4b9db213c6dd7b75aef832f12bf1da7070d4d/lib/organisation_importer.rb#L67)
 - [Transition](https://github.com/alphagov/transition/blob/v50/lib/transition/import/whitehall_orgs.rb#L51)
+- [Knowledge graph](https://github.com/alphagov/govuk-knowledge-graph-gcp/)


### PR DESCRIPTION
Inadvertently removed in #4104 as it referenced an archived repo. Now swapped out for the active repo.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
