### PR TITLE
Remove unnecessary main role from main element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
       <% if content_for?(:recruitment_banner) %>
         <%= yield :recruitment_banner %>
       <% end %>
-      <%= content_tag(:main, id: "content", role: "main", class: main_classes, lang: lang) do %>
+      <%= content_tag(:main, id: "content", class: main_classes, lang: lang) do %>
         <%= yield %>
       <% end %>
     <% end %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Remove the unnecessary role="main" attribute from the main HTML element in the Collections & Frontend applications.

## Why

To resolve the W3C validation warning:
Warning: The main role is unnecessary for element main.

The main element already has an implicit ARIA role of main, so explicitly setting role="main" is redundant. Removing it clears the W3C validation warning and aligns with the [Design System page template guidance](https://design-system.service.gov.uk/styles/page-template/#default). 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18897

## Visual changes

None. This is a markup-only change — removing a redundant HTML attribute has no impact on the rendered page.

## Testing

✅ Confirmed the role="main" attribute has been removed from all relevant templates in Collections.
✅ Checked in browsers (Chrome, Firefox, Safari) that the main element still behaves as expected.
✅ Ran the affected pages through the [W3C validator](https://validator.w3.org/nu/) and confirmed the "The main role is unnecessary for element main" warning no longer appears. (Note: Local and Heroku URLs cannot be ran using the validator. Workaround is to paste the page HTML into the validator for comparison)

| Live  | Main role removed |
| ------------- | ------------- |
| <img width="848" height="1144" alt="Screenshot 2026-05-05 at 16 02 51" src="https://github.com/user-attachments/assets/6b780c31-f4e2-40eb-b139-790c25f25df3" /> | <img width="849" height="1147" alt="Screenshot 2026-05-05 at 16 04 10" src="https://github.com/user-attachments/assets/dead40af-a7e8-42ac-9ea6-4035961cad70" /> |