### PR TITLE
Update paragraphs in organisation contact section to use Design System styles

### DIFF
--- a/app/assets/stylesheets/views/_organisation.scss
+++ b/app/assets/stylesheets/views/_organisation.scss
@@ -38,10 +38,6 @@
   }
 }
 
-.organisation__paragraph {
-  @include govuk-font(19);
-}
-
 .organisation__parent-organisations {
   margin-top: govuk-spacing(3);
   @include govuk-font(19);

--- a/app/presenters/organisations/contacts_presenter.rb
+++ b/app/presenters/organisations/contacts_presenter.rb
@@ -112,7 +112,7 @@ module Organisations
     end
 
     def contact_description(description)
-      tag.p(description.gsub("\r\n", "<br/>").html_safe, class: "organisation__paragraph") if description.present?
+      tag.p(description.gsub("\r\n", "<br/>").html_safe, class: "govuk-body") if description.present?
     end
   end
 end

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -13,63 +13,56 @@
       font_size: 19,
     } %>
 
-    <div class="govuk-grid-row">
-      <% if contact[:post_addresses].any? %>
-        <address class="govuk-grid-column-two-thirds organisation__margin-bottom organisation__address">
-          <% contact[:post_addresses].each do |post| %>
-            <%= post.html_safe %>
-          <% end %>
-        </address>
-      <% end %>
+    <% if contact[:post_addresses].any? %>
+      <address class="organisation__margin-bottom organisation__address">
+        <% contact[:post_addresses].each do |post| %>
+          <%= post.html_safe %>
+        <% end %>
+      </address>
+    <% end %>
 
-      <% if contact[:email_addresses].any? || contact[:links].any? || contact[:phone_numbers].any?  %>
-        <div class="govuk-grid-column-two-thirds">
-          <% if contact[:email_addresses].any? %>
-            <div class="organisation__margin-bottom">
-              <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>
-                <p class="govuk-body"><%= t('organisations.contact.email') %></p>
-              <% else %>
-                <p class="govuk-body" lang="en"><%= t('organisations.contact.email') %></p>
-              <% end %>
-
-              <% contact[:email_addresses].each do |email| %>
-                <p
-                  class="govuk-body"
-                  data-module="ga4-link-tracker"
-                  data-ga4-do-not-redact
-                  data-ga4-link="<%= ga4_email_link_data.to_json %>">
-                    <%= email.html_safe %>
-                </p>
-              <% end %>
-            </div>
+    <% if contact[:email_addresses].any? || contact[:links].any? || contact[:phone_numbers].any?  %>
+      <% if contact[:email_addresses].any? %>
+        <div class="organisation__margin-bottom">
+          <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>
+            <p class="govuk-body"><%= t('organisations.contact.email') %></p>
+          <% else %>
+            <p class="govuk-body" lang="en"><%= t('organisations.contact.email') %></p>
           <% end %>
 
-          <% if contact[:links].any? %>
-            <div class="organisation__margin-bottom">
-              <% contact[:links].each do |link| %>
-                <p class="govuk-body"><%= link.html_safe %></p>
-              <% end %>
-            </div>
+          <% contact[:email_addresses].each do |email| %>
+            <p
+              class="govuk-body"
+              data-module="ga4-link-tracker"
+              data-ga4-do-not-redact
+              data-ga4-link="<%= ga4_email_link_data.to_json %>">
+                <%= email.html_safe %>
+            </p>
           <% end %>
-
-          <% if contact[:phone_numbers].any? %>
-            <div class="organisation__margin-bottom">
-              <% contact[:phone_numbers].each do |phone| %>
-                <p class="govuk-body"><%= phone[:title] %></p>
-                <p class="govuk-body"><%= phone[:number] %></p>
-              <% end %>
-            </div>
-          <% end %>
-
         </div>
       <% end %>
-    </div>
+
+      <% if contact[:links].any? %>
+        <div class="organisation__margin-bottom">
+          <% contact[:links].each do |link| %>
+            <p class="govuk-body"><%= link.html_safe %></p>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% if contact[:phone_numbers].any? %>
+        <div class="organisation__margin-bottom">
+          <% contact[:phone_numbers].each do |phone| %>
+            <p class="govuk-body"><%= phone[:title] %></p>
+            <p class="govuk-body"><%= phone[:number] %></p>
+          <% end %>
+        </div>
+      <% end %>
+
+    <% end %>
+  
     <% if contact[:description] %>
-      <div class="govuk-grid-row">  
-        <div class="govuk-grid-column-two-thirds">
-            <%= auto_link(contact[:description], html: { class: "brand__color govuk-link" }) %>
-        </div>
-      </div>
+      <%= auto_link(contact[:description], html: { class: "brand__color govuk-link" }) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -27,14 +27,14 @@
           <% if contact[:email_addresses].any? %>
             <div class="organisation__margin-bottom">
               <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>
-                <p class="organisation__paragraph"><%= t('organisations.contact.email') %></p>
+                <p class="govuk-body"><%= t('organisations.contact.email') %></p>
               <% else %>
-                <p class="organisation__paragraph" lang="en"><%= t('organisations.contact.email') %></p>
+                <p class="govuk-body" lang="en"><%= t('organisations.contact.email') %></p>
               <% end %>
 
               <% contact[:email_addresses].each do |email| %>
                 <p
-                  class="organisation__paragraph"
+                  class="govuk-body"
                   data-module="ga4-link-tracker"
                   data-ga4-do-not-redact
                   data-ga4-link="<%= ga4_email_link_data.to_json %>">
@@ -47,7 +47,7 @@
           <% if contact[:links].any? %>
             <div class="organisation__margin-bottom">
               <% contact[:links].each do |link| %>
-                <p class="organisation__paragraph"><%= link.html_safe %></p>
+                <p class="govuk-body"><%= link.html_safe %></p>
               <% end %>
             </div>
           <% end %>
@@ -55,8 +55,8 @@
           <% if contact[:phone_numbers].any? %>
             <div class="organisation__margin-bottom">
               <% contact[:phone_numbers].each do |phone| %>
-                <p class="organisation__paragraph"><%= phone[:title] %></p>
-                <p class="organisation__contact-number organisation__paragraph"><%= phone[:number] %></p>
+                <p class="govuk-body"><%= phone[:title] %></p>
+                <p class="govuk-body"><%= phone[:number] %></p>
               <% end %>
             </div>
           <% end %>

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -15,7 +15,7 @@
 
     <div class="govuk-grid-row">
       <% if contact[:post_addresses].any? %>
-        <address class="govuk-grid-column-one-half organisation__margin-bottom organisation__address">
+        <address class="govuk-grid-column-two-thirds organisation__margin-bottom organisation__address">
           <% contact[:post_addresses].each do |post| %>
             <%= post.html_safe %>
           <% end %>
@@ -23,7 +23,7 @@
       <% end %>
 
       <% if contact[:email_addresses].any? || contact[:links].any? || contact[:phone_numbers].any?  %>
-        <div class="<%= contact[:post_addresses].any? ? "govuk-grid-column-one-half" : "govuk-grid-column-two-thirds" %>">
+        <div class="govuk-grid-column-two-thirds">
           <% if contact[:email_addresses].any? %>
             <div class="organisation__margin-bottom">
               <% if I18n.exists?('organisations.contact.email', contact[:locale]) %>

--- a/app/views/organisations/_contacts.html.erb
+++ b/app/views/organisations/_contacts.html.erb
@@ -64,7 +64,13 @@
         </div>
       <% end %>
     </div>
-    <%= auto_link(contact[:description], html: { class: "brand__color govuk-link" }) if contact[:description] %>
+    <% if contact[:description] %>
+      <div class="govuk-grid-row">  
+        <div class="govuk-grid-column-two-thirds">
+            <%= auto_link(contact[:description], html: { class: "brand__color govuk-link" }) %>
+        </div>
+      </div>
+    <% end %>
   </div>
 <% end %>
 <% end %>

--- a/spec/presenters/organisations/contacts_presenter_spec.rb
+++ b/spec/presenters/organisations/contacts_presenter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/to/some/foi/stuff\">Click me</a>",
           ],
-          description: "<p class=\"organisation__paragraph\">FOI requests<br/><br/>are possible</p>",
+          description: "<p class=\"govuk-body\">FOI requests<br/><br/>are possible</p>",
         },
         {
           locale: "en",
@@ -37,7 +37,7 @@ RSpec.describe Organisations::ContactsPresenter do
           links: [
             "<a class=\"govuk-link brand__color\" href=\"/foi/stuff\">FOI contact form</a>",
           ],
-          description: "<p class=\"organisation__paragraph\">Something here<br/><br/>Something there</p>",
+          description: "<p class=\"govuk-body\">Something here<br/><br/>Something there</p>",
         },
         {
           locale: "en",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
Update paragraphs in organisation contact sections to use the Design System styles. Remove the now redundant `organisation__paragraph`.

There are some spacing changes around the Contact link when it sits inline below or above text as can be seen on the No 10 screenshots below. We'll ask our designer to review the change to see if we want to replicate the existing spacing.

## Why

We should be using the Design System styles for consistency including spacing.

https://gov-uk.atlassian.net/browse/NAV-18517

## Visual changes

### Before

<img width="653" height="746" alt="Screenshot 2026-07-31 at 16 03 34" src="https://github.com/user-attachments/assets/51dc0b88-f528-4b3b-8793-4c19c5c315eb" />

### After

<img width="652" height="701" alt="Screenshot 2026-07-31 at 16 52 14" src="https://github.com/user-attachments/assets/b592ade5-44e1-48f0-a074-ea05fdee912a" />

### Before
<img width="222" height="401" alt="Screenshot 2026-07-31 at 16 53 04" src="https://github.com/user-attachments/assets/311daecf-5f1b-4d9d-a0a7-82dd27abbe50" />

### After

<img width="216" height="366" alt="Screenshot 2026-07-31 at 16 53 46" src="https://github.com/user-attachments/assets/b329e25d-267f-4039-968c-752227992ec6" />

### Before
<img width="650" height="575" alt="Screenshot 2026-07-31 at 16 02 03" src="https://github.com/user-attachments/assets/a5bb8363-7b6c-4c65-ba7e-c480747ddb7f" />

### After

<img width="642" height="556" alt="Screenshot 2026-07-31 at 16 55 15" src="https://github.com/user-attachments/assets/c6325223-2f7f-4883-9d61-637889bdead8" />

### Before
<img width="658" height="573" alt="Screenshot 2026-07-31 at 17 20 19" src="https://github.com/user-attachments/assets/5fc722f1-d9b0-4f6f-833c-b67e3d418d71" />

### After

<img width="656" height="550" alt="Screenshot 2026-07-31 at 17 20 10" src="https://github.com/user-attachments/assets/c9135f47-5e57-4086-b8bf-3f1fa65b22c7" />


