### PR TITLE
Make 'Tell us here' link text more descriptive

### DIFF
--- a/config/locales/en/organisations.yml
+++ b/config/locales/en/organisations.yml
@@ -47,7 +47,7 @@ en:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: See all transparency and freedom of information releases
         title: Transparency and freedom of information releases
-    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body"><a class="govuk-link" href="/contact/govuk">Tell us if there's an error or omission</a>. For official lists of non–departmental public bodies <a class="govuk-link" href="/government/collections/public-bodies">see public bodies</a>.</p>
     foi:
       contact_form: FOI contact form
       foi_exemption_html: |

--- a/config/locales/he/organisations.yml
+++ b/config/locales/he/organisations.yml
@@ -47,7 +47,7 @@ he:
           path: "/search/transparency-and-freedom-of-information-releases?organisations[]=%{organisation}&parent=%{organisation}"
           text: ראה את כל השקיפות וחופש המידע שפורסם
         title: שקיפות וחופש פרסומי מידע
-    errors_or_omissions_html: <p class="govuk-body">Errors or omissions? <a class="govuk-link" href="/contact/govuk">Tell us here</a>. לרשימות רשמיות של גופים ציבוריים שאינם מחלקתיים <a class="govuk-link" href="/government/collections/public-bodies">ראו גופים ציבורייםs</a>.</p>
+    errors_or_omissions_html: <p class="govuk-body"><a class="govuk-link" href="/contact/govuk">Tell us if there's an error or omission</a>. לרשימות רשמיות של גופים ציבוריים שאינם מחלקתיים <a class="govuk-link" href="/government/collections/public-bodies">ראו גופים ציבורייםs</a>.</p>
     foi:
       contact_form: טופס יצירת קשר של חופש מידע
       foi_exemption_html: |-


### PR DESCRIPTION
## What
Update the 'Tell us here' link text on /government/organisations to be more descriptive. This updates both the English and Hebrew locale files as those use the same copy for this section. The other locale files will need to have a translation obtained to update them.

The change has been approved by our content designer.

## Why
This fixes an issue reported by DAC where the link was not descriptive enough for users to determine its purpose or relationship to surrounding page content when navigating out of context. This means that screen reader navigating out of context would have needed to leave the link and investigate the surrounding elements / information to determine the link's destination or purpose.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18555

## Visual changes

### Before
<img width="753" height="96" alt="Screenshot 2025-12-10 at 13 34 25" src="https://github.com/user-attachments/assets/78c30e57-1e9a-4b6a-b47f-e584b5df76c7" />

### After
<img width="789" height="100" alt="Screenshot 2025-12-10 at 13 35 33" src="https://github.com/user-attachments/assets/3a5899bf-f45e-457c-bdb8-7a03b0dd7a5f" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.