### PR TITLE
Organisations API: increase cache expiry

### DIFF
--- a/app/controllers/organisations_api_controller.rb
+++ b/app/controllers/organisations_api_controller.rb
@@ -72,7 +72,7 @@ private
       start: 0,
     }
 
-    @organisation_from_search ||= Services.cached_search(params, metric_key: "organisation_api.search.request_time")
+    @organisation_from_search ||= Services.cached_search(params, metric_key: "organisation_api.search.request_time", expires_in: 2.hours)
   end
 
   def set_link_header(links:)


### PR DESCRIPTION
## What
Cache the Organisation API list response for 2hours instead of 5 minutes 


## Why
Reduce load on SearchAPI


Jira card: https://gov-uk.atlassian.net/browse/SCH-2243

