### PR TITLE
Exclude organisation page from latest documents on translated pages

### DIFF
--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -50,7 +50,7 @@ module Organisations
         metric_key: "organisations.search.request_time",
       )["results"]
 
-      documents.reject { |doc| doc["link"] == @org.base_path }.take(3)
+      documents.reject { |doc| doc["link"] == get_untranslated_organisation_base_path(@org.base_path) }.take(3)
     end
 
     def featured_news(featured, first_featured: false)
@@ -78,6 +78,21 @@ module Organisations
       end
 
       news_stories
+    end
+
+    def get_untranslated_organisation_base_path(base_path)
+      organisation_base_path = base_path
+
+      content_item = Services.content_store.content_item(base_path)
+      if content_item.parsed_content.dig("links", "available_translations")
+        content_item.parsed_content["links"]["available_translations"].each do |t|
+          if t["locale"] == "en"
+            organisation_base_path = t["base_path"]
+          end
+        end
+      end
+
+      organisation_base_path
     end
   end
 end

--- a/spec/presenters/organisations/documents_presenter_spec.rb
+++ b/spec/presenters/organisations/documents_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Organisations::DocumentsPresenter do
     before do
       stub_empty_search_api_requests("org-with-no-docs")
       stub_search_api_latest_content_requests("attorney-generals-office")
+      stub_content_store_has_item("/government/organisations/attorney-generals-office", content_item_for_base_path("/government/organisations/attorney-generals-office"))
     end
 
     context "page is No. 10 organisation page" do


### PR DESCRIPTION
In the list of latest documents for an organisation, the organisation page should be excluded. But on the translated version, it is still present in the latest documents list.
This is because search api returns a list of English version of documents, and we were filtering out using the page base path, which was for the Welsh version.

## Visual changes

Example: https://www.gov.uk/government/organisations/charity-commission.cy

Before:
<img width="982" height="526" alt="Screenshot 2026-05-14 at 14 47 16" src="https://github.com/user-attachments/assets/cc0f4688-2786-4741-8402-1b4ee18670e2" />

After:
<img width="859" height="499" alt="Screenshot 2026-05-14 at 15 01 59" src="https://github.com/user-attachments/assets/f9ff2775-e363-4e80-b4f4-d0cd1672d2aa" />
