### PR TITLE
Add support for recruitment banners on step nav pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,9 @@
           <%= render 'breadcrumbs' %>
         <% end %>
       <% end %>
+      <% if content_for?(:recruitment_banner) %>
+        <%= yield :recruitment_banner %>
+      <% end %>
       <%= content_tag(:main, id: "content", role: "main", class: main_classes, lang: lang) do %>
         <%= yield %>
       <% end %>

--- a/app/views/step_nav/show.html.erb
+++ b/app/views/step_nav/show.html.erb
@@ -5,6 +5,10 @@
 
 <% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %>
 
+<% content_for :recruitment_banner do %>
+  <%= render "govuk_web_banners/recruitment_banner" %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {


### PR DESCRIPTION
We don't have support for recruitment banners on step nav pages. This PR is to enable this.
Example page https://collections-pr-4350.herokuapp.com/set-up-limited-company


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

