### PR TITLE
Surround YouTube video with paragraph

### DIFF
--- a/app/views/organisations/_videos.html.erb
+++ b/app/views/organisations/_videos.html.erb
@@ -20,7 +20,9 @@
           lang: "en"
       } %>
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <a href="<%= @documents.promotional_video_feature_youtube_url %>" class="govuk-link brand__color"><%= @documents.promotional_video_feature_youtube_url %></a>
+        <p>
+          <a href="<%= @documents.promotional_video_feature_youtube_url %>" class="govuk-link brand__color"><%= @documents.promotional_video_feature_youtube_url %></a>
+        </p>
       <% end %>
     </div>
     <div class="govuk-grid-column-one-third govuk-!-margin-top-7">


### PR DESCRIPTION
## What / Why
- We noticed that on https://www.gov.uk/government/organisations/prime-ministers-office-10-downing-street the YouTube link on that page is not being enhanced into a YouTube embed
- This is because `govspeak` expects YouTube links to be wrapped in a `<p>` tag.
- Therefore this change adds that `<p>` tag in to the view.
- See the YT embed working at (accept cookies first) https://collections-pr-4121.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
- https://trello.com/c/jqxpOnFd/698-fix-bug-with-no-10-org-page-youtube-video

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
