### PR TITLE
[PP-7232] Increase GraphQL traffic rates

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -3,7 +3,7 @@ class MinistersController < ApplicationController
 
   around_action :switch_locale
 
-  GRAPHQL_TRAFFIC_RATE = 0.04094748 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
 
   def index
     content_item_data = if params[:graphql] == "false"

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -3,7 +3,7 @@ class RolesController < ApplicationController
 
   around_action :switch_locale
 
-  GRAPHQL_TRAFFIC_RATE = 0.02207862 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = 0.15 # This is a decimal version of a percentage, so can be between 0 and 1
 
   def show
     content_item_data = if params[:graphql] == "false"

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,7 +1,7 @@
 class WorldController < ApplicationController
   include PrometheusSupport
 
-  GRAPHQL_TRAFFIC_RATE = 0.07404692 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
   def index
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store


### PR DESCRIPTION
This increases the rate of traffic to the GraphQL rendered version of the ministers index and world index page to 50%, and the roles to 15%.

In later work, we may consider moving this configuration to environment variables.