### PR TITLE
Fix encoding in page titles

### DIFF
--- a/app/views/organisations/_meta.html.erb
+++ b/app/views/organisations/_meta.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, organisation.title %>
+<% content_for :title, organisation.title.html_safe %>
 
 <% content_for :meta_tags do %>
   <%= tag("meta", name: "description", content: organisation.description) if organisation.description %>

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe "Organisation pages" do
 
   it "sets the page title" do
     visit "/government/organisations/prime-ministers-office-10-downing-street"
-    expect(page).to have_title("Prime Minister&#39;s Office, 10 Downing Street - GOV.UK")
+    expect(page).to have_title("Prime Minister's Office, 10 Downing Street - GOV.UK")
 
     visit "/government/organisations/attorney-generals-office"
-    expect(page).to have_title("Attorney General&#39;s Office - GOV.UK")
+    expect(page).to have_title("Attorney General's Office - GOV.UK")
 
     visit "/government/organisations/charity-commission"
     expect(page).to have_title("Charity Commission - GOV.UK")


### PR DESCRIPTION
## What
Page titles were not being marked as html safe causing issues with the page title e.g. "Prime Minister&#39;s Office, 10 Downing Street - GOV.UK" was being displayed to users in the page tab label.

By marking the text as html_safe it unescapes the content.

Jira card: https://gov-uk.atlassian.net/browse/[CARD-ID]

## Visual changes

| Before | After |
|--------|--------|
| <img width="250" height="56" alt="image" src="https://github.com/user-attachments/assets/d680405a-2c90-4612-8f5c-d43a438fbb3d" /> | <img width="231" height="47" alt="image" src="https://github.com/user-attachments/assets/b1e62713-3bb8-464d-8f46-70e80b72643d" /> | 
