### PR TITLE
Add cooldown for dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -21,8 +25,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+      exclude:
+        - govuk_*
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Sets the values according to GOV.UK Developer docs recommendations:
- 3 days for programming language dependencies
- 7 days for infrastructure tooling (Terraform, Docker), as these changes tend to carry more risk.
