### PR TITLE
Update frontend apps to ensure the new functional colour custom prope…

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .translation-nav-header {

--- a/app/assets/stylesheets/views/_browse.scss
+++ b/app/assets/stylesheets/views/_browse.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 // This isn't proper BEM - but the convention is to have the view name as the

--- a/app/assets/stylesheets/views/_bunting.scss
+++ b/app/assets/stylesheets/views/_bunting.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 %responsive-bunting-height {

--- a/app/assets/stylesheets/views/_covid.scss
+++ b/app/assets/stylesheets/views/_covid.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 $covid-grey: #272828;

--- a/app/assets/stylesheets/views/_history_people.scss
+++ b/app/assets/stylesheets/views/_history_people.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .historic-people-index__section-row-header {

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .organisation__brand-border-top {

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .organisations {

--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .content-list__sticky {

--- a/app/assets/stylesheets/views/_topical_events.scss
+++ b/app/assets/stylesheets/views/_topical_events.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .topical-events-show {

--- a/app/assets/stylesheets/views/_world_index.scss
+++ b/app/assets/stylesheets/views/_world_index.scss
@@ -1,3 +1,5 @@
+$govuk-output-custom-properties: false;
+
 @import "govuk_publishing_components/base";
 
 .world-locations {


### PR DESCRIPTION
## What

In preparing to upgrade to Design System v6 this PR configures any secondary and standalone stylesheets to exclude duplicate custom properties by utilising the `$govuk-output-custom-properties` setting. 

## Why

In v6, importing the core `base` styles automatically outputs a large block of CSS custom properties. 

This `$govuk-output-custom-properties` setting is not added to `application.scss` as this performs the initial load for the custom properties and functional colours. We've added `$govuk-output-custom-properties: false;` to the top of any other standalone/secondary stylesheets that independently import `govuk_publishing_components/base` preventing an identical second load. 

This follows the implementation pattern outlined in this [GOV.UK Frontend PR](https://github.com/alphagov/govuk-frontend/pull/6606).

Jira card: https://gov-uk.atlassian.net/browse/NAV-18925

## Visual changes

This is an under-the-hood optimisation to the asset pipeline. The custom property definitions are still loaded globally via the primary layout's `application.css`, so components rendered on these pages will inherit their functional colours as expected.

## Testing

This change was tested locally by pointing the application's Gemfile directly to the `v6-upgrade-feature-branch` of the `govuk_publishing_components` gem to simulate the upcoming production environment. Ran local asset compilation to ensure the build completes without errors.