### PR TITLE
Add GA4 indexes to image cards

### DIFF
--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -3,14 +3,11 @@
   render_first_featured_news = @organisation.is_news_organisation? && !@organisation.is_no_10?
 
   # GA4 attributes
-  ga4_index_offset = 1
+  ga4_index = 1
   ga4_index_total = @documents.remaining_featured_news.count
 
-  # Increment GA4 indexes by 1 if 'First featured news' is rendered
-  if render_first_featured_news
-    ga4_index_offset += 1
-    ga4_index_total += 1
-  end
+  # Increment GA4 index total by 1 if 'First featured news' is rendered
+  ga4_index_total += 1 if render_first_featured_news
 
   ga4_image_card_json = {
     "event_name": "navigation",
@@ -32,10 +29,11 @@
   </div>
 
   <% if render_first_featured_news %>
-      <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news.merge({ data_attributes: { module: "ga4-link-tracker", ga4_link: ga4_image_card_json.merge({ index: { index_link: 1 } }) }}) %>
+      <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news.merge({ data_attributes: { module: "ga4-link-tracker", ga4_link: ga4_image_card_json.merge({ index: { index_link: ga4_index } }) }}) %>
+      <% ga4_index += 1 %>
   <% end %>
 
-  <% @documents.remaining_featured_news.in_groups_of(3, false).each_with_index do |news, index| %>
+  <% @documents.remaining_featured_news.in_groups_of(3, false).each do |news| %>
     <div class="govuk-grid-row" data-module="ga4-link-tracker">
       <% news.each do |news_item| %>
         <% classes = %w[] %>
@@ -43,7 +41,8 @@
         <% classes << "govuk-grid-column-full" if news_item[:large] %>
 
         <%= content_tag(:div, class: classes) do %>
-          <%= render "govuk_publishing_components/components/image_card", news_item.merge({ data_attributes: { ga4_link: ga4_image_card_json.merge({ index: { index_link: index + ga4_index_offset }}) }}) %>
+          <%= render "govuk_publishing_components/components/image_card", news_item.merge({ data_attributes: { ga4_link: ga4_image_card_json.merge({ index: { index_link: ga4_index }}) }}) %>
+          <% ga4_index +=1 %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/organisations/_featured_news.html.erb
+++ b/app/views/organisations/_featured_news.html.erb
@@ -1,10 +1,23 @@
 <% if @documents.has_featured_news? %>
 <%
+  render_first_featured_news = @organisation.is_news_organisation? && !@organisation.is_no_10?
+
+  # GA4 attributes
+  ga4_index_offset = 1
+  ga4_index_total = @documents.remaining_featured_news.count
+
+  # Increment GA4 indexes by 1 if 'First featured news' is rendered
+  if render_first_featured_news
+    ga4_index_offset += 1
+    ga4_index_total += 1
+  end
+
   ga4_image_card_json = {
     "event_name": "navigation",
     "type": "image card",
-    "section": t('shared.featured', locale: :en)
-  }.to_json
+    "section": t('shared.featured', locale: :en),
+    "index_total": ga4_index_total
+  }
 %>
 <section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom" id="featured-documents">
   <div class="govuk-grid-row">
@@ -18,21 +31,19 @@
     </div>
   </div>
 
-  <% if @organisation.is_news_organisation? && !@organisation.is_no_10? %>
-    <div data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
-      <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news %>
-    </div>
+  <% if render_first_featured_news %>
+      <%= render "govuk_publishing_components/components/image_card", @documents.first_featured_news.merge({ data_attributes: { module: "ga4-link-tracker", ga4_link: ga4_image_card_json.merge({ index: { index_link: 1 } }) }}) %>
   <% end %>
 
-  <% @documents.remaining_featured_news.in_groups_of(3, false) do |news| %>
-    <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+  <% @documents.remaining_featured_news.in_groups_of(3, false).each_with_index do |news, index| %>
+    <div class="govuk-grid-row" data-module="ga4-link-tracker">
       <% news.each do |news_item| %>
         <% classes = %w[] %>
         <% classes << "govuk-grid-column-one-third" unless news_item[:large] %>
         <% classes << "govuk-grid-column-full" if news_item[:large] %>
 
         <%= content_tag(:div, class: classes) do %>
-          <%= render "govuk_publishing_components/components/image_card", news_item %>
+          <%= render "govuk_publishing_components/components/image_card", news_item.merge({ data_attributes: { ga4_link: ga4_image_card_json.merge({ index: { index_link: index + ga4_index_offset }}) }}) %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/organisations/_featured_news_no10.html.erb
+++ b/app/views/organisations/_featured_news_no10.html.erb
@@ -3,7 +3,9 @@
   ga4_image_card_json = {
     "event_name": "navigation",
     "type": "image card",
-    "section": t('shared.featured', locale: :en)
+    "section": t('shared.featured', locale: :en),
+    "index_link": 1,
+    "index_total": 1,
   }.to_json
 %>
 <section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom" id="featured-documents-small">

--- a/app/views/organisations/_latest_news.html.erb
+++ b/app/views/organisations/_latest_news.html.erb
@@ -2,7 +2,9 @@
   ga4_image_card_json = {
     "event_name": "navigation",
     "type": "image card",
-    "section": t("organisations.latest_news", lang: :en)
+    "section": t("organisations.latest_news", lang: :en),
+    "index_link": 1,
+    "index_total": 1,
   }.to_json
 %>
 <section class="brand--<%= @organisation.brand %> brand__border-color organisation__brand-border-top organisation__section-wrap organisation__margin-bottom" id="latest-news">

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -2,11 +2,13 @@
   content_for :title, @world_location_news.title.html_safe
   page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing"
 
+
   ga4_image_card_json = {
     "event_name": "navigation",
     "type": "image card",
-    "section": I18n.t("shared.featured", locale: :en)
-  }.to_json
+    "section": I18n.t("shared.featured", locale: :en),
+    "index_total": @world_location_news.ordered_featured_documents&.count
+  }
 %>
 
 <% content_for :meta_tags do %>
@@ -49,13 +51,14 @@
           border_top: 2,
           margin_bottom: 4,
         } %>
-
+        <% ga4_index = 1 %>
         <% @world_location_news.ordered_featured_documents.in_groups_of(3, false) do |row| %>
           <div class="govuk-grid-row">
             <% row.each do |document| %>
-              <div class="govuk-grid-column-one-third" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
-                <%= render "govuk_publishing_components/components/image_card", document %>
+              <div class="govuk-grid-column-one-third" data-module="ga4-link-tracker">
+                <%= render "govuk_publishing_components/components/image_card", document.merge({ data_attributes: { ga4_link: ga4_image_card_json.merge({ index: { index_link: ga4_index } })  }}) %>
               </div>
+              <% ga4_index += 1 %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -2,7 +2,6 @@
   content_for :title, @world_location_news.title.html_safe
   page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing"
 
-
   ga4_image_card_json = {
     "event_name": "navigation",
     "type": "image card",

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe "Organisation pages" do
     test_ga4_image_cards("#latest-news div")
 
     visit "/government/organisations/attorney-generals-office"
-    test_ga4_image_cards("#featured-documents div")
+    test_ga4_image_cards_with_index("#featured-documents div")
     test_ga4_image_cards("[data-people-id=our-ministers] div")
     test_ga4_image_cards("[data-people-id=our-management] div")
 

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -43,9 +43,12 @@ RSpec.feature "World Location News pages" do
 
     it "includes GA4 tracking on links to the featured documents" do
       visit base_path
-      within("#featured") do
-        ga4_link_data = JSON.parse(page.first("div[data-module='ga4-link-tracker'][data-ga4-track-links-only]")["data-ga4-link"])
-        expect(ga4_link_data).to eq({ "event_name" => "navigation", "section" => "Featured", "type" => "image card" })
+
+      all('#featured div[data-module="ga4-link-tracker"]').each_with_index do |image_card, index|
+        within(image_card) do
+          ga4_link_data = JSON.parse(image_card.first("div[data-ga4-link]")["data-ga4-link"])
+          expect(ga4_link_data).to eq({ "event_name" => "navigation", "section" => "Featured", "index_total" => 2, "type" => "image card", "index" => { "index_link" => index + 1 } })
+        end
       end
     end
   end

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -883,6 +883,22 @@ module OrganisationHelpers
     stub_search_api_latest_content_requests(slug)
   end
 
+  def test_ga4_image_cards_with_index(selector, section_heading = nil)
+    links = page.all("#{selector}[data-ga4-link]")
+    section_heading ||= page.first("#{selector} h2").text
+
+    expect(links.first["data-module"]).to eq("ga4-link-tracker")
+
+    links.each.with_index(1) do |link, index|
+      ga4_link_data = JSON.parse(link["data-ga4-link"])
+      expect(ga4_link_data["event_name"]).to eq "navigation"
+      expect(ga4_link_data["type"]).to eq "image card"
+      expect(ga4_link_data["section"]).to eq section_heading
+      expect(ga4_link_data["index"]["index_link"]).to eq index
+      expect(ga4_link_data["index_total"]).to eq links.count
+    end
+  end
+
   def test_ga4_image_cards(selector, section_heading = nil)
     ga4_selector = "#{selector}[data-module='ga4-link-tracker']"
     expect(page).to have_css(ga4_selector)

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -884,7 +884,7 @@ module OrganisationHelpers
   end
 
   def test_ga4_image_cards(selector, section_heading = nil)
-    ga4_selector = "#{selector}[data-module='ga4-link-tracker'][data-ga4-track-links-only]"
+    ga4_selector = "#{selector}[data-module='ga4-link-tracker']"
     expect(page).to have_css(ga4_selector)
 
     ga4_link_data = JSON.parse(page.first(ga4_selector)["data-ga4-link"])


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What/Why
- Adds GA4 indexes to the image cards on the following routes:
  - Organisations: https://collections-pr-4504.herokuapp.com/government/organisations/ministry-of-housing-communities-local-government
  - No. 10 page: https://collections-pr-4504.herokuapp.com/government/organisations/prime-ministers-office-10-downing-street
  - World location news: https://collections-pr-4504.herokuapp.com/world/canada/news
- As requested by PA in https://gov-uk.atlassian.net/browse/PNP-9952

## Visual changes
