### PR TITLE
Fix template error in organisations (header) page

### DIFF
--- a/app/presenters/organisations/show_presenter.rb
+++ b/app/presenters/organisations/show_presenter.rb
@@ -30,7 +30,10 @@ module Organisations
     end
 
     def parent_organisations
-      parent_org_links = @org.ordered_parent_organisations.map do |parent_organisation|
+      parent_orgs = @org.ordered_parent_organisations
+      return if parent_orgs.blank?
+
+      parent_org_links = parent_orgs.map do |parent_organisation|
         link_to(
           parent_organisation["title"],
           parent_organisation["base_path"],


### PR DESCRIPTION
## What

Fix template error on Organisation page header when `ordered_parent_organisations` is missing.

See: https://govuk.sentry.io/issues/6896645898/?project=202213&query=is%3Aunresolved&referrer=issue-stream.

https://gov-uk.atlassian.net/browse/NAV-18523

**Review URL**: https://collections-pr-4224.herokuapp.com/government/organisations/pension-compensation-and-welfare-support-for-armed-forces-and-veterans

## Why

When `ordered_parent_organisations` is not present, a template error occurs. This causes the mirrored version of the page to load, displaying the old pre-brand refresh branding.

## Visual changes

### Before

<img width="2732" height="2048" alt="www gov uk_government_organisations_pension-compensation-and-welfare-support-for-armed-forces-and-veterans(iPad Pro) (1)" src="https://github.com/user-attachments/assets/267f985f-9fd1-4068-a36f-ad6cdbda77e2" />

<img width="2732" height="2048" alt="127 0 0 1_3070_government_organisations_pension-compensation-and-welfare-support-for-armed-forces-and-veterans(iPad Pro) (1)" src="https://github.com/user-attachments/assets/40debe23-da67-4872-a9db-1074dc78bd2a" />

### After

<img width="2732" height="2048" alt="127 0 0 1_3070_government_organisations_pension-compensation-and-welfare-support-for-armed-forces-and-veterans(iPad Pro)" src="https://github.com/user-attachments/assets/92d72766-e648-405f-a7df-a433dea165b9" />