### PR TITLE
Add role to person announcement metadata

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -53,7 +53,7 @@ class Person
   end
 
   def announcements
-    @announcements ||= AnnouncementsPresenter.new(slug, filter_key: "people")
+    @announcements ||= AnnouncementsPresenter.new(slug, filter_key: "people", roles: current_roles.map { |role| role["base_path"] })
   end
 
   def translations

--- a/app/presenters/announcements_presenter.rb
+++ b/app/presenters/announcements_presenter.rb
@@ -1,14 +1,18 @@
 class AnnouncementsPresenter
   attr_reader :slug, :slug_prefix, :filter_key
 
-  def initialize(slug, filter_key:, slug_prefix: nil)
+  def initialize(slug, filter_key:, slug_prefix: nil, roles: [])
     @slug = slug
     @slug_prefix = slug_prefix || filter_key
     @filter_key = filter_key
+    @roles = roles
+    puts roles
   end
 
   def items
     announcements.map do |announcement|
+      role = announcement["roles"].filter {|role| @roles.include?(role["link"]) }.map{ |role| role["title"] }.first
+
       {
         link: {
           text: announcement["title"],
@@ -17,6 +21,7 @@ class AnnouncementsPresenter
         metadata: {
           public_timestamp: Date.parse(announcement["public_timestamp"]).strftime("%d %B %Y"),
           content_store_document_type: announcement["content_store_document_type"].humanize,
+          role:
         },
       }
     end
@@ -41,7 +46,7 @@ private
       count: 10,
       order: "-public_timestamp",
       reject_content_purpose_supergroup: "other",
-      fields: %w[title link content_store_document_type public_timestamp],
+      fields: %w[title link content_store_document_type public_timestamp roles],
     }.tap do |hash|
       hash[:"filter_#{filter_key}"] = slug_without_locale
     end


### PR DESCRIPTION
This is a quick spike to be discarded

Check out the extra metadata on ministers' person pages, eg
- https://collections-pr-4159.herokuapp.com/government/people/keir-starmer
- https://collections-pr-4159.herokuapp.com/government/people/angela-rayner

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
