### PR TITLE
Update the Civil Service organisation page to use its official brand colour

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -9,14 +9,6 @@
   overflow-wrap: break-word;
 }
 
-// This is only used to apply to promotional orgs where the border colour is always black
-// regardless of the link colour. This can be removed if we add the black border
-// colour as branding to the organisation.
-.organisation__section-border-top {
-  border-top: 5px solid govuk-colour("black");
-  padding-top: govuk-spacing(3);
-}
-
 .organisation__corporate-information {
   .organisation__float-section {
     @include govuk-media-query($from: tablet) {

--- a/app/views/organisations/_corporate_information.html.erb
+++ b/app/views/organisations/_corporate_information.html.erb
@@ -9,7 +9,7 @@
       } %>
     <% end %>
   <% if @show.corporate_information[:corporate_information_links][:items].any? && !@organisation.is_no_10? %>
-    <div class="<%= "organisation__section-border-top" if @organisation.is_civil_service? %>">
+    <div class="<%= "brand--civil-service brand__border-color organisation__brand-border-top govuk-!-static-padding-top-3" if @organisation.is_civil_service? %>">
       <%= render "shared/featured_links", @show.corporate_information[:corporate_information_links].merge({ ga4_data: { section: t('organisations.corporate_information', locale: :en) } }) %>
     </div>
   <% end %>


### PR DESCRIPTION
## What
In this PR we're updating the [Civil Service organisation page](https://www.gov.uk/government/organisations/civil-service) to use its [official brand colour](https://www.brand.gov.uk/department/civil-service/) (#b2292e) for borders, removing any hardcoded overrides. This brings the page in line with the brand guidelines and the Design System.

## Why
Historically, an override was put in place to force Civil Service page borders to black because the anchor links on the page were also red, causing a visual clash.

Jira card: https://gov-uk.atlassian.net/browse/NAV-19016

## Visual Changes

| Before | After |
|--------|--------|
| <img width="1035" height="919" alt="Screenshot 2026-07-22 at 15 49 58" src="https://github.com/user-attachments/assets/1fd68de4-e8b4-499b-aaeb-c3eb90dc3b22" /> | <img width="1044" height="905" alt="Screenshot 2026-07-22 at 15 50 24" src="https://github.com/user-attachments/assets/3a3499ff-3ea3-4cc2-9fec-be0d11d673a4" /> | 
| <img width="1021" height="912" alt="Screenshot 2026-07-23 at 14 54 00" src="https://github.com/user-attachments/assets/09be2159-e1de-47c7-8c0d-da9ab4c84e8d" /> | <img width="1025" height="909" alt="Screenshot 2026-07-23 at 14 53 53" src="https://github.com/user-attachments/assets/9fc6bdcb-2bc2-49f1-afdb-445bcf22e703" /> |
