### PR TITLE
Remove X-Frame-Options response header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -107,11 +107,6 @@ module Collections
 
     config.assets.prefix = "/assets/collections/"
 
-    # Override Rails 6 default which restricts framing to SAMEORIGIN.
-    config.action_dispatch.default_headers = {
-      "X-Frame-Options" => "ALLOWALL",
-    }
-
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.


### PR DESCRIPTION
## What

Remove X-Frame-Options response header

## Why

This header is no longer required. It was previously suggested that we remove it because it is not considered safe. Since then, the Content Security Policy has been defined elsewhere, and this case is now handled by the frame-ancestors directive: https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/govuk_content_security_policy.rb#L91

This change follows discussion of the issue among the web teams and at the tech leads meeting.

## Anything else

See:

- https://github.com/alphagov/govuk_app_config/pull/322
- https://github.com/alphagov/frontend/pull/5229
- https://github.com/alphagov/collections/issues/1007