### PR TITLE
Enable recruitment banner on organisations index page

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -10,6 +10,8 @@
   <%= auto_discovery_link_tag(:json, api_organisations_url, title: @presented_organisations.title) %>
 <% end %>
 
+<%= render "govuk_web_banners/recruitment_banner" %>
+
 <div data-module="list-filter">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

We need to put a recruitment banner on organisations index page.
https://collections-pr-4567.herokuapp.com/government/organisations
