### PR TITLE
[PP-7471] Retrieve GraphQL traffic rates from environment variables

### DIFF
--- a/app/controllers/ministers_controller.rb
+++ b/app/controllers/ministers_controller.rb
@@ -3,7 +3,7 @@ class MinistersController < ApplicationController
 
   around_action :switch_locale
 
-  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = Rails.application.config.graphql_traffic_rates.fetch("ministers_index", 0)
 
   def index
     content_item_data = if params[:graphql] == "false"

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -3,7 +3,7 @@ class RolesController < ApplicationController
 
   around_action :switch_locale
 
-  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = Rails.application.config.graphql_traffic_rates.fetch("role", 0)
 
   def show
     content_item_data = if params[:graphql] == "false"

--- a/app/controllers/topical_events_controller.rb
+++ b/app/controllers/topical_events_controller.rb
@@ -3,7 +3,7 @@ class TopicalEventsController < ApplicationController
 
   enable_request_formats show: :atom
 
-  GRAPHQL_TRAFFIC_RATE = 0.01 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = Rails.application.config.graphql_traffic_rates.fetch("topical_event", 0)
 
   def show
     if params[:graphql] == "false"

--- a/app/controllers/world_controller.rb
+++ b/app/controllers/world_controller.rb
@@ -1,7 +1,7 @@
 class WorldController < ApplicationController
   include PrometheusSupport
 
-  GRAPHQL_TRAFFIC_RATE = 0.5 # This is a decimal version of a percentage, so can be between 0 and 1
+  GRAPHQL_TRAFFIC_RATE = Rails.application.config.graphql_traffic_rates.fetch("world_index", 0)
   def index
     content_item_data = if params[:graphql] == "false"
                           load_from_content_store

--- a/config/initializers/graphql_traffic_rates.rb
+++ b/config/initializers/graphql_traffic_rates.rb
@@ -1,0 +1,4 @@
+Rails.application.config.graphql_traffic_rates = ENV
+  .select { |key, _| key.starts_with?("GRAPHQL_RATE_") }
+  .transform_keys { |key| key.sub(/^GRAPHQL_RATE_/, "").downcase }
+  .transform_values(&:to_f)

--- a/spec/initializers/graphql_traffic_rates_spec.rb
+++ b/spec/initializers/graphql_traffic_rates_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "graphql_traffic_rates initializer" do
+  let(:initializer_path) { Rails.root.join("config/initializers/graphql_traffic_rates.rb") }
+
+  around do |example|
+    ClimateControl.modify(
+      "GRAPHQL_RATE_FIRST_SCHEMA": "0.25",
+      "GRAPHQL_RATE_SECOND_SCHEMA": "0.75",
+    ) do
+      example.run
+    end
+  end
+
+  it "populates Rails.application.config.graphql_traffic_rates from ENV" do
+    load initializer_path
+
+    expect(Rails.application.config.graphql_traffic_rates).to eq(
+      {
+        "first_schema" => 0.25,
+        "second_schema" => 0.75,
+      },
+    )
+  end
+end


### PR DESCRIPTION
The rate of GraphQL traffic for each schema is currently hardcoded into the application. This means we have the same traffic rate in every environment.

Switching to use environment variables, so we can adjust traffic rates to be different across the environments.

This also makes changing the traffic levels faster, as we don't need to deploy a new version of the application.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/3838.

This mirrors the same change that was made in Frontend: https://github.com/alphagov/frontend/pull/5158.