### PR TITLE
Fix layout of get emails for this topic on taxon pages

### DIFF
--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -25,7 +25,7 @@
 <% if taxon_is_live?(presented_taxon) %>
   <div class="taxon-page__email-link-wrapper">
     <div
-      class="full-page-width-wrapper"
+      class="govuk-width-container"
       data-module="ga4-link-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
       data-ga4-track-links-only


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What / why
Fix the 'get emails for this page' link layout - it's not constrained to the page width.

The class that was on this element wasn't doing anything - it's not defined anywhere.

## Visual changes

See https://www.gov.uk/education

Before | After
----- | -----
<img width="1213" height="862" alt="Screenshot 2025-11-05 at 14 05 47" src="https://github.com/user-attachments/assets/af340696-43cb-4b32-a5b9-900ac7326821" /> | <img width="1201" height="855" alt="Screenshot 2025-11-05 at 14 05 59" src="https://github.com/user-attachments/assets/815b577b-0f89-4664-abe2-2752f5985051" />

