### PR TITLE
Move to using govuk-functional-colour for borders and secondary text

### DIFF
--- a/app/assets/stylesheets/views/_bunting.scss
+++ b/app/assets/stylesheets/views/_bunting.scss
@@ -13,7 +13,7 @@
   left: 0;
   width: 100%;
   overflow: visible;
-  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-top: 1px solid govuk-functional-colour("border");
   @extend %responsive-bunting-height;
 }
 

--- a/app/assets/stylesheets/views/_ministers.scss
+++ b/app/assets/stylesheets/views/_ministers.scss
@@ -3,6 +3,6 @@
 }
 
 .footnotes {
-  color: govuk-colour("black", $variant: "tint-25");
+  color: govuk-functional-colour("secondary-text");
   display: block;
 }

--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -56,7 +56,7 @@
 }
 
 .organisation__contact-section--border-top {
-  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+  border-top: 1px solid govuk-functional-colour("border");
   margin-bottom: govuk-spacing(3);
 }
 

--- a/app/assets/stylesheets/views/_organisations.scss
+++ b/app/assets/stylesheets/views/_organisations.scss
@@ -8,7 +8,7 @@
   .organisations-list__item {
     list-style-type: none;
     margin-bottom: govuk-spacing(3);
-    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-bottom: 1px solid govuk-functional-colour("border");
 
     h3 {
       margin: 0;

--- a/app/assets/stylesheets/views/_world_index.scss
+++ b/app/assets/stylesheets/views/_world_index.scss
@@ -26,7 +26,7 @@
 
   .world_locations-group__item {
     list-style-type: none;
-    border-bottom: 1px solid govuk-colour("black", $variant: "tint-80");
+    border-bottom: 1px solid govuk-functional-colour("border");
     padding: govuk-spacing(1) 0;
     @include govuk-font(19);
   }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
Replace instances where`govuk-colour("black", $variant: "tint-80")` is being used as border colour with `govuk-functional-colour("border")`.

Replace instances where `govuk-colour("black", $variant: "tint-25")` is being used as secondary text colour with `govuk-functional-colour("secondary-text")`.

## Why
https://gov-uk.atlassian.net/browse/NAV-18929

## Note
The tests are failing as the branch is not using the govuk-frontend v6.0. I've tested the branch locally against `v6-upgrade-feature-branch` in the gem and the stylesheet compiles correctly then.