### PR TITLE
Increase OrganisationsAPI page size

### DIFF
--- a/app/controllers/organisations_api_controller.rb
+++ b/app/controllers/organisations_api_controller.rb
@@ -25,7 +25,7 @@ class OrganisationsApiController < ApplicationController
 
 private
 
-  RESULTS_PER_PAGE = 20
+  RESULTS_PER_PAGE = 100
 
   def presented_organisations(start:)
     organisations = organisations_from_search(count: RESULTS_PER_PAGE, start:)

--- a/spec/support/organisations_api_test_helper.rb
+++ b/spec/support/organisations_api_test_helper.rb
@@ -3,7 +3,7 @@ module OrganisationsApiTestHelper
     {
       filter_format: "organisation",
       order: "title",
-      count: "20",
+      count: "100",
       start:,
     }
   end


### PR DESCRIPTION
## What

The OrganisationsAPI index action[1] returns a paginated list of organisations obtained from SearchAPI. There are currently 1259 organisations[2], and these are fetched 20 at a time requiring in excess of 60 requests.

If we return 100 results, we reduce the number of requests needed to 12. It increases the size of the request from 7kb to 30kb. It has a negligable impact on response time.

[1] https://www.gov.uk/api/organisations
[2] https://www.gov.uk/api/search.json?filter_format=organisation&count=0

## Why

To reduce load on SearchAPI

- Pact tests will fail until gds-api-adapters is updated to expect 100 results instead of 20
- Jira card: https://gov-uk.atlassian.net/browse/SCH-2243
