### PR TITLE
[DO NOT MERGE] Add an in-page search/filter to the list of embassies page

### DIFF
--- a/app/assets/stylesheets/views/_embassies.scss
+++ b/app/assets/stylesheets/views/_embassies.scss
@@ -1,0 +1,18 @@
+@import "govuk_publishing_components/base";
+
+.embassies-list {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.embassies-list__item {
+  padding-bottom: 0;
+  margin-bottom: govuk-spacing(3);
+  border-bottom: solid 1px $govuk-border-colour;
+
+  @include govuk-media-query($from: "tablet") {
+    padding-bottom: govuk-spacing(4);
+    margin-bottom: govuk-spacing(4);
+  }
+}

--- a/app/views/embassies/_organisation.html.erb
+++ b/app/views/embassies/_organisation.html.erb
@@ -1,8 +1,9 @@
 <li>
   <%= render "govuk_publishing_components/components/heading", {
     text: organisation.locality,
-    heading_level: 3,
-    margin_bottom: 1
+    heading_level: 4,
+    margin_bottom: 1,
+    font_size: "s",
   } %>
   <%= link_to(organisation.name, organisation.path, class: "govuk-link") %>
 </li>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -28,10 +28,10 @@
       margin_bottom: 6,
       } %>
   </aside>
-  <section class="govuk-grid-column-three-quarters">
+  <section class="govuk-grid-column-three-quarters" data-module="filter-list" data-filter-label="Search">
     <ol class="embassies-list">
       <% @presented_embassies.embassies_by_location.each do |embassy| -%>
-        <li class="embassies-list__item">
+        <li class="embassies-list__item" data-filter-item>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -8,55 +8,57 @@
 
 <% page_class "govuk-main-wrapper govuk-main-wrapper--auto-spacing" %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  context: t('embassies.context'),
-  text: @presented_embassies.title,
-  heading_level: 1,
-  margin_bottom: 8,
-  font_size: "xl",
-} %>
-
-<div class="govuk-main-wrapper">
-  <div class="govuk-grid-row">
-    <aside class="govuk-grid-column-one-quarter">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: raw("<span class=\" govuk-visually-hidden\">#{t('embassies.visually_hidden_ordering_hint')} </span> #{t('embassies.ordering_title')}"),
-        font_size: "l",
-        margin_bottom: 6,
-        } %>
-    </aside>
-    <section class="govuk-grid-column-three-quarters">
-      <ol class="embassies-list">
-        <% @presented_embassies.embassies_by_location.each do |embassy| -%>
-          <li class="embassies-list__item">
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-one-third">
-                <%= render "govuk_publishing_components/components/heading", {
-                  text: embassy.name, margin_bottom: 1
-                  } %>
-              </div>
-              <div class="govuk-grid-column-two-thirds">
-                <% if embassy.can_assist_british_nationals? %>
-                  <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
-                    <% if embassy.can_assist_in_location? %>
-                      <%= render partial: "organisation", collection: embassy.organisations_with_embassy_offices %>
-                    <% else %>
-                      <li>
-                        <p class="govuk-body">
-                          <%= t('embassies.contact_office_name_in_location', name: embassy.remote_office.name, location: embassy.remote_office.location) %>.
-                        </p>
-                        <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
-                      </li>
-                    <% end %>
-                  </ul>
-                <% else %>
-                  <p class="govuk-body"><%= t('embassies.contact_local_authorities') %>.</p>
-                <% end %>
-              </div>
-            </div>
-          </li>
-        <% end %>
-      </ol>
-    </section>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      context: t('embassies.context'),
+      text: @presented_embassies.title,
+      heading_level: 1,
+      margin_bottom: 8,
+      font_size: "xl",
+    } %>
   </div>
+</div>
+
+<div class="govuk-grid-row">
+  <aside class="govuk-grid-column-one-quarter">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: raw("<span class=\" govuk-visually-hidden\">#{t('embassies.visually_hidden_ordering_hint')} </span> #{t('embassies.ordering_title')}"),
+      font_size: "l",
+      margin_bottom: 6,
+      } %>
+  </aside>
+  <section class="govuk-grid-column-three-quarters">
+    <ol class="embassies-list">
+      <% @presented_embassies.embassies_by_location.each do |embassy| -%>
+        <li class="embassies-list__item">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+              <%= render "govuk_publishing_components/components/heading", {
+                text: embassy.name, margin_bottom: 1
+                } %>
+            </div>
+            <div class="govuk-grid-column-two-thirds">
+              <% if embassy.can_assist_british_nationals? %>
+                <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
+                  <% if embassy.can_assist_in_location? %>
+                    <%= render partial: "organisation", collection: embassy.organisations_with_embassy_offices %>
+                  <% else %>
+                    <li>
+                      <p class="govuk-body">
+                        <%= t('embassies.contact_office_name_in_location', name: embassy.remote_office.name, location: embassy.remote_office.location) %>.
+                      </p>
+                      <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="govuk-body"><%= t('embassies.contact_local_authorities') %>.</p>
+              <% end %>
+            </div>
+          </div>
+        </li>
+      <% end %>
+    </ol>
+  </section>
 </div>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -21,22 +21,22 @@
 </div>
 
 <div class="govuk-grid-row">
-  <aside class="govuk-grid-column-one-quarter">
+  <section class="govuk-grid-column-three-quarters-from-desktop" data-module="filter-list" data-filter-label="Search for an embassy by country">
     <%= render "govuk_publishing_components/components/heading", {
       text: raw("<span class=\" govuk-visually-hidden\">#{t('embassies.visually_hidden_ordering_hint')} </span> #{t('embassies.ordering_title')}"),
       font_size: "l",
       margin_bottom: 6,
-      } %>
-  </aside>
-  <section class="govuk-grid-column-three-quarters" data-module="filter-list" data-filter-label="Search">
+    } %>
     <ol class="embassies-list">
       <% @presented_embassies.embassies_by_location.each do |embassy| -%>
         <li class="embassies-list__item" data-filter-item>
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <%= render "govuk_publishing_components/components/heading", {
-                text: embassy.name, margin_bottom: 1
-                } %>
+                text: embassy.name,
+                margin_bottom: 1,
+                heading_level: 3,
+              } %>
             </div>
             <div class="govuk-grid-column-two-thirds">
               <% if embassy.can_assist_british_nationals? %>

--- a/app/views/embassies/index.html.erb
+++ b/app/views/embassies/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, @presented_embassies.title.html_safe %>
+<% content_for :head do %>
+  <%= stylesheet_link_tag "views/_embassies", media: "all" %>
+<% end %>
 <% content_for :meta_tags do %>
   <meta name="description" content="<%= t('embassies.meta_description') %>.">
 <% end %>
@@ -23,34 +26,35 @@
         } %>
     </aside>
     <section class="govuk-grid-column-three-quarters">
-      <ol class="govuk-list govuk-list--spaced">
+      <ol class="embassies-list">
         <% @presented_embassies.embassies_by_location.each do |embassy| -%>
-          <li class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
-              <%= render "govuk_publishing_components/components/heading", {
-                text: embassy.name, margin_bottom: 1
-                } %>
-            </div>
-            <div class="govuk-grid-column-two-thirds">
-              <% if embassy.can_assist_british_nationals? %>
-                <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
-                  <% if embassy.can_assist_in_location? %>
-                    <%= render partial: "organisation", collection: embassy.organisations_with_embassy_offices %>
-                  <% else %>
-                    <li>
-                      <p class="govuk-body">
-                        <%= t('embassies.contact_office_name_in_location', name: embassy.remote_office.name, location: embassy.remote_office.location) %>.
-                      </p>
-                      <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
-                    </li>
-                  <% end %>
-                </ul>
-              <% else %>
-                <p class="govuk-body"><%= t('embassies.contact_local_authorities') %>.</p>
-              <% end %>
+          <li class="embassies-list__item">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-one-third">
+                <%= render "govuk_publishing_components/components/heading", {
+                  text: embassy.name, margin_bottom: 1
+                  } %>
+              </div>
+              <div class="govuk-grid-column-two-thirds">
+                <% if embassy.can_assist_british_nationals? %>
+                  <ul class="govuk-list govuk-list--spaced govuk-!-margin-top-0">
+                    <% if embassy.can_assist_in_location? %>
+                      <%= render partial: "organisation", collection: embassy.organisations_with_embassy_offices %>
+                    <% else %>
+                      <li>
+                        <p class="govuk-body">
+                          <%= t('embassies.contact_office_name_in_location', name: embassy.remote_office.name, location: embassy.remote_office.location) %>.
+                        </p>
+                        <%= link_to(embassy.remote_office.name, embassy.remote_office.path, class: "govuk-link") %>
+                      </li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <p class="govuk-body"><%= t('embassies.contact_local_authorities') %>.</p>
+                <% end %>
+              </div>
             </div>
           </li>
-          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         <% end %>
       </ol>
     </section>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -4,6 +4,7 @@ APP_STYLESHEETS = {
   "views/_browse.scss" => "views/_browse.css",
   "views/_bunting.scss" => "views/_bunting.css",
   "views/_covid.scss" => "views/_covid.css",
+  "views/_embassies.scss" => "views/_embassies.css",
   "views/_history_people.scss" => "views/_history_people.css",
   "views/_ministers.scss" => "views/_ministers.css",
   "views/_organisation.scss" => "views/_organisation.css",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds an in-page search/filter to the [list of embassies page](https://www.gov.uk/world/embassies)

Have been doing some digging about the `A-Z` heading, as it seems potentially redundant. This was added when the page was first created in `whitehall` [twelve years ago in this commit](https://github.com/alphagov/whitehall/pull/1714/changes/f830acaee395c13ebfb787e7a33794973319e7e1#diff-f59581422b3782032aa502ece3d00f8a5df03a11f29981c0fdab64ef1ce702e8) and there's [no explanation in the PR](https://github.com/alphagov/whitehall/pull/1714) specifically about it. The PR does have a broken link to what looks like a trello equivalent but I doubt we'll be able to find anything through that.

## Why
Relates to this open issue about similar pages: https://github.com/alphagov/govuk_publishing_components/issues/5093

## Visual changes
Before | After
------ | ------
<img width="1098" height="937" alt="Screenshot 2026-08-20 at 16 34 53" src="https://github.com/user-attachments/assets/94bd6352-53d8-4ff4-8968-a5eff6e12442" /> | <img width="1079" height="1029" alt="Screenshot 2026-08-20 at 16 40 29" src="https://github.com/user-attachments/assets/b34bafc2-85e6-4b33-8835-d697f473ecf8" />

