### PR TITLE
Remove data-ga4-track-links-only references

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -7,7 +7,6 @@ module BrowseHelper
         href: link[:link],
         data_attributes: {
           module: "ga4-link-tracker",
-          ga4_track_links_only: "",
           ga4_link: {
             event_name: "navigation",
             type: "action",

--- a/app/views/coronavirus_landing_page/show.html.erb
+++ b/app/views/coronavirus_landing_page/show.html.erb
@@ -69,7 +69,6 @@
         index_total: 1,
         section: "Footer"
       },
-      ga4_track_links_only: ""
     } do
     render 'govuk_publishing_components/components/signup_link', {
       link_text:  "Sign up to get emails when we change any COVID-19 information on the GOV.UK website",

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -1,5 +1,5 @@
 <% if contacts.present? %>
-<% 
+<%
   ga4_section ||= nil
   ga4_email_link_data = { event_name: "navigation", type: "email" }
   ga4_email_link_data[:section] = ga4_section if ga4_section
@@ -36,7 +36,6 @@
                 <p
                   class="organisation__paragraph"
                   data-module="ga4-link-tracker"
-                  data-ga4-track-links-only
                   data-ga4-do-not-redact
                   data-ga4-link="<%= ga4_email_link_data.to_json %>">
                     <%= email.html_safe %>

--- a/app/views/organisations/_featured_news_no10.html.erb
+++ b/app/views/organisations/_featured_news_no10.html.erb
@@ -25,12 +25,12 @@
     documents_without_first = @documents.remaining_featured_news.drop(1).first(6)
   %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+    <div class="govuk-grid-column-full" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
       <%= render "govuk_publishing_components/components/image_card", first_document.merge({ large: true }) %>
     </div>
   </div>
   <% documents_without_first.in_groups_of(3, false) do |news| %>
-    <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+    <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
       <% news.each do |news_item| %>
         <% classes = %w[] %>
         <% classes << "govuk-grid-column-one-third" %>

--- a/app/views/organisations/_latest_documents.html.erb
+++ b/app/views/organisations/_latest_documents.html.erb
@@ -28,7 +28,6 @@
       <div
         data-module="ga4-link-tracker"
         data-ga4-link="<%= { "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": ga4_section }.to_json %>"
-        data-ga4-track-links-only
       >
         <%= render "govuk_publishing_components/components/subscription_links", @show.subscription_links %>
       </div>

--- a/app/views/organisations/_latest_news.html.erb
+++ b/app/views/organisations/_latest_news.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>" data-ga4-track-links-only>
+    <div class="govuk-grid-column-one-half" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
       <% latest_news_items = latest_news_items(@organisation, get_first_image: true) %>
       <%= render "govuk_publishing_components/components/image_card", latest_news_items.shift %>
     </div>

--- a/app/views/organisations/_organisations_list.html.erb
+++ b/app/views/organisations/_organisations_list.html.erb
@@ -24,7 +24,6 @@
     <div class="govuk-grid-column-two-thirds <%= "organisations-list__without-number" if @presented_organisations.executive_office?(organisation_type) %>">
       <ol
         data-module="ga4-link-tracker"
-        data-ga4-track-links-only
         data-ga4-link="<%= { event_name: "navigation", type: "filter" }.to_json %>">
         <% organisations.each do |organisation| %>
           <%= content_tag :li, {

--- a/app/views/organisations/_promotional_features.html.erb
+++ b/app/views/organisations/_promotional_features.html.erb
@@ -8,7 +8,7 @@
         "section": feature[:title]
       }.to_json
     %>
-    <div class="organisation__promotion" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+    <div class="organisation__promotion" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
       <%= render "govuk_publishing_components/components/heading", {
         text: feature[:title],
         heading_level: 2,

--- a/app/views/organisations/_promotional_features_side_by_side.html.erb
+++ b/app/views/organisations/_promotional_features_side_by_side.html.erb
@@ -10,7 +10,7 @@
           }.to_json
         %>
         <div class="govuk-grid-column-one-half">
-          <div class="organisation__promotion" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+          <div class="organisation__promotion" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
             <%= render "govuk_publishing_components/components/heading", {
               text: feature[:title],
               heading_level: 2,

--- a/app/views/organisations/_related_people.html.erb
+++ b/app/views/organisations/_related_people.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <% people.in_groups_of(4, false) do |people| %>
-      <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+      <div class="govuk-grid-row" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
         <% people.each do |person| %>
           <div class="govuk-grid-column-one-quarter">
             <%= render "govuk_publishing_components/components/image_card", person %>

--- a/app/views/shared/_announcements.html.erb
+++ b/app/views/shared/_announcements.html.erb
@@ -9,7 +9,6 @@
     <div
       data-module="ga4-link-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
-      data-ga4-track-links-only
     >
       <%= render "govuk_publishing_components/components/subscription_links", {
           email_signup_link: announcements.links[:email_signup],

--- a/app/views/shared/_featured_links.html.erb
+++ b/app/views/shared/_featured_links.html.erb
@@ -4,7 +4,7 @@
   margin_bottom ||= false
   ga4_data ||= {}
 
-  wrapper_data_attributes = { "module": "ga4-link-tracker", "ga4-track-links-only": "" } if !ga4_data.empty?
+  wrapper_data_attributes = { "module": "ga4-link-tracker" } if !ga4_data.empty?
 
   brand ||= false
   brand_helper = GovukPublishingComponents::AppHelpers::BrandHelper.new(brand)

--- a/app/views/taxons/_common.html.erb
+++ b/app/views/taxons/_common.html.erb
@@ -27,7 +27,6 @@
       class="govuk-width-container"
       data-module="ga4-link-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-      data-ga4-track-links-only
     >
       <%= render "govuk_publishing_components/components/signup_link", {
         link_text: t("shared.get_emails"),

--- a/app/views/taxons/show.html.erb
+++ b/app/views/taxons/show.html.erb
@@ -51,7 +51,6 @@
             <%
               ga4_data = {
                 module: "ga4-link-tracker",
-                ga4_track_links_only: "",
                 ga4_set_indexes: "",
                 ga4_link: {
                   event_name: "navigation",

--- a/app/views/topical_events/show.html.erb
+++ b/app/views/topical_events/show.html.erb
@@ -119,7 +119,7 @@
         <% @topical_event.ordered_featured_documents.in_groups_of(3, false) do |row| %>
           <div class="govuk-grid-row">
             <% row.each do |document| %>
-              <div class="govuk-grid-column-one-third" data-module="ga4-link-tracker" data-ga4-track-links-only data-ga4-link="<%= ga4_image_card_json %>">
+              <div class="govuk-grid-column-one-third" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_image_card_json %>">
                 <%= render "govuk_publishing_components/components/image_card", document %>
               </div>
             <% end %>
@@ -150,7 +150,6 @@
       <div
         data-module="ga4-link-tracker"
         data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
-        data-ga4-track-links-only
       >
         <%= render "govuk_publishing_components/components/subscription_links", {
           email_signup_link: "/email-signup?link=#{topical_event_path(@topical_event.slug)}"

--- a/app/views/world/index.html.erb
+++ b/app/views/world/index.html.erb
@@ -62,7 +62,6 @@
         <ol
           class="world-locations-groups"
           data-module="ga4-link-tracker"
-          data-ga4-track-links-only
           data-ga4-link="<%= { event_name: "navigation", type: "filter" }.to_json %>">
           <% @presented_index.grouped_world_locations.each do |letter, locations| %>
             <li class="world-locations-group" data-filter="inner-block">

--- a/app/views/world_location_news/show.html.erb
+++ b/app/views/world_location_news/show.html.erb
@@ -87,7 +87,6 @@
         <div
           data-module="ga4-link-tracker"
           data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Content" }'
-          data-ga4-track-links-only
         >
           <%= render "govuk_publishing_components/components/subscription_links", {
             email_signup_link: "/email/subscriptions/new?topic_id=#{@world_location_news.slug}"

--- a/app/views/world_wide_taxons/_email_alerts.html.erb
+++ b/app/views/world_wide_taxons/_email_alerts.html.erb
@@ -2,7 +2,6 @@
   <div
     data-module="ga4-link-tracker"
     data-ga4-link='{ "event_name": "navigation", "type": "subscribe", "index_link": 1, "index_total": 1, "section": "Top" }'
-    data-ga4-track-links-only
   >
     <% if presented_taxon.renders_as_accordion? %>
       <%= render "govuk_publishing_components/components/subscription_links", {

--- a/spec/features/content_store_organisations_spec.rb
+++ b/spec/features/content_store_organisations_spec.rb
@@ -74,7 +74,6 @@ RSpec.feature "Content store organisations" do
   scenario "renders links with GA4 tracking" do
     ga4_module = "ol[data-module=ga4-link-tracker]"
     expect(page).to have_css(ga4_module)
-    expect(page).to have_css("ol[data-ga4-track-links-only]")
 
     ga4_link_data = JSON.parse(page.first(ga4_module)["data-ga4-link"])
     expect(ga4_link_data["event_name"]).to eq "navigation"

--- a/spec/features/topical_event_spec.rb
+++ b/spec/features/topical_event_spec.rb
@@ -275,7 +275,7 @@ RSpec.feature "Topical Event pages" do
     it "includes GA4 tracking on links to the featured documents" do
       visit base_path
       within("#featured") do
-        ga4_link_data = JSON.parse(page.first("div[data-module='ga4-link-tracker'][data-ga4-track-links-only]")["data-ga4-link"])
+        ga4_link_data = JSON.parse(page.first("div[data-module='ga4-link-tracker']")["data-ga4-link"])
         expect(ga4_link_data).to eq({ "event_name" => "navigation", "section" => "Featured", "type" => "image card" })
       end
     end

--- a/spec/features/world_index_spec.rb
+++ b/spec/features/world_index_spec.rb
@@ -59,7 +59,6 @@ RSpec.feature "World index page" do
   scenario "renders links with GA4 tracking" do
     ga4_module = "ol[data-module=ga4-link-tracker]"
     expect(page).to have_css(ga4_module)
-    expect(page).to have_css("ol[data-ga4-track-links-only]")
 
     ga4_link_data = JSON.parse(page.first(ga4_module)["data-ga4-link"])
     expect(ga4_link_data["event_name"]).to eq "navigation"

--- a/spec/features/world_location_news_spec.rb
+++ b/spec/features/world_location_news_spec.rb
@@ -97,7 +97,7 @@ RSpec.feature "World Location News pages" do
 
     it "includes GA4 tracking on the featured links" do
       visit base_path
-      within "[data-featured-links][data-module='ga4-link-tracker'][data-ga4-track-links-only]" do
+      within "[data-featured-links][data-module='ga4-link-tracker']" do
         first_ga4_link_data = JSON.parse(page.first("a[data-ga4-link]")["data-ga4-link"])
         expect(first_ga4_link_data).to eq({ "event_name" => "navigation", "index_link" => 1, "index_total" => 2, "section" => "UK and Mock Country", "type" => "document list" })
 

--- a/spec/helpers/browse_helper_spec.rb
+++ b/spec/helpers/browse_helper_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe BrowseHelper do
           href: "/foo/policy_paper",
           data_attributes: {
             module: "ga4-link-tracker",
-            ga4_track_links_only: "",
             ga4_link: {
               event_name: "navigation",
               type: "action",
@@ -38,7 +37,6 @@ RSpec.describe BrowseHelper do
           href: "/foo/news_story",
           data_attributes: {
             module: "ga4-link-tracker",
-            ga4_track_links_only: "",
             ga4_link: {
               event_name: "navigation",
               type: "action",
@@ -54,7 +52,6 @@ RSpec.describe BrowseHelper do
           href: "/foo/anything",
           data_attributes: {
             module: "ga4-link-tracker",
-            ga4_track_links_only: "",
             ga4_link: {
               event_name: "navigation",
               type: "action",

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -944,7 +944,6 @@ module OrganisationHelpers
   def test_ga4_get_emails_link(section_heading = nil)
     email_div = page.find("#latest-documents ul.gem-c-document-list ~ div")
     expect(email_div["data-module"]).to eq "ga4-link-tracker"
-    expect(email_div["data-ga4-track-links-only"]).to eq ""
     ga4_link_data = JSON.parse(email_div["data-ga4-link"])
     expect(ga4_link_data["event_name"]).to eq "navigation"
     expect(ga4_link_data["type"]).to eq "subscribe"
@@ -960,7 +959,6 @@ module OrganisationHelpers
     links.each do |link|
       expect(link["data-module"]).to eq "ga4-link-tracker"
       expect(link["data-ga4-do-not-redact"]).to eq ""
-      expect(link["data-ga4-track-links-only"]).to eq ""
       ga4_link_data = JSON.parse(link["data-ga4-link"])
       expect(ga4_link_data["event_name"]).to eq "navigation"
       expect(ga4_link_data["type"]).to eq "email"


### PR DESCRIPTION
## What/Why
- This attribute was removed from govuk_publishing_components as it wasn't actually needed, so we can remove it from this app.
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10043

## Visual changes
None.