### PR TITLE
Update colours to Design System v6 

### DIFF
--- a/app/assets/stylesheets/views/_bunting.scss
+++ b/app/assets/stylesheets/views/_bunting.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -148,7 +148,7 @@ $c19-landing-page-header-background: $govuk-blue-tint-80;
 
 .covid__page-guidance {
   padding: govuk-spacing(8) 0 govuk-spacing(9);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   color: govuk-colour("black");
 }
 

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -3,6 +3,6 @@
 }
 
 .footnotes {
-  color: #505a5f;
+  color: govuk-colour("black", $variant: "tint-25");
   display: block;
 }

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -56,7 +56,7 @@
 }
 
 .organisation__contact-section--border-top {
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
   margin-bottom: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -8,7 +8,7 @@
   .organisations-list__item {
     list-style-type: none;
     margin-bottom: govuk-spacing(3);
-    border-bottom: 1px solid govuk-colour("mid-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
 
     h3 {
       margin: 0;

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -18,7 +18,7 @@
 }
 
 .taxon-page__email-link-wrapper {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   margin-top: -(govuk-spacing(6));
   margin-bottom: govuk-spacing(6);
   border-bottom: 1px solid $govuk-border-colour;

--- a/app/assets/stylesheets/views/_world_index.scss
+++ b/app/assets/stylesheets/views/_world_index.scss
@@ -26,7 +26,7 @@
 
   .world_locations-group__item {
     list-style-type: none;
-    border-bottom: 1px solid govuk-colour("mid-grey");
+    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
     padding: govuk-spacing(1) 0;
     @include govuk-font(19);
   }


### PR DESCRIPTION
## What
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.

This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

## Why
Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-18921