### PR TITLE
[IA-1793] Fix GA4 organisation logo typo

### DIFF
--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -201,7 +201,7 @@
             data_attributes: {
               ga4_link: {
                 event_name: "navigation",
-                type: "organisation_logo",
+                type: "organisation logo",
                 index_link: index + 1,
                 index_total: ga4_organisations_length,
                 section: ga4_organisations_section,

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -161,7 +161,7 @@
                   data_attributes: {
                     ga4_link: {
                       event_name: "navigation",
-                      type: "organisation_logo",
+                      type: "organisation logo",
                       index_link: index + 1,
                       index_total: ga4_organisations_length,
                       section: ga4_organisations_section,

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -214,7 +214,7 @@ RSpec.feature "Topical Event pages" do
       visit base_path
       within(".govuk-list[data-module='ga4-link-tracker']") do
         ga4_link_data = JSON.parse(page.first("div[data-ga4-link]")["data-ga4-link"])
-        expect(ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation_logo", "index_link" => 1, "index_total" => 1, "section" => "Who’s involved" })
+        expect(ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation logo", "index_link" => 1, "index_total" => 1, "section" => "Who’s involved" })
       end
     end
   end

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -268,10 +268,10 @@ RSpec.feature "World Location News pages" do
       visit base_path
       within("#organisations[data-module='ga4-link-tracker']") do
         first_ga4_link_data = JSON.parse(page.all("div[data-ga4-link]").first["data-ga4-link"])
-        expect(first_ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation_logo", "index_link" => 1, "index_total" => 2, "section" => "Who’s involved" })
+        expect(first_ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation logo", "index_link" => 1, "index_total" => 2, "section" => "Who’s involved" })
 
         second_ga4_link_data = JSON.parse(page.all("div[data-ga4-link]").last["data-ga4-link"])
-        expect(second_ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation_logo", "index_link" => 2, "index_total" => 2, "section" => "Who’s involved" })
+        expect(second_ga4_link_data).to eq({ "event_name" => "navigation", "type" => "organisation logo", "index_link" => 2, "index_total" => 2, "section" => "Who’s involved" })
       end
     end
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What/Why
- Rename GA4 `organisation_logo` references to `organisation logo`
- This was a mistake I introduced in the initial PR for this tracking

Jira card: https://gov-uk.atlassian.net/browse/IA-1793

## Visual changes

None.