### PR TITLE
Remove `faraday` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "rails", "8.1.3"
 gem "bootsnap", require: false
 gem "dalli", "~> 4"
 gem "dartsass-rails"
-gem "faraday"
 gem "gds-api-adapters"
 gem "govspeak"
 gem "govuk_ab_testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,12 +172,6 @@ GEM
     execjs (2.10.0)
     expgen (0.1.1)
       parslet
-    faraday (2.14.1)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-darwin)
@@ -333,8 +327,6 @@ GEM
     multi_test (1.1.0)
     multi_xml (0.8.0)
       bigdecimal (>= 3.1, < 5)
-    net-http (0.9.1)
-      uri (>= 0.11.1)
     net-imap (0.6.4)
       date
       net-protocol
@@ -835,7 +827,6 @@ DEPENDENCIES
   dalli (~> 4)
   dartsass-rails
   erb_lint
-  faraday
   gds-api-adapters
   govspeak
   govuk_ab_testing


### PR DESCRIPTION
## What

Remove faraday Ruby gem

## Why

The `faraday` gem was originally added in https://github.com/alphagov/collections/pull/2315 to support showing statistics on the coronavirus landing page

The coronavirus landing page was later removed in https://github.com/alphagov/collections/pull/2730, but the `faraday` gem was not removed.

It looks like the `faraday` and `net-http` gem are no longer used in collections and can be removed, this should help reduce the maintenance burden of keeping them up-to-date
