### PR TITLE
Add mechanism for iOS banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,4 +79,14 @@ module ApplicationHelper
                 end
     elements.join(separator)
   end
+
+  def show_ios_banner?
+    return unless request.path
+
+    [
+      "/learn-to-drive-a-car",
+      "/drive-abroad",
+      "/buy-a-vehicle",
+    ].include?(request.path)
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,9 @@
   <%= javascript_include_tag "application", type: "module" %>
   <%= csrf_meta_tags %>
   <%= yield :meta_tags %>
+  <% if show_ios_banner? %>
+    <meta name="apple-itunes-app" content="app-id=6572293285">
+  <% end %>
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
   <%= stylesheet_link_tag "application.css", :media => "all", integrity: false %>
   <%=

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -140,4 +140,21 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "iOS banner" do
+    it "shows the banner when the page is in the list" do
+      controller.request = ActionDispatch::TestRequest.create("PATH_INFO" => "/learn-to-drive-a-car")
+      expect(helper.show_ios_banner?).to be(true)
+    end
+
+    it "does not show the banner when the page is not in the list" do
+      controller.request = ActionDispatch::TestRequest.create("PATH_INFO" => "/parking-permits-in-london")
+      expect(helper.show_ios_banner?).to be(false)
+    end
+
+    it "does not show the banner when the page does not have a base path" do
+      controller.request = ActionDispatch::TestRequest.create("PATH_INFO" => nil)
+      expect(helper.show_ios_banner?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enable iOS banners for the GOV.UK app on certain pages. Adds a helper method to return true if the current page matches any of the agreed list of pages where an iOS banner should appear.

## Why

## Visual changes
Banner should appear on chosen pages in Safari on iOS in the top of the browser window.

https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9617
