### PR TITLE
Fix phone number conditional to prevent rendering empty div

### DIFF
--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -53,7 +53,7 @@
             </div>
           <% end %>
 
-          <% if contact[:phone_numbers] %>
+          <% if contact[:phone_numbers].any? %>
             <div class="organisation__margin-bottom">
               <% contact[:phone_numbers].each do |phone| %>
                 <p class="organisation__paragraph"><%= phone[:title] %></p>


### PR DESCRIPTION
## What

Fix phone number conditional to prevent rendering empty div

Review URLs:
- https://collections-pr-4297.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
- https://collections-pr-4297.herokuapp.com/government/organisations/attorney-generals-office

## Why

This change updates the logic used when checking for phone numbers on a contact. Since contact[:phone_numbers] is always truthy (even when it's an empty array) - the view was rendering an empty div whenever a contact had no phone numbers.

## Visual changes

There are no visible changes, but in DevTools you can see the empty div being rendered.

<img width="1728" height="1117" alt="Screenshot 2025-11-28 at 10 32 51" src="https://github.com/user-attachments/assets/044bc5bc-891b-4291-9ea1-89fe068ac671" />