### PR TITLE
Retun translated search results when documents have a translated version

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -8,11 +8,32 @@ module OrganisationHelper
     I18n.t("organisations.type.#{organisation_type}", default: I18n.t("organisations.type.other"))
   end
 
+  def translated_search_result(result)
+    return result if I18n.locale == :en
+
+    content_item = Services.content_store.content_item(result["link"])
+
+    return result if content_item.parsed_content.dig("links", "available_translations").nil?
+
+    content_item.parsed_content["links"]["available_translations"].each do |t|
+      if t["locale"] == I18n.locale.to_s
+        return {
+          "title" => t["title"],
+          "link" => t["base_path"],
+          "content_store_document_type" => t["document_type"],
+          "public_timestamp" => t["public_updated_at"],
+        }
+      end
+    end
+
+    result
+  end
+
   def search_results_to_documents(search_results, organisation, include_metadata: true)
     {
       brand: (organisation.brand if organisation.is_live?),
       items: search_results.map do |result|
-        Organisations::DocumentPresenter.new(result, include_metadata:).present
+        Organisations::DocumentPresenter.new(translated_search_result(result), include_metadata:).present
       end,
     }
   end

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe "Organisation pages" do
     stub_content_and_search(content_item_separate_student_loans)
     stub_latest_news_for_organisation("prime-ministers-office-10-downing-street")
     stub_content_store_has_item("/government/organisations/office-of-the-secretary-of-state-for-wales.cy", content_item_wales_office_cy)
+    stub_content_store_has_item("/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector", content_item_for_base_path("/government/news/attorney-general-launches-recruitment-campaign-for-new-chief-inspector"))
+    stub_content_store_has_item("/content-item-1", content_item_for_base_path("/content-item-1"))
+    stub_content_store_has_item("/content-item-2", content_item_for_base_path("/content-item-2"))
   end
 
   it "doesn't fail if the content item is missing any data" do
@@ -224,6 +227,40 @@ RSpec.describe "Organisation pages" do
     expect(page).to have_css(".gem-c-heading", text: "Guidance and regulation")
     expect(page).not_to have_css(".gem-c-heading", text: "Services")
     expect(page).not_to have_css(".gem-c-heading", text: "Statistics")
+  end
+
+  it "shows latest documents with translated version on Welsh" do
+    content_item_with_translated_latest_documents = {
+      "title" => "The Wales Office",
+      "base_path" => "/content-item-1",
+      "details" => {
+        "body" => "",
+        "brand" => "",
+        "logo" => {},
+        "organisation_govuk_status" => { "status" => "" },
+      },
+      "links" => {
+        "available_translations" => [
+          {
+            "base_path" => "/content-item-1.cy",
+            "locale" => "cy",
+            "public_updated_at" => "2024-07-29T23:00:00Z",
+            "title" => "Swyddfa Cymru",
+          },
+          {
+            "base_path" => "/content-item-1",
+            "locale" => "en",
+            "public_updated_at" => "2024-07-29T23:00:00Z",
+            "title" => "Wales Office",
+          },
+        ],
+      },
+    }
+    stub_content_store_has_item("/content-item-1", content_item_with_translated_latest_documents)
+
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    expect(page).to have_css(".gem-c-heading", text: "Newyddion a chyfathrebu")
+    expect(page).to have_css(".gem-c-document-list__item-title [href='/content-item-1.cy']", text: "Swyddfa Cymru")
   end
 
   it "does not show the latest documents by type section if there are none" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

We have a number of Welsh translated Org pages which currently are showing English content in ‘Documents' and ‘Latest from' when there is a Welsh equivalent link. 

To ensure we are always showing the most relevant content we should default to showing the Welsh links in these sections when available. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18906

## Visual changes

https://collections-pr-4500.herokuapp.com/government/organisations/wales-office.cy

| Before | After |
|--------|--------|
| <img width="1131" height="553" alt="Screenshot 2026-05-05 at 08 47 39" src="https://github.com/user-attachments/assets/077b67af-8647-42aa-bffe-588074d88a7a" /> | <img width="990" height="496" alt="Screenshot 2026-05-05 at 08 47 46" src="https://github.com/user-attachments/assets/ec2854ca-dcf6-43f4-8640-28fe7f0486e9" /> |
| <img width="1115" height="1139" alt="Screenshot 2026-05-05 at 08 48 23" src="https://github.com/user-attachments/assets/542f4a89-55a5-4951-a054-7e268db4db05" /> | <img width="1022" height="1043" alt="Screenshot 2026-05-05 at 08 48 29" src="https://github.com/user-attachments/assets/7916eb2d-aaae-4e31-aee1-587d8dcff612" /> |
