### PR TITLE
Remove scroll tracking from some browse pages

### DIFF
--- a/app/views/second_level_browse_page/show_curated.html.erb
+++ b/app/views/second_level_browse_page/show_curated.html.erb
@@ -3,8 +3,6 @@
   <% if [
           "/browse/business/limited-company",
           "/browse/business/childcare-providers",
-          "/browse/business/food-hospitality-retail",
-          "/browse/business/manufacturing-industry",
         ].include?(page.base_path) %>
     <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
   <% end %>


### PR DESCRIPTION
## What / Why
- Removes tracking from `/browse/business/food-hospitality-retail` and `/browse/business/manufacturing-industry`
- These were missed in the original PR as we originally removed their old URLs, and those URLs redirect to these ones now.

Jira card: https://gov-uk.atlassian.net/browse/IA-2403

## Visual changes

None.