### PR TITLE
DSIT: update banner to link to new DCMS and Cabinet Office [WHIT-3915]

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,7 +10,7 @@ class Organisation
   CUSTOM_BANNERS_DATA = {
     "department-for-business-and-trade" => "This organisation is changing. It’s now called the <a href=\"https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade\">Department for Business, Innovation, Science and Trade</a>.",
     "department-for-culture-media-and-sport" => "This organisation is changing. It’s now called the <a href=\"https://www.gov.uk/government/organisations/department-for-digital-culture-media-and-sport\">Department for Digital, Culture, Media and Sport</a>.",
-    "department-for-science-innovation-and-technology" => "This organisation is changing. It’s being replaced by the <a href=\"https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade\">Department for Business, Innovation, Science and Trade</a>, the Department for Digital, Culture, Media and Sport and the Cabinet Office.",
+    "department-for-science-innovation-and-technology" => "This organisation is changing. It’s being replaced by the <a href=\"https://www.gov.uk/government/organisations/department-for-business-innovation-science-and-trade\">Department for Business, Innovation, Science and Trade</a>, the <a href=\"https://www.gov.uk/government/organisations/department-for-digital-culture-media-and-sport\">Department for Digital, Culture, Media and Sport</a> and the <a href=\"https://www.gov.uk/government/organisations/cabinet-office\">Cabinet Office</a>.",
   }.freeze
 
   def initialize(content_item)


### PR DESCRIPTION
## What

Change banner contents as per the request from the content team.

## Why

Jira card: https://gov-uk.atlassian.net/browse/WHIT-3915

## Visual changes

| Before | After |
|-------|-------|
| <img width="1003" height="495" alt="Screenshot 2026-08-21 at 13 21 13" src="https://github.com/user-attachments/assets/dbab35bb-373a-40f2-96eb-3ef059aac140" /> | <img width="987" height="500" alt="Screenshot 2026-08-21 at 13 21 18" src="https://github.com/user-attachments/assets/dedfa09f-2956-491e-9946-3c05d2992125" /> |

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.