### PR TITLE
Show translated latest mainstream documents on Welsh organisation pages

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -41,10 +41,10 @@ module OrganisationHelper
 
     return { "title" => content_item["title"], "link" => content_item["base_path"] } if introductory_paragraph.nil?
 
-    welsh_translation_link_regex = /This (.*) also available <a href="(.*)">in Welsh/
+    welsh_translation_link_regex = /This (.*) also available (in )?<a href="(.*)">(in )?Welsh/
 
     if welsh_translation_link_regex.match?(introductory_paragraph)
-      base_path = welsh_translation_link_regex.match(introductory_paragraph)[2]
+      base_path = welsh_translation_link_regex.match(introductory_paragraph)[3]
       translated_item = get_content_item(base_path)
 
       { "title" => translated_item["title"], "link" => translated_item["base_path"] }

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -13,6 +13,8 @@ module OrganisationHelper
 
     content_item = get_content_item(result["link"])
 
+    return get_translation_for_mainstream_pages(content_item) if content_item["publishing_app"] == "publisher"
+
     return result if content_item.dig("links", "available_translations").nil?
 
     content_item["links"]["available_translations"].each do |t|
@@ -27,6 +29,28 @@ module OrganisationHelper
     end
 
     result
+  end
+
+  def get_translation_for_mainstream_pages(content_item)
+    content_details = content_item["details"] || {}
+
+    introductory_paragraph =
+      content_details["introductory_paragraph"] ||
+      content_details.dig("parts", 0, "body") ||
+      content_details["body"]
+
+    return { "title" => content_item["title"], "link" => content_item["base_path"] } if introductory_paragraph.nil?
+
+    welsh_translation_link_regex = /This (.*) also available <a href="(.*)">in Welsh/
+
+    if welsh_translation_link_regex.match?(introductory_paragraph)
+      base_path = welsh_translation_link_regex.match(introductory_paragraph)[2]
+      translated_item = get_content_item(base_path)
+
+      { "title" => translated_item["title"], "link" => translated_item["base_path"] }
+    else
+      { "title" => content_item["title"], "link" => content_item["base_path"] }
+    end
   end
 
   def get_untranslated_organisation_base_path(base_path)

--- a/spec/features/organisation_spec.rb
+++ b/spec/features/organisation_spec.rb
@@ -263,6 +263,26 @@ RSpec.describe "Organisation pages" do
     expect(page).to have_css(".gem-c-document-list__item-title [href='/content-item-1.cy']", text: "Swyddfa Cymru")
   end
 
+  it "shows latest mainstream documents with translated version on Welsh" do
+    content_item_with_translated_latest_documents = {
+      "title" => "The Wales Office",
+      "base_path" => "/content-item-1",
+      "publishing_app" => "publisher",
+      "details" => {
+        "introductory_paragraph" => 'This guide is also available <a href="/content-item-1.cy">in Welsh',
+        "brand" => "",
+        "logo" => {},
+        "organisation_govuk_status" => { "status" => "" },
+      },
+    }
+    stub_content_store_has_item("/content-item-1", content_item_with_translated_latest_documents)
+    stub_content_store_has_item("/content-item-1.cy", { "title" => "Swyddfa Cymru123", "base_path" => "/content-item-1.cy" })
+
+    visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"
+    expect(page).to have_css(".gem-c-heading", text: "Newyddion a chyfathrebu")
+    expect(page).to have_css(".gem-c-document-list__item-title [href='/content-item-1.cy']", text: "Swyddfa Cymru")
+  end
+
   it "shows organisation page when a latest document url returns 404" do
     stub_content_store_does_not_have_item("/content-item-1")
     visit "/government/organisations/office-of-the-secretary-of-state-for-wales.cy"


### PR DESCRIPTION
Previously we worked on showing the translated latest documents on Welsh organisation pages. But that solution worked only for documents published in whitehall.
The mainstream pages don’t have the available translations linked in content store. So we were still showing the English version, even though a Welsh page exists.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18963

Before:
<img width="596" height="370" alt="Screenshot 2026-06-22 at 16 43 29" src="https://github.com/user-attachments/assets/309ed2b9-cd4e-43ec-913f-8c1170f4726e" />

After:
<img width="544" height="330" alt="Screenshot 2026-06-22 at 16 43 10" src="https://github.com/user-attachments/assets/0b86832b-0888-4353-bad8-3eef1e15069d" />


Example of pages:
https://collections-pr-4556.herokuapp.com/government/organisations/department-for-work-pensions.cy
https://collections-pr-4556.herokuapp.com/government/organisations/driver-and-vehicle-licensing-agency.cy
https://collections-pr-4556.herokuapp.com/government/organisations/food-standards-agency.cy


