### PR TITLE
[PP-636] Add prometheus labels for graphql reporting

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -18,7 +18,15 @@ class MinistersController < ApplicationController
 
   def load_from_graphql
     @ministers_index = Graphql::MinistersIndex.find!(request.path)
-    @ministers_index.content_item
+    if @ministers_index.content_item.nil?
+      load_from_content_store
+    else
+      @ministers_index.content_item
+    end
+  rescue GdsApi::HTTPErrorResponse
+    load_from_content_store
+  rescue GdsApi::TimedOutException
+    load_from_content_store
   end
 
   def load_from_content_store

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -1,4 +1,6 @@
 class RolesController < ApplicationController
+  include PrometheusSupport
+
   around_action :switch_locale
 
   GRAPHQL_TRAFFIC_RATE = 0.02207862 # This is a decimal version of a percentage, so can be between 0 and 1
@@ -19,13 +21,16 @@ class RolesController < ApplicationController
   def load_from_graphql
     @role = Graphql::Role.find!(request.path)
     if @role.content_item.nil?
+      set_prometheus_labels("graphql_contains_errors" => true)
       load_from_content_store
     else
       @role.content_item
     end
   rescue GdsApi::HTTPErrorResponse => e
+    set_prometheus_labels("graphql_status_code" => e.code)
     load_from_content_store
   rescue GdsApi::TimedOutException
+    set_prometheus_labels("graphql_api_timeout" => true)
     load_from_content_store
   end
 

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -18,7 +18,15 @@ class RolesController < ApplicationController
 
   def load_from_graphql
     @role = Graphql::Role.find!(request.path)
-    @role.content_item
+    if @role.content_item.nil?
+      load_from_content_store
+    else
+      @role.content_item
+    end
+  rescue GdsApi::HTTPErrorResponse => e
+    load_from_content_store
+  rescue GdsApi::TimedOutException
+    load_from_content_store
   end
 
   def load_from_content_store

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -15,7 +15,15 @@ class WorldController < ApplicationController
 
   def load_from_graphql
     @world_index = Graphql::WorldIndex.find!(request.path)
-    @world_index.content_item
+    if @world_index.content_item.nil?
+      load_from_content_store
+    else
+      @world_index.content_item
+    end
+  rescue GdsApi::HTTPErrorResponse
+    load_from_content_store
+  rescue GdsApi::TimedOutException
+    load_from_content_store
   end
 
   def load_from_content_store

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,4 +1,6 @@
 class WorldController < ApplicationController
+  include PrometheusSupport
+
   GRAPHQL_TRAFFIC_RATE = 0.07404692 # This is a decimal version of a percentage, so can be between 0 and 1
   def index
     content_item_data = if params[:graphql] == "false"
@@ -16,13 +18,16 @@ class WorldController < ApplicationController
   def load_from_graphql
     @world_index = Graphql::WorldIndex.find!(request.path)
     if @world_index.content_item.nil?
+      set_prometheus_labels("graphql_contains_errors" => true)
       load_from_content_store
     else
       @world_index.content_item
     end
-  rescue GdsApi::HTTPErrorResponse
+  rescue GdsApi::HTTPErrorResponse => e
+    set_prometheus_labels("graphql_status_code" => e.code)
     load_from_content_store
   rescue GdsApi::TimedOutException
+    set_prometheus_labels("graphql_api_timeout" => true)
     load_from_content_store
   end
 

--- a/app/lib/prometheus_support.rb
+++ b/app/lib/prometheus_support.rb
@@ -1,0 +1,9 @@
+module PrometheusSupport
+  def set_prometheus_labels(hash)
+    return unless hash
+
+    prometheus_labels = request.env.fetch("govuk.prometheus_labels", {})
+
+    request.env["govuk.prometheus_labels"] = prometheus_labels.merge(hash)
+  end
+end

--- a/spec/controllers/ministers_controller_spec.rb
+++ b/spec/controllers/ministers_controller_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe MinistersController do
+  def ministers
+    GovukSchemas::Example.find("ministers_index", example_name: "ministers_index-reshuffle-mode-off")
+  end
+
+  let(:base_path) { ministers["base_path"] }
+
+  describe "index" do
+    context "the request is for content store" do
+      before do
+        stub_content_store_has_item(base_path, ministers)
+      end
+
+      it "when the content item exists" do
+        get :index, params: { graphql: false }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context "the request is for graphql" do
+      context "and the graphql query is successful" do
+        before do
+          stub_publishing_api_graphql_query(
+            Graphql::MinistersIndexQuery.new("/government/ministers").query,
+            edition_data,
+          )
+        end
+
+        let(:edition_data) do
+          fetch_graphql_fixture("ministers_index-reshuffle-mode-off")
+        end
+
+        it "the request is successful" do
+          get :index, params: { graphql: true }
+
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template(:index)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/ministers_controller_spec.rb
+++ b/spec/controllers/ministers_controller_spec.rb
@@ -39,6 +39,50 @@ RSpec.describe MinistersController do
           expect(response).to render_template(:index)
         end
       end
+
+      context "and the graphql query is not successful" do
+        before do
+          stub_publishing_api_graphql_query(
+            Graphql::MinistersIndexQuery.new("/government/ministers").query,
+            { "errors": [{ "message": "some_error" }] },
+          )
+          stub_content_store_has_item(base_path, ministers)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :index, params: { graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "and publishing-api returns an error status code" do
+        before do
+          stub_any_publishing_api_call_to_return_not_found
+          stub_content_store_has_item(base_path, ministers)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :index, params: { graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "and GDS API Adapters times-out the request" do
+        before do
+          allow(Services.publishing_api).to receive(:graphql_query)
+            .and_raise(GdsApi::TimedOutException)
+
+          stub_content_store_has_item(base_path, ministers)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :index, params: { graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/ministers_controller_spec.rb
+++ b/spec/controllers/ministers_controller_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe MinistersController do
 
           expect(response).to have_http_status(:success)
         end
+
+        it "pushes the errors to prometheus when the response contains some" do
+          get :index, params: { graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_contains_errors"]).to be(true)
+        end
       end
 
       context "and publishing-api returns an error status code" do
@@ -66,6 +72,12 @@ RSpec.describe MinistersController do
           get :index, params: { graphql: true }
 
           expect(response).to have_http_status(:success)
+        end
+
+        it "pushes the status codes to prometheus" do
+          get :index, params: { graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_status_code"]).to eq(404)
         end
       end
 
@@ -81,6 +93,12 @@ RSpec.describe MinistersController do
           get :index, params: { graphql: true }
 
           expect(response).to have_http_status(:success)
+        end
+
+        it "pushes the errors to prometheus" do
+          get :index, params: { graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_api_timeout"]).to be(true)
         end
       end
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -9,21 +9,89 @@ RSpec.describe RolesController do
   let(:role) { base_path.split("/").last }
 
   describe "GET show" do
-    before do
-      stub_content_store_has_item(base_path, prime_minister)
-      stub_content_store_does_not_have_item("/government/ministers/she-ra")
-      stub_minister_announcements(role)
+    context "the request is for content store" do
+      before do
+        stub_content_store_has_item(base_path, prime_minister)
+        stub_content_store_does_not_have_item("/government/ministers/she-ra")
+        stub_minister_announcements(role)
+      end
+
+      it "when the content item exists" do
+        get :show, params: { name: role }
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:show)
+      end
+
+      it "when there is no content item" do
+        get :show, params: { name: "she-ra" }
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
-    it "when the content item exists" do
-      get :show, params: { name: role }
-      expect(response).to have_http_status(:success)
-      expect(response).to render_template(:show)
-    end
+    context "when the request is for graphql" do
+      context "and the graphql query is successful" do
+        before do
+          stub_publishing_api_graphql_query(
+            Graphql::RoleQuery.new("/government/ministers/prime-minister").query,
+            role_edition_data,
+          )
+        end
 
-    it "when there is no content item" do
-      get :show, params: { name: "she-ra" }
-      expect(response).to have_http_status(:not_found)
+        let(:role_edition_data) do
+          fetch_graphql_fixture("prime_minister")
+        end
+
+        it "the request is successful" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template(:show)
+        end
+      end
+
+      context "and the graphql query is not successful" do
+        before do
+          stub_publishing_api_graphql_query(
+            Graphql::RoleQuery.new("/government/ministers/prime-minister").query,
+            { "errors": [{ "message": "some_error" }] },
+          )
+          stub_content_store_has_item(base_path, prime_minister)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "and publishing-api returns an error status code" do
+        before do
+          stub_any_publishing_api_call_to_return_not_found
+          stub_content_store_has_item(base_path, prime_minister)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      context "and GDS API Adapters times-out the request" do
+        before do
+          allow(Services.publishing_api).to receive(:graphql_query)
+            .and_raise(GdsApi::TimedOutException)
+
+          stub_content_store_has_item(base_path, prime_minister)
+        end
+
+        it "falls back to loading from Content Store" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(response).to have_http_status(:success)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe RolesController do
 
           expect(response).to have_http_status(:success)
         end
+
+        it "pushes the errors to prometheus when the response contains some" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_contains_errors"]).to be(true)
+        end
       end
 
       context "and publishing-api returns an error status code" do
@@ -75,6 +81,12 @@ RSpec.describe RolesController do
           get :show, params: { name: role, graphql: true }
 
           expect(response).to have_http_status(:success)
+        end
+
+        it "pushes the status codes to prometheus" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_status_code"]).to eq(404)
         end
       end
 
@@ -90,6 +102,12 @@ RSpec.describe RolesController do
           get :show, params: { name: role, graphql: true }
 
           expect(response).to have_http_status(:success)
+        end
+
+        it "pushes the errors to prometheus" do
+          get :show, params: { name: role, graphql: true }
+
+          expect(request.env["govuk.prometheus_labels"]["graphql_api_timeout"]).to be(true)
         end
       end
     end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe RolesController do
       end
 
       it "when the content item exists" do
-        get :show, params: { name: role }
+        get :show, params: { name: role, graphql: false }
         expect(response).to have_http_status(:success)
         expect(response).to render_template(:show)
       end
 
       it "when there is no content item" do
-        get :show, params: { name: "she-ra" }
+        get :show, params: { name: "she-ra", graphql: false }
         expect(response).to have_http_status(:not_found)
       end
     end

--- a/spec/controllers/world_controller_spec.rb
+++ b/spec/controllers/world_controller_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe WorldController do
 
         expect(response).to have_http_status(:success)
       end
+
+      it "pushes the errors to prometheus when the response contains some" do
+        get :index, params: { graphql: true }
+
+        expect(request.env["govuk.prometheus_labels"]["graphql_contains_errors"]).to be(true)
+      end
     end
 
     context "and publishing-api returns an error status code" do
@@ -67,6 +73,12 @@ RSpec.describe WorldController do
         get :index, params: { graphql: true }
 
         expect(response).to have_http_status(:success)
+      end
+
+      it "pushes the status codes to prometheus" do
+        get :index, params: { graphql: true }
+
+        expect(request.env["govuk.prometheus_labels"]["graphql_status_code"]).to eq(404)
       end
     end
 
@@ -82,6 +94,12 @@ RSpec.describe WorldController do
         get :index, params: { graphql: true }
 
         expect(response).to have_http_status(:success)
+      end
+
+      it "pushes the errors to prometheus" do
+        get :index, params: { graphql: true }
+
+        expect(request.env["govuk.prometheus_labels"]["graphql_api_timeout"]).to be(true)
       end
     end
   end

--- a/spec/controllers/world_controller_spec.rb
+++ b/spec/controllers/world_controller_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe WorldController do
+  def world
+    GovukSchemas::Example.find("world_index", example_name: "world_index")
+  end
+
+  let(:base_path) { world["base_path"] }
+
+  describe "GET index" do
+    context "the request is for content store" do
+      before do
+        stub_content_store_has_item(base_path, world)
+      end
+
+      it "successfully renders the page" do
+        get :index, params: { graphql: false }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+
+  context "the request is for graphql" do
+    context "and the graphql query is successful" do
+      before do
+        stub_publishing_api_graphql_query(
+          Graphql::WorldIndexQuery.new("/world").query,
+          edition_data,
+        )
+      end
+
+      let(:edition_data) do
+        fetch_graphql_fixture("world_index")
+      end
+
+      it "the request is successful" do
+        get :index, params: { graphql: true }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of the graphql testing work, publishing-platform team have decided it would be helpful to directly monitor error rates across different applications rendering graphql content. 

This PR adds direct monitoring for graphql query errors, any http error codes generated from trying to query the graphql endpoint, and Api timeouts when trying to do those queries. Instances of these are then pushed to prometheus under appropriate labels, where they can then be monitored in grafana.

Equivalent PR for frontend: https://github.com/alphagov/frontend/pull/4851

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
