### PR TITLE
Supergroup caching

### DIFF
--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -4,18 +4,6 @@ module Search
 
     DEFAULT_SORT_ORDER = "-public_timestamp".freeze
 
-    SUPERGROUP_ADDITIONAL_SEARCH_PARAMS = {
-      "guidance_and_regulation" => {
-        order: "-popularity",
-      },
-      "news_and_communications" => {
-        reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
-      },
-      "services" => {
-        order: "-popularity",
-      },
-    }.freeze
-
     def initialize(organisation_slug:, content_purpose_supergroup:)
       @organisation_slug = organisation_slug
       @content_purpose_supergroup = content_purpose_supergroup
@@ -36,11 +24,21 @@ module Search
       }.merge(additional_search_params)
     end
 
-    def additional_search_params
-      SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(@content_purpose_supergroup, {})
-    end
-
   private
+
+    def additional_search_params
+      {
+        "guidance_and_regulation" => {
+          order: "-popularity",
+        },
+        "news_and_communications" => {
+          reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+        },
+        "services" => {
+          order: "-popularity",
+        },
+      }.fetch(content_purpose_supergroup, {})
+    end
 
     def search_search_api(additional_params)
       params = default_search_api_params.merge(additional_params).compact

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -14,7 +14,7 @@ module Search
     end
 
     def documents
-      @documents ||= search_search_api
+      @documents ||= fetch_search_results["results"]
     end
 
   private
@@ -33,10 +33,10 @@ module Search
       }.fetch(content_purpose_supergroup, {})
     end
 
-    def search_search_api
+    def fetch_search_results
       params = default_search_api_params.merge(additional_search_params).compact
 
-      Services.search_api.search(params)["results"]
+      Services.search_api.search(params)
     end
 
     def default_search_api_params

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -35,8 +35,13 @@ module Search
 
     def fetch_search_results
       params = default_search_api_params.merge(additional_search_params).compact
+      search_service(params)
+    end
 
-      Services.search_api.search(params)
+    def search_service(params)
+      expires_in = params[:order] == "-popularity" ? 12.hours : 60.minutes
+
+      Services.cached_search(params, expires_in:)
     end
 
     def default_search_api_params

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -1,13 +1,24 @@
 module Search
   class Supergroup
-    attr_reader :content_purpose_supergroup, :additional_search_params
+    attr_reader :content_purpose_supergroup
 
     DEFAULT_SORT_ORDER = "-public_timestamp".freeze
 
-    def initialize(organisation_slug:, content_purpose_supergroup:, additional_search_params: {})
+    SUPERGROUP_ADDITIONAL_SEARCH_PARAMS = {
+      "guidance_and_regulation" => {
+        order: "-popularity",
+      },
+      "news_and_communications" => {
+        reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+      },
+      "services" => {
+        order: "-popularity",
+      },
+    }.freeze
+
+    def initialize(organisation_slug:, content_purpose_supergroup:)
       @organisation_slug = organisation_slug
       @content_purpose_supergroup = content_purpose_supergroup
-      @additional_search_params = additional_search_params
     end
 
     def has_documents?
@@ -23,6 +34,10 @@ module Search
         filter_organisations: @organisation_slug,
         filter_content_purpose_supergroup: @content_purpose_supergroup,
       }.merge(additional_search_params)
+    end
+
+    def additional_search_params
+      SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(@content_purpose_supergroup, {})
     end
 
   private

--- a/app/services/search/supergroup.rb
+++ b/app/services/search/supergroup.rb
@@ -14,14 +14,7 @@ module Search
     end
 
     def documents
-      @documents ||= search_search_api(documents_query)
-    end
-
-    def documents_query
-      {
-        filter_organisations: @organisation_slug,
-        filter_content_purpose_supergroup: @content_purpose_supergroup,
-      }.merge(additional_search_params)
+      @documents ||= search_search_api
     end
 
   private
@@ -40,8 +33,8 @@ module Search
       }.fetch(content_purpose_supergroup, {})
     end
 
-    def search_search_api(additional_params)
-      params = default_search_api_params.merge(additional_params).compact
+    def search_search_api
+      params = default_search_api_params.merge(additional_search_params).compact
 
       Services.search_api.search(params)["results"]
     end
@@ -51,6 +44,8 @@ module Search
         count: 2,
         order: DEFAULT_SORT_ORDER,
         fields: %w[title link content_store_document_type public_timestamp],
+        filter_organisations: @organisation_slug,
+        filter_content_purpose_supergroup: @content_purpose_supergroup,
       }
     end
   end

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -9,18 +9,6 @@ module Search
       transparency
     ].freeze
 
-    SUPERGROUP_ADDITIONAL_SEARCH_PARAMS = {
-      "guidance_and_regulation" => {
-        order: "-popularity",
-      },
-      "news_and_communications" => {
-        reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
-      },
-      "services" => {
-        order: "-popularity",
-      },
-    }.freeze
-
     def initialize(organisation_slug:)
       @organisation_slug = organisation_slug
     end
@@ -34,7 +22,6 @@ module Search
         Supergroup.new(
           organisation_slug: @organisation_slug,
           content_purpose_supergroup: group,
-          additional_search_params: SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {}),
         )
       end
     end

--- a/app/services/search/supergroups.rb
+++ b/app/services/search/supergroups.rb
@@ -1,6 +1,6 @@
 module Search
   class Supergroups
-    SUPERGROUP_TYPES = %w[
+    CONTENT_PURPOSE_SUPERGROUPS = %w[
       services
       guidance_and_regulation
       news_and_communications
@@ -30,7 +30,7 @@ module Search
     end
 
     def groups
-      @groups ||= SUPERGROUP_TYPES.map do |group|
+      @groups ||= CONTENT_PURPOSE_SUPERGROUPS.map do |group|
         Supergroup.new(
           organisation_slug: @organisation_slug,
           content_purpose_supergroup: group,

--- a/spec/services/search/supergroup_spec.rb
+++ b/spec/services/search/supergroup_spec.rb
@@ -1,35 +1,70 @@
 describe Search::Supergroup do
   include SearchApiHelpers
 
-  let(:supergroup) { described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "news_and_communications") }
-  let(:no_docs_supergroup) { described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "services") }
+  let(:news_and_comms_supergroup) { described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "news_and_communications") }
+  let(:services_supergroup) { described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "services") }
+  let(:guidance_and_regulation_supergroup) { described_class.new(organisation_slug: "attorney-generals-office", content_purpose_supergroup: "guidance_and_regulation") }
+
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
 
   before do
-    stub_services_supergroup_request
     stub_news_and_comms_supergroup_request
+    stub_services_supergroup_request_to_return_no_docs
+    stub_guidance_and_regulation_supergroup_request
+
+    allow(Rails).to receive(:cache).and_return(cache)
   end
 
   describe "#has_documents?" do
     it "returns false if there are no docs" do
-      expect(no_docs_supergroup.has_documents?).to eq(false)
+      expect(services_supergroup.has_documents?).to eq(false)
     end
 
     it "returns true if there are docs" do
-      expect(supergroup.has_documents?).to eq(true)
+      expect(news_and_comms_supergroup.has_documents?).to eq(true)
     end
   end
 
   describe "#documents" do
     it "provides a set of raw search_api search results" do
-      expect([raw_search_api_result]).to eq(supergroup.documents)
+      expect([raw_search_api_result("news_story")]).to eq(news_and_comms_supergroup.documents)
     end
 
     it "provides a set of raw search_api search results even if the set is empty" do
-      expect([]).to eq(no_docs_supergroup.documents)
+      expect([]).to eq(services_supergroup.documents)
+    end
+
+    context "when requesting search results sorted by public_timestamp" do
+      let(:search_params) do
+        { count: 2,
+          fields: %w[title link content_store_document_type public_timestamp],
+          filter_content_purpose_supergroup: "news_and_communications",
+          filter_organisations: "attorney-generals-office",
+          order: "-public_timestamp",
+          reject_content_purpose_subgroup: %w[decisions updates_and_alerts] }
+      end
+
+      let(:supergroup_documents) { news_and_comms_supergroup.documents }
+
+      it_behaves_like "a cached Search API request for supergroup documents", expected_expiry: 60.minutes
+    end
+
+    context "when fetching documents sorted by -popularity" do
+      let(:search_params) do
+        { count: 2,
+          fields: %w[title link content_store_document_type public_timestamp],
+          filter_content_purpose_supergroup: "guidance_and_regulation",
+          filter_organisations: "attorney-generals-office",
+          order: "-popularity" }
+      end
+
+      let(:supergroup_documents) { guidance_and_regulation_supergroup.documents }
+
+      it_behaves_like "a cached Search API request for supergroup documents", expected_expiry: 12.hours
     end
   end
 
-  def stub_services_supergroup_request
+  def stub_services_supergroup_request_to_return_no_docs
     stub_supergroup_request(
       results: [],
       additional_params: {
@@ -40,22 +75,33 @@ describe Search::Supergroup do
     )
   end
 
-  def raw_search_api_result
-    {
-      "title" => "Quiddich World Cup 2022 begins",
-      "link" => "/government/news/its-coming-home",
-      "content_store_document_type" => "news_story",
-      "public_timestamp " => "2022-11-21T12:00:00.000+01:00",
-    }
-  end
-
   def stub_news_and_comms_supergroup_request
     stub_supergroup_request(
-      results: [raw_search_api_result],
+      results: [raw_search_api_result("news_story")],
       additional_params: {
         filter_content_purpose_supergroup: "news_and_communications",
         filter_organisations: "attorney-generals-office",
       },
     )
+  end
+
+  def stub_guidance_and_regulation_supergroup_request
+    stub_supergroup_request(
+      results: [raw_search_api_result("guide")],
+      additional_params: {
+        filter_organisations: "attorney-generals-office",
+        filter_content_purpose_supergroup: "guidance_and_regulation",
+        order: "-popularity",
+      },
+    )
+  end
+
+  def raw_search_api_result(doc_type)
+    {
+      "title" => "Quiddich World Cup 2022 begins",
+      "link" => "/government/news/its-coming-home",
+      "content_store_document_type" => doc_type,
+      "public_timestamp " => "2022-11-21T12:00:00.000+01:00",
+    }
   end
 end

--- a/spec/services/search/supergroup_spec.rb
+++ b/spec/services/search/supergroup_spec.rb
@@ -35,6 +35,7 @@ describe Search::Supergroup do
       additional_params: {
         filter_organisations: "attorney-generals-office",
         filter_content_purpose_supergroup: "services",
+        order: "-popularity",
       },
     )
   end

--- a/spec/services/search/supergroups_spec.rb
+++ b/spec/services/search/supergroups_spec.rb
@@ -35,7 +35,7 @@ describe Search::Supergroups do
 
     it "applies the given additional search parameters" do
       supergroups.groups.each do |group|
-        params = Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(
+        params = Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(
           group.content_purpose_supergroup,
           {},
         )
@@ -61,7 +61,7 @@ describe Search::Supergroups do
         filter_content_purpose_supergroup: group,
         filter_organisations: organisation_slug,
         order: Search::Supergroup::DEFAULT_SORT_ORDER,
-      }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
+      }.merge(Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
     )
   end
 end

--- a/spec/services/search/supergroups_spec.rb
+++ b/spec/services/search/supergroups_spec.rb
@@ -8,7 +8,7 @@ describe Search::Supergroups do
   let(:no_docs_supergroups) { described_class.new(organisation_slug: slug_for_org_with_no_docs) }
 
   before do
-    Search::Supergroups::SUPERGROUP_TYPES.each do |supergroup|
+    Search::Supergroups::CONTENT_PURPOSE_SUPERGROUPS.each do |supergroup|
       stub_search_api_supergroup_request(supergroup, slug_for_org_with_docs, [raw_search_api_result])
       stub_search_api_supergroup_request(supergroup, slug_for_org_with_no_docs, [])
     end

--- a/spec/services/search/supergroups_spec.rb
+++ b/spec/services/search/supergroups_spec.rb
@@ -32,17 +32,6 @@ describe Search::Supergroups do
     it "returns an array of supergroups regardless of doc responses" do
       expect(no_docs_supergroups.groups.map(&:content_purpose_supergroup)).to eq(supergroups.groups.map(&:content_purpose_supergroup))
     end
-
-    it "applies the given additional search parameters" do
-      supergroups.groups.each do |group|
-        params = Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(
-          group.content_purpose_supergroup,
-          {},
-        )
-        query = group.documents_query
-        expect(query).to eq(query.merge(params))
-      end
-    end
   end
 
   def raw_search_api_result
@@ -55,13 +44,24 @@ describe Search::Supergroups do
   end
 
   def stub_search_api_supergroup_request(group, organisation_slug, results)
+    additional_search_params = {
+      "guidance_and_regulation" => {
+        order: "-popularity",
+      },
+      "news_and_communications" => {
+        reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+      },
+      "services" => {
+        order: "-popularity",
+      },
+    }.fetch(group, {})
     stub_supergroup_request(
       results:,
       additional_params: {
         filter_content_purpose_supergroup: group,
         filter_organisations: organisation_slug,
         order: Search::Supergroup::DEFAULT_SORT_ORDER,
-      }.merge(Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
+      }.merge(additional_search_params),
     )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,10 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  config.after(:each) do
+    Rails.cache.clear
+  end
 end
 
 def fetch_fixture(filename)

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -15,7 +15,7 @@ module OrganisationHelpers
           filter_organisations: organisation_slug,
           filter_content_purpose_supergroup: group,
           order: Search::Supergroup::DEFAULT_SORT_ORDER,
-        }.merge(Search::Supergroups::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
+        }.merge(Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
       )
 
       stub_request(:get, url).to_return(body: build_result_body(group, empty).to_json)

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -9,7 +9,7 @@ module OrganisationHelpers
   end
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty: false)
-    Search::Supergroups::SUPERGROUP_TYPES.each do |group|
+    Search::Supergroups::CONTENT_PURPOSE_SUPERGROUPS.each do |group|
       url = build_search_api_query_url(
         {
           filter_organisations: organisation_slug,

--- a/spec/support/organisation_helpers.rb
+++ b/spec/support/organisation_helpers.rb
@@ -10,12 +10,23 @@ module OrganisationHelpers
 
   def stub_latest_content_from_supergroups_request(organisation_slug, empty: false)
     Search::Supergroups::CONTENT_PURPOSE_SUPERGROUPS.each do |group|
+      additional_search_params = {
+        "guidance_and_regulation" => {
+          order: "-popularity",
+        },
+        "news_and_communications" => {
+          reject_content_purpose_subgroup: %w[decisions updates_and_alerts],
+        },
+        "services" => {
+          order: "-popularity",
+        },
+      }.fetch(group, {})
       url = build_search_api_query_url(
         {
           filter_organisations: organisation_slug,
           filter_content_purpose_supergroup: group,
           order: Search::Supergroup::DEFAULT_SORT_ORDER,
-        }.merge(Search::Supergroup::SUPERGROUP_ADDITIONAL_SEARCH_PARAMS.fetch(group, {})),
+        }.merge(additional_search_params),
       )
 
       stub_request(:get, url).to_return(body: build_result_body(group, empty).to_json)

--- a/spec/support/shared_examples/supergroup_caching.rb
+++ b/spec/support/shared_examples/supergroup_caching.rb
@@ -1,0 +1,29 @@
+RSpec.shared_examples "a cached Search API request for supergroup documents" do |expected_expiry:|
+  it "fetches documents from Search API and stores them in the cache with an expiry of #{expected_expiry}" do
+    allow(cache).to receive(:fetch).and_call_original
+
+    supergroup_documents
+
+    expect(Rails.cache)
+      .to have_received(:fetch)
+            .with(search_params, expires_in: expected_expiry)
+
+    assert_requested :get, "#{Plek.find('search-api')}/search.json", query: search_params
+  end
+
+  it "does not request documents from Search API if the cache already contains a valid copy" do
+    freeze_time do
+      cache.write(search_params, expires_in: expected_expiry)
+
+      allow(cache).to receive(:fetch).and_call_original
+
+      supergroup_documents
+
+      expect(Rails.cache)
+        .to have_received(:fetch)
+              .with(search_params, expires_in: expected_expiry)
+
+      assert_not_requested :get, "#{Plek.find('search-api')}/search.json", query: search_params
+    end
+  end
+end


### PR DESCRIPTION
## What

Cache documents fetched from SearchAPI:

- Supergroups with documents that are ordered by popularity are now cached for 12 hours.
  - guidance_and_regulation
  - services
  
- Supergroups with documents that are ordered by recency are now cached for 1 hour
  - news_and_communications
  - research_and_statistics
  - policy_and_engagement
  - transparency

<img width="1001" height="682" alt="Screenshot 2026-08-18 at 22 44 41" src="https://github.com/user-attachments/assets/d094811f-7c0a-45e0-bd09-710b6500cc72" />

## Why?

Collections accounts for approx 70% of traffic to SearchAPI. In a sample week, we observed that 36% of the traffic to SearchAPI was to fetch Supergroup sections on organisations pages ordered by recency. And 17% was to fetch Supergroup sections on organisations pages ordered by popularity.

Given the significance of the traffic, caching these requests would help to reduce load on SearchAPI.

It feels likely that:
- popularity of content is relatively static and so caching those searches for 12 hours won't have
a perceivable impact on the website. This is also the cache expiration of [popular browse tasks](https://github.com/alphagov/collections/blob/main/app/models/popular_list_set.rb#L32).
- a 1 hour window in recent content showing up in a supergroup on an organisation page is an acceptable lag.

https://gov-uk.atlassian.net/browse/SCH-2243
