### PR TITLE
Fix ARIA list item hierarchy

### DIFF
--- a/app/views/historic_appointments/_grouped_historical_people.html.erb
+++ b/app/views/historic_appointments/_grouped_historical_people.html.erb
@@ -9,9 +9,9 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   </div>
 </div>
-<div id=<%= "historical-people-#{heading.downcase.gsub(' ', '-')}" %>>
+<div id="<%= "historical-people-#{heading.downcase.gsub(' ', '-')}" %>" role="list">
   <% people.each_slice(4) do |row| %>
-    <div class="govuk-grid-row historic-people-index__section-row">
+    <div class="govuk-grid-row historic-people-index__section-row" role="presentation">
       <% row.map(&:deep_symbolize_keys).each do |info| %>
         <% if include_images %>
           <div role="listitem" class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
## What

- Added role="list" to the outer wrapper container of list items in the section
- Added role="presentation" to the row element within that section
- Fixed missing quotes around the dynamic ID attribute on the wrapper div

## Why

W3C / HTML validators fail with:
`An element with role=listitem must be contained in, or owned by, an element with the role value list, or group.`
The grid layout requires intermediate row divs, without explicit ARIA roles, these intermediate divs break the expected parent-child hierarchy in the accessibility tree between the list container and the role="listitem" elements.

Adding role="presentation" instructs screen readers and assistive technologies to ignore the purely presentational grid row wrappers while preserving the CSS grid visual layout. This allows assistive tools to map the items directly to the parent role="list".

Jira card: https://gov-uk.atlassian.net/browse/NAV-18949

Fixes: https://github.com/alphagov/collections/issues/4502

## Visual changes

### Before

<img width="1908" height="833" alt="Screenshot 2026-08-05 at 16 49 26" src="https://github.com/user-attachments/assets/2e060d9a-93bc-4b30-b8d9-c205217b5e3c" />

### After

<img width="1914" height="837" alt="Screenshot 2026-08-05 at 16 49 43" src="https://github.com/user-attachments/assets/85841732-fe08-4355-be41-213f8f336981" />

