### PR TITLE
Handle content store errors on organsiation pages

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -31,6 +31,21 @@ module OrganisationHelper
     result
   end
 
+  def get_untranslated_organisation_base_path(base_path)
+    organisation_base_path = base_path
+
+    content_item = Services.content_store.content_item(base_path)
+    if content_item.parsed_content.dig("links", "available_translations")
+      content_item.parsed_content["links"]["available_translations"].each do |t|
+        if t["locale"] == "en"
+          organisation_base_path = t["base_path"]
+        end
+      end
+    end
+
+    organisation_base_path
+  end
+
   def search_results_to_documents(search_results, organisation, include_metadata: true)
     {
       brand: (organisation.brand if organisation.is_live?),

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -11,11 +11,13 @@ module OrganisationHelper
   def translated_search_result(result)
     return result if I18n.locale == :en
 
-    content_item = Services.content_store.content_item(result["link"])
+    content_item ||= handle_api_errors do
+      Services.content_store.content_item(result["link"]).parsed_content
+    end
 
-    return result if content_item.parsed_content.dig("links", "available_translations").nil?
+    return result if content_item.dig("links", "available_translations").nil?
 
-    content_item.parsed_content["links"]["available_translations"].each do |t|
+    content_item["links"]["available_translations"].each do |t|
       if t["locale"] == I18n.locale.to_s
         return {
           "title" => t["title"],
@@ -37,4 +39,13 @@ module OrganisationHelper
       end,
     }
   end
+
+private
+
+  def handle_api_errors
+    yield
+  rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl
+    {}
+  end
+
 end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -11,9 +11,7 @@ module OrganisationHelper
   def translated_search_result(result)
     return result if I18n.locale == :en
 
-    content_item ||= handle_api_errors do
-      Services.content_store.content_item(result["link"]).parsed_content
-    end
+    content_item = get_content_item(result["link"])
 
     return result if content_item.dig("links", "available_translations").nil?
 
@@ -34,9 +32,9 @@ module OrganisationHelper
   def get_untranslated_organisation_base_path(base_path)
     organisation_base_path = base_path
 
-    content_item = Services.content_store.content_item(base_path)
-    if content_item.parsed_content.dig("links", "available_translations")
-      content_item.parsed_content["links"]["available_translations"].each do |t|
+    content_item = get_content_item(base_path)
+    if content_item.dig("links", "available_translations")
+      content_item["links"]["available_translations"].each do |t|
         if t["locale"] == "en"
           organisation_base_path = t["base_path"]
         end
@@ -63,4 +61,9 @@ private
     {}
   end
 
+  def get_content_item(base_path)
+    handle_api_errors do
+      Services.content_store.content_item(base_path).parsed_content
+    end
+  end
 end

--- a/app/presenters/organisations/documents_presenter.rb
+++ b/app/presenters/organisations/documents_presenter.rb
@@ -79,20 +79,5 @@ module Organisations
 
       news_stories
     end
-
-    def get_untranslated_organisation_base_path(base_path)
-      organisation_base_path = base_path
-
-      content_item = Services.content_store.content_item(base_path)
-      if content_item.parsed_content.dig("links", "available_translations")
-        content_item.parsed_content["links"]["available_translations"].each do |t|
-          if t["locale"] == "en"
-            organisation_base_path = t["base_path"]
-          end
-        end
-      end
-
-      organisation_base_path
-    end
   end
 end

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -263,6 +263,13 @@ RSpec.describe "Organisation pages" do
     expect(page).to have_css(".gem-c-document-list__item-title [href='/content-item-1.cy']", text: "Swyddfa Cymru")
   end
 
+  it "shows organisation page when a latest document url returns 404" do
+    stub_content_store_does_not_have_item("/content-item-1")
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    expect(page).to have_css(".gem-c-heading", text: "Newyddion a chyfathrebu")
+    expect(page).to have_css(".gem-c-document-list__item-title [href='/content-item-1']", text: "Content item 1")
+  end
+
   it "does not show the latest documents by type section if there are none" do
     stub_empty_search_api_requests("attorney-generals-office")
     visit "/government/organisations/attorney-generals-office"


### PR DESCRIPTION
Organisation pages return 404's, despite having a content item. This happens when a recent document showing on the page is returning 404. 

The GDS API call for content store is raising an error when the page is not found, instead of returning a http response. We need to catch this error in order for the org page to work even if the linked pages are not available.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18939