### PR TITLE
Add David Lammy as past Foreign Secretary

### DIFF
--- a/config/past_foreign_secretaries/content_item.yml
+++ b/config/past_foreign_secretaries/content_item.yml
@@ -4,6 +4,9 @@ title: Past Foreign Secretaries
 body:
   centuries:
     21st_century:
+      - name: David Lammy
+        service:
+          - 2024 to 2025
       - name: Lord Cameron
         service:
           - 2023 to 2024


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

David Lammy should be added as a past Foreign Secretary, from 2024 to 2025.

Zendesk ticket https://govuk.zendesk.com/agent/tickets/6271472

