### PR TITLE
Silence sass compilation @import warnings

### DIFF
--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -15,3 +15,4 @@ all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_st
 Rails.application.config.dartsass.builds = all_stylesheets
 
 Rails.application.config.dartsass.build_options << " --quiet-deps"
+Rails.application.config.dartsass.build_options << " --silence-deprecation=import"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Silence Sass compilation warnings for use of `@import`, which has been deprecated. See https://github.com/alphagov/govuk_publishing_components/issues/4864 for more details.

## Why
We're currently seeing a lot of compilation warnings for `@import`, which is drowning out other warnings and filling up log files.

## Visual changes
None.

Trello card: https://trello.com/c/8vKVSmVz/764-switch-from-import-to-use-in-sass-compilation