### PR TITLE
Fix H1 headings on mainstream browse pages

### DIFF
--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -21,6 +21,7 @@
 <%= render "shared/browse_header", { margin_bottom: 9 } do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: t("browse.title"),
+    heading_level: 1,
     font_size: "xl",
     margin_bottom: 6,
   } %>

--- a/app/views/browse/show.html.erb
+++ b/app/views/browse/show.html.erb
@@ -25,6 +25,7 @@
 <%= render "shared/browse_header", { margin_bottom: page.slug == "benefits" ? 7 : 9 } do %>
   <%= render "govuk_publishing_components/components/heading", {
     text: page.title,
+    heading_level: 1,
     font_size: "xl",
     margin_bottom: 6,
   } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Mainstream browse pages are currently missing a H1.

- https://www.gov.uk/browse
- https://www.gov.uk/browse/driving

It appears the issue was introduced as [part of this PR](https://github.com/alphagov/collections/pull/3724).

## Why

A missing H1 causes various issues due to the loss of page context. For screen readers, it removes the landmark visually impaired users rely on to skip the noise and immediately know what page they just landed on. For search engines, it harms the strongest on page signal used to categorise and rank content.

https://webaim.org/standards/wcag/checklist#sc1.3.1
https://webaim.org/standards/wcag/checklist#sc2.4.6

Fix reverts the heading level back to heading level 1 on mainstream browse pages. 

Jira card: https://gov-uk.atlassian.net/browse/NAV-18934

## Visual changes

None. This is a markup-only change on a heading element.

## Testing

✅ Confirmed the /browse and /browse/{slug} pages now contain an H1.
✅ Warnings using various tooling such as 'This document has heading elements but none of them has a computed heading level of 1.' no longer appear. 

| Live  | Corrected H1 |
| ------------- | ------------- |
| <img width="597" height="685" alt="Screenshot 2026-05-21 at 16 18 30" src="https://github.com/user-attachments/assets/4a01b82d-800c-4c98-827a-2bd5c562546e" /> | <img width="598" height="686" alt="Screenshot 2026-05-21 at 16 19 05" src="https://github.com/user-attachments/assets/63d99a82-4fe6-49fe-9789-cff79e10f9cb" /> |