### PR TITLE
Translation nav header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 // for components and views on pages where they are needed.
 
 // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md
+@import "helpers/header";

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -1,0 +1,15 @@
+@import "govuk_publishing_components/individual_component_support";
+
+.translation-nav-header {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    align-items: end;
+    margin-bottom: govuk-spacing(8);
+  }
+}
+
+.translation-nav-header__child {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(6);
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
+  <%= stylesheet_link_tag "application.css", :media => "all", integrity: false %>
   <%=
     render_component_stylesheets
   %>

--- a/app/views/people/_header.html.erb
+++ b/app/views/people/_header.html.erb
@@ -1,20 +1,22 @@
 <% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %>
 
-<header class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<header class="govuk-grid-row translation-nav-header">
+  <div class="govuk-grid-column-two-thirds translation-nav-header__child">
     <%= render "govuk_publishing_components/components/heading", {
       context: person.current_roles_title,
       text: person.title,
       heading_level: 1,
-      margin_bottom: 8,
+      margin_bottom: 0,
       font_size: "xl",
       dir: page_text_direction
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+  <div class="govuk-grid-column-one-third translation-nav-header__child <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
     <%= render "govuk_publishing_components/components/translation_nav", {
-      translations: person.translations
+      translations: person.translations,
+      no_margin_top: true,
+      margin_bottom: 0
     } %>
   </div>
 </header>

--- a/app/views/roles/_header.html.erb
+++ b/app/views/roles/_header.html.erb
@@ -1,20 +1,22 @@
 <% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %>
 
-<header class="govuk-grid-row <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
-  <div class="govuk-grid-column-two-thirds">
+<header class="govuk-grid-row translation-nav-header <%= direction_rtl_class %>" <%= dir_attribute %> <%= lang_attribute %>>
+  <div class="govuk-grid-column-two-thirds translation-nav-header__child">
     <%= render "govuk_publishing_components/components/heading", {
       context: t("roles.ministerial"),
       context_locale: t_fallback("roles.ministerial"),
       text: role.title,
       heading_level: 1,
-      margin_bottom: 8,
+      margin_bottom: 0,
       font_size: "xl",
     } %>
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third translation-nav-header__child">
     <%= render "govuk_publishing_components/components/translation_nav", {
-      translations: role.translations
+      translations: role.translations,
+      no_margin_top: true,
+      margin_bottom: 0
     } %>
   </div>
 </header>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,4 +1,6 @@
 APP_STYLESHEETS = {
+  "application.scss" => "application.css",
+  "helpers/_header.scss" => "helpers/_header.css",
   "views/_browse.scss" => "views/_browse.css",
   "views/_bunting.scss" => "views/_bunting.css",
   "views/_covid.scss" => "views/_covid.css",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the appearance of the people and role pages to align the translation nav better with the page heading.

## Why
The translation nav component has a default top margin, which I'm trying to remove. The component is used in other places in `collections` but in those places the `no_margin_top` option is applied to remove that margin, so they're not relevant. Currently the translation nav looks like it's supposed to appear vertically aligned to the middle of the heading, which is sort of the case for most pages, however on extreme examples this doesn't quite work. In conversation with @nnagewad decided that flexbox align to the bottom was the way to go to make all of these pages more consistent.

## Visual changes
The translation nav appears to the right of the H1 on these pages. Changes apply only to desktop and tablet, mobile should look as before.

People pages (e.g. https://www.gov.uk/government/people/dame-nia-griffith)

Before | After
------ | -----
<img width="1081" height="546" alt="Screenshot 2025-08-11 at 12 51 05" src="https://github.com/user-attachments/assets/f0803dd0-e4cc-4b20-a3e5-40be50eeaafc" /> | <img width="1085" height="543" alt="Screenshot 2025-08-11 at 12 51 21" src="https://github.com/user-attachments/assets/a9c4fc8f-1079-45f7-8fb7-95e77962e847" />


Role pages (e.g. https://www.gov.uk/government/ministers/secretary-of-state-for-wales)

Before | After
------ | -----
<img width="1078" height="550" alt="Screenshot 2025-08-11 at 12 54 01" src="https://github.com/user-attachments/assets/d166bf1d-94a9-4959-8f92-2d21d335ca35" /> | <img width="1079" height="551" alt="Screenshot 2025-08-11 at 12 54 11" src="https://github.com/user-attachments/assets/9256ed27-8c32-4a7f-b739-56c142b321f0" />
