### PR TITLE
Revert "Bump rack-utf8_sanitizer from 1.10.1 to 1.11.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -575,7 +575,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rack-utf8_sanitizer (1.11.0)
+    rack-utf8_sanitizer (1.10.1)
       rack (>= 1.0, < 4.0)
     rackup (2.2.1)
       rack (>= 3)


### PR DESCRIPTION
Reverts alphagov/collections#4306 as the version no longer exists