### PR TITLE
Add missing Govspeak link formatting to ministers reshuffle page

### DIFF
--- a/app/views/ministers/index.html.erb
+++ b/app/views/ministers/index.html.erb
@@ -1,4 +1,5 @@
 <% add_view_stylesheet("ministers") %>
+<% add_gem_component_stylesheet("govspeak") if @presented_ministers.is_during_reshuffle? %>
 
 <% content_for :title, t("ministers.govuk_title") %>
 


### PR DESCRIPTION
## What

Add missing Govspeak link formatting to ministers reshuffle page

## Why

Links are not formatted correctly.

## Visual changes

### Before

<img width="2360" height="1640" alt="127 0 0 1_3070_government_ministers(iPad Air)" src="https://github.com/user-attachments/assets/d0696c87-85f2-42cb-835d-6e13df810807" />

### After

<img width="2360" height="1640" alt="127 0 0 1_3070_government_ministers(iPad Air) (1)" src="https://github.com/user-attachments/assets/ec57ff43-9bf8-4336-91c0-b37bd437b747" />