### PR TITLE
Revert "Order executive offices with 'Number 10' first"

### DIFF
--- a/app/presenters/organisations/index_presenter.rb
+++ b/app/presenters/organisations/index_presenter.rb
@@ -40,9 +40,7 @@ module Organisations
 
     def all_organisations
       {
-        number_10: ordered_executive_offices(
-          @organisations.number_10,
-        ),
+        number_10: @organisations.number_10,
         ministerial_departments: reject_joining_organisations(
           @organisations.ministerial_departments,
         ),
@@ -72,12 +70,6 @@ module Organisations
       non_joining_works_with_categorised_links(organisation, @organisations.by_href)
         .to_a
         .sort_by { |type, _departments| LISTING_ORDER.index(type) || 999 }
-    end
-
-    def ordered_executive_offices(organisations)
-      organisations.sort_by do |org|
-        org["slug"] == "prime-ministers-office-10-downing-street" ? [0, org["slug"]] : [1, org["slug"]]
-      end
     end
 
     def works_with_statement(organisation)


### PR DESCRIPTION
Reverts alphagov/collections#4144
Changes to support displaying additional executive offices are no longer needed.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18522