### PR TITLE
Adjust position of translation nav header

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -2,8 +2,6 @@
 
 .translation-nav-header {
   @include govuk-media-query($from: tablet) {
-    display: flex;
-    align-items: end;
     margin-bottom: govuk-spacing(8);
   }
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
- slight adjustment to the work done in https://github.com/alphagov/collections/pull/4182
- allow the translation nav to sit at the top, rather than the bottom
- some examples where the number of translations is high, previously resulting in the page title being pushed down
- removing flexbox entirely as not needed now

Making consistent with frontend: https://github.com/alphagov/frontend/pull/5011

## Visual changes
Header and translation nav now start at the top of the screen. No change on mobile.

Before | After
------ | ------
<img width="1077" height="636" alt="Screenshot 2025-09-18 at 14 26 15" src="https://github.com/user-attachments/assets/7725c9f9-2edf-455a-9d39-6d14b9514ad1" /> | <img width="1087" height="639" alt="Screenshot 2025-09-18 at 14 26 29" src="https://github.com/user-attachments/assets/bdfc120f-916c-499a-8da0-8a1efcec3b7f" />
