### PR TITLE
Fix missing default image on organisation pages

### DIFF
--- a/app/helpers/latest_news_helper.rb
+++ b/app/helpers/latest_news_helper.rb
@@ -28,7 +28,13 @@ module LatestNewsHelper
     return nil unless results["results"].any?
 
     news_item = Services.content_store.content_item(results["results"].first["link"])
-    news_item.parsed_content["details"]["image"]
+    image_details = news_item.parsed_content["details"]["image"] || news_item.parsed_content["details"]["images"].find { |img| img["type"] == "lead" }
+    if image_details
+      {
+        "url" => image_details["url"] || image_details.dig("sources", "s465"),
+        "alt_text" => image_details["alt_text"] || "",
+      }
+    end
   rescue StandardError
     GovukError.notify("News item in Latest News Section doesn't exist or doesn't have an image")
     {


### PR DESCRIPTION
## What

Fix missing default image on organisation pages

## Why

https://gds.slack.com/archives/C052X8S2P8A/p1778247553902209

## Visual changes

### Before and after

<img width="1728" height="1117" alt="Screenshot 2026-05-11 at 13 43 30" src="https://github.com/user-attachments/assets/d1398975-7206-4c92-9b5a-f4a2a1f4160f" />
