### PR TITLE
Hide 'Part of' text if parent org doesn't exist

### DIFF
--- a/app/views/organisations/_header.html.erb
+++ b/app/views/organisations/_header.html.erb
@@ -7,7 +7,7 @@
       organisation: @header.organisation_logo
     } %>
 
-    <% if @organisation.is_sub_organisation? %>
+    <% if @organisation.is_sub_organisation? && @show.parent_organisations %>
       <div class="organisation__parent-organisations brand--<%= @organisation.brand %>">
         <%= t('organisations.part_of') %>
         <%= @show.parent_organisations %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What/Why
- Hides "Part of" text if the parent organisation doesn't exist
- The "Part of" text is showing on https://www.gov.uk/government/organisations/pension-compensation-and-welfare-support-for-armed-forces-and-veterans when there is no parent organisation
- This PR should fix that with pages with parent orgs still working e.g. https://www.gov.uk/government/organisations/office-for-health-improvement-and-disparities

## Test pages
- https://collections-pr-4277.herokuapp.com/government/organisations/pension-compensation-and-welfare-support-for-armed-forces-and-veterans
- https://collections-pr-4277.herokuapp.com/government/organisations/office-for-health-improvement-and-disparities

## Visual changes

<img width="366" height="275" alt="image" src="https://github.com/user-attachments/assets/01990eea-5e26-4ca9-8e7d-9262d565a8ab" />
<img width="366" height="275" alt="image" src="https://github.com/user-attachments/assets/92da6330-269a-49e4-99d0-382cf59aed1b" />
