### PR TITLE
Fix past prime ministers bug

### DIFF
--- a/app/presenters/past_prime_ministers_index_presenter.rb
+++ b/app/presenters/past_prime_ministers_index_presenter.rb
@@ -40,8 +40,13 @@ private
   end
 
   def sorted_prime_ministers_with_start_dates(past_prime_ministers)
-    past_prime_ministers.map { |pm_data| [pm_data, earliest_start_date(dates_data(pm_data))] }
-                        .sort_by { |_data, earliest_start_date| -earliest_start_date }
+    past_prime_ministers.map { |pm_data|
+      [
+        pm_data,
+        earliest_start_date(dates_data(pm_data)),
+        earliest_end_date(dates_data(pm_data)),
+      ]
+    }.sort_by { |_data, earliest_start_date, earliest_end_date| [-earliest_start_date, -earliest_end_date] }
   end
 
   def dates_data(prime_minister)
@@ -50,5 +55,9 @@ private
 
   def earliest_start_date(dates_in_office_object)
     dates_in_office_object.map { |date_in_office| date_in_office["start_year"] }.max
+  end
+
+  def earliest_end_date(dates_in_office_object)
+    dates_in_office_object.map { |date_in_office| date_in_office["end_year"] }.max
   end
 end

--- a/app/presenters/past_prime_ministers_index_presenter.rb
+++ b/app/presenters/past_prime_ministers_index_presenter.rb
@@ -5,9 +5,9 @@ class PastPrimeMinistersIndexPresenter
 
   def featured_profile_groups
     {
-      "21st_century" => prime_minsters_between(2001, 2099),
-      "20th_century" => prime_minsters_between(1901, 2000),
-      "18th_and_19th_centuries" => prime_minsters_between(1701, 1900),
+      "21st_century" => prime_ministers_between(2001, 2099),
+      "20th_century" => prime_ministers_between(1901, 2000),
+      "18th_and_19th_centuries" => prime_ministers_between(1701, 1900),
     }
   end
 
@@ -15,7 +15,7 @@ class PastPrimeMinistersIndexPresenter
     {}
   end
 
-  def prime_minsters_between(start_date, end_date)
+  def prime_ministers_between(start_date, end_date)
     @sorted_prime_ministers_with_start_dates.filter_map do |data, earliest_start_date|
       formatted_data(data) if earliest_start_date.between?(start_date, end_date)
     end

--- a/spec/presenters/past_prime_ministers_index_presenter_spec.rb
+++ b/spec/presenters/past_prime_ministers_index_presenter_spec.rb
@@ -68,6 +68,30 @@ RSpec.describe PastPrimeMinistersIndexPresenter do
         expect(actual_pm_names).to eq expected_pm_names
       end
     end
+
+    context "it can order prime ministers with the same start years" do
+      it "can do a fallback sort to end year" do
+        pm_one = {
+          "title" => "The Rt Honourable Mr E",
+          "image" => {
+            "url" => "The Rt Honourable Mr E",
+            "alt_text" => "The Rt Honourable Mr E",
+          },
+          "dates_in_office" => [{ "start_year" => 2002, "end_year" => 2002 }],
+        }
+        pm_two = {
+          "title" => "The Rt Honourable Mrs F",
+          "image" => {
+            "url" => "The Rt Honourable Mrs F",
+            "alt_text" => "The Rt Honourable Mrs F",
+          },
+          "dates_in_office" => [{ "start_year" => 2002, "end_year" => 2004 }],
+        }
+        presenter = PastPrimeMinistersIndexPresenter.new([pm_one, pm_two])
+        actual_order = presenter.prime_minsters_between(2000, 2025).map { |pm| pm[:heading_text] }
+        expect(actual_order).to eq ["The Rt Honourable Mrs F", "The Rt Honourable Mr E"]
+      end
+    end
   end
 
   describe "formatted_data" do

--- a/spec/presenters/past_prime_ministers_index_presenter_spec.rb
+++ b/spec/presenters/past_prime_ministers_index_presenter_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe PastPrimeMinistersIndexPresenter do
       }
 
       date_ranges_to_expected_pms.each do |date_range, expected_pms|
-        actual_pm_names = presenter.prime_minsters_between(date_range.first, date_range.second).map { |pm| pm[:heading_text] }
+        actual_pm_names = presenter.prime_ministers_between(date_range.first, date_range.second).map { |pm| pm[:heading_text] }
         expected_pm_names = expected_pms.map { |pm| pm[:name] }
         expect(actual_pm_names).to eq expected_pm_names
       end
@@ -88,7 +88,7 @@ RSpec.describe PastPrimeMinistersIndexPresenter do
           "dates_in_office" => [{ "start_year" => 2002, "end_year" => 2004 }],
         }
         presenter = PastPrimeMinistersIndexPresenter.new([pm_one, pm_two])
-        actual_order = presenter.prime_minsters_between(2000, 2025).map { |pm| pm[:heading_text] }
+        actual_order = presenter.prime_ministers_between(2000, 2025).map { |pm| pm[:heading_text] }
         expect(actual_order).to eq ["The Rt Honourable Mrs F", "The Rt Honourable Mr E"]
       end
     end


### PR DESCRIPTION
The past prime ministers page was not sorting correctly. When two prime ministers had the same start_year it would default to alphabetical sorting. 

This PR adds a fallback sort using end_year so that the person who served most recently is returned last.

| Before | After |
|--------|--------|
| <img width="1000" alt="image" src="https://github.com/user-attachments/assets/0f65f61c-3e7c-46ca-9c2a-3456075d6e36" /> | <img width="1023" alt="image" src="https://github.com/user-attachments/assets/e786b1ab-250b-4364-a539-c5868999147a" /> | 

Trello card: https://trello.com/c/YgvtwvpJ/3536-past-prime-ministers-in-wrong-order