### PR TITLE
[PP-7232] Increase GraphQL traffic level for roles

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -3,7 +3,7 @@ class RolesController < ApplicationController
 
   around_action :switch_locale
 
-  GRAPHQL_TRAFFIC_RATE = 0.15 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
 
   def show
     content_item_data = if params[:graphql] == "false"


### PR DESCRIPTION
We have been serving 15% of traffic to roles pages using GraphQL for the last 3 hours. There has been no noticeable reduction in performance compared to the previous level.

Therefore increasing the level of traffic served by GraphQL to 50%, to match the Ministers Index and World Index pages.