### PR TITLE
Update references to Sass variables to use the govuk-functional-colour function

### DIFF
--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -25,7 +25,7 @@
 }
 
 .browse__section--top-border {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 1px solid govuk-functional-colour(border);
   padding-top: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/views/_history_people.scss
+++ b/app/assets/stylesheets/views/_history_people.scss
@@ -9,7 +9,7 @@
 
 .historic-people-index__section-row {
   .govuk-body {
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
 
     // Targets all of the years / periods of service but the last one.
     &:nth-last-child(n+2) {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -21,7 +21,7 @@
   background-color: govuk-colour("black", $variant: "tint-95");
   margin-top: -(govuk-spacing(6));
   margin-bottom: govuk-spacing(6);
-  border-bottom: 1px solid $govuk-border-colour;
+  border-bottom: 1px solid govuk-functional-colour(border);
   padding: govuk-spacing(6) 0;
 }
 
@@ -31,7 +31,7 @@
 }
 
 .taxon-page__section-group {
-  border-top: 2px solid $govuk-brand-colour;
+  border-top: 2px solid govuk-functional-colour(brand);
   margin-top: 45px;
   padding-top: govuk-spacing(3);
 }
@@ -73,7 +73,7 @@
 
   .taxon-page__organisation {
     margin-bottom: govuk-spacing(4);
-    border-bottom: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid govuk-functional-colour(border);
     padding-bottom: govuk-spacing(3);
   }
 }


### PR DESCRIPTION
## What

Replace colour variables with govuk-functional-colour function

## Why

The Sass variables for accessing functional colours are deprecated, and will be removed in a future breaking release of govuk-frontend

Jira card: https://gov-uk.atlassian.net/browse/NAV-18923
