### PR TITLE
Ensure taxon org logos have html_safe names

### DIFF
--- a/app/presenters/taxon_organisations_presenter.rb
+++ b/app/presenters/taxon_organisations_presenter.rb
@@ -43,7 +43,7 @@ private
   def organisation_list_with_logos
     organisations_with_logos.map.with_index do |org, index|
       {
-        name: org.logo_formatted_title,
+        name: org.logo_formatted_title.html_safe,
         url: org.link,
         brand: org.brand,
         crest: org.crest,

--- a/spec/presenters/taxon_organisations_presenter_spec.rb
+++ b/spec/presenters/taxon_organisations_presenter_spec.rb
@@ -179,6 +179,27 @@ RSpec.describe TaxonOrganisationsPresenter do
       expect(taxon_organisations_presenter.promoted_organisation_list).to eq(expected)
     end
 
+    it "returns an organisation with HTML safe parsing" do
+      organisation = [
+        SearchApiOrganisation.new(
+          title: "Driver &amp; Vehicle<br/>Standards<br/>Agency",
+          content_id: "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
+          link: "/government/organisations/driver-and-vehicle-standards-agency",
+          slug: "driver-and-vehicle-standards-agency",
+          organisation_state: "live",
+          logo_formatted_title: "Driver &amp; Vehicle<br/>Standards<br/>Agency",
+          brand: "driver-and-vehicle-standards-agency",
+          crest: "single-identity",
+          logo_url: nil,
+          document_count: 89,
+        ),
+      ]
+
+      allow_any_instance_of(TaggedOrganisations).to receive(:fetch).and_return(organisation)
+
+      expect(taxon_organisations_presenter.promoted_organisation_list[:promoted_with_logos][0][:name].html_safe?).to eq(true)
+    end
+
     it "returns the organisations with and without logos as promoted content if less than 5 organisations have logos" do
       tagged_organisations = multiple_organisations_with_logo("single-identity", 3) + tagged_organisation
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What/Why

- Adds `.html_safe` to the organisation names for taxon pages
- Currently on https://www.gov.uk/transport/mots the organisation logos are rendering without the HTML being parsed
- Test pages: [heroku](https://collections-pr-4342.herokuapp.com/transport/mots) / [production](https://www.gov.uk/transport/mots)

## Visual changes

| Before | After |
|--------|--------|
|<img width="488" height="561" alt="image" src="https://github.com/user-attachments/assets/e23caf9b-f9cd-4af5-a6f1-24ec099994a8" /> | <img width="488" height="599" alt="image" src="https://github.com/user-attachments/assets/b918b16b-2efb-4f06-9be7-7467a1a1cade" /> |