### PR TITLE
Rescue InvalidUrl errors from content-store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from GdsApi::ContentStore::ItemNotFound, with: :error_404
   rescue_from GdsApi::HTTPForbidden, with: :error_403
+  rescue_from GdsApi::InvalidUrl, with: :error_404
 
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(


### PR DESCRIPTION
Collections is not catching Invalid Urls for organisation pages, for example:

https://www.gov.uk/government/organisations/parole-board/about[breakingExample results in a 503 - Service unavailable error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


Jira card: https://gov-uk.atlassian.net/browse/NAV-18599

