### PR TITLE
Remove the yellow bar from the COVID-19 homepage

### DIFF
--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -1,7 +1,6 @@
 @import "govuk_publishing_components/individual_component_support";
 
 $covid-grey: #272828;
-$covid-yellow: #fff500;
 $c19-landing-page-header-background: govuk-colour("blue");
 
 .covid__page {


### PR DESCRIPTION
Remove the yellow bar from the covid homepage, to align the page with the new colour palette. This was confirmed by our designer.

I did a quick bit of testing on different viewports and mobile devices and browsers, to confirm that removing the bar doesn't cause any layout issues.

Remove also the covid yellow variable as it no longer gets used anywhere in the app.

## Before

<img width="772" height="490" alt="Screenshot 2025-07-22 at 17 50 40" src="https://github.com/user-attachments/assets/8a35c5a6-b752-45fe-a255-d8bbe930c00e" />

## After


<img width="772" height="516" alt="Screenshot 2025-07-23 at 09 45 31" src="https://github.com/user-attachments/assets/eee5d8f4-992c-4c79-855d-6db1a1bfe06b" />

Fixes https://trello.com/c/DoXkYxwa/3584-remove-support-for-coronavirus-yellow-from-coronavirus-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
