### PR TITLE
Add method to easily toggle scroll tracking 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,4 +89,12 @@ module ApplicationHelper
       "/buy-a-vehicle",
     ].include?(request.path)
   end
+
+  PERCENTAGE_SCROLL_TRACKING_URLS = [].freeze
+
+  def include_percentage_scroll_tracking?(base_path = nil)
+    return false unless base_path
+
+    PERCENTAGE_SCROLL_TRACKING_URLS.include?(base_path)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,23 @@ module ApplicationHelper
     ].include?(request.path)
   end
 
-  PERCENTAGE_SCROLL_TRACKING_URLS = [].freeze
+  PERCENTAGE_SCROLL_TRACKING_URLS = [
+    "/browse/business/start-your-business",
+    "/browse/business/buying-selling-outside-great-britain",
+    "/browse/business/food-hospitality-retail",
+    "/browse/business/manufacturing-industry",
+    "/browse/business/keep-your-business-running",
+    "/browse/business/grow-your-business",
+    "/browse/business/business-debt-continuity-options",
+    "/browse/business/business-waste",
+    "/browse/business/sell-transfer-your-business",
+    "/browse/business/childcare-education-providers",
+    "/browse/business/construction-property-management",
+    "/browse/business/running-charity",
+    "/browse/business/commercial-transport-logistics",
+    "/browse/business/farming-forestry-fishing",
+    "/browse/business/media-creative-entertainment",
+  ].freeze
 
   def include_percentage_scroll_tracking?(base_path = nil)
     return false unless base_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,10 @@
   <%= render 'govuk_publishing_components/components/meta_tags', content_item: content_item_h %>
 
   <%= javascript_include_tag "test-dependencies", type: "module" if Rails.env.test? %>
+
+  <% if include_percentage_scroll_tracking?(content_item_h["base_path"]) %>
+    <meta name="govuk:scroll-tracker" content="" data-module="ga4-scroll-tracker">
+  <% end %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -157,4 +157,32 @@ RSpec.describe ApplicationHelper do
       expect(helper.show_app_promo_banner?).to be(false)
     end
   end
+
+  describe "include_percentage_scroll_tracking?" do
+    before do
+      stub_const("ApplicationHelper::PERCENTAGE_SCROLL_TRACKING_URLS", ["/browse"])
+    end
+
+    describe "when nothing is passed to it" do
+      it "does not include tracking" do
+        expect(include_percentage_scroll_tracking?).to be(false)
+      end
+    end
+
+    describe "when the page is not in the list" do
+      it "does not include scroll tracking" do
+        expect(include_percentage_scroll_tracking?("/government/speeches/test")).to be(false)
+      end
+
+      it "does not include scroll tracking even when the parent path is in the list" do
+        expect(include_percentage_scroll_tracking?("/browse/something")).to be(false)
+      end
+    end
+
+    describe "when the page is in the list" do
+      it "does include scroll tracking" do
+        expect(include_percentage_scroll_tracking?("/browse")).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What/Why

- Adds method to add scroll tracking based on https://github.com/alphagov/frontend/pull/5384
- Adds scroll tracking to some DBT pages, as requested by PAs in https://gov-uk.atlassian.net/browse/IA-2767

## Visual changes

None.
