### PR TITLE
Upgrade stylelint-config-gds from v2 to v3

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,15 +2,5 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-packageExtensions:
-  stylelint-config-gds@*:
-    peerDependencies:
-      postcss: 8
-  stylelint-config-recommended-scss@*:
-    peerDependencies:
-      postcss: 8
-  stylelint-config-standard-scss@*:
-    peerDependencies:
-      postcss: 8
 
 yarnPath: .yarn/releases/yarn-3.4.1.cjs

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -6,7 +6,7 @@
 }
 
 .organisation__section-wrap {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 // This is only used to apply to promotional orgs where the border colour is always black
@@ -34,7 +34,7 @@
 }
 
 .organisation__contact-section {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 
   .organisation__address {
     font-style: normal;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jasmine-core": "^6.2.0",
     "standardx": "^7.0.0",
     "stylelint": "^17.12.0",
-    "stylelint-config-gds": "^2.0.0"
+    "stylelint-config-gds": "3.0.0"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,7 +551,7 @@ __metadata:
     jasmine-core: ^6.2.0
     standardx: ^7.0.0
     stylelint: ^17.12.0
-    stylelint-config-gds: ^2.0.0
+    stylelint-config-gds: 3.0.0
   languageName: unknown
   linkType: soft
 
@@ -1910,6 +1910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
 "is-promise@npm:^4.0.0":
   version: 4.0.0
   resolution: "is-promise@npm:4.0.0"
@@ -2107,10 +2114,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"known-css-properties@npm:^0.29.0":
-  version: 0.29.0
-  resolution: "known-css-properties@npm:0.29.0"
-  checksum: daa6562e907f856cbfd58a00c42f532c9bba283388984da6a3bffb494e56612e5f23c52f30b0d9885f0ea07ad5d88bfa0470ee65017a6ce6c565289a1afd78af
+"known-css-properties@npm:^0.37.0":
+  version: 0.37.0
+  resolution: "known-css-properties@npm:0.37.0"
+  checksum: 8a0f8a85abd45b22c048b64b9e841dd395367715ecd9b04d8b882e147b150f2f58b09364bc24bf516a6d713871edb02d7a01db046c0c616eecc73007d2abc7ec
   languageName: node
   linkType: hard
 
@@ -2736,10 +2743,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-resolve-nested-selector@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "postcss-resolve-nested-selector@npm:0.1.1"
-  checksum: b08fb76ab092a09ee01328bad620a01dcb445ac5eb02dd0ed9ed75217c2f779ecb3bf99a361c46e695689309c08c09f1a1ad7354c8d58c2c2c40d364657fcb08
+"postcss-resolve-nested-selector@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "postcss-resolve-nested-selector@npm:0.1.6"
+  checksum: 85453901afe2a4db497b4e0d2c9cf2a097a08fa5d45bc646547025176217050334e423475519a1e6c74a1f31ade819d16bb37a39914e5321e250695ee3feea14
   languageName: node
   linkType: hard
 
@@ -2758,16 +2765,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.29
   checksum: dc358bafc23d52ed3a9a29333808825deba213042be74ece6eae7a61c692f67d0e6691fa7005367b013c01c79562fbb9ef2fe4c0485075233931bd90715f5132
-  languageName: node
-  linkType: hard
-
-"postcss-selector-parser@npm:^6.0.15":
-  version: 6.0.15
-  resolution: "postcss-selector-parser@npm:6.0.15"
-  dependencies:
-    cssesc: ^3.0.0
-    util-deprecate: ^1.0.2
-  checksum: 57decb94152111004f15e27b9c61131eb50ee10a3288e7fcf424cebbb4aba82c2817517ae718f8b5d704ee9e02a638d4a2acff8f47685c295a33ecee4fd31055
   languageName: node
   linkType: hard
 
@@ -3441,83 +3438,89 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylelint-config-gds@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "stylelint-config-gds@npm:2.0.0"
+"stylelint-config-gds@npm:3.0.0":
+  version: 3.0.0
+  resolution: "stylelint-config-gds@npm:3.0.0"
   dependencies:
-    stylelint-config-standard: ^36.0.0
-    stylelint-config-standard-scss: ^13.0.0
+    stylelint-config-standard: ^40.0.0
+    stylelint-config-standard-scss: ^17.0.0
   peerDependencies:
-    stylelint: ^16.0.2
-  checksum: 5a1c7c32ece891b8c4bbfac352674ea0e90078bfa33313ecdca205f9ce43a625a9f0e532ff089687d986d2b2d98028c52062afd70011ae29c2f90093705f6bbb
+    stylelint: ^17.4.0
+  checksum: 6e166c762253f977544ee03646bc7fa9da16590a71bd1c9195a6b2f1cfb0bf484ac1327900709239dcd0dda429a10f26932d4c536f5e9a8dd3d8e906c1006681
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended-scss@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "stylelint-config-recommended-scss@npm:14.0.0"
+"stylelint-config-recommended-scss@npm:^17.0.0":
+  version: 17.0.1
+  resolution: "stylelint-config-recommended-scss@npm:17.0.1"
   dependencies:
     postcss-scss: ^4.0.9
-    stylelint-config-recommended: ^14.0.0
-    stylelint-scss: ^6.0.0
+    stylelint-config-recommended: ^18.0.0
+    stylelint-scss: ^7.0.0
   peerDependencies:
     postcss: ^8.3.3
-    stylelint: ^16.0.2
+    stylelint: ^17.0.0
   peerDependenciesMeta:
     postcss:
       optional: true
-  checksum: 512fba4d81654b65a7a36d531f165c7d8f0c938e63a0f90daca0c21d623cc637e29195fec5e0ae1edd862502d69717f6f3e90016cd7ba8458e4a8afcd87bb3b4
+  checksum: 633b07237649be61f6edd1f17f48d1ec797f3b0a763f06af97d38a8b6161cb2a4542c460b0e734a957d57ca7ab9d4a522ab1347b0522e64611ff4a7f28333ec8
   languageName: node
   linkType: hard
 
-"stylelint-config-recommended@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "stylelint-config-recommended@npm:14.0.0"
+"stylelint-config-recommended@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "stylelint-config-recommended@npm:18.0.0"
   peerDependencies:
-    stylelint: ^16.0.0
-  checksum: 36511115b06d9f51aa0edc05f6064a7aae98cc990da14dd03629951f63a029d9e66a4d5b1ca678cce699e24413a62c2cd608cc07413ca5026f9680ddb8993858
+    stylelint: ^17.0.0
+  checksum: 7fadaca52bcd4522f5c053fc0b3722f4ade02682bcac26055b7814e9ba99bd7cef6b82c166e6d7ad8cbe1d27d9da2736f48b644a270fa51d93f8255a63e92fcc
   languageName: node
   linkType: hard
 
-"stylelint-config-standard-scss@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "stylelint-config-standard-scss@npm:13.0.0"
+"stylelint-config-standard-scss@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "stylelint-config-standard-scss@npm:17.0.0"
   dependencies:
-    stylelint-config-recommended-scss: ^14.0.0
-    stylelint-config-standard: ^36.0.0
+    stylelint-config-recommended-scss: ^17.0.0
+    stylelint-config-standard: ^40.0.0
   peerDependencies:
     postcss: ^8.3.3
-    stylelint: ^16.1.0
+    stylelint: ^17.0.0
   peerDependenciesMeta:
     postcss:
       optional: true
-  checksum: 72e8fbb8d49b76e30031d05470d610790a966714fef0101418b889c564d9cc324788519733cad714316224c68541466dce534c51092d13bae3f9e596916415c3
+  checksum: 0d8ab178f3b19923c3f4c5f2306ed16641a9d3a73422f346c8364188ef537790a4222b8fcefbb9cd04187246a011e7bd4d8cedf8dced9694dcfef49ba4747510
   languageName: node
   linkType: hard
 
-"stylelint-config-standard@npm:^36.0.0":
-  version: 36.0.0
-  resolution: "stylelint-config-standard@npm:36.0.0"
+"stylelint-config-standard@npm:^40.0.0":
+  version: 40.0.0
+  resolution: "stylelint-config-standard@npm:40.0.0"
   dependencies:
-    stylelint-config-recommended: ^14.0.0
+    stylelint-config-recommended: ^18.0.0
   peerDependencies:
-    stylelint: ^16.1.0
-  checksum: 78b14cdfdd03be409687acc863ef88d0e79d9a7f7ab3a9158e7dcd74212893db24841d22f076f248f3b1b6419d778538a5c885dc42fc056eaeb240463edf2f8f
+    stylelint: ^17.0.0
+  checksum: 837a4443ff109591e46aa195a342a569e17459947e3e14984a5da05a01291fbaceb16747f7b4a2ce7bf9c83159bbaab9d6d757fdc4b4d32bb7bb2d91d5261cdf
   languageName: node
   linkType: hard
 
-"stylelint-scss@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "stylelint-scss@npm:6.1.0"
+"stylelint-scss@npm:^7.0.0":
+  version: 7.1.1
+  resolution: "stylelint-scss@npm:7.1.1"
   dependencies:
-    known-css-properties: ^0.29.0
+    "@csstools/css-calc": ^3.2.0
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-syntax-patches-for-csstree": ^1.1.3
+    "@csstools/css-tokenizer": ^4.0.0
+    css-tree: ^3.2.1
+    is-plain-object: ^5.0.0
+    known-css-properties: ^0.37.0
     postcss-media-query-parser: ^0.2.3
-    postcss-resolve-nested-selector: ^0.1.1
-    postcss-selector-parser: ^6.0.15
+    postcss-resolve-nested-selector: ^0.1.6
+    postcss-selector-parser: ^7.1.1
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    stylelint: ^16.0.2
-  checksum: ff3b1c97e8379e45acd1b5b28bafa11251539366f362ff6a674690fd9aef0c7da926b2445304699d48edd1c375acb51b5fcb8039a4106ef4a6f4e29b8515e00b
+    stylelint: ^16.8.2 || ^17.0.0
+  checksum: acd2ab6b515a58ff8c0d5a7bedf1d0189ecc2842b487ae29e71ffcac26b5cb7204e458cc8d71bf1181507cdaf8c592600d08c054d701d5b72267abd64c943aab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Upgrade `styleling-config-gds` from v2 to v3 and fix linting errors
- Remove `packageExtensions` settings previously used to fix a peer dependency issue with postcss, this is no longer required and is now producing warnings

## Why

The Design System team have a released v3 of stylelint-config-gds which supports Stylelint v17

Changelog: https://github.com/alphagov/stylelint-config-gds/blob/3.0.0/CHANGELOG.md#300

We are [already running Stylelint v17 in collections](https://github.com/alphagov/collections/blob/main/package.json#L35-L40), however we are running this with v2 of styelint-config-gds which does not support Stylelint v17.

This currently throws some warnings when running `yarn install`, side note, if using `npm install` it will fail completely.

Upgrading will ensure that we are using compatible and supported versions of the software used to check our CSS Styles.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18950

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.