### PR TITLE
Bump js-yaml to 4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "resolutions": {
     "js-yaml@^3.13.1": "^3.15.0",
-    "js-yaml@^4.1.0": "^4.3.0"
+    "js-yaml@^4.3.0": "^4.3.2"
   },
   "packageManager": "yarn@3.4.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,14 +2190,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.3.0":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+"js-yaml@npm:^4.1.0":
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 482740e69a1769b355d7182234c0fa197237f02e6a5c8c0b70a763af6a712c9741de350d784a5659e00cf03cedd6ebfa506d59ca45967e3ee50dd4f4df18f2e7
+  checksum: 3c9294448ed83fec340f017f2be056dab05bcba3fc742468a80275d264e982dfd94350a93640eb810e0fdf283bef7c1c810690cc69b7b04a187f781e079d2555
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

- Bump `js-yaml` from `4.3.1` to `4.3.2`
- Update resolution rule in package.json

