### PR TITLE
Remove cookies from GraphQL A/B test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,4 +108,9 @@ private
   def render_partial(partial_name, locals = {})
     render_to_string(partial_name, formats: [:html], layout: false, locals:)
   end
+
+  def graphql_ab_test?(graphql_traffic_rate)
+    random_number = Random.rand(1.0)
+    random_number < graphql_traffic_rate
+  end
 end

--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -1,18 +1,12 @@
 class MinistersController < ApplicationController
   around_action :switch_locale
 
-  def index
-    ab_test = GovukAbTesting::AbTest.new(
-      "GraphQLMinistersIndex",
-      allowed_variants: %w[A B Z],
-      control_variant: "Z",
-    )
-    @requested_variant = ab_test.requested_variant(request.headers)
-    @requested_variant.configure_response(response)
+  GRAPHQL_TRAFFIC_RATE = 0.04094748 # This is a decimal version of a percentage, so can be between 0 and 1
 
+  def index
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true" || @requested_variant.variant?("B")
+                        elsif params[:graphql] == "true" || graphql_ab_test?(GRAPHQL_TRAFFIC_RATE)
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,16 +1,9 @@
 class WorldController < ApplicationController
+  GRAPHQL_TRAFFIC_RATE = 0.07404692 # This is a decimal version of a percentage, so can be between 0 and 1
   def index
-    ab_test = GovukAbTesting::AbTest.new(
-      "GraphQLWorldIndex",
-      allowed_variants: %w[A B Z],
-      control_variant: "Z",
-    )
-    @requested_variant = ab_test.requested_variant(request.headers)
-    @requested_variant.configure_response(response)
-
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store
-                        elsif params[:graphql] == "true" || @requested_variant.variant?("B")
+                        elsif params[:graphql] == "true" || graphql_ab_test?(GRAPHQL_TRAFFIC_RATE)
                           load_from_graphql
                         else
                           load_from_content_store

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,6 @@
   <%=
     render_component_stylesheets
   %>
-  <%= @requested_variant.analytics_meta_tag.html_safe if @requested_variant %>
 </head>
 <body>
   <div class="wrapper" id="wrapper">

--- a/spec/features/ministers_spec.rb
+++ b/spec/features/ministers_spec.rb
@@ -1,8 +1,6 @@
 require "integration_spec_helper"
 
 RSpec.feature "Ministers index page" do
-  include GovukAbTesting::RspecHelpers
-
   shared_examples "ministers index page" do
     scenario "returns 200 when visiting ministers page" do
       expect(page.status_code).to eq(200)
@@ -199,6 +197,8 @@ RSpec.feature "Ministers index page" do
 
   context "when the GraphQL parameter is not set" do
     before do
+      allow(Random).to receive(:rand).with(1.0).and_return(1)
+
       visit "/government/ministers"
     end
 
@@ -226,36 +226,24 @@ RSpec.feature "Ministers index page" do
     it_behaves_like "ministers index page rendered from Content Store"
   end
 
-  context "when the GraphQL A/B A variant is selected" do
+  context "when the GraphQL A/B Content Store variant is selected" do
     before do
-      with_variant GraphQLMinistersIndex: "A" do
-        visit "/government/ministers"
-      end
+      allow(Random).to receive(:rand).with(1.0).and_return(1)
+      visit "/government/ministers"
     end
 
     it_behaves_like "ministers index page rendered from Content Store"
   end
 
-  context "when the GraphQL A/B test control is selected" do
-    before do
-      with_variant GraphQLMinistersIndex: "Z" do
-        visit "/government/ministers"
-      end
-    end
-
-    it_behaves_like "ministers index page rendered from Content Store"
-  end
-
-  context "when the GraphQL A/B B variant is selected" do
+  context "when the GraphQL A/B GraphQL variant is selected" do
     before do
       stub_publishing_api_graphql_query(
         Graphql::MinistersIndexQuery.new("/government/ministers").query,
         document,
       )
 
-      with_variant GraphQLMinistersIndex: "B" do
-        visit "/government/ministers"
-      end
+      allow(Random).to receive(:rand).with(1.0).and_return(MinistersController::GRAPHQL_TRAFFIC_RATE - 0.000001)
+      visit "/government/ministers"
     end
 
     it_behaves_like "ministers index page rendered from GraphQL"

--- a/spec/features/role_spec.rb
+++ b/spec/features/role_spec.rb
@@ -1,7 +1,6 @@
 require "integration_spec_helper"
 
 RSpec.feature "Role page" do
-  include GovukAbTesting::RspecHelpers
   include SearchApiHelpers
 
   before do
@@ -11,6 +10,7 @@ RSpec.feature "Role page" do
     )
     stub_search(body: { results: [] })
 
+    allow(Random).to receive(:rand).with(1.0).and_return(1)
     visit "/government/ministers/prime-minister"
   end
 
@@ -49,6 +49,10 @@ RSpec.feature "Role page" do
   end
 
   context "when there is no GraphQL parameter" do
+    before do
+      allow(Random).to receive(:rand).with(1.0).and_return(1)
+    end
+
     it "renders the page successfully" do
       expect(page).to have_selector("h1", text: "Prime Minister")
     end
@@ -176,11 +180,10 @@ RSpec.feature "Role page" do
     end
   end
 
-  context "when the GraphQL A/B A variant is selected" do
+  context "when the GraphQL A/B Content Store variant is selected" do
     before do
-      with_variant GraphQLRoles: "A" do
-        visit "/government/ministers/prime-minister"
-      end
+      allow(Random).to receive(:rand).with(1.0).and_return(1)
+      visit "/government/ministers/prime-minister"
     end
 
     it "does not get the data from GraphQL" do
@@ -188,28 +191,15 @@ RSpec.feature "Role page" do
     end
   end
 
-  context "when the GraphQL A/B test control is selected" do
-    before do
-      with_variant GraphQLRoles: "Z" do
-        visit "/government/ministers/prime-minister"
-      end
-    end
-
-    it "does not get the data from GraphQL" do
-      expect(a_request(:post, "#{Plek.find('publishing-api')}/graphql")).not_to have_been_made
-    end
-  end
-
-  context "when the GraphQL A/B B variant is selected" do
+  context "when the GraphQL A/B GraphQL variant is selected" do
     before do
       stub_publishing_api_graphql_query(
         Graphql::RoleQuery.new("/government/ministers/prime-minister").query,
         role_edition_data,
       )
 
-      with_variant GraphQLRoles: "B" do
-        visit "/government/ministers/prime-minister"
-      end
+      allow(Random).to receive(:rand).with(1.0).and_return(RolesController::GRAPHQL_TRAFFIC_RATE - 0.000001)
+      visit "/government/ministers/prime-minister"
     end
 
     let(:role_edition_data) do


### PR DESCRIPTION
We are currently using the GOV.UK A/B testing framework to run an A/B test for GraphQL.

This relies of users opting into analytics cookies, so we are seeing very little traffic. Especially as these pages represent very small levels of traffic in the first place.

We don't actually need cookies for this A/B test, since the changes are all behind the scenes, so users won't see any difference.

Therefore updating the GraphQL A/B testing code to assign a variant for each request, without needing any cookies.

The initial traffic rates have been selected by using the rate of traffic seen to each document type's GraphQL variant in the last 3 days.  This will be adjusted once the new A/B test is in place.

[Trello card](https://trello.com/c/GRDVWkv1)