### PR TITLE
Apply consistent spacing for taxon page breadcrumbs

### DIFF
--- a/app/assets/stylesheets/views/_taxons.scss
+++ b/app/assets/stylesheets/views/_taxons.scss
@@ -10,7 +10,10 @@
 
 .taxon-page__breadcrumbs-wrapper {
   background-color: $govuk-blue-tint-80;
-  padding: govuk-spacing(3) 0 govuk-spacing(4);
+  // Setting the overflow to auto is required to prevent the breadcrumb
+  // component's margin from collapsing.
+  overflow: auto;
+  padding-bottom: govuk-spacing(4);
 
   @include govuk-media-query($from: tablet) {
     padding-bottom: govuk-spacing(8);


### PR DESCRIPTION
## What

The spacing between breadcrumbs on taxon pages is larger than the spacing used elsewhere. This change updates the spacing to make it consistent with other pages e.g. https://www.gov.uk/browse.

## Why

To address a style inconsistency.

## Visual changes

### Before, after (desktop)

https://www.gov.uk/transport/driving-and-motorcycle-tests

<img width="1728" height="1117" alt="Screenshot 2026-07-17 at 11 31 21" src="https://github.com/user-attachments/assets/2053185a-0c6c-4410-b27e-8ba355240f73" />

### Before, after (mobile)

<img width="1728" height="1117" alt="Screenshot 2026-07-17 at 11 30 41" src="https://github.com/user-attachments/assets/eb2c15bb-12a9-409e-a61d-438e1fb7a2c9" />

### Comparison with browse page (after changes)

https://www.gov.uk/transport/driving-and-motorcycle-tests and https://www.gov.uk/browse

<img width="1728" height="1117" alt="Screenshot 2026-07-17 at 11 28 33" src="https://github.com/user-attachments/assets/c88c9b59-7319-4397-982f-d6c0a27ee445" />

## Anything else

The taxon and browse page breadcrumb styles could likely be consolidated. However, the correct spacing should be confirmed with design, so that change should be handled separately.