### PR TITLE
Update banner on old DCMS org page [WHIT-3915]

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,7 @@ class Organisation
 
   CUSTOM_BANNERS_DATA = {
     "department-for-business-and-trade" => "This organisation is changing. It’s now called the <a href=\"https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade\">Department for Business, Innovation, Science and Trade</a>.",
-    "department-for-culture-media-and-sport" => "This organisation is changing. It will be called the Department for Digital, Culture, Media and Sport.",
+    "department-for-culture-media-and-sport" => "This organisation is changing. It’s now called the <a href=\"https://www.gov.uk/government/organisations/department-for-digital-culture-media-and-sport\">Department for Digital, Culture, Media and Sport</a>.",
     "department-for-science-innovation-and-technology" => "This organisation is changing. It’s being replaced by the <a href=\"https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade\">Department for Business, Innovation, Science and Trade</a>, the Department for Digital, Culture, Media and Sport and the Cabinet Office.",
   }.freeze
 


### PR DESCRIPTION
## What

Change banner contents as per the request from the content team.

## Why

Jira card: https://gov-uk.atlassian.net/browse/WHIT-3915

## Visual changes

| Before | After |
|--------|------|
| <img width="1017" height="507" alt="Screenshot 2026-08-21 at 13 15 55" src="https://github.com/user-attachments/assets/5fc16d5f-cd26-4b29-9f9d-1ff97a757dd6" /> | <img width="1027" height="498" alt="Screenshot 2026-08-21 at 13 16 02" src="https://github.com/user-attachments/assets/101e7769-fc15-4313-9e4e-a740551254aa" /> |

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
